### PR TITLE
Move State to data package

### DIFF
--- a/core/src/main/scala/cats/data/StateT.scala
+++ b/core/src/main/scala/cats/data/StateT.scala
@@ -1,7 +1,5 @@
 package cats
-package state
-
-import cats.data.Kleisli
+package data
 
 /**
  * `StateT[F, S, A]` is similar to `Kleisli[F, S, A]` in that it takes an `S`
@@ -123,7 +121,7 @@ object StateT extends StateTInstances {
     StateT(s => F.pure((s, a)))
 }
 
-private[state] sealed abstract class StateTInstances {
+private[data] sealed abstract class StateTInstances {
   implicit def stateTMonadState[F[_], S](implicit F: Monad[F]): MonadState[StateT[F, S, ?], S] =
     new MonadState[StateT[F, S, ?], S] {
       def pure[A](a: A): StateT[F, S, A] =
@@ -143,7 +141,7 @@ private[state] sealed abstract class StateTInstances {
 
 // To workaround SI-7139 `object State` needs to be defined inside the package object
 // together with the type alias.
-private[state] abstract class StateFunctions {
+private[data] abstract class StateFunctions {
 
   def apply[S, A](f: S => (S, A)): State[S, A] =
     StateT.applyF(Now((s: S) => Now(f(s))))

--- a/core/src/main/scala/cats/data/package.scala
+++ b/core/src/main/scala/cats/data/package.scala
@@ -46,4 +46,7 @@ package object data {
   object Writer {
     def apply[L, V](l: L, v: V): WriterT[Id, L, V] = WriterT[Id, L, V]((l, v))
   }
+
+  type State[S, A] = StateT[Eval, S, A]
+  object State extends StateFunctions
 }

--- a/core/src/main/scala/cats/state/package.scala
+++ b/core/src/main/scala/cats/state/package.scala
@@ -1,6 +1,0 @@
-package cats
-
-package object state {
-  type State[S, A] = StateT[Eval, S, A]
-  object State extends StateFunctions
-}

--- a/docs/src/main/tut/state.md
+++ b/docs/src/main/tut/state.md
@@ -2,8 +2,8 @@
 layout: default
 title:  "State"
 section: "data"
-source: "https://github.com/non/cats/blob/master/core/src/main/scala/cats/state/StateT.scala"
-scaladoc: "#cats.state.StateT"
+source: "https://github.com/non/cats/blob/master/core/src/main/scala/cats/data/StateT.scala"
+scaladoc: "#cats.data.StateT"
 ---
 # State
 
@@ -131,7 +131,7 @@ Our `nextLong` function takes a `Seed` and returns an updated `Seed` and a `Long
 Let's write a new version of `nextLong` using `State`:
 
 ```tut:silent
-import cats.state.State
+import cats.data.State
 
 val nextLong: State[Seed, Long] = State(seed =>
   (seed.next, seed.long))

--- a/tests/src/test/scala/cats/tests/FreeApplicativeTests.scala
+++ b/tests/src/test/scala/cats/tests/FreeApplicativeTests.scala
@@ -5,8 +5,7 @@ import cats.arrow.NaturalTransformation
 import cats.free.FreeApplicative
 import cats.laws.discipline.{CartesianTests, ApplicativeTests, SerializableTests}
 import cats.laws.discipline.eq.{tuple3Eq, tuple2Eq}
-import cats.data.Const
-import cats.state.State
+import cats.data.{Const, State}
 
 import org.scalacheck.{Arbitrary, Gen}
 

--- a/tests/src/test/scala/cats/tests/StateTTests.scala
+++ b/tests/src/test/scala/cats/tests/StateTTests.scala
@@ -2,7 +2,7 @@ package cats
 package tests
 
 import cats.laws.discipline.{CartesianTests, MonadStateTests, MonoidKTests, SerializableTests}
-import cats.state.{State, StateT}
+import cats.data.{State, StateT}
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
 import org.scalacheck.{Arbitrary, Gen}

--- a/tests/src/test/scala/cats/tests/WordCountTest.scala
+++ b/tests/src/test/scala/cats/tests/WordCountTest.scala
@@ -10,7 +10,7 @@ import Func.{ appFunc, appFuncU }
  */
 class WordCountTest extends CatsSuite {
   test("wordcount") {
-    import cats.state.State.{ get, set }
+    import cats.data.State.{ get, set }
     val text = "Faith, I must leave thee, love, and shortly too.\nMy operant powers their functions leave to do.\n".toList
     // A type alias to treat Int as cartesian applicative
     type Count[A] = Const[Int, A]


### PR DESCRIPTION
This is a partial partial fix for #785. So far I've moved `state` but not `free`. There are several different types within the `free` package, so it might warrant its own package. However, `State`/`StateT` was just sitting in the `state` package by itself, so I've gone ahead and moved it (so it now parallels `Writer/WriterT`).