### PR TITLE
Adds a MonadTrans typeclass

### DIFF
--- a/core/src/main/scala/cats/Monad.scala
+++ b/core/src/main/scala/cats/Monad.scala
@@ -18,5 +18,5 @@ import simulacrum.typeclass
   /**
    * Lift a value of type M[A] into a monad transformer MT[M, A]
    */
-  def liftM[MT[_[_], _]](ma: M[A])(implicit MT: MonadTrans[MT]): MT[F, A] = MT.liftM(ma)
+  def liftM[MT[_[_], _], A](ma: F[A])(implicit MT: MonadTrans[MT]): MT[F, A] = MT.liftM(ma)(this)
 }

--- a/core/src/main/scala/cats/Monad.scala
+++ b/core/src/main/scala/cats/Monad.scala
@@ -14,4 +14,9 @@ import simulacrum.typeclass
 @typeclass trait Monad[F[_]] extends FlatMap[F] with Applicative[F] {
   override def map[A, B](fa: F[A])(f: A => B): F[B] =
     flatMap(fa)(a => pure(f(a)))
+
+  /**
+   * Lift a value of type M[A] into a monad transformer MT[M, A]
+   */
+  def liftM[MT[_[_], _]](ma: M[A])(implicit MT: MonadTrans[MT]): MT[F, A] = MT.liftM(ma)
 }

--- a/core/src/main/scala/cats/MonadTrans.scala
+++ b/core/src/main/scala/cats/MonadTrans.scala
@@ -1,0 +1,26 @@
+package cats
+
+/**
+ * A typeclass which abstracts over monad transformers, providing the
+ * ability to lift a monad, into the the monad transformer for another
+ * monad.
+ */
+trait MonadTrans[MT[_[_], _]] {
+  /**
+   * Lift a value of type M[A] into a monad transformer MT[M, A]
+   */
+  def liftM[M[_]: Monad, A](ma: M[A]): MT[M, A]
+
+  /**
+   * Lift a value of type M[A] into a monad transformer MT[M, A] using
+   * Unapply, this will be useful when the M[A] monad is actually not
+   * in the * -> * shape. For example Xor[E,A].
+   */
+  def liftMU[MA](ma: MA)(implicit U: Unapply[Monad, MA]): MT[U.M, U.A] = {
+    liftM[U.M, U.A](U.subst(ma))(U.TC)
+  }
+}
+
+object MonadTrans {
+  def apply[MT[_[_], _]](implicit MT: MonadTrans[MT]) = MT
+}

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -136,6 +136,11 @@ private[data] sealed trait OptionTInstances1 {
       override def map[A, B](fa: OptionT[F, A])(f: A => B): OptionT[F, B] =
         fa.map(f)
     }
+
+  implicit val optionTMonadTrans: MonadTrans[OptionT] = new MonadTrans[OptionT] {
+    def liftM[M[_], A](ma: M[A])(implicit M: Monad[M]): OptionT[M, A] =
+      OptionT(M.map(ma)(Some.apply))
+  }
 }
 
 private[data] sealed trait OptionTInstances extends OptionTInstances1 {

--- a/core/src/main/scala/cats/data/StreamingT.scala
+++ b/core/src/main/scala/cats/data/StreamingT.scala
@@ -452,6 +452,12 @@ private[data] sealed trait StreamingTInstances extends StreamingTInstances1 {
       def compare(x: StreamingT[F, A], y: StreamingT[F, A]): Int =
         x.toList compare y.toList
     }
+
+  implicit val streamingTMonadTrans: MonadTrans[StreamingT] =
+    new MonadTrans[StreamingT] {
+      def liftM[M[_], A](ma: M[A])(implicit M: Monad[M]): StreamingT[M, A] =
+        StreamingT.single(ma)
+    }
 }
 
 private[data] sealed trait StreamingTInstances1 extends StreamingTInstances2 {

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -62,6 +62,12 @@ private[data] sealed abstract class WriterTInstances extends WriterTInstances0 {
       def bimap[A, B, C, D](fab: WriterT[F, A, B])(f: A => C, g: B => D): WriterT[F, C, D] =
         fab.bimap(f, g)
     }
+
+  implicit def writerTMonadTrans[W](implicit W: Monoid[W]): MonadTrans[({type λ[α[_], β]=WriterT[α,W,β]})#λ] =
+    new MonadTrans[({type λ[α[_], β]=WriterT[α,W,β]})#λ] {
+      def liftM[M[_], A](ma: M[A])(implicit M: Monad[M]): WriterT[M,W,A] =
+        WriterT(M.map(ma)((W.empty, _)))
+  }
 }
 
 private[data] sealed abstract class WriterTInstances0 extends WriterTInstances1 {

--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -193,6 +193,12 @@ private[data] abstract class XorTInstances extends XorTInstances1 {
     new XorTTraverse[F, L] {
       val F0: Traverse[F] = F
     }
+
+  implicit def xortTMonadTrans[A]: MonadTrans[({type λ[α[_], β] = XorT[α, A, β]})#λ] =
+    new MonadTrans[({type λ[α[_], β] = XorT[α, A, β]})#λ] {
+    def liftM[M[_], B](ma: M[B])(implicit M: Monad[M]): XorT[M, A, B] =
+      XorT(M.map(ma)(Xor.right))
+  }
 }
 
 private[data] abstract class XorTInstances1 extends XorTInstances2 {

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -3,8 +3,8 @@ package syntax
 
 trait AllSyntax
     extends ApplySyntax
-    with MonoidalSyntax
     with BifunctorSyntax
+    with CartesianSyntax
     with CoflatMapSyntax
     with ComonadSyntax
     with ComposeSyntax
@@ -17,9 +17,9 @@ trait AllSyntax
     with GroupSyntax
     with InvariantSyntax
     with ListSyntax
+    with MonadSyntax
     with MonadCombineSyntax
     with MonadFilterSyntax
-    with MonadSyntax
     with OptionSyntax
     with OrderSyntax
     with PartialOrderSyntax

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -19,6 +19,7 @@ trait AllSyntax
     with ListSyntax
     with MonadCombineSyntax
     with MonadFilterSyntax
+    with MonadSyntax
     with OptionSyntax
     with OrderSyntax
     with PartialOrderSyntax

--- a/core/src/main/scala/cats/syntax/monad.scala
+++ b/core/src/main/scala/cats/syntax/monad.scala
@@ -1,0 +1,18 @@
+package cats
+package syntax
+
+trait MonadSyntax1 {
+  implicit def monadSyntaxU[FA](fa: FA)(implicit U: Unapply[Monad, FA]): Monad.Ops[U.M, U.A] =
+    new Monad.Ops[U.M, U.A] {
+      val self = U.subst(fa)
+      val typeClassInstance = U.TC
+    }
+}
+
+trait MonadSyntax extends MonadSyntax1 {
+  implicit def monadSyntax[F[_], A](fa: F[A])(implicit F: Monad[F]): Monad.Ops[F, A] =
+    new Monad.Ops[F,A] {
+      val self = fa
+      val typeClassInstance = F
+    }
+}

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -4,7 +4,9 @@ package object syntax {
   object all extends AllSyntax
   object apply extends ApplySyntax
   object bifunctor extends BifunctorSyntax
+  object cartesian extends CartesianSyntax
   object coflatMap extends CoflatMapSyntax
+  object coproduct extends CoproductSyntax
   object comonad extends ComonadSyntax
   object compose extends ComposeSyntax
   object contravariant extends ContravariantSyntax
@@ -15,10 +17,9 @@ package object syntax {
   object functor extends FunctorSyntax
   object group extends GroupSyntax
   object invariant extends InvariantSyntax
+  object monad extends MonadSyntax
   object monadCombine extends MonadCombineSyntax
   object monadFilter extends MonadFilterSyntax
-  object monoidal extends MonoidalSyntax
-  object monad extends MonadSyntax
   object option extends OptionSyntax
   object order extends OrderSyntax
   object partialOrder extends PartialOrderSyntax
@@ -30,6 +31,6 @@ package object syntax {
   object streaming extends StreamingSyntax
   object strong extends StrongSyntax
   object traverse extends TraverseSyntax
-  object validated extends ValidatedSyntax
   object xor extends XorSyntax
+  object validated extends ValidatedSyntax
 }

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -3,7 +3,6 @@ package cats
 package object syntax {
   object all extends AllSyntax
   object apply extends ApplySyntax
-  object monoidal extends MonoidalSyntax
   object bifunctor extends BifunctorSyntax
   object coflatMap extends CoflatMapSyntax
   object comonad extends ComonadSyntax
@@ -18,6 +17,8 @@ package object syntax {
   object invariant extends InvariantSyntax
   object monadCombine extends MonadCombineSyntax
   object monadFilter extends MonadFilterSyntax
+  object monoidal extends MonoidalSyntax
+  object monad extends MonadSyntax
   object option extends OptionSyntax
   object order extends OrderSyntax
   object partialOrder extends PartialOrderSyntax
@@ -29,6 +30,6 @@ package object syntax {
   object streaming extends StreamingSyntax
   object strong extends StrongSyntax
   object traverse extends TraverseSyntax
-  object xor extends XorSyntax
   object validated extends ValidatedSyntax
+  object xor extends XorSyntax
 }

--- a/tests/src/test/scala/cats/tests/MonadTransTests.scala
+++ b/tests/src/test/scala/cats/tests/MonadTransTests.scala
@@ -1,0 +1,20 @@
+package cats
+package tests
+
+import data.{OptionT,XorT,WriterT,StreamingT}
+
+class MonadTransTests extends CatsSuite {
+
+  test("monadTrans syntax on monad works"){
+
+    val x: OptionT[List, Int] = List(1).liftM[OptionT]
+    x.value should === (List(Option(1)))
+  }
+
+  test("we have monadTrans for XorT, OptionT, StreamingT, WriterT"){
+    val a: WriterT[List, Int, Int] = List(1).liftM[({type λ[α[_], β] = WriterT[α, Int, β]})#λ]
+    val b: StreamingT[List, Int]   = List(1).liftM[StreamingT]
+    val c: OptionT[List, Int]      = List(1).liftM[OptionT]
+    val d: XorT[List, Int, Int]    = List(1).liftM[({type λ[α[_], β] = XorT[α, Int, β]})#λ]
+  }
+}


### PR DESCRIPTION
This is similar to MonadTrans in scalaz. It allows you to lift a Monad into a transformer wrapping that monad

I skipped Hoist, since I've never seen that actually used in the wild.

I was shamed into doing this by @djspiewak :)