### PR TITLE
Fix Streaming and StreamingT dropWhile functions

### DIFF
--- a/core/src/main/scala/cats/data/Streaming.scala
+++ b/core/src/main/scala/cats/data/Streaming.scala
@@ -534,7 +534,7 @@ sealed abstract class Streaming[A] extends Product with Serializable { lhs =>
     this match {
       case Empty() => Empty()
       case Wait(lt) => Wait(lt.map(_.dropWhile(f)))
-      case Cons(a, lt) => if (f(a)) Wait(lt.map(_.dropWhile(f))) else Cons(a, lt)
+      case s @ Cons(a, lt) => if (f(a)) Wait(lt.map(_.dropWhile(f))) else s
     }
 
   /**

--- a/core/src/main/scala/cats/data/Streaming.scala
+++ b/core/src/main/scala/cats/data/Streaming.scala
@@ -524,7 +524,7 @@ sealed abstract class Streaming[A] extends Product with Serializable { lhs =>
    *
    * For example:
    *
-   *   Streaming(1, 2, 3, 4, 5, 6, 7).takeWhile(n => n != 4)
+   *   Streaming(1, 2, 3, 4, 5, 6, 7).dropWhile(n => n != 4)
    *
    * Will result in: Streaming(4, 5, 6, 7)
    */
@@ -532,7 +532,7 @@ sealed abstract class Streaming[A] extends Product with Serializable { lhs =>
     this match {
       case Empty() => Empty()
       case Wait(lt) => Wait(lt.map(_.dropWhile(f)))
-      case Cons(a, lt) => if (f(a)) Empty() else Cons(a, lt.map(_.dropWhile(f)))
+      case Cons(a, lt) => if (f(a)) Wait(lt.map(_.dropWhile(f))) else Cons(a, lt)
     }
 
   /**

--- a/core/src/main/scala/cats/data/StreamingT.scala
+++ b/core/src/main/scala/cats/data/StreamingT.scala
@@ -251,7 +251,7 @@ sealed abstract class StreamingT[F[_], A] extends Product with Serializable { lh
    */
   def dropWhile(f: A => Boolean)(implicit ev: Functor[F]): StreamingT[F, A] =
     this match {
-      case Cons(a, ft) => if (f(a)) Empty() else Cons(a, ft.map(_.dropWhile(f)))
+      case Cons(a, ft) => if (f(a)) Wait(ft.map(_.dropWhile(f))) else Cons(a, ft)
       case Wait(ft) => Wait(ft.map(_.dropWhile(f)))
       case Empty() => Empty()
     }

--- a/core/src/main/scala/cats/data/StreamingT.scala
+++ b/core/src/main/scala/cats/data/StreamingT.scala
@@ -255,7 +255,7 @@ sealed abstract class StreamingT[F[_], A] extends Product with Serializable { lh
    */
   def dropWhile(f: A => Boolean)(implicit ev: Functor[F]): StreamingT[F, A] =
     this match {
-      case Cons(a, ft) => if (f(a)) Wait(ft.map(_.dropWhile(f))) else Cons(a, ft)
+      case s @ Cons(a, ft) => if (f(a)) Wait(ft.map(_.dropWhile(f))) else s
       case Wait(ft) => Wait(ft.map(_.dropWhile(f)))
       case Empty() => Empty()
     }

--- a/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
@@ -11,6 +11,12 @@ import org.scalacheck.Arbitrary.{arbitrary => getArbitrary}
  */
 object arbitrary extends ArbitraryInstances0 {
 
+  // A special function1Arbitrary for testing operations like dropWhile specifically
+  // in the context of Int => Boolean. Once scalacheck supports better Function1 arbitrary
+  // instances this can be removed.
+  implicit def function1Arbitrary: Arbitrary[(Int) => Boolean] =
+    Arbitrary(getArbitrary[Int].map(x => (input) => input < x))
+
   implicit def constArbitrary[A, B](implicit A: Arbitrary[A]): Arbitrary[Const[A, B]] =
     Arbitrary(A.arbitrary.map(Const[A, B]))
 


### PR DESCRIPTION
Default `Int => Boolean` in scalacheck just returns a function which
always returns the same value (`true` or `false`). This means that
operations like `dropWhile` are not tested accurately, as whilst the bounds (all `true` and all `false`) are checked, intermediate results which return different values based on input are not tested.

This fix creates a temporary `Arbitrary` instance for `Int => Boolean` and fixes the `dropWhile` on `Streaming` and `StreamingT` which were broken, and didn’t show up due to the deficiency in the `Arbitrary[Int => Boolean]` instance provided by scalacheck.

Maybe there is a better way to do these instances? This kind of hardcodes that the `Int => Boolean` returned is always just a comparison between the `Int` values, but seems better than always `true`/`false`.