### PR TITLE
support collectNonEmpty operation over Foldables

### DIFF
--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -266,6 +266,15 @@ import simulacrum.typeclass
     !isEmpty(fa)
 
   /**
+    * Lazily converts F[A] to a Streaming[B] containing only elements mapped to non-empty Options by f.
+    */
+  def collectNonEmpty[A, B](fa: F[A])(f: A => Option[B]): Streaming[B] =
+    Streaming.wait(foldRight(fa, Now(Streaming.empty[B])) { (a, lbs) =>
+      f(a).fold(lbs)(a => Now(Streaming.cons(a, lbs)))
+    })
+
+
+  /**
    * Compose this `Foldable[F]` with a `Foldable[G]` to create
    * a `Foldable[F[G]]` instance.
    */

--- a/laws/src/main/scala/cats/laws/FoldableLaws.scala
+++ b/laws/src/main/scala/cats/laws/FoldableLaws.scala
@@ -49,6 +49,15 @@ trait FoldableLaws[F[_]] {
     i == (if (F.isEmpty(fa)) 0 else 1)
   }
 
+  def collectNonEmptyLazy[A](fa: F[A]): Boolean = {
+        var i = 0
+        F.collectNonEmpty(fa){ a =>
+            i = i + 1
+            Some(a)
+          }.take(1).toList
+        i == (if (F.isEmpty(fa)) 0 else 1)
+      }
+
   def forallConsistentWithExists[A](
     fa: F[A],
     p: A => Boolean

--- a/laws/src/main/scala/cats/laws/discipline/FoldableTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FoldableTests.scala
@@ -23,7 +23,8 @@ trait FoldableTests[F[_]] extends Laws {
       "forall consistent with exists" -> forAll(laws.forallConsistentWithExists[A] _),
       "forall true if empty" -> forAll(laws.forallEmpty[A] _),
       "exists is lazy" -> forAll(laws.existsLazy[A] _),
-      "forall is lazy" -> forAll(laws.forallLazy[A] _)
+      "forall is lazy" -> forAll(laws.forallLazy[A] _),
+      "collectNonEmpty is lazy" -> forAll(laws.collectNonEmptyLazy[A] _)
     )
   }
 }

--- a/tests/src/test/scala/cats/tests/FoldableTests.scala
+++ b/tests/src/test/scala/cats/tests/FoldableTests.scala
@@ -23,14 +23,18 @@ abstract class FoldableCheck[F[_]: Foldable](name: String)(implicit ArbFInt: Arb
     }
   }
 
-  test("find/exists/forall/filter_/dropWhile_") {
+  test("find/exists/forall/filter_/dropWhile_/collectNonEmpty") {
     forAll { (fa: F[Int], n: Int) =>
       fa.find(_ > n)   should === (iterator(fa).find(_ > n))
       fa.exists(_ > n) should === (iterator(fa).exists(_ > n))
       fa.forall(_ > n) should === (iterator(fa).forall(_ > n))
       fa.filter_(_ > n) should === (iterator(fa).filter(_ > n).toList)
       fa.dropWhile_(_ > n) should === (iterator(fa).dropWhile(_ > n).toList)
-      fa.takeWhile_(_ > n) should === (iterator(fa).takeWhile(_ > n).toList)
+      fa.takeWhile_(_ > n) should === (iterator(fa).takeWhile(_ > n).toList);
+      {
+        val f = (x: Int) => if (x > n) Option(x) else Option.empty
+        fa.collectNonEmpty(f).toList should === (iterator(fa).map(f).flatten.toList)
+      }
     }
   }
 


### PR DESCRIPTION
collectNonEmpty lazily maps to Option and flattens in single pass. 

Replaces & closes earlier findMap PR #827 & issue #826 