### PR TITLE
Optimize Eq[Vector[A]] instance

### DIFF
--- a/core/src/main/scala/cats/std/vector.scala
+++ b/core/src/main/scala/cats/std/vector.scala
@@ -68,16 +68,11 @@ trait VectorInstances {
   implicit def eqVector[A](implicit ev: Eq[A]): Eq[Vector[A]] =
     new Eq[Vector[A]] {
       def eqv(x: Vector[A], y: Vector[A]): Boolean = {
-        def loop(xs: Vector[A], ys: Vector[A]): Boolean =
-          xs match {
-            case Seq() => ys.isEmpty
-            case a +: xs =>
-              ys match {
-                case Seq() => false
-                case b +: ys => if (ev.neqv(a, b)) false else loop(xs, ys)
-              }
-          }
-        loop(x, y)
+        @tailrec def loop(from: Int): Boolean =
+          if(from == x.size) true
+          else ev.eqv(x(from), y(from)) && loop(from + 1)
+
+        (x.size == y.size) && loop(0)
       }
     }
 }

--- a/core/src/main/scala/cats/std/vector.scala
+++ b/core/src/main/scala/cats/std/vector.scala
@@ -68,11 +68,11 @@ trait VectorInstances {
   implicit def eqVector[A](implicit ev: Eq[A]): Eq[Vector[A]] =
     new Eq[Vector[A]] {
       def eqv(x: Vector[A], y: Vector[A]): Boolean = {
-        @tailrec def loop(from: Int): Boolean =
-          if(from == x.size) true
-          else ev.eqv(x(from), y(from)) && loop(from + 1)
+        @tailrec def loop(to: Int): Boolean =
+          if(to == -1) true
+          else ev.eqv(x(to), y(to)) && loop(to - 1)
 
-        (x.size == y.size) && loop(0)
+        (x.size == y.size) && loop(x.size - 1)
       }
     }
 }


### PR DESCRIPTION
 * Check size equality first.
 * Avoid pattern matching on Vector via `x +: xs`, which creates a new Vector instance via `Vector.tail`.
 * Added `@tailrec` annotation to the `loop` method.

I used this mini-benchmark to assess the improvement:

```scala
import cats.Eq
import cats.std.vector._
import cats.std.int._

val v = (1 to 10000000).toVector
val EqV = Eq[Vector[Int]]

{
  val t0 = System.currentTimeMillis
  EqV.eqv(v, v)
  val t1 = System.currentTimeMillis
  println(s"${t1 - t0}ms")
}
```

The result is 

before refactoring | after refactoring
--------- | -------
6542ms | 161ms
