### PR TITLE
Delegate to Traverse.sequence in Applicative.sequence

### DIFF
--- a/core/src/main/scala/cats/Applicative.scala
+++ b/core/src/main/scala/cats/Applicative.scala
@@ -45,8 +45,8 @@ import simulacrum.typeclass
   def traverse[A, G[_], B](value: G[A])(f: A => F[B])(implicit G: Traverse[G]): F[G[B]] =
     G.traverse(value)(f)(this)
 
-  def sequence[G[_]: Traverse, A](as: G[F[A]]): F[G[A]] =
-    traverse(as)(a => a)
+  def sequence[G[_], A](as: G[F[A]])(implicit G: Traverse[G]): F[G[A]] =
+    G.sequence(as)(this)
 
 }
 


### PR DESCRIPTION
The previous approach duplicated the implementation of `sequence`, which
is a slight code stink. More importantly though, this approach will
benefit from an optimized override implementation of `sequence` if the
`Traverse` instance has one.