### PR TITLE
Add Applicative syntax

### DIFF
--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -2,7 +2,8 @@ package cats
 package syntax
 
 trait AllSyntax
-    extends ApplySyntax
+    extends ApplicativeSyntax
+    with ApplySyntax
     with BifunctorSyntax
     with BifoldableSyntax
     with CartesianSyntax

--- a/core/src/main/scala/cats/syntax/applicative.scala
+++ b/core/src/main/scala/cats/syntax/applicative.scala
@@ -1,0 +1,15 @@
+package cats
+package syntax
+
+trait ApplicativeSyntax {
+  implicit def applicativeIdSyntax[A](a: A): ApplicativeIdOps[A] = new ApplicativeIdOps[A](a)
+  implicit def applicativeEvalSyntax[A](a: Eval[A]): ApplicativeEvalOps[A] = new ApplicativeEvalOps[A](a)
+}
+
+final class ApplicativeIdOps[A](val a: A) extends AnyVal {
+  def pure[F[_]](implicit F: Applicative[F]): F[A] = F.pure(a)
+}
+
+final class ApplicativeEvalOps[A](val a: Eval[A]) extends AnyVal {
+  def pureEval[F[_]](implicit F: Applicative[F]): F[A] = F.pureEval(a)
+}

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -2,6 +2,7 @@ package cats
 
 package object syntax {
   object all extends AllSyntax
+  object applicative extends ApplicativeSyntax
   object apply extends ApplySyntax
   object bifunctor extends BifunctorSyntax
   object bifoldable extends BifoldableSyntax

--- a/tests/src/test/scala/cats/tests/SyntaxTests.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxTests.scala
@@ -201,4 +201,12 @@ class SyntaxTests extends AllInstances with AllSyntax {
     val g2 = mock[B => D]
     val d0 = fab.bifoldMap(f2, g2)
   }
+
+  def testApplicative[F[_]: Applicative, A]: Unit = {
+    val a = mock[A]
+    val fa = a.pure[F]
+
+    val la = mock[Eval[A]]
+    val lfa = la.pureEval[F]
+  }
 }


### PR DESCRIPTION
This PR adds `Applicative` syntax. Fixes #882.
Not sure if I should test for `Applicative#traverse` and `Applicative#sequence`.
I don’t know if simulacrum generates anything for these methods.