### PR TITLE
Add map method to OneAnd. Fix for #885

### DIFF
--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -3,6 +3,7 @@ package data
 
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
+import cats.std.list._
 
 /**
  * A data type which represents a single element (head) and some other
@@ -110,7 +111,7 @@ private[data] sealed trait OneAndInstances extends OneAndLowPriority2 {
     }
 
   implicit def oneAndSemigroup[F[_]: MonadCombine, A]: Semigroup[OneAnd[F, A]] =
-    oneAndSemigroupK.algebra
+    oneAndSemigroupK(MonadCombine[F]).algebra
 
   implicit def oneAndReducible[F[_]](implicit F: Foldable[F]): Reducible[OneAnd[F, ?]] =
     new NonEmptyReducible[OneAnd[F,?], F] {
@@ -137,8 +138,6 @@ private[data] sealed trait OneAndInstances extends OneAndLowPriority2 {
 }
 
 trait OneAndLowPriority0 {
-  import cats.std.list._
-
   implicit val nelComonad: Comonad[OneAnd[List, ?]] =
     new Comonad[OneAnd[List, ?]] {
       def coflatMap[A, B](fa: OneAnd[List, A])(f: OneAnd[List, A] => B): OneAnd[List, B] = {

--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -111,7 +111,7 @@ private[data] sealed trait OneAndInstances extends OneAndLowPriority2 {
     }
 
   implicit def oneAndSemigroup[F[_]: MonadCombine, A]: Semigroup[OneAnd[F, A]] =
-    oneAndSemigroupK(MonadCombine[F]).algebra
+    oneAndSemigroupK[F].algebra
 
   implicit def oneAndReducible[F[_]](implicit F: Foldable[F]): Reducible[OneAnd[F, ?]] =
     new NonEmptyReducible[OneAnd[F,?], F] {

--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -66,6 +66,12 @@ final case class OneAnd[F[_], A](head: A, tail: F[A]) {
     Eval.defer(f(head, F.foldRight(tail, lb)(f)))
 
   /**
+    * Applies f to all the elements of the structure
+    */
+  def map[B](f: A => B)(implicit F: Functor[F]): OneAnd[F, B] =
+    OneAnd(f(head), F.map(tail)(f))
+
+  /**
    * Typesafe equality operator.
    *
    * This method is similar to == except that it only allows two

--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -120,7 +120,7 @@ private[data] sealed trait OneAndInstances extends OneAndLowPriority2 {
   implicit def oneAndMonad[F[_]](implicit monad: MonadCombine[F]): Monad[OneAnd[F, ?]] =
     new Monad[OneAnd[F, ?]] {
       override def map[A, B](fa: OneAnd[F, A])(f: A => B): OneAnd[F, B] =
-        OneAnd(f(fa.head), monad.map(fa.tail)(f))
+        fa map f
 
       def pure[A](x: A): OneAnd[F, A] =
         OneAnd(x, monad.empty)
@@ -139,6 +139,11 @@ private[data] sealed trait OneAndInstances extends OneAndLowPriority2 {
 trait OneAndLowPriority0 {
   implicit val nelComonad: Comonad[OneAnd[List, ?]] =
     new Comonad[OneAnd[List, ?]] {
+      val functorList: Functor[List] =
+        new Functor[List] {
+          def map[A, B](fa: List[A])(f: A => B): List[B] =
+            fa map f
+        }
 
       def coflatMap[A, B](fa: OneAnd[List, A])(f: OneAnd[List, A] => B): OneAnd[List, B] = {
         @tailrec def consume(as: List[A], buf: ListBuffer[B]): List[B] =
@@ -153,7 +158,7 @@ trait OneAndLowPriority0 {
         fa.head
 
       def map[A, B](fa: OneAnd[List, A])(f: A => B): OneAnd[List, B] =
-        OneAnd(f(fa.head), fa.tail.map(f))
+        fa.map(f)(functorList)
     }
 }
 
@@ -161,7 +166,7 @@ trait OneAndLowPriority1 extends OneAndLowPriority0 {
   implicit def oneAndFunctor[F[_]](implicit F: Functor[F]): Functor[OneAnd[F, ?]] =
     new Functor[OneAnd[F, ?]] {
       def map[A, B](fa: OneAnd[F, A])(f: A => B): OneAnd[F, B] =
-        OneAnd(f(fa.head), F.map(fa.tail)(f))
+        fa map f
     }
 
 }

--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -137,14 +137,10 @@ private[data] sealed trait OneAndInstances extends OneAndLowPriority2 {
 }
 
 trait OneAndLowPriority0 {
+  import cats.std.list._
+
   implicit val nelComonad: Comonad[OneAnd[List, ?]] =
     new Comonad[OneAnd[List, ?]] {
-      val functorList: Functor[List] =
-        new Functor[List] {
-          def map[A, B](fa: List[A])(f: A => B): List[B] =
-            fa map f
-        }
-
       def coflatMap[A, B](fa: OneAnd[List, A])(f: OneAnd[List, A] => B): OneAnd[List, B] = {
         @tailrec def consume(as: List[A], buf: ListBuffer[B]): List[B] =
           as match {
@@ -158,7 +154,7 @@ trait OneAndLowPriority0 {
         fa.head
 
       def map[A, B](fa: OneAnd[List, A])(f: A => B): OneAnd[List, B] =
-        fa.map(f)(functorList)
+        fa map f
     }
 }
 

--- a/tests/src/test/scala/cats/tests/OneAndTests.scala
+++ b/tests/src/test/scala/cats/tests/OneAndTests.scala
@@ -109,4 +109,11 @@ class OneAndTests extends CatsSuite {
       nel.forall(p) should === (list.forall(p))
     }
   }
+
+  test("NonEmptyList#map is consistent with List#map") {
+    forAll { (nel: NonEmptyList[Int], p: Int => String) =>
+      val list = nel.unwrap
+      nel.map(p).unwrap should === (list.map(p))
+    }
+  }
 }


### PR DESCRIPTION
OneAnd was missing an instance of map. This commit tries to solve this.