### PR TITLE
Add cats.io and IO monad

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -95,22 +95,22 @@ lazy val cats = project.in(file("."))
   .settings(moduleName := "root")
   .settings(catsSettings)
   .settings(noPublishSettings)
-  .aggregate(catsJVM, catsJS)
-  .dependsOn(catsJVM, catsJS, testsJVM % "test-internal -> test", bench % "compile-internal;test-internal -> test")
+  .aggregate(catsJVM, catsJS, ioJVM, ioJS)
+  .dependsOn(catsJVM, catsJS, ioJVM, ioJS, testsJVM % "test-internal -> test", bench % "compile-internal;test-internal -> test")
 
 lazy val catsJVM = project.in(file(".catsJVM"))
   .settings(moduleName := "cats")
   .settings(catsSettings)
   .settings(commonJvmSettings)
-  .aggregate(macrosJVM, coreJVM, lawsJVM, testsJVM, jvm, docs, bench)
-  .dependsOn(macrosJVM, coreJVM, lawsJVM, testsJVM % "test-internal -> test", jvm, bench % "compile-internal;test-internal -> test")
+  .aggregate(macrosJVM, coreJVM, ioJVM, lawsJVM, testsJVM, jvm, docs, bench)
+  .dependsOn(macrosJVM, coreJVM, ioJVM, lawsJVM, testsJVM % "test-internal -> test", jvm, bench % "compile-internal;test-internal -> test")
 
 lazy val catsJS = project.in(file(".catsJS"))
   .settings(moduleName := "cats")
   .settings(catsSettings)
   .settings(commonJsSettings)
-  .aggregate(macrosJS, coreJS, lawsJS, testsJS, js)
-  .dependsOn(macrosJS, coreJS, lawsJS, testsJS % "test-internal -> test", js)
+  .aggregate(macrosJS, coreJS, ioJS, lawsJS, testsJS, js)
+  .dependsOn(macrosJS, coreJS, ioJS, lawsJS, testsJS % "test-internal -> test", js)
   .enablePlugins(ScalaJSPlugin)
 
 
@@ -138,6 +138,17 @@ lazy val core = crossProject.crossType(CrossType.Pure)
 
 lazy val coreJVM = core.jvm
 lazy val coreJS = core.js
+
+lazy val io = crossProject.crossType(CrossType.Pure)
+  .dependsOn(core, tests % "test-internal -> test")
+  .settings(moduleName := "cats-io")
+  .settings(catsSettings: _*)
+  .jsSettings(commonJsSettings: _*)
+  .jsSettings()
+  .jvmSettings(commonJvmSettings: _*)
+
+lazy val ioJVM = io.jvm
+lazy val ioJS = io.js
 
 lazy val laws = crossProject.crossType(CrossType.Pure)
   .dependsOn(macros, core)
@@ -259,11 +270,11 @@ lazy val publishSettings = Seq(
 ) ++ credentialSettings ++ sharedPublishSettings ++ sharedReleaseProcess
 
 // These aliases serialise the build for the benefit of Travis-CI.
-addCommandAlias("buildJVM", ";macrosJVM/compile;coreJVM/compile;coreJVM/test;lawsJVM/compile;testsJVM/test;jvm/test;bench/test")
+addCommandAlias("buildJVM", ";macrosJVM/compile;coreJVM/compile;coreJVM/test;ioJVM/compile;lawsJVM/compile;testsJVM/test;ioJVM/test;jvm/test;bench/test")
 
 addCommandAlias("validateJVM", ";scalastyle;buildJVM;makeSite")
 
-addCommandAlias("validateJS", ";macrosJS/compile;coreJS/compile;lawsJS/compile;testsJS/test;js/test")
+addCommandAlias("validateJS", ";macrosJS/compile;coreJS/compile;ioJS/compile;ioJS/test;lawsJS/compile;testsJS/test;js/test")
 
 addCommandAlias("validate", ";validateJS;validateJVM")
 

--- a/io/src/main/scala/cats/io/IO.scala
+++ b/io/src/main/scala/cats/io/IO.scala
@@ -1,0 +1,43 @@
+package cats
+package io
+
+import cats.data.Xor
+
+import java.lang.Throwable
+
+import scala.reflect.ClassTag
+
+final class IO[A] private[io] (private val eval: Eval[A]) extends Serializable {
+  def unsafePerformIO(): A = eval.value
+
+  def catchOnly[T >: Null <: Throwable: ClassTag]: IO[T Xor A] =
+    new IO(Eval.always(Xor.catchOnly[T](eval.value)))
+
+  def catchNonFatal: IO[Throwable Xor A] =
+    new IO(Eval.always(Xor.catchNonFatal(eval.value)))
+
+  def map[B](f: A => B): IO[B] =
+    new IO(eval.map(f))
+
+  def flatMap[B](f: A => IO[B]): IO[B] =
+    new IO(eval.flatMap(a => f(a).eval))
+}
+
+object IO extends IOInstances {
+  /** Capture a side-effecting expression as a new IO primitive. */
+  def always[A](a: => A): IO[A] =
+    new IO[A](Eval.always(a))
+
+  def pure[A](a: A): IO[A] =
+    new IO[A](Eval.now(a))
+}
+
+trait IOInstances {
+  implicit val ioInstances: Monad[IO] =
+    new Monad[IO] {
+      def pure[A](a: A): IO[A] = IO.pure(a)
+      override def pureEval[A](a: Eval[A]): IO[A] = new IO(a)
+      def flatMap[A, B](ma: IO[A])(f: A => IO[B]): IO[B] = ma.flatMap(f)
+      override def map[A, B](ma: IO[A])(f: A => B): IO[B] = ma.map(f)
+    }
+}

--- a/io/src/test/scala/cats/io/IOSuite.scala
+++ b/io/src/test/scala/cats/io/IOSuite.scala
@@ -1,0 +1,15 @@
+package cats
+package io
+
+import cats.laws.discipline.arbitrary._
+
+import org.scalacheck.Arbitrary
+import org.scalacheck.Arbitrary.arbitrary
+
+trait IOSuite {
+  implicit def ioArbitrary[A: Arbitrary]: Arbitrary[IO[A]] =
+    Arbitrary(arbitrary[Eval[A]].map(ea => new IO(ea)))
+
+  implicit def ioEq[A: Eq]: Eq[IO[A]] =
+    Eq.by(_.unsafePerformIO())
+}

--- a/io/src/test/scala/cats/io/IOTests.scala
+++ b/io/src/test/scala/cats/io/IOTests.scala
@@ -1,0 +1,11 @@
+package cats
+package io
+
+import cats.laws.discipline.{MonadTests, SerializableTests}
+import cats.tests.CatsSuite
+import cats.laws.discipline.eq.tuple3Eq
+
+class IOTests extends CatsSuite with IOSuite {
+  checkAll("IO", MonadTests[IO].monad[Int, String, Double])
+  checkAll("Monad[IO]", SerializableTests.serializable(Monad[IO]))
+}

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -28,7 +28,7 @@ fi
 sbt_cmd="sbt ++$TRAVIS_SCALA_VERSION"
 
 coverage="$sbt_cmd coverage validateJVM coverageReport && bash <(curl -s https://codecov.io/bash)"
-scala_js="$sbt_cmd macrosJS/compile coreJS/compile lawsJS/compile && $sbt_cmd testsJS/test && $sbt_cmd js/test"
+scala_js="$sbt_cmd macrosJS/compile coreJS/compile ioJS/compile lawsJS/compile && $sbt_cmd testsJS/test && $sbt_cmd js/test && $sbt_cmd ioJS/test"
 scala_jvm="$sbt_cmd validateJVM"
 
 run_cmd="$coverage && $scala_js && $scala_jvm $publish_cmd"


### PR DESCRIPTION
This PR serves two purposes

1. Add an IO monad in a separate package
2. Get a discussion going around how Cats wants to approach IO/Task. It seems there is a mismatch in the nature of async on JVM and JS and it's tricky to get a Task with the same API on both JVM and JS. Furthermore, many folks will be using Task for FS2, and perhaps others the Task from Scalaz. There is also a relatively simple formulation of Task in the form of a thin wrapper around Eval [in dogs](https://github.com/stew/dogs/blob/64451b9083f78d3148c738d806ef0bdc07b2b2d2/core/src/main/scala/Task.scala), but that works on the JVM only. There's [another](https://github.com/scalaz/scalaz/compare/series/7.3.x...puffnfresh:feature/concurrent-io) that builds on Task using IO and MVars... I'm sure there are other approaches I don't know about.

I am proposing the possibility of Cats just having a simple IO and letting users of Cats decide where they want to get their Task from and how much cross-platform support they want.