### PR TITLE
Monad writer, fixes #889

### DIFF
--- a/core/src/main/scala/cats/MonadWriter.scala
+++ b/core/src/main/scala/cats/MonadWriter.scala
@@ -11,8 +11,16 @@ trait MonadWriter[F[_], W] extends Monad[F] {
   /** Apply the effectful function to the accumulator */
   def pass[A](fa: F[(A, W => W)]): F[A]
 
-  /** An effect that when run, logs w */
+  /** Lift the log into the effect */
   def tell(w: W): F[Unit] = writer(((), w))
+
+  /** Pair the value with an inspection of the accumulator */
+  def listens[A, B](fa: F[A])(f: W => B): F[(A, B)] =
+    map(listen(fa)) { case (a, w) => (a, f(w)) }
+
+  /** Modify the accumulator */
+  def censor[A](fa: F[A])(f: W => W): F[A] =
+    flatMap(listen(fa)) { case (a, w) => writer((a, f(w))) }
 }
 
 object MonadWriter {

--- a/core/src/main/scala/cats/MonadWriter.scala
+++ b/core/src/main/scala/cats/MonadWriter.scala
@@ -1,0 +1,20 @@
+package cats
+
+/** A monad that support monoidal accumulation (e.g. logging List[String]) */
+trait MonadWriter[F[_], W] extends Monad[F] {
+  /** Lift a writer action into the effect */
+  def writer[A](aw: (A, W)): F[A]
+
+  /** Run the effect and pair the accumulator with the result */
+  def listen[A](fa: F[A]): F[(A, W)]
+
+  /** Apply the effectful function to the accumulator */
+  def pass[A](fa: F[(A, W => W)]): F[A]
+
+  /** An effect that when run, logs w */
+  def tell(w: W): F[Unit] = writer(((), w))
+}
+
+object MonadWriter {
+  def apply[F[_], W](implicit F: MonadWriter[F, W]): MonadWriter[F, W] = F
+}

--- a/core/src/main/scala/cats/MonadWriter.scala
+++ b/core/src/main/scala/cats/MonadWriter.scala
@@ -3,24 +3,24 @@ package cats
 /** A monad that support monoidal accumulation (e.g. logging List[String]) */
 trait MonadWriter[F[_], W] extends Monad[F] {
   /** Lift a writer action into the effect */
-  def writer[A](aw: (A, W)): F[A]
+  def writer[A](aw: (W, A)): F[A]
 
   /** Run the effect and pair the accumulator with the result */
-  def listen[A](fa: F[A]): F[(A, W)]
+  def listen[A](fa: F[A]): F[(W, A)]
 
   /** Apply the effectful function to the accumulator */
-  def pass[A](fa: F[(A, W => W)]): F[A]
+  def pass[A](fa: F[(W => W, A)]): F[A]
 
   /** Lift the log into the effect */
-  def tell(w: W): F[Unit] = writer(((), w))
+  def tell(w: W): F[Unit] = writer((w, ()))
 
   /** Pair the value with an inspection of the accumulator */
-  def listens[A, B](fa: F[A])(f: W => B): F[(A, B)] =
-    map(listen(fa)) { case (a, w) => (a, f(w)) }
+  def listens[A, B](fa: F[A])(f: W => B): F[(B, A)] =
+    map(listen(fa)) { case (w, a) => (f(w), a) }
 
   /** Modify the accumulator */
   def censor[A](fa: F[A])(f: W => W): F[A] =
-    flatMap(listen(fa)) { case (a, w) => writer((a, f(w))) }
+    flatMap(listen(fa)) { case (w, a) => writer((f(w), a)) }
 }
 
 object MonadWriter {

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -191,14 +191,14 @@ private[data] sealed trait WriterTMonad[F[_], L] extends WriterTApplicative[F, L
 }
 
 private[data] sealed trait WriterTMonadWriter[F[_], L] extends MonadWriter[WriterT[F, L, ?], L] with WriterTMonad[F, L] {
-  def writer[A](aw: (A, L)): WriterT[F, L, A] =
-    WriterT.put(aw._1)(aw._2)
+  def writer[A](aw: (L, A)): WriterT[F, L, A] =
+    WriterT.put(aw._2)(aw._1)
 
-  def listen[A](fa: WriterT[F, L, A]): WriterT[F, L, (A, L)] =
-    WriterT(F0.flatMap(fa.value)(a => F0.map(fa.written)(l => (l, (a, l)))))
+  def listen[A](fa: WriterT[F, L, A]): WriterT[F, L, (L, A)] =
+    WriterT(F0.flatMap(fa.value)(a => F0.map(fa.written)(l => (l, (l, a)))))
 
-  def pass[A](fa: WriterT[F, L, (A, L => L)]): WriterT[F, L, A] =
-    WriterT(F0.flatMap(fa.value) { case (a, f) => F0.map(fa.written)(l => (f(l), a)) })
+  def pass[A](fa: WriterT[F, L, (L => L, A)]): WriterT[F, L, A] =
+    WriterT(F0.flatMap(fa.value) { case (f, a) => F0.map(fa.written)(l => (f(l), a)) })
 }
 
 private[data] sealed trait WriterTSemigroupK[F[_], L] extends SemigroupK[WriterT[F, L, ?]] {

--- a/laws/src/main/scala/cats/laws/MonadWriterLaws.scala
+++ b/laws/src/main/scala/cats/laws/MonadWriterLaws.scala
@@ -1,0 +1,23 @@
+package cats
+package laws
+
+trait MonadWriterLaws[F[_], W] extends MonadLaws[F] {
+  implicit override def F: MonadWriter[F, W]
+
+  def monadWriterWriterPure[A](a: A)(implicit W: Monoid[W]): IsEq[F[A]] =
+    F.writer((a, W.empty)) <-> F.pure(a)
+
+  def monadWriterTellFusion(x: W, y: W)(implicit W: Monoid[W]): IsEq[F[Unit]] =
+    F.flatMap(F.tell(x))(_ => F.tell(y)) <-> F.tell(W.combine(x, y))
+
+  def monadWriterListenPure[A](a: A)(implicit W: Monoid[W]): IsEq[F[(A, W)]] =
+    F.listen(F.pure(a)) <-> F.pure((a, W.empty))
+
+  def monadWriterListenWriter[A](aw: (A, W)): IsEq[F[(A, W)]] =
+    F.listen(F.writer(aw)) <-> F.map(F.tell(aw._2))(_ => aw)
+}
+
+object MonadWriterLaws {
+  def apply[F[_], W](implicit FW: MonadWriter[F, W]): MonadWriterLaws[F, W] =
+    new MonadWriterLaws[F, W] { def F: MonadWriter[F, W] = FW }
+}

--- a/laws/src/main/scala/cats/laws/MonadWriterLaws.scala
+++ b/laws/src/main/scala/cats/laws/MonadWriterLaws.scala
@@ -5,16 +5,16 @@ trait MonadWriterLaws[F[_], W] extends MonadLaws[F] {
   implicit override def F: MonadWriter[F, W]
 
   def monadWriterWriterPure[A](a: A)(implicit W: Monoid[W]): IsEq[F[A]] =
-    F.writer((a, W.empty)) <-> F.pure(a)
+    F.writer((W.empty, a)) <-> F.pure(a)
 
   def monadWriterTellFusion(x: W, y: W)(implicit W: Monoid[W]): IsEq[F[Unit]] =
     F.flatMap(F.tell(x))(_ => F.tell(y)) <-> F.tell(W.combine(x, y))
 
-  def monadWriterListenPure[A](a: A)(implicit W: Monoid[W]): IsEq[F[(A, W)]] =
-    F.listen(F.pure(a)) <-> F.pure((a, W.empty))
+  def monadWriterListenPure[A](a: A)(implicit W: Monoid[W]): IsEq[F[(W, A)]] =
+    F.listen(F.pure(a)) <-> F.pure((W.empty, a))
 
-  def monadWriterListenWriter[A](aw: (A, W)): IsEq[F[(A, W)]] =
-    F.listen(F.writer(aw)) <-> F.map(F.tell(aw._2))(_ => aw)
+  def monadWriterListenWriter[A](aw: (W, A)): IsEq[F[(W, A)]] =
+    F.listen(F.writer(aw)) <-> F.map(F.tell(aw._1))(_ => aw)
 }
 
 object MonadWriterLaws {

--- a/laws/src/main/scala/cats/laws/discipline/MonadWriterTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadWriterTests.scala
@@ -16,7 +16,7 @@ trait MonadWriterTests[F[_], W] extends MonadTests[F] {
     ArbFAtoB: Arbitrary[F[A => B]],
     ArbFBtoC: Arbitrary[F[B => C]],
     EqFA: Eq[F[A]],
-    EqFAW: Eq[F[(A, W)]],
+    EqFAW: Eq[F[(W, A)]],
     EqFB: Eq[F[B]],
     EqFC: Eq[F[C]],
     EqFU: Eq[F[Unit]],

--- a/laws/src/main/scala/cats/laws/discipline/MonadWriterTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadWriterTests.scala
@@ -1,0 +1,46 @@
+package cats
+package laws
+package discipline
+
+import cats.laws.discipline.CartesianTests.Isomorphisms
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop.forAll
+
+trait MonadWriterTests[F[_], W] extends MonadTests[F] {
+  def laws: MonadWriterLaws[F, W]
+
+  def monadWriter[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq](implicit
+    ArbFA: Arbitrary[F[A]],
+    ArbFB: Arbitrary[F[B]],
+    ArbFC: Arbitrary[F[C]],
+    ArbFAtoB: Arbitrary[F[A => B]],
+    ArbFBtoC: Arbitrary[F[B => C]],
+    EqFA: Eq[F[A]],
+    EqFAW: Eq[F[(A, W)]],
+    EqFB: Eq[F[B]],
+    EqFC: Eq[F[C]],
+    EqFU: Eq[F[Unit]],
+    EqFABC: Eq[F[(A, B, C)]],
+    WA: Arbitrary[W],
+    WM: Monoid[W],
+    iso: Isomorphisms[F]
+  ): RuleSet =
+    new RuleSet {
+      def name = "monadWriter"
+      def bases = Nil
+      def parents = Seq(monad[A, B, C])
+      def props = Seq(
+        "monadWriter writer pure" -> forAll(laws.monadWriterWriterPure[A] _),
+        "monadWriter tell fusion" -> forAll(laws.monadWriterTellFusion _),
+        "monadWriter listen pure" -> forAll(laws.monadWriterListenPure[A] _),
+        "monadWriter listen writer" -> forAll(laws.monadWriterListenWriter[A] _)
+      )
+    }
+}
+
+object MonadWriterTests {
+  def apply[F[_], W](implicit FW: MonadWriter[F, W]): MonadWriterTests[F, W] =
+    new MonadWriterTests[F, W] {
+      def laws: MonadWriterLaws[F, W] = MonadWriterLaws[F, W]
+    }
+}

--- a/tests/src/test/scala/cats/tests/WriterTTests.scala
+++ b/tests/src/test/scala/cats/tests/WriterTTests.scala
@@ -178,8 +178,8 @@ class WriterTTests extends CatsSuite {
     Apply[WriterT[ListWrapper, ListWrapper[Int], ?]]
     Applicative[WriterT[ListWrapper, ListWrapper[Int], ?]]
     FlatMap[WriterT[ListWrapper, ListWrapper[Int], ?]]
-    checkAll("WriterT[ListWrapper, ListWrapper[Int], ?]", MonadTests[WriterT[ListWrapper, ListWrapper[Int], ?]].monad[Int, Int, Int])
-    checkAll("Monad[WriterT[ListWrapper, ListWrapper[Int], ?]]", SerializableTests.serializable(Monad[WriterT[ListWrapper, ListWrapper[Int], ?]]))
+    checkAll("WriterT[ListWrapper, ListWrapper[Int], ?]", MonadWriterTests[WriterT[ListWrapper, ListWrapper[Int], ?], ListWrapper[Int]].monadWriter[Int, Int, Int])
+    checkAll("MonadWriter[WriterT[ListWrapper, ListWrapper[Int], ?], List[String]]", SerializableTests.serializable(MonadWriter[WriterT[ListWrapper, ListWrapper[Int], ?], ListWrapper[Int]]))
 
     Functor[WriterT[Id, ListWrapper[Int], ?]]
     Apply[WriterT[Id, ListWrapper[Int], ?]]


### PR DESCRIPTION
Other instances are possible: https://hackage.haskell.org/package/mtl-2.2.1/docs/Control-Monad-Writer-Class.html

But I realized we also don't have similar instances for the other MTL type classes, so I'll add it all in one fell swoop