### PR TITLE
Add .tell and .writer syntax for creating Writers. Fixes #920.

### DIFF
--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -37,3 +37,4 @@ trait AllSyntax
     with XorSyntax
     with ValidatedSyntax
     with CoproductSyntax
+    with WriterSyntax

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -35,4 +35,5 @@ package object syntax {
   object traverse extends TraverseSyntax
   object xor extends XorSyntax
   object validated extends ValidatedSyntax
+  object writer extends WriterSyntax
 }

--- a/core/src/main/scala/cats/syntax/writer.scala
+++ b/core/src/main/scala/cats/syntax/writer.scala
@@ -1,0 +1,13 @@
+package cats
+package syntax
+
+import cats.data.Writer
+
+trait WriterSyntax {
+  implicit def writerIdSyntax[A](a: A): WriterIdSyntax[A] = new WriterIdSyntax(a)
+}
+
+final class WriterIdSyntax[A](val a: A) extends AnyVal {
+  def tell: Writer[A, Unit] = Writer(a, ())
+  def writer[W](w: W): Writer[W, A] = Writer(w, a)
+}

--- a/tests/src/test/scala/cats/tests/WriterTests.scala
+++ b/tests/src/test/scala/cats/tests/WriterTests.scala
@@ -1,0 +1,26 @@
+package cats
+package tests
+
+import cats.data.Writer
+import cats.laws.discipline.eq._
+
+class WriterTests extends CatsSuite {
+  test("pure syntax creates a writer with an empty log"){
+    forAll { (result: String) =>
+      type Logged[A] = Writer[List[Int], A]
+      result.pure[Logged] should === (Writer(List.empty[Int], result))
+    }
+  }
+
+  test("tell syntax creates a writer with a unit result"){
+    forAll { (log: List[Int]) =>
+      log.tell should === (Writer(log, ()))
+    }
+  }
+
+  test("writer syntax creates a writer with the specified result and log") {
+    forAll { (result: String, log: List[Int]) =>
+      result.writer(log) should === (Writer(log, result))
+    }
+  }
+}


### PR DESCRIPTION
This adds the following syntax for the `Writer` monad, as outlined in #920:

~~~ scala
log.tell

result.writer(log)
~~~

This is my first PR to Cats so there's probably stuff that's wrong in here. I'm happy to fix stuff if required, or close the PR if people think it's not worthwhile. I figured it was easier to have a discussion over a concrete PR than an issue.