### PR TITLE
#607: Add missing Show instances

### DIFF
--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -44,6 +44,8 @@ final case class WriterT[F[_], L, V](run: F[(L, V)]) {
 
   def reset(implicit monoidL: Monoid[L], functorF: Functor[F]): WriterT[F, L, V] =
     mapWritten(_ => monoidL.empty)
+
+  def show(implicit F: Show[F[(L, V)]]): String = F.show(run)
 }
 object WriterT extends WriterTInstances with WriterTFunctions
 
@@ -68,6 +70,10 @@ private[data] sealed abstract class WriterTInstances extends WriterTInstances0 {
       def liftT[A](ma: M[A]): WriterT[M, W, A] =
         WriterT(M.map(ma)((W.empty, _)))
     }
+
+  implicit def writerTShow[F[_], L, V](implicit F: Show[F[(L, V)]]): Show[WriterT[F, L, V]] = new Show[WriterT[F, L, V]] {
+    override def show(f: WriterT[F, L, V]): String = f.show
+  }
 }
 
 private[data] sealed abstract class WriterTInstances0 extends WriterTInstances1 {

--- a/core/src/main/scala/cats/std/tuple.scala
+++ b/core/src/main/scala/cats/std/tuple.scala
@@ -18,9 +18,6 @@ sealed trait Tuple2Instances {
 
   implicit def tuple2Show[A, B](implicit aShow: Show[A], bShow: Show[B]): Show[(A, B)] = new Show[(A, B)] {
     override def show(f: (A, B)): String = {
-      // Note: the toString method for Tuple2 does not always include a space after the comma. For example,
-      // ("foo", "").toString returns "(foo,)" instead of "(foo, )" and ("","쾷").toString returns "(,쾷)".  This
-      // implementation avoids this question of consistency by never including a space.
       s"(${aShow.show(f._1)},${bShow.show(f._2)})"
     }
   }

--- a/core/src/main/scala/cats/std/tuple.scala
+++ b/core/src/main/scala/cats/std/tuple.scala
@@ -15,4 +15,13 @@ sealed trait Tuple2Instances {
       def bifoldRight[A, B, C](fab: (A, B), c: Eval[C])(f: (A, Eval[C]) => Eval[C], g: (B, Eval[C]) => Eval[C]): Eval[C] =
         g(fab._2, f(fab._1, c))
     }
+
+  implicit def tuple2Show[A, B](implicit aShow: Show[A], bShow: Show[B]): Show[(A, B)] = new Show[(A, B)] {
+    override def show(f: (A, B)): String = {
+      // Note: the toString method for Tuple2 does not always include a space after the comma. For example,
+      // ("foo", "").toString returns "(foo,)" instead of "(foo, )" and ("","쾷").toString returns "(,쾷)".  This
+      // implementation avoids this question of consistency by never including a space.
+      s"(${aShow.show(f._1)},${bShow.show(f._2)})"
+    }
+  }
 }

--- a/tests/src/test/scala/cats/tests/TupleTests.scala
+++ b/tests/src/test/scala/cats/tests/TupleTests.scala
@@ -12,7 +12,7 @@ class TupleTests extends CatsSuite {
     (1, 2).show should === ("(1,2)")
 
     forAll { fs: (String, String) =>
-      fs.show should === (s"(${fs._1},${fs._2})")
+      fs.show should === (fs.toString)
     }
 
     // Provide some "non-standard" Show instances to make sure the tuple2 is actually use the Show instances for the

--- a/tests/src/test/scala/cats/tests/TupleTests.scala
+++ b/tests/src/test/scala/cats/tests/TupleTests.scala
@@ -7,4 +7,27 @@ import cats.laws.discipline.eq.tuple2Eq
 class TupleTests extends CatsSuite {
   checkAll("Tuple2", BitraverseTests[Tuple2].bitraverse[Option, Int, Int, Int, String, String, String])
   checkAll("Bitraverse[Tuple2]", SerializableTests.serializable(Bitraverse[Tuple2]))
+
+  test("show") {
+    (1, 2).show should === ("(1,2)")
+
+    forAll { fs: (String, String) =>
+      fs.show should === (s"(${fs._1},${fs._2})")
+    }
+
+    // Provide some "non-standard" Show instances to make sure the tuple2 is actually use the Show instances for the
+    // relevant types instead of blindly calling toString
+    case class Foo(x: Int)
+    implicit val fooShow: Show[Foo] = new Show[Foo] {
+      override def show(f: Foo): String = s"foo.x = ${f.x}"
+    }
+    case class Bar(y: Int)
+    implicit val barShow: Show[Bar] = new Show[Bar] {
+      override def show(f: Bar): String = s"bar.y = ${f.y}"
+    }
+
+    val foo = Foo(1)
+    val bar = Bar(2)
+    (foo, bar).show should === (s"(${fooShow.show(foo)},${barShow.show(bar)})")
+  }
 }

--- a/tests/src/test/scala/cats/tests/WriterTTests.scala
+++ b/tests/src/test/scala/cats/tests/WriterTTests.scala
@@ -62,6 +62,11 @@ class WriterTTests extends CatsSuite {
     }
   }
 
+  test("show") {
+    val writerT: WriterT[Id, List[String], String] = WriterT.put("foo")(List("Some log message"))
+    writerT.show should === ("(List(Some log message),foo)")
+  }
+
   {
     // F has a SemigroupK
     implicit val F: SemigroupK[ListWrapper] = ListWrapper.semigroupK


### PR DESCRIPTION
Randomly picked up this issue as I saw it was marked as "low hanging fruit" and I wanted to get more familiar with cats (and associated FP concepts).

One thing of note: I had to add a show instance for Tuple2 to make this work.  I can't claim to be intimately familiar with Miles' Kittens project (see: https://github.com/milessabin/kittens), but it seemed like defining Show instances for Tuples and case classes would be particularly tedious and _possibly_ something that Kittens/Shapeless could make a lot easier.

Without further ado, here is my initial attempt to address issue #607 and add a Show instance for WriterT.