### PR TITLE
ScalaCheck 1.13.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -66,7 +66,7 @@ lazy val commonJvmSettings = Seq(
 
 lazy val catsSettings = buildSettings ++ commonSettings ++ publishSettings ++ scoverageSettings
 
-lazy val scalacheckVersion = "1.12.5"
+lazy val scalacheckVersion = "1.13.0"
 
 lazy val disciplineDependencies = Seq(
   libraryDependencies += "org.scalacheck" %%% "scalacheck" % scalacheckVersion,

--- a/laws/src/main/scala/cats/laws/discipline/AlternativeTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/AlternativeTests.scala
@@ -3,14 +3,13 @@ package laws
 package discipline
 
 import cats.laws.discipline.CartesianTests.Isomorphisms
-import org.scalacheck.Arbitrary
-import org.scalacheck.Prop
+import org.scalacheck.{Arbitrary, Cogen, Prop}
 import Prop._
 
 trait AlternativeTests[F[_]] extends ApplicativeTests[F] with MonoidKTests[F]  {
   def laws: AlternativeLaws[F]
 
-  def alternative[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
+  def alternative[A: Arbitrary: Cogen, B: Arbitrary: Cogen, C: Arbitrary: Cogen](implicit
     ArbFA: Arbitrary[F[A]],
     ArbFB: Arbitrary[F[B]],
     ArbFC: Arbitrary[F[C]],

--- a/laws/src/main/scala/cats/laws/discipline/ApplicativeErrorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ApplicativeErrorTests.scala
@@ -5,19 +5,20 @@ package discipline
 import cats.data.{ Xor, XorT }
 import cats.laws.discipline.CartesianTests.Isomorphisms
 import cats.laws.discipline.arbitrary._
-import org.scalacheck.{Arbitrary, Prop}
+import org.scalacheck.{Arbitrary, Cogen, Prop}
 import org.scalacheck.Prop.forAll
 
 trait ApplicativeErrorTests[F[_], E] extends ApplicativeTests[F] {
   def laws: ApplicativeErrorLaws[F, E]
 
-  def applicativeError[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq](implicit
+  def applicativeError[A: Arbitrary: Eq: Cogen, B: Arbitrary: Eq: Cogen, C: Arbitrary: Cogen: Eq](implicit
     ArbFA: Arbitrary[F[A]],
     ArbFB: Arbitrary[F[B]],
     ArbFC: Arbitrary[F[C]],
     ArbFAtoB: Arbitrary[F[A => B]],
     ArbFBtoC: Arbitrary[F[B => C]],
     ArbE: Arbitrary[E],
+    CogenE: Cogen[E],
     EqFA: Eq[F[A]],
     EqFB: Eq[F[B]],
     EqFC: Eq[F[C]],

--- a/laws/src/main/scala/cats/laws/discipline/ApplicativeTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ApplicativeTests.scala
@@ -3,14 +3,13 @@ package laws
 package discipline
 
 import cats.laws.discipline.CartesianTests.Isomorphisms
-import org.scalacheck.Arbitrary
-import org.scalacheck.Prop
+import org.scalacheck.{Arbitrary, Cogen, Prop}
 import Prop._
 
 trait ApplicativeTests[F[_]] extends ApplyTests[F] {
   def laws: ApplicativeLaws[F]
 
-  def applicative[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
+  def applicative[A: Arbitrary: Cogen, B: Arbitrary: Cogen, C: Arbitrary: Cogen](implicit
     ArbFA: Arbitrary[F[A]],
     ArbFB: Arbitrary[F[B]],
     ArbFC: Arbitrary[F[C]],

--- a/laws/src/main/scala/cats/laws/discipline/ApplyTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ApplyTests.scala
@@ -3,14 +3,13 @@ package laws
 package discipline
 
 import cats.laws.discipline.CartesianTests.Isomorphisms
-import org.scalacheck.Arbitrary
-import org.scalacheck.Prop
+import org.scalacheck.{Arbitrary, Cogen, Prop}
 import Prop._
 
 trait ApplyTests[F[_]] extends FunctorTests[F] with CartesianTests[F] {
   def laws: ApplyLaws[F]
 
-  def apply[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
+  def apply[A: Arbitrary: Cogen, B: Arbitrary: Cogen, C: Arbitrary: Cogen](implicit
     ArbFA: Arbitrary[F[A]],
     ArbFB: Arbitrary[F[B]],
     ArbFC: Arbitrary[F[C]],

--- a/laws/src/main/scala/cats/laws/discipline/ArrowTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ArrowTests.scala
@@ -3,14 +3,13 @@ package laws
 package discipline
 
 import cats.arrow.Arrow
-import org.scalacheck.Arbitrary
-import org.scalacheck.Prop
+import org.scalacheck.{Arbitrary, Cogen, Prop}
 import Prop._
 
 trait ArrowTests[F[_, _]] extends CategoryTests[F] with SplitTests[F] with StrongTests[F] {
   def laws: ArrowLaws[F]
 
-  def arrow[A: Arbitrary, B: Arbitrary, C: Arbitrary, D: Arbitrary, E: Arbitrary, G: Arbitrary](implicit
+  def arrow[A: Arbitrary: Cogen, B: Arbitrary: Cogen, C: Arbitrary: Cogen, D: Arbitrary: Cogen, E: Arbitrary: Cogen, G: Arbitrary](implicit
     ArbFAB: Arbitrary[F[A, B]],
     ArbFBC: Arbitrary[F[B, C]],
     ArbFCD: Arbitrary[F[C, D]],

--- a/laws/src/main/scala/cats/laws/discipline/BifoldableTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/BifoldableTests.scala
@@ -2,14 +2,14 @@ package cats
 package laws
 package discipline
 
-import org.scalacheck.Arbitrary
+import org.scalacheck.{Arbitrary, Cogen}
 import org.scalacheck.Prop._
 import org.typelevel.discipline.Laws
 
 trait BifoldableTests[F[_, _]] extends Laws {
   def laws: BifoldableLaws[F]
 
-  def bifoldable[A: Arbitrary, B: Arbitrary, C: Arbitrary: Monoid: Eq](implicit
+  def bifoldable[A: Arbitrary: Cogen, B: Arbitrary: Cogen, C: Arbitrary: Monoid: Eq](implicit
     ArbFAB: Arbitrary[F[A, B]]
   ): RuleSet =
     new DefaultRuleSet(

--- a/laws/src/main/scala/cats/laws/discipline/BimonadTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/BimonadTests.scala
@@ -3,15 +3,16 @@ package laws
 package discipline
 
 import cats.laws.discipline.CartesianTests.Isomorphisms
-import org.scalacheck.Arbitrary
-import org.scalacheck.Prop
+import org.scalacheck.{Arbitrary, Cogen, Prop}
 import Prop._
 
 trait BimonadTests[F[_]] extends MonadTests[F] with ComonadTests[F] {
   def laws: BimonadLaws[F]
 
-  def bimonad[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq](implicit
+  def bimonad[A: Arbitrary: Cogen: Eq, B: Arbitrary: Cogen: Eq, C: Arbitrary: Cogen: Eq](implicit
     ArbFA: Arbitrary[F[A]],
+    CogenFA: Cogen[F[A]],
+    CogenFB: Cogen[F[B]],
     ArbFFA: Arbitrary[F[F[A]]],
     ArbFB: Arbitrary[F[B]],
     ArbFC: Arbitrary[F[C]],

--- a/laws/src/main/scala/cats/laws/discipline/BitraverseTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/BitraverseTests.scala
@@ -2,7 +2,7 @@ package cats
 package laws
 package discipline
 
-import org.scalacheck.Arbitrary
+import org.scalacheck.{Arbitrary, Cogen}
 import org.scalacheck.Prop.forAll
 
 trait BitraverseTests[F[_, _]] extends BifoldableTests[F] with BifunctorTests[F] {
@@ -22,6 +22,11 @@ trait BitraverseTests[F[_, _]] extends BifoldableTests[F] with BifunctorTests[F]
     ArbC: Arbitrary[C],
     ArbE: Arbitrary[E],
     ArbH: Arbitrary[H],
+    CogenA: Cogen[A],
+    CogenB: Cogen[B],
+    CogenC: Cogen[C],
+    CogenD: Cogen[D],
+    CogenE: Cogen[E],
     EqFAB: Eq[F[A, B]],
     EqFAD: Eq[F[A, D]],
     EqFAH: Eq[F[A, H]],

--- a/laws/src/main/scala/cats/laws/discipline/CoflatMapTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/CoflatMapTests.scala
@@ -2,8 +2,7 @@ package cats
 package laws
 package discipline
 
-import org.scalacheck.Arbitrary
-import org.scalacheck.Prop
+import org.scalacheck.{Arbitrary, Cogen, Prop}
 import Prop._
 import org.typelevel.discipline.Laws
 
@@ -12,6 +11,8 @@ trait CoflatMapTests[F[_]] extends Laws {
 
   def coflatMap[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
     ArbFA: Arbitrary[F[A]],
+    CogenFA: Cogen[F[A]],
+    CogenFB: Cogen[F[B]],
     EqFA: Eq[F[A]],
     EqFC: Eq[F[C]]
   ): RuleSet = {

--- a/laws/src/main/scala/cats/laws/discipline/ComonadTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ComonadTests.scala
@@ -2,16 +2,17 @@ package cats
 package laws
 package discipline
 
-import org.scalacheck.Arbitrary
-import org.scalacheck.Prop
+import org.scalacheck.{Arbitrary, Cogen, Prop}
 import Prop._
 
 trait ComonadTests[F[_]] extends CoflatMapTests[F] {
 
   def laws: ComonadLaws[F]
 
-  def comonad[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq](implicit
+  def comonad[A: Arbitrary: Cogen: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq](implicit
     ArbFA: Arbitrary[F[A]],
+    CogenFA: Cogen[F[A]],
+    CogenFB: Cogen[F[B]],
     EqFA: Eq[F[A]],
     EqFFA: Eq[F[F[A]]],
     EqFFFA: Eq[F[F[F[A]]]],

--- a/laws/src/main/scala/cats/laws/discipline/ContravariantTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ContravariantTests.scala
@@ -3,13 +3,13 @@ package laws
 package discipline
 
 import cats.functor.Contravariant
-import org.scalacheck.Arbitrary
+import org.scalacheck.{Arbitrary, Cogen}
 import org.scalacheck.Prop._
 
 trait ContravariantTests[F[_]] extends InvariantTests[F] {
   def laws: ContravariantLaws[F]
 
-  def contravariant[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
+  def contravariant[A: Arbitrary: Cogen, B: Arbitrary: Cogen, C: Arbitrary: Cogen](implicit
     ArbFA: Arbitrary[F[A]],
     EqFA: Eq[F[A]],
     EqFC: Eq[F[C]]

--- a/laws/src/main/scala/cats/laws/discipline/FlatMapTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FlatMapTests.scala
@@ -3,14 +3,13 @@ package laws
 package discipline
 
 import cats.laws.discipline.CartesianTests.Isomorphisms
-import org.scalacheck.Arbitrary
-import org.scalacheck.Prop
+import org.scalacheck.{Arbitrary, Cogen, Prop}
 import Prop._
 
 trait FlatMapTests[F[_]] extends ApplyTests[F] {
   def laws: FlatMapLaws[F]
 
-  def flatMap[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
+  def flatMap[A: Arbitrary: Cogen, B: Arbitrary: Cogen, C: Arbitrary: Cogen](implicit
     ArbFA: Arbitrary[F[A]],
     ArbFB: Arbitrary[F[B]],
     ArbFC: Arbitrary[F[C]],

--- a/laws/src/main/scala/cats/laws/discipline/FoldableTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FoldableTests.scala
@@ -2,14 +2,14 @@ package cats
 package laws
 package discipline
 
-import org.scalacheck.Arbitrary
+import org.scalacheck.{Arbitrary, Cogen}
 import org.scalacheck.Prop._
 import org.typelevel.discipline.Laws
 
 trait FoldableTests[F[_]] extends Laws {
   def laws: FoldableLaws[F]
 
-  def foldable[A: Arbitrary, B: Arbitrary](implicit
+  def foldable[A: Arbitrary: Cogen, B: Arbitrary](implicit
     ArbFA: Arbitrary[F[A]],
     B: Monoid[B],
     EqB: Eq[B]

--- a/laws/src/main/scala/cats/laws/discipline/FunctorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FunctorTests.scala
@@ -2,14 +2,13 @@ package cats
 package laws
 package discipline
 
-import org.scalacheck.Arbitrary
-import org.scalacheck.Prop
+import org.scalacheck.{Arbitrary, Cogen, Prop}
 import Prop._
 
 trait FunctorTests[F[_]] extends InvariantTests[F] {
   def laws: FunctorLaws[F]
 
-  def functor[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
+  def functor[A: Arbitrary: Cogen, B: Arbitrary: Cogen, C: Arbitrary: Cogen](implicit
     ArbFA: Arbitrary[F[A]],
     EqFA: Eq[F[A]],
     EqFC: Eq[F[C]]

--- a/laws/src/main/scala/cats/laws/discipline/InvariantTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/InvariantTests.scala
@@ -3,15 +3,14 @@ package laws
 package discipline
 
 import cats.functor.Invariant
-import org.scalacheck.Arbitrary
-import org.scalacheck.Prop
+import org.scalacheck.{Arbitrary, Cogen, Prop}
 import Prop._
 import org.typelevel.discipline.Laws
 
 trait InvariantTests[F[_]] extends Laws {
   def laws: InvariantLaws[F]
 
-  def invariant[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
+  def invariant[A: Arbitrary: Cogen, B: Arbitrary: Cogen, C: Arbitrary: Cogen](implicit
     ArbFA: Arbitrary[F[A]],
     EqFA: Eq[F[A]],
     EqFC: Eq[F[C]]

--- a/laws/src/main/scala/cats/laws/discipline/MonadCombineTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadCombineTests.scala
@@ -3,14 +3,13 @@ package laws
 package discipline
 
 import cats.laws.discipline.CartesianTests.Isomorphisms
-import org.scalacheck.Arbitrary
-import org.scalacheck.Prop
+import org.scalacheck.{Arbitrary, Cogen, Prop}
 import Prop._
 
 trait MonadCombineTests[F[_]] extends MonadFilterTests[F] with AlternativeTests[F] {
   def laws: MonadCombineLaws[F]
 
-  def monadCombine[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq](implicit
+  def monadCombine[A: Arbitrary: Cogen: Eq, B: Arbitrary: Cogen: Eq, C: Arbitrary: Cogen: Eq](implicit
     ArbFA: Arbitrary[F[A]],
     ArbFB: Arbitrary[F[B]],
     ArbFC: Arbitrary[F[C]],

--- a/laws/src/main/scala/cats/laws/discipline/MonadErrorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadErrorTests.scala
@@ -4,19 +4,20 @@ package discipline
 
 import cats.data.{ Xor, XorT }
 import cats.laws.discipline.CartesianTests.Isomorphisms
-import org.scalacheck.{Arbitrary, Prop}
+import org.scalacheck.{Arbitrary, Cogen, Prop}
 import org.scalacheck.Prop.forAll
 
 trait MonadErrorTests[F[_], E] extends ApplicativeErrorTests[F, E] with MonadTests[F] {
   def laws: MonadErrorLaws[F, E]
 
-  def monadError[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq](implicit
+  def monadError[A: Arbitrary: Cogen: Eq, B: Arbitrary: Cogen: Eq, C: Arbitrary: Cogen: Eq](implicit
     ArbFA: Arbitrary[F[A]],
     ArbFB: Arbitrary[F[B]],
     ArbFC: Arbitrary[F[C]],
     ArbFAtoB: Arbitrary[F[A => B]],
     ArbFBtoC: Arbitrary[F[B => C]],
     ArbE: Arbitrary[E],
+    CogenE: Cogen[E],
     EqFA: Eq[F[A]],
     EqFB: Eq[F[B]],
     EqFC: Eq[F[C]],

--- a/laws/src/main/scala/cats/laws/discipline/MonadFilterTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadFilterTests.scala
@@ -3,14 +3,13 @@ package laws
 package discipline
 
 import cats.laws.discipline.CartesianTests.Isomorphisms
-import org.scalacheck.Arbitrary
-import org.scalacheck.Prop
+import org.scalacheck.{Arbitrary, Cogen, Prop}
 import Prop._
 
 trait MonadFilterTests[F[_]] extends MonadTests[F] {
   def laws: MonadFilterLaws[F]
 
-  def monadFilter[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq](implicit
+  def monadFilter[A: Arbitrary: Cogen: Eq, B: Arbitrary: Cogen: Eq, C: Arbitrary: Cogen: Eq](implicit
     ArbFA: Arbitrary[F[A]],
     ArbFB: Arbitrary[F[B]],
     ArbFC: Arbitrary[F[C]],

--- a/laws/src/main/scala/cats/laws/discipline/MonadReaderTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadReaderTests.scala
@@ -3,19 +3,20 @@ package laws
 package discipline
 
 import cats.laws.discipline.CartesianTests.Isomorphisms
-import org.scalacheck.{Arbitrary, Prop}
+import org.scalacheck.{Arbitrary, Cogen, Prop}
 import org.scalacheck.Prop.forAll
 
 trait MonadReaderTests[F[_], R] extends MonadTests[F] {
   def laws: MonadReaderLaws[F, R]
 
-  def monadReader[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq](implicit
+  def monadReader[A: Arbitrary: Cogen: Eq, B: Arbitrary: Cogen: Eq, C: Arbitrary: Cogen: Eq](implicit
     ArbFA: Arbitrary[F[A]],
     ArbFB: Arbitrary[F[B]],
     ArbFC: Arbitrary[F[C]],
     ArbFAtoB: Arbitrary[F[A => B]],
     ArbFBtoC: Arbitrary[F[B => C]],
     ArbR: Arbitrary[R],
+    CogenR: Cogen[R],
     EqFA: Eq[F[A]],
     EqFB: Eq[F[B]],
     EqFC: Eq[F[C]],

--- a/laws/src/main/scala/cats/laws/discipline/MonadStateTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadStateTests.scala
@@ -3,13 +3,13 @@ package laws
 package discipline
 
 import cats.laws.discipline.CartesianTests.Isomorphisms
-import org.scalacheck.{Arbitrary, Prop}
+import org.scalacheck.{Arbitrary, Cogen, Prop}
 import org.scalacheck.Prop.forAll
 
 trait MonadStateTests[F[_], S] extends MonadTests[F] {
   def laws: MonadStateLaws[F, S]
 
-  def monadState[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq](implicit
+  def monadState[A: Arbitrary: Cogen: Eq, B: Arbitrary: Cogen: Eq, C: Arbitrary: Cogen: Eq](implicit
     ArbFA: Arbitrary[F[A]],
     ArbFB: Arbitrary[F[B]],
     ArbFC: Arbitrary[F[C]],

--- a/laws/src/main/scala/cats/laws/discipline/MonadTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadTests.scala
@@ -3,14 +3,13 @@ package laws
 package discipline
 
 import cats.laws.discipline.CartesianTests.Isomorphisms
-import org.scalacheck.Arbitrary
-import org.scalacheck.Prop
+import org.scalacheck.{Arbitrary, Cogen, Prop}
 import Prop._
 
 trait MonadTests[F[_]] extends ApplicativeTests[F] with FlatMapTests[F] {
   def laws: MonadLaws[F]
 
-  def monad[A: Arbitrary: Eq, B: Arbitrary: Eq, C: Arbitrary: Eq](implicit
+  def monad[A: Arbitrary: Cogen: Eq, B: Arbitrary: Cogen: Eq, C: Arbitrary: Cogen: Eq](implicit
     ArbFA: Arbitrary[F[A]],
     ArbFB: Arbitrary[F[B]],
     ArbFC: Arbitrary[F[C]],

--- a/laws/src/main/scala/cats/laws/discipline/ProfunctorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ProfunctorTests.scala
@@ -3,15 +3,14 @@ package laws
 package discipline
 
 import cats.functor.Profunctor
-import org.scalacheck.Arbitrary
-import org.scalacheck.Prop
+import org.scalacheck.{Arbitrary, Cogen, Prop}
 import Prop._
 import org.typelevel.discipline.Laws
 
 trait ProfunctorTests[F[_, _]] extends Laws {
   def laws: ProfunctorLaws[F]
 
-  def profunctor[A: Arbitrary, B: Arbitrary, C: Arbitrary, D: Arbitrary, E: Arbitrary, G: Arbitrary](implicit
+  def profunctor[A: Arbitrary: Cogen, B: Arbitrary: Cogen, C: Arbitrary: Cogen, D: Arbitrary: Cogen, E: Arbitrary: Cogen, G: Arbitrary](implicit
     ArbFAB: Arbitrary[F[A, B]],
     ArbFCD: Arbitrary[F[C, D]],
     EqFAB: Eq[F[A, B]],

--- a/laws/src/main/scala/cats/laws/discipline/ReducibleTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ReducibleTests.scala
@@ -2,13 +2,13 @@ package cats
 package laws
 package discipline
 
-import org.scalacheck.Arbitrary
+import org.scalacheck.{Arbitrary, Cogen}
 import org.scalacheck.Prop.forAll
 
 trait ReducibleTests[F[_]] extends FoldableTests[F] {
   def laws: ReducibleLaws[F]
 
-  def reducible[A: Arbitrary, B: Arbitrary](implicit
+  def reducible[A: Arbitrary: Cogen, B: Arbitrary](implicit
     ArbFA: Arbitrary[F[A]],
     B: Monoid[B],
     EqB: Eq[B]

--- a/laws/src/main/scala/cats/laws/discipline/StrongTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/StrongTests.scala
@@ -3,14 +3,13 @@ package laws
 package discipline
 
 import cats.functor.Strong
-import org.scalacheck.Arbitrary
-import org.scalacheck.Prop
+import org.scalacheck.{Arbitrary, Cogen, Prop}
 import Prop._
 
 trait StrongTests[F[_, _]] extends ProfunctorTests[F] {
   def laws: StrongLaws[F]
 
-  def strong[A: Arbitrary, B: Arbitrary, C: Arbitrary, D: Arbitrary, E: Arbitrary, G: Arbitrary](implicit
+  def strong[A: Arbitrary: Cogen, B: Arbitrary: Cogen, C: Arbitrary: Cogen, D: Arbitrary: Cogen, E: Arbitrary: Cogen, G: Arbitrary](implicit
     ArbFAB: Arbitrary[F[A, B]],
     ArbFBC: Arbitrary[F[B, C]],
     ArbFCD: Arbitrary[F[C, D]],

--- a/laws/src/main/scala/cats/laws/discipline/TraverseTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/TraverseTests.scala
@@ -2,14 +2,14 @@ package cats
 package laws
 package discipline
 
-import org.scalacheck.{Prop, Arbitrary}
+import org.scalacheck.{Arbitrary, Cogen, Prop}
 import Prop._
 
 
 trait TraverseTests[F[_]] extends FunctorTests[F] with FoldableTests[F] {
   def laws: TraverseLaws[F]
 
-  def traverse[A: Arbitrary, B: Arbitrary, C: Arbitrary, M: Arbitrary, X[_]: Applicative, Y[_]: Applicative](implicit
+  def traverse[A: Arbitrary: Cogen, B: Arbitrary: Cogen, C: Arbitrary: Cogen, M: Arbitrary, X[_]: Applicative, Y[_]: Applicative](implicit
     ArbFA: Arbitrary[F[A]],
     ArbXB: Arbitrary[X[B]],
     ArbYB: Arbitrary[Y[B]],

--- a/tests/src/test/scala/cats/tests/CatsSuite.scala
+++ b/tests/src/test/scala/cats/tests/CatsSuite.scala
@@ -11,11 +11,6 @@ import org.scalatest.{FunSuite, Matchers}
 import org.scalatest.prop.{Configuration, GeneratorDrivenPropertyChecks}
 import org.typelevel.discipline.scalatest.Discipline
 
-import org.scalacheck.{Arbitrary, Gen}
-import org.scalacheck.Arbitrary.arbitrary
-
-import scala.util.{Failure, Success, Try}
-
 trait TestSettings extends Configuration with Matchers {
 
   lazy val checkConfiguration: PropertyCheckConfiguration =
@@ -32,7 +27,7 @@ trait TestSettings extends Configuration with Matchers {
  * An opinionated stack of traits to improve consistency and reduce
  * boilerplate in Cats tests.
  */
-trait CatsSuite extends FunSuite with Matchers with GeneratorDrivenPropertyChecks with Discipline with TestSettings with AllInstances with AllSyntax with TestInstances with StrictCatsEquality {
+trait CatsSuite extends FunSuite with Matchers with GeneratorDrivenPropertyChecks with Discipline with TestSettings with AllInstances with AllSyntax with StrictCatsEquality {
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     checkConfiguration
 
@@ -44,12 +39,4 @@ trait CatsSuite extends FunSuite with Matchers with GeneratorDrivenPropertyCheck
 trait SlowCatsSuite extends CatsSuite {
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     slowCheckConfiguration
-}
-
-sealed trait TestInstances {
-  // To be replaced by https://github.com/rickynils/scalacheck/pull/170
-  implicit def arbitraryTry[A: Arbitrary]: Arbitrary[Try[A]] =
-    Arbitrary(Gen.oneOf(
-      arbitrary[A].map(Success(_)),
-      arbitrary[Throwable].map(Failure(_))))
 }

--- a/tests/src/test/scala/cats/tests/OneAndTests.scala
+++ b/tests/src/test/scala/cats/tests/OneAndTests.scala
@@ -5,7 +5,7 @@ import algebra.laws.{GroupLaws, OrderLaws}
 
 import cats.data.{NonEmptyList, OneAnd}
 import cats.laws.discipline.{ComonadTests, FunctorTests, SemigroupKTests, FoldableTests, MonadTests, SerializableTests, CartesianTests, TraverseTests, ReducibleTests}
-import cats.laws.discipline.arbitrary.oneAndArbitrary
+import cats.laws.discipline.arbitrary.{oneAndArbitrary, oneAndCogen}
 import cats.laws.discipline.eq._
 
 class OneAndTests extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/StateTTests.scala
+++ b/tests/src/test/scala/cats/tests/StateTTests.scala
@@ -5,7 +5,7 @@ import cats.laws.discipline.{CartesianTests, MonadStateTests, SerializableTests}
 import cats.data.{State, StateT}
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
-import org.scalacheck.Arbitrary
+import org.scalacheck.{Arbitrary, Cogen}
 
 class StateTTests extends CatsSuite {
   import StateTTests._
@@ -124,7 +124,7 @@ object StateTTests extends StateTTestsInstances {
   implicit def stateEq[S:Eq:Arbitrary, A:Eq]: Eq[State[S, A]] =
     stateTEq[Eval, S, A]
 
-  implicit def stateArbitrary[S: Arbitrary, A: Arbitrary]: Arbitrary[State[S, A]] =
+  implicit def stateArbitrary[S: Arbitrary: Cogen, A: Arbitrary]: Arbitrary[State[S, A]] =
     stateTArbitrary[Eval, S, A]
 
   val add1: State[Int, Int] = State(n => (n + 1, n))

--- a/tests/src/test/scala/cats/tests/StreamTests.scala
+++ b/tests/src/test/scala/cats/tests/StreamTests.scala
@@ -2,6 +2,7 @@ package cats
 package tests
 
 import cats.laws.discipline.{CoflatMapTests, MonadCombineTests, SerializableTests, TraverseTests, CartesianTests}
+import cats.laws.discipline.arbitrary.streamCogen
 import cats.laws.discipline.eq.tuple3Eq
 
 class StreamTests extends CatsSuite {


### PR DESCRIPTION
Proposed fix for https://github.com/typelevel/cats/issues/810

This currently **compiles**, but **does not run**! When I try running it I get:

```
[error] Could not run test cats.tests.RegressionTests: java.lang.IncompatibleClassChangeError: Implementing class
[info] DeferredAbortedSuite:
[info] Exception encountered when attempting to run a suite with class name: org.scalatest.DeferredAbortedSuite *** ABORTED *** (0 milliseconds)
[info]   java.lang.IncompatibleClassChangeError: Implementing class
```

many many times. I thought it might be Discipline so I cloned Discipline, bumped ScalaCheck to 1.13.0, did a `publishLocal`, and bumped the Cats Discipline version. Still same error. Leaving here for comments/if anyone else has suggestions/wants to give it a shot.