### PR TITLE
Syntax for ApplicativeError

### DIFF
--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -3,6 +3,7 @@ package syntax
 
 trait AllSyntax
     extends ApplicativeSyntax
+    with ApplicativeErrorSyntax
     with ApplySyntax
     with BifunctorSyntax
     with BifoldableSyntax

--- a/core/src/main/scala/cats/syntax/applicativeError.scala
+++ b/core/src/main/scala/cats/syntax/applicativeError.scala
@@ -1,0 +1,37 @@
+package cats
+package syntax
+
+import cats.data.{Xor, XorT}
+
+trait ApplicativeErrorSyntax {
+  implicit def applicativeErrorIdSyntax[E](e: E): ApplicativeErrorIdOps[E] =
+    new ApplicativeErrorIdOps(e)
+
+  implicit def applicativeErrorSyntax[F[_, _], E, A](fa: F[E, A])(implicit F: ApplicativeError[F[E, ?], E]): ApplicativeErrorOps[F[E, ?], E, A] =
+    new ApplicativeErrorOps[F[E, ?], E, A](fa)
+}
+
+final class ApplicativeErrorIdOps[E](e: E) {
+  def raiseError[F[_], A](implicit F: ApplicativeError[F, E]): F[A] =
+    F.raiseError(e)
+}
+
+final class ApplicativeErrorOps[F[_], E, A](fa: F[A])(implicit F: ApplicativeError[F, E]) {
+  def handleError(f: E => A): F[A] =
+    F.handleError(fa)(f)
+
+  def handleErrorWith(f: E => F[A]): F[A] =
+    F.handleErrorWith(fa)(f)
+
+  def attempt: F[E Xor A] =
+    F.attempt(fa)
+
+  def attemptT: XorT[F, E, A] =
+    F.attemptT(fa)
+
+  def recover(pf: PartialFunction[E, A]): F[A] =
+    F.recover(fa)(pf)
+
+  def recoverWith(pf: PartialFunction[E, F[A]]): F[A] =
+    F.recoverWith(fa)(pf)
+}

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -3,6 +3,7 @@ package cats
 package object syntax {
   object all extends AllSyntax
   object applicative extends ApplicativeSyntax
+  object applicativeError extends ApplicativeErrorSyntax
   object apply extends ApplySyntax
   object bifunctor extends BifunctorSyntax
   object bifoldable extends BifoldableSyntax

--- a/tests/src/test/scala/cats/tests/ApplicativeErrorTests.scala
+++ b/tests/src/test/scala/cats/tests/ApplicativeErrorTests.scala
@@ -1,0 +1,42 @@
+package cats
+package tests
+
+import cats.data.{Xor, XorT}
+
+class ApplicativeErrorCheck extends CatsSuite {
+
+  type ErrorOr[A] = String Xor A
+
+  val failed: String Xor Int =
+    "Badness".raiseError[ErrorOr, Int]
+
+  test("raiseError syntax creates an Xor with the correct type parameters") {
+    failed should === ("Badness".left[Int])
+  }
+
+  test("handleError syntax transforms an error to a success") {
+    failed.handleError(error => error.length) should === (7.right)
+  }
+
+  test("handleErrorWith transforms an error to a success") {
+    failed.handleErrorWith(error => error.length.right) should === (7.right)
+  }
+
+  test("attempt syntax creates a wrapped Xor") {
+    failed.attempt should === ("Badness".left.right)
+  }
+
+  test("attemptT syntax creates an XorT") {
+    type ErrorOrT[A] = XorT[ErrorOr, String, A]
+    failed.attemptT should === (XorT[ErrorOr, String, Int](failed.right))
+  }
+
+  test("recover syntax transforms an error to a success") {
+    failed.recover { case error => error.length } should === (7.right)
+  }
+
+  test("recoverWith transforms an error to a success") {
+    failed.recoverWith { case error => error.length.right } should === (7.right)
+  }
+
+}

--- a/tests/src/test/scala/cats/tests/ApplicativeErrorTests.scala
+++ b/tests/src/test/scala/cats/tests/ApplicativeErrorTests.scala
@@ -27,7 +27,6 @@ class ApplicativeErrorCheck extends CatsSuite {
   }
 
   test("attemptT syntax creates an XorT") {
-    type ErrorOrT[A] = XorT[ErrorOr, String, A]
     failed.attemptT should === (XorT[ErrorOr, String, Int](failed.right))
   }
 

--- a/tests/src/test/scala/cats/tests/SyntaxTests.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxTests.scala
@@ -214,4 +214,29 @@ class SyntaxTests extends AllInstances with AllSyntax {
     val la = mock[Eval[A]]
     val lfa = la.pureEval[F]
   }
+
+  def testApplicativeError[F[_, _], E, A](implicit F: ApplicativeError[F[E, ?], E]): Unit = {
+    type G[X] = F[E, X]
+
+    val e = mock[E]
+    val ga = e.raiseError[G, A]
+
+    val gea = mock[G[A]]
+
+    val ea = mock[E => A]
+    val gea1 = ga.handleError(ea)
+
+    val egea = mock[E => G[A]]
+    val gea2 = ga.handleErrorWith(egea)
+
+    val gxea = ga.attempt
+
+    val gxtea = ga.attemptT
+
+    val pfea = mock[PartialFunction[E, A]]
+    val gea3 = ga.recover(pfea)
+
+    val pfegea = mock[PartialFunction[E, G[A]]]
+    val gea4 = ga.recoverWith(pfegea)
+  }
 }


### PR DESCRIPTION
I've added syntax for the methods I mentioned in #561.

I'm happy with `raiseError`, `handleError`, `handleErrorWith`, `recover`, and `recoverWith`. However, I'm not sure about `attemptT` because the tests in `ApplicativeErrorTests.scala` required a bunch of heavyweight type hinting.

My inclination is to remove `attempt` and `attemptT` and leave the other methods intact. What do you think?