### PR TITLE
Use travis_wait as temporary fix for stalled builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ scala:
 - 2.11.8
 
 script:
-  - scripts/travis-publish.sh
+  - travis_wait scripts/travis-publish.sh
 
 notifications:
   webhooks:


### PR DESCRIPTION
https://docs.travis-ci.com/user/common-build-problems/#Build-times-out-because-no-output-was-received

We can use this as a temporary fix (maybe..) while waiting for progress on https://github.com/typelevel/cats/pull/942 to unblock some of the PRs we have waiting. According to the link above we now get 20 minutes of radio silence instead of 10.

See: https://github.com/typelevel/cats/issues/810 for more info on the problem.