### PR TITLE
Add .ensime_cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ project/boot
 target
 .ensime
 .ensime_lucene
+.ensime_cache
 TAGS
 \#*#
 *~


### PR DESCRIPTION
I just installed and started using ensime in Atom. For cats it created a .ensime_cache directory following the default setup steps, so I guess it makes sense to add this .gitignore for the project.
