### PR TITLE
Add curried version of .fold to Xor and Validated

### DIFF
--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -15,7 +15,7 @@ sealed abstract class Validated[+E, +A] extends Product with Serializable {
       case Valid(a) => fa(a)
     }
 
-  def fold[B](fe: E => B): (A => B) => B = fold(fe, _)
+  def foldC[B](fe: E => B): (A => B) => B = fold(fe, _)
 
   def isValid: Boolean = fold(_ => false, _ => true)
   def isInvalid: Boolean = fold(_ => true, _ => false)

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -15,6 +15,8 @@ sealed abstract class Validated[+E, +A] extends Product with Serializable {
       case Valid(a) => fa(a)
     }
 
+  def fold[B](fe: E => B): (A => B) => B = fold(fe, _)
+
   def isValid: Boolean = fold(_ => false, _ => true)
   def isInvalid: Boolean = fold(_ => true, _ => false)
 

--- a/core/src/main/scala/cats/data/Xor.scala
+++ b/core/src/main/scala/cats/data/Xor.scala
@@ -26,6 +26,8 @@ sealed abstract class Xor[+A, +B] extends Product with Serializable {
     case Xor.Right(b) => fb(b)
   }
 
+  def fold[C](fa: A => C): (B => C) => C = fold(fa, _)
+
   def isLeft: Boolean = fold(_ => true, _ => false)
 
   def isRight: Boolean = fold(_ => false, _ => true)

--- a/core/src/main/scala/cats/data/Xor.scala
+++ b/core/src/main/scala/cats/data/Xor.scala
@@ -26,7 +26,7 @@ sealed abstract class Xor[+A, +B] extends Product with Serializable {
     case Xor.Right(b) => fb(b)
   }
 
-  def fold[C](fa: A => C): (B => C) => C = fold(fa, _)
+  def foldC[C](fa: A => C): (B => C) => C = fold(fa, _)
 
   def isLeft: Boolean = fold(_ => true, _ => false)
 

--- a/tests/src/test/scala/cats/tests/ValidatedTests.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedTests.scala
@@ -155,6 +155,16 @@ class ValidatedTests extends CatsSuite {
     }
   }
 
+  test("fold curried works") {
+    forAll { (x: Validated[String, Int], s: String, t: String) =>
+      val folded = x.fold(_ => s)(_ => t)
+      if (x.isValid)
+        folded should === (t)
+      else
+        folded should === (s)
+    }
+  }
+
   test("isValid after combine, iff both are valid") {
     forAll { (lhs: Validated[Int, String], rhs: Validated[Int, String]) =>
       lhs.combine(rhs).isValid should === (lhs.isValid && rhs.isValid)

--- a/tests/src/test/scala/cats/tests/ValidatedTests.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedTests.scala
@@ -157,7 +157,7 @@ class ValidatedTests extends CatsSuite {
 
   test("fold curried works") {
     forAll { (x: Validated[String, Int], s: String, t: String) =>
-      val folded = x.fold(_ => s)(_ => t)
+      val folded = x.foldC(_ => s)(_ => t)
       if (x.isValid)
         folded should === (t)
       else

--- a/tests/src/test/scala/cats/tests/XorTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTests.scala
@@ -127,7 +127,7 @@ class XorTests extends CatsSuite {
 
   test("fold curried works") {
     forAll { (x: Int Xor String, s: String, t: String) =>
-      val folded = x.fold(_ => s)(_ => t)
+      val folded = x.foldC(_ => s)(_ => t)
       if (x.isRight)
         folded should === (t)
       else

--- a/tests/src/test/scala/cats/tests/XorTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTests.scala
@@ -125,6 +125,16 @@ class XorTests extends CatsSuite {
     }
   }
 
+  test("fold curried works") {
+    forAll { (x: Int Xor String, s: String, t: String) =>
+      val folded = x.fold(_ => s)(_ => t)
+      if (x.isRight)
+        folded should === (t)
+      else
+        folded should === (s)
+    }
+  }
+
   test("orElse") {
     forAll { (x: Int Xor String, y: Int Xor String) =>
       val z = x.orElse(y)


### PR DESCRIPTION
This is just a personal preference, but I like the curried syntax for `.fold`ing things. This pr doesn't remove the current form of `.fold`ing, it just adds the curried form (to both `Xor` and `Validated`). You can use either! This is more inline with `Option.fold` which is maybe why I prefer it. 