### PR TITLE
Are builds hanging because of 2.11.8?

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ git:
 
 scala:
 - 2.10.6
-- 2.11.8
+- 2.11.7
 
 script:
   - scripts/travis-publish.sh

--- a/build.sbt
+++ b/build.sbt
@@ -14,8 +14,8 @@ lazy val scoverageSettings = Seq(
 
 lazy val buildSettings = Seq(
   organization := "org.typelevel",
-  scalaVersion := "2.11.8",
-  crossScalaVersions := Seq("2.10.6", "2.11.8")
+  scalaVersion := "2.11.7",
+  crossScalaVersions := Seq("2.10.6", "2.11.7")
 )
 
 lazy val catsDoctestSettings = Seq(


### PR DESCRIPTION
I have no reason to believe this would solve anything, the only basis I have is it seems builds have stalled more since bumping to 2.11.8. Wondering if this will "fix" the build... for science. And stuff.