### PR TITLE
Reduce maxSize and minSuccessful in Scalacheck params

### DIFF
--- a/laws/src/main/scala/cats/laws/discipline/Eq.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Eq.scala
@@ -13,7 +13,7 @@ object eq {
    */
   implicit def function1Eq[A, B](implicit A: Arbitrary[A], B: Eq[B]): Eq[A => B] = new Eq[A => B] {
     def eqv(f: A => B, g: A => B): Boolean = {
-      val samples = List.fill(100)(A.arbitrary.sample).collect{
+      val samples = List.fill(10)(A.arbitrary.sample).collect{
         case Some(a) => a
         case None => sys.error("Could not generate arbitrary values to compare two functions")
       }

--- a/laws/src/main/scala/cats/laws/discipline/Eq.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Eq.scala
@@ -2,6 +2,7 @@ package cats
 package laws
 package discipline
 
+import catalysts.Platform
 import algebra.Eq
 import org.scalacheck.Arbitrary
 
@@ -12,8 +13,10 @@ object eq {
    * and comparing the application of the two functions.
    */
   implicit def function1Eq[A, B](implicit A: Arbitrary[A], B: Eq[B]): Eq[A => B] = new Eq[A => B] {
+    val sampleCnt: Int = if (Platform.isJvm) 50 else 5
+
     def eqv(f: A => B, g: A => B): Boolean = {
-      val samples = List.fill(10)(A.arbitrary.sample).collect{
+      val samples = List.fill(sampleCnt)(A.arbitrary.sample).collect{
         case Some(a) => a
         case None => sys.error("Could not generate arbitrary values to compare two functions")
       }

--- a/tests/src/test/scala/cats/tests/CatsSuite.scala
+++ b/tests/src/test/scala/cats/tests/CatsSuite.scala
@@ -20,10 +20,10 @@ trait TestSettings extends Configuration with Matchers {
 
   lazy val checkConfiguration: PropertyCheckConfiguration =
     PropertyCheckConfiguration(
-      minSuccessful = PosInt(5),
+      minSuccessful = if (Platform.isJvm) PosInt(50) else PosInt(5),
       maxDiscardedFactor = if (Platform.isJvm) PosZDouble(5.0) else PosZDouble(50.0),
       minSize = PosZInt(0),
-      sizeRange = PosZInt(5),
+      sizeRange = if (Platform.isJvm) PosZInt(10) else PosZInt(5),
       workers = PosInt(1))
 
   lazy val slowCheckConfiguration: PropertyCheckConfiguration =

--- a/tests/src/test/scala/cats/tests/CatsSuite.scala
+++ b/tests/src/test/scala/cats/tests/CatsSuite.scala
@@ -6,7 +6,7 @@ import catalysts.Platform
 import cats.std.AllInstances
 import cats.syntax.{AllSyntax, EqOps}
 
-import org.scalactic.anyvals.{PosZDouble, PosInt}
+import org.scalactic.anyvals.{PosZDouble, PosInt, PosZInt}
 import org.scalatest.{FunSuite, Matchers}
 import org.scalatest.prop.{Configuration, GeneratorDrivenPropertyChecks}
 import org.typelevel.discipline.scalatest.Discipline
@@ -20,8 +20,11 @@ trait TestSettings extends Configuration with Matchers {
 
   lazy val checkConfiguration: PropertyCheckConfiguration =
     PropertyCheckConfiguration(
-      minSuccessful = if (Platform.isJvm) PosInt(100) else PosInt(10),
-      maxDiscardedFactor = if (Platform.isJvm) PosZDouble(5.0) else PosZDouble(50.0))
+      minSuccessful = PosInt(5),
+      maxDiscardedFactor = if (Platform.isJvm) PosZDouble(5.0) else PosZDouble(50.0),
+      minSize = PosZInt(0),
+      sizeRange = PosZInt(5),
+      workers = PosInt(1))
 
   lazy val slowCheckConfiguration: PropertyCheckConfiguration =
     if (Platform.isJvm) checkConfiguration


### PR DESCRIPTION
This is an experiment to see if builds time out less if we don't run as
many samples with Scalacheck.