### PR TITLE
Disable scaladoc during packaging for scala 2.10

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -231,6 +231,12 @@ lazy val publishSettings = Seq(
   scmInfo := Some(ScmInfo(url("https://github.com/typelevel/cats"), "scm:git:git@github.com:typelevel/cats.git")),
   autoAPIMappings := true,
   apiURL := Some(url("http://typelevel.org/cats/api/")),
+  publishArtifact in (Compile, packageDoc) := {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, 10)) => false  // don't package scaladoc when publishing for 2.10
+      case _ => true
+    }
+  },
   pomExtra := (
     <developers>
       <developer>


### PR DESCRIPTION
My previous PR #958 missed the fact that the shell script which executes the build runs a publish as the final command. In the case of Pull Requests this is a publishLocal. On master it runs something different, which appears to publish snapshots.

As such, the previous PR allowed #898 to pass the site generation process, but it failed during the publish stage - the last command executed during the pull request build process.

Sorry about that.

This one disables the scaladoc packaging phase during publish for 2.10, which hopefully finally allows #898 to pass.

I tested publishLocal and it passes fine on 2.10 now albeit with docs not generated. 2.11 still generates scaladoc during the publish phase.