### PR TITLE
Fix build for scaladoc generation of Laws

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,14 +90,14 @@ lazy val disciplineDependencies = Seq(
  * it does mean that the scaladocs cannot be generated when the build is in 2.10 mode.
  */
 def noDocProjects(sv: String): Seq[ProjectReference] = CrossVersion.partialVersion(sv) match {
-    case Some((2, 10)) => Seq[ProjectReference](coreJVM)
+    case Some((2, 10)) => Seq[ProjectReference](coreJVM, lawsJVM)
     case _ => Nil
   }
 
 lazy val docSettings = Seq(
   autoAPIMappings := true,
   unidocProjectFilter in (ScalaUnidoc, unidoc) :=
-    inProjects(coreJVM) -- inProjects(noDocProjects(scalaVersion.value): _*),
+    inProjects(coreJVM, lawsJVM) -- inProjects(noDocProjects(scalaVersion.value): _*),
   site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "api"),
   site.addMappingsToSiteDir(tut, "_tut"),
   ghpagesNoJekyll := false,

--- a/laws/src/main/scala/cats/laws/AlternativeLaws.scala
+++ b/laws/src/main/scala/cats/laws/AlternativeLaws.scala
@@ -8,13 +8,13 @@ trait AlternativeLaws[F[_]] extends ApplicativeLaws[F] with MonoidKLaws[F] {
   implicit def algebra[A]: Monoid[F[A]] = F.algebra[A]
 
   def alternativeRightAbsorption[A, B](ff: F[A => B]): IsEq[F[B]] =
-    (ff ap F.empty[A]) <-> F.empty[B]
+    F.ap(ff)(F.empty[A]) <-> F.empty[B]
 
   def alternativeLeftDistributivity[A, B](fa: F[A], fa2: F[A], f: A => B): IsEq[F[B]] =
     ((fa |+| fa2) map f) <-> ((fa map f) |+| (fa2 map f))
 
   def alternativeRightDistributivity[A, B](fa: F[A], ff: F[A => B], fg: F[A => B]): IsEq[F[B]] =
-    ((ff |+| fg) ap fa) <-> ((ff ap fa) |+| (fg ap fa))
+    F.ap(ff |+| fg)(fa) <-> (F.ap(ff)(fa) |+| F.ap(fg)(fa))
 
 }
 

--- a/laws/src/main/scala/cats/laws/ApplicativeLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplicativeLaws.scala
@@ -1,7 +1,6 @@
 package cats
 package laws
 
-import cats.syntax.apply._
 import cats.syntax.functor._
 
 /**
@@ -11,16 +10,16 @@ trait ApplicativeLaws[F[_]] extends ApplyLaws[F] {
   implicit override def F: Applicative[F]
 
   def applicativeIdentity[A](fa: F[A]): IsEq[F[A]] =
-    F.pure((a: A) => a).ap(fa) <-> fa
+    F.ap(F.pure((a: A) => a))(fa) <-> fa
 
   def applicativeHomomorphism[A, B](a: A, f: A => B): IsEq[F[B]] =
-    F.pure(f).ap(F.pure(a)) <-> F.pure(f(a))
+    F.ap(F.pure(f))(F.pure(a)) <-> F.pure(f(a))
 
   def applicativeInterchange[A, B](a: A, ff: F[A => B]): IsEq[F[B]] =
-    ff.ap(F.pure(a)) <-> F.pure((f: A => B) => f(a)).ap(ff)
+    F.ap(ff)(F.pure(a)) <-> F.ap(F.pure((f: A => B) => f(a)))(ff)
 
   def applicativeMap[A, B](fa: F[A], f: A => B): IsEq[F[B]] =
-    fa.map(f) <-> F.pure(f).ap(fa)
+    fa.map(f) <-> F.ap(F.pure(f))(fa)
 
   /**
    * This law is [[applyComposition]] stated in terms of `pure`. It is a
@@ -29,7 +28,7 @@ trait ApplicativeLaws[F[_]] extends ApplyLaws[F] {
    */
   def applicativeComposition[A, B, C](fa: F[A], fab: F[A => B], fbc: F[B => C]): IsEq[F[C]] = {
     val compose: (B => C) => (A => B) => (A => C) = _.compose
-    F.pure(compose).ap(fbc).ap(fab).ap(fa) <-> fbc.ap(fab.ap(fa))
+    F.ap(F.ap(F.ap(F.pure(compose))(fbc))(fab))(fa) <-> F.ap(fbc)(F.ap(fab)(fa))
   }
 
   def apProductConsistent[A, B](fa: F[A], f: F[A => B]): IsEq[F[B]] =

--- a/laws/src/main/scala/cats/laws/ApplyLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplyLaws.scala
@@ -1,7 +1,6 @@
 package cats
 package laws
 
-import cats.syntax.apply._
 import cats.syntax.functor._
 
 /**
@@ -12,7 +11,7 @@ trait ApplyLaws[F[_]] extends FunctorLaws[F] with CartesianLaws[F] {
 
   def applyComposition[A, B, C](fa: F[A], fab: F[A => B], fbc: F[B => C]): IsEq[F[C]] = {
     val compose: (B => C) => (A => B) => (A => C) = _.compose
-    fbc.ap(fab.ap(fa)) <-> fbc.map(compose).ap(fab).ap(fa)
+    F.ap(fbc)(F.ap(fab)(fa)) <-> F.ap(F.ap(fbc.map(compose))(fab))(fa)
   }
 }
 

--- a/laws/src/main/scala/cats/laws/BimonadLaws.scala
+++ b/laws/src/main/scala/cats/laws/BimonadLaws.scala
@@ -2,7 +2,7 @@ package cats
 package laws
 
 /**
- * Laws that must be obeyed by any `Bimonad`.
+ * Laws that must be obeyed by any [[Bimonad]].
  *
  * For more information, see definition 4.1 from this paper:
  * http://arxiv.org/pdf/0710.1163v3.pdf

--- a/laws/src/main/scala/cats/laws/FlatMapLaws.scala
+++ b/laws/src/main/scala/cats/laws/FlatMapLaws.scala
@@ -2,7 +2,6 @@ package cats
 package laws
 
 import cats.data.Kleisli
-import cats.syntax.apply._
 import cats.syntax.flatMap._
 import cats.syntax.functor._
 
@@ -16,7 +15,7 @@ trait FlatMapLaws[F[_]] extends ApplyLaws[F] {
     fa.flatMap(f).flatMap(g) <-> fa.flatMap(a => f(a).flatMap(g))
 
   def flatMapConsistentApply[A, B](fa: F[A], fab: F[A => B]): IsEq[F[B]] =
-    fab.ap(fa) <-> fab.flatMap(f => fa.map(f))
+    F.ap(fab)(fa) <-> fab.flatMap(f => fa.map(f))
 
   /**
    * The composition of `cats.data.Kleisli` arrows is associative. This is

--- a/laws/src/main/scala/cats/laws/FoldableLaws.scala
+++ b/laws/src/main/scala/cats/laws/FoldableLaws.scala
@@ -12,7 +12,7 @@ trait FoldableLaws[F[_]] {
   )(implicit
     M: Monoid[B]
   ): IsEq[B] = {
-    fa.foldMap(f) <-> fa.foldLeft(M.empty) { (b, a) => b |+| f(a) }
+    F.foldMap(fa)(f) <-> F.foldLeft(fa, M.empty) { (b, a) => b |+| f(a) }
   }
 
   def rightFoldConsistentWithFoldMap[A, B](
@@ -21,7 +21,7 @@ trait FoldableLaws[F[_]] {
   )(implicit
     M: Monoid[B]
   ): IsEq[B] = {
-    fa.foldMap(f) <-> fa.foldRight(Later(M.empty))((a, lb) => lb.map(f(a) |+| _)).value
+    F.foldMap(fa)(f) <-> F.foldRight(fa, Later(M.empty))((a, lb) => lb.map(f(a) |+| _)).value
   }
 
   def existsConsistentWithFind[A](

--- a/laws/src/main/scala/cats/laws/ReducibleLaws.scala
+++ b/laws/src/main/scala/cats/laws/ReducibleLaws.scala
@@ -12,7 +12,7 @@ trait ReducibleLaws[F[_]] extends FoldableLaws[F] {
   )(implicit
     B: Semigroup[B]
   ): IsEq[B] =
-    fa.reduceMap(f) <-> fa.reduceLeftTo(f)((b, a) => b |+| f(a))
+    F.reduceMap(fa)(f) <-> F.reduceLeftTo(fa)(f)((b, a) => b |+| f(a))
 
   def reduceRightToConsistentWithReduceMap[A, B](
     fa: F[A],
@@ -20,13 +20,13 @@ trait ReducibleLaws[F[_]] extends FoldableLaws[F] {
   )(implicit
     B: Semigroup[B]
   ): IsEq[B] =
-    fa.reduceMap(f) <-> fa.reduceRightTo(f)((a, eb) => eb.map(f(a) |+| _)).value
+    F.reduceMap(fa)(f) <-> F.reduceRightTo(fa)(f)((a, eb) => eb.map(f(a) |+| _)).value
 
   def traverseConsistent[G[_]: Applicative, A, B](fa: F[A], f: A => G[B]): IsEq[G[Unit]] =
-    fa.traverse1_(f) <-> fa.traverse_(f)
+    F.traverse1_(fa)(f) <-> F.traverse_(fa)(f)
 
   def sequenceConsistent[G[_]: Applicative, A](fa: F[G[A]]): IsEq[G[Unit]] =
-    fa.sequence1_ <-> fa.sequence_
+    F.sequence1_(fa) <-> fa.sequence_
 }
 
 object ReducibleLaws {

--- a/laws/src/main/scala/cats/laws/TraverseLaws.scala
+++ b/laws/src/main/scala/cats/laws/TraverseLaws.scala
@@ -4,7 +4,6 @@ package laws
 import cats.Id
 import cats.data.Const
 import cats.syntax.traverse._
-import cats.syntax.foldable._
 
 trait TraverseLaws[F[_]] extends FunctorLaws[F] with FoldableLaws[F] {
   implicit override def F: Traverse[F]
@@ -64,7 +63,7 @@ trait TraverseLaws[F[_]] extends FunctorLaws[F] with FoldableLaws[F] {
     f: A => B
   )(implicit B: Monoid[B]): IsEq[B] = {
     val lhs: B = fa.traverse[Const[B, ?], B](a => Const(f(a))).getConst
-    val rhs: B = fa.foldMap(f)
+    val rhs: B = F.foldMap(fa)(f)
     lhs <-> rhs
   }
 }


### PR DESCRIPTION
This PR changes a number of laws classes to *not* use syntax, and updates build.sbt to enable scaladoc generation for the law project.

The problem outlined in #516 only occur if syntax is used to reference the operations on Apply and Foldable. This PR changes these references to use the type classes directly instead of using the syntax.

Once this is in place, the scaladoc generates correctly for the laws project during the makeSite project.

This PR would fix #510 as it publishes the scaladoc for laws as part of the site.

The fix is a bit ugly, because specific syntax has to be avoided, and a deeper investigation into how to make that syntax work with scaladoc is probably required, but given where things are, this is probably a useful step forward, despite the kludginess.

Note that this has conflicts with both #959 and #960 so will need to merge to latest once those have been merged. 