### PR TITLE
Add toValidatedNel to Xor

### DIFF
--- a/core/src/main/scala/cats/data/Xor.scala
+++ b/core/src/main/scala/cats/data/Xor.scala
@@ -70,6 +70,10 @@ sealed abstract class Xor[+A, +B] extends Product with Serializable {
 
   def toValidated: Validated[A,B] = fold(Validated.Invalid.apply, Validated.Valid.apply)
 
+  /** Returns a [[ValidatedNel]] representation of this disjunction with the `Left` value
+   * as a single element on the `Invalid` side of the [[NonEmptyList]]. */
+  def toValidatedNel[AA >: A]: ValidatedNel[AA,B] = fold(Validated.invalidNel, Validated.valid)
+
   def withValidated[AA,BB](f: Validated[A,B] => Validated[AA,BB]): AA Xor BB =
     f(toValidated).toXor
 

--- a/tests/src/test/scala/cats/tests/XorTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTests.scala
@@ -204,6 +204,7 @@ class XorTests extends CatsSuite {
       x.isLeft should === (x.toOption.isEmpty)
       x.isLeft should === (x.toList.isEmpty)
       x.isLeft should === (x.toValidated.isInvalid)
+      x.isLeft should === (x.toValidatedNel.isInvalid)
     }
   }
 


### PR DESCRIPTION
As a convenient shorthand for `xor.toValidated.toValidatedNel`.

I suppose `.toValidatedNel` should be the version more often used since the point of `Validated` is to accumulate errors?