### PR TITLE
Add syntax for separate from MonadCombine.

### DIFF
--- a/core/src/main/scala/cats/syntax/monadCombine.scala
+++ b/core/src/main/scala/cats/syntax/monadCombine.scala
@@ -1,15 +1,13 @@
 package cats
 package syntax
 
-trait MonadCombineSyntax extends MonadCombineSyntax1 {
+trait MonadCombineSyntax {
   // TODO: use simulacrum instances eventually
   implicit def monadCombineSyntax[F[_]: MonadCombine, G[_], A](fga: F[G[A]]): MonadCombineOps[F, G, A] =
     new MonadCombineOps[F, G, A](fga)
-}
 
-private[syntax] trait MonadCombineSyntax1 {
-  implicit def nestedMonadCombineSyntax[F[_]: MonadCombine, G[_, _], A, B](fgab: F[G[A, B]]): NestedMonadCombineOps[F, G, A, B] =
-    new NestedMonadCombineOps[F, G, A, B](fgab)
+  implicit def separateSyntax[F[_]: MonadCombine, G[_, _], A, B](fgab: F[G[A, B]]): SeparateOps[F, G, A, B] =
+    new SeparateOps[F, G, A, B](fgab)
 }
 
 final class MonadCombineOps[F[_], G[_], A](fga: F[G[A]])(implicit F: MonadCombine[F]) {
@@ -30,7 +28,7 @@ final class MonadCombineOps[F[_], G[_], A](fga: F[G[A]])(implicit F: MonadCombin
   def unite(implicit G: Foldable[G]): F[A] = F.unite(fga)
 }
 
-final class NestedMonadCombineOps[F[_], G[_, _], A, B](fgab: F[G[A, B]])(implicit F: MonadCombine[F]) {
+final class SeparateOps[F[_], G[_, _], A, B](fgab: F[G[A, B]])(implicit F: MonadCombine[F]) {
 
   /**
    * @see [[MonadCombine.separate]]

--- a/core/src/main/scala/cats/syntax/monadCombine.scala
+++ b/core/src/main/scala/cats/syntax/monadCombine.scala
@@ -1,13 +1,18 @@
 package cats
 package syntax
 
-trait MonadCombineSyntax {
+trait MonadCombineSyntax extends MonadCombineSyntax1 {
   // TODO: use simulacrum instances eventually
-  implicit def nestedMonadCombineSyntax[F[_]: MonadCombine, G[_], A](fga: F[G[A]]): NestedMonadCombineOps[F, G, A] =
-    new NestedMonadCombineOps[F, G, A](fga)
+  implicit def monadCombineSyntax[F[_]: MonadCombine, G[_], A](fga: F[G[A]]): MonadCombineOps[F, G, A] =
+    new MonadCombineOps[F, G, A](fga)
 }
 
-final class NestedMonadCombineOps[F[_], G[_], A](fga: F[G[A]])(implicit F: MonadCombine[F]) {
+private[syntax] trait MonadCombineSyntax1 {
+  implicit def nestedMonadCombineSyntax[F[_]: MonadCombine, G[_, _], A, B](fgab: F[G[A, B]]): NestedMonadCombineOps[F, G, A, B] =
+    new NestedMonadCombineOps[F, G, A, B](fgab)
+}
+
+final class MonadCombineOps[F[_], G[_], A](fga: F[G[A]])(implicit F: MonadCombine[F]) {
 
   /**
    * @see [[MonadCombine.unite]]
@@ -15,7 +20,7 @@ final class NestedMonadCombineOps[F[_], G[_], A](fga: F[G[A]])(implicit F: Monad
    * Example:
    * {{{
    * scala> import cats.std.list._
-    * scala> import cats.std.vector._
+   * scala> import cats.std.vector._
    * scala> import cats.syntax.monadCombine._
    * scala> val x: List[Vector[Int]] = List(Vector(1, 2), Vector(3, 4))
    * scala> x.unite
@@ -23,4 +28,22 @@ final class NestedMonadCombineOps[F[_], G[_], A](fga: F[G[A]])(implicit F: Monad
    * }}}
    */
   def unite(implicit G: Foldable[G]): F[A] = F.unite(fga)
+}
+
+final class NestedMonadCombineOps[F[_], G[_, _], A, B](fgab: F[G[A, B]])(implicit F: MonadCombine[F]) {
+
+  /**
+   * @see [[MonadCombine.separate]]
+   *
+   * Example:
+   * {{{
+   * scala> import cats.data.Xor
+   * scala> import cats.std.list._
+   * scala> import cats.syntax.monadCombine._
+   * scala> val l: List[Xor[String, Int]] = List(Xor.right(1), Xor.left("error"))
+   * scala> l.separate
+   * res0: (List[String], List[Int]) = (List(error),List(1))
+   * }}}
+   */
+  def separate(implicit G: Bifoldable[G]): (F[A], F[B]) = F.separate(fgab)
 }

--- a/tests/src/test/scala/cats/tests/SyntaxTests.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxTests.scala
@@ -207,6 +207,14 @@ class SyntaxTests extends AllInstances with AllSyntax {
     val gfab = fgagb.bisequence
   }
 
+  def testMonadCombine[F[_]: MonadCombine, G[_]: Foldable, H[_, _]: Bifoldable, A, B]: Unit = {
+    val fga = mock[F[G[A]]]
+    val fa = fga.unite
+
+    val fhab = mock[F[H[A, B]]]
+    val fafb = fhab.separate
+  }
+
   def testApplicative[F[_]: Applicative, A]: Unit = {
     val a = mock[A]
     val fa = a.pure[F]


### PR DESCRIPTION
I based myself on the structure in syntax.bitraverse for the two implicit conversions (the
existing for unite and the new for separate).

MonadCombine separate was added in #864 by @adelbertc.