### PR TITLE
Add object `reducible` for reducible syntax

### DIFF
--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -27,6 +27,7 @@ package object syntax {
   object order extends OrderSyntax
   object partialOrder extends PartialOrderSyntax
   object profunctor extends ProfunctorSyntax
+  object reducible extends ReducibleSyntax
   object semigroup extends SemigroupSyntax
   object semigroupk extends SemigroupKSyntax
   object show extends Show.ToShowOps

--- a/core/src/main/scala/cats/syntax/reducible.scala
+++ b/core/src/main/scala/cats/syntax/reducible.scala
@@ -2,7 +2,7 @@ package cats
 package syntax
 
 trait ReducibleSyntax1 {
-  implicit def foldableSyntaxU[FA](fa: FA)(implicit U: Unapply[Reducible,FA]): Reducible.Ops[U.M, U.A] =
+  implicit def reducibleSyntaxU[FA](fa: FA)(implicit U: Unapply[Reducible,FA]): Reducible.Ops[U.M, U.A] =
     new Reducible.Ops[U.M, U.A] {
       val self = U.subst(fa)
       val typeClassInstance = U.TC


### PR DESCRIPTION
Seems like there is no object for `cats.syntax.reducible` ;)