### PR TITLE
Add `Bitraverse` instances for `Validated` and `XorT`.

### DIFF
--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -2,7 +2,6 @@ package cats
 package data
 
 import cats.data.Validated.{Invalid, Valid}
-import cats.functor.Bifunctor
 
 import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
@@ -238,10 +237,31 @@ private[data] sealed abstract class ValidatedInstances extends ValidatedInstance
     def show(f: Validated[A,B]): String = f.show
   }
 
-  implicit def validatedBifunctor: Bifunctor[Validated] =
-    new Bifunctor[Validated] {
-      override def bimap[A, B, C, D](fab: Validated[A, B])(f: A => C, g: B => D): Validated[C, D] = fab.bimap(f, g)
-      override def leftMap[A, B, C](fab: Validated[A, B])(f: A => C): Validated[C, B] = fab.leftMap(f)
+  implicit val validatedBitraverse: Bitraverse[Validated] =
+    new Bitraverse[Validated] {
+      def bitraverse[G[_], A, B, C, D](fab: Validated[A, B])(f: A => G[C], g: B => G[D])(implicit G: Applicative[G]): G[Validated[C, D]] =
+        fab match {
+          case Invalid(a) => G.map(f(a))(Validated.invalid)
+          case Valid(b) => G.map(g(b))(Validated.valid)
+        }
+
+      def bifoldLeft[A, B, C](fab: Validated[A, B], c: C)(f: (C, A) => C, g: (C, B) => C): C =
+        fab match {
+          case Invalid(a) => f(c, a)
+          case Valid(b) => g(c, b)
+        }
+
+      def bifoldRight[A, B, C](fab: Validated[A, B], c: Eval[C])(f: (A, Eval[C]) => Eval[C], g: (B, Eval[C]) => Eval[C]): Eval[C] =
+        fab match {
+          case Invalid(a) => f(a, c)
+          case Valid(b) => g(b, c)
+        }
+
+      override def bimap[A, B, C, D](fab: Validated[A, B])(f: A => C, g: B => D): Validated[C, D] =
+        fab.bimap(f, g)
+
+      override def leftMap[A, B, C](fab: Validated[A, B])(f: A => C): Validated[C, B] =
+        fab.leftMap(f)
     }
 
   implicit def validatedInstances[E](implicit E: Semigroup[E]): Traverse[Validated[E, ?]] with ApplicativeError[Validated[E, ?], E] =

--- a/core/src/main/scala/cats/data/Xor.scala
+++ b/core/src/main/scala/cats/data/Xor.scala
@@ -176,7 +176,7 @@ private[data] sealed abstract class XorInstances extends XorInstances1 {
       }
     }
 
-  implicit def xorBifunctor: Bitraverse[Xor] =
+  implicit val xorBitraverse: Bitraverse[Xor] =
     new Bitraverse[Xor] {
       def bitraverse[G[_], A, B, C, D](fab: Xor[A, B])(f: A => G[C], g: B => G[D])(implicit G: Applicative[G]): G[Xor[C, D]] =
         fab match {

--- a/tests/src/test/scala/cats/tests/ValidatedTests.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedTests.scala
@@ -3,7 +3,7 @@ package tests
 
 import cats.data.{NonEmptyList, Validated, ValidatedNel, Xor, XorT}
 import cats.data.Validated.{Valid, Invalid}
-import cats.laws.discipline.{BifunctorTests, TraverseTests, ApplicativeErrorTests, SerializableTests, CartesianTests}
+import cats.laws.discipline.{BitraverseTests, TraverseTests, ApplicativeErrorTests, SerializableTests, CartesianTests}
 import org.scalacheck.Arbitrary._
 import cats.laws.discipline.{SemigroupKTests}
 import cats.laws.discipline.arbitrary._
@@ -16,7 +16,8 @@ class ValidatedTests extends CatsSuite {
   checkAll("Validated[String, Int]", CartesianTests[Validated[String,?]].cartesian[Int, Int, Int])
   checkAll("Cartesian[Validated[String,?]]", SerializableTests.serializable(Cartesian[Validated[String,?]]))
 
-  checkAll("Validated[?, ?]", BifunctorTests[Validated].bifunctor[Int, Int, Int, Int, Int, Int])
+  checkAll("Validated[?, ?]", BitraverseTests[Validated].bitraverse[Option, Int, Int, Int, String, String, String])
+  checkAll("Bitraverse[Validated]", SerializableTests.serializable(Bitraverse[Validated]))
 
   implicit val eq0 = XorT.xorTEq[Validated[String, ?], String, Int]
 

--- a/tests/src/test/scala/cats/tests/XorTTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTTests.scala
@@ -15,6 +15,8 @@ class XorTTests extends CatsSuite {
   checkAll("MonadError[XorT[List, ?, ?]]", SerializableTests.serializable(MonadError[XorT[List, String, ?], String]))
   checkAll("XorT[List, ?, ?]", BifunctorTests[XorT[List, ?, ?]].bifunctor[Int, Int, Int, String, String, String])
   checkAll("Bifunctor[XorT[List, ?, ?]]", SerializableTests.serializable(Bifunctor[XorT[List, ?, ?]]))
+  checkAll("XorT[List, ?, ?]", BitraverseTests[XorT[List, ?, ?]].bitraverse[Option, Int, Int, Int, String, String, String])
+  checkAll("Bitraverse[XorT[List, ?, ?]]", SerializableTests.serializable(Bitraverse[XorT[List, ?, ?]]))
   checkAll("XorT[List, Int, ?]", TraverseTests[XorT[List, Int, ?]].traverse[Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[XorT[List, Int, ?]]", SerializableTests.serializable(Traverse[XorT[List, Int, ?]]))
   checkAll("XorT[List, String, Int]", OrderLaws[XorT[List, String, Int]].order)


### PR DESCRIPTION
While experimenting with `MonadCombine.separate` (for #975), I noticed there were no `Bitraverse` instances for `Validated` and `XorT`.

I would welcome suggestions, possible improvements, ... (maybe for `XorTBifoldable` ?)