### PR TITLE
Use by-name parameter in Applicatve.replicateA

### DIFF
--- a/core/src/main/scala/cats/Applicative.scala
+++ b/core/src/main/scala/cats/Applicative.scala
@@ -35,7 +35,7 @@ import cats.std.list._
   /**
     * Given `fa` and `n`, apply `fa` `n` times to construct an `F[List[A]]` value.
     */
-  def replicateA[A](n: Int, fa: F[A]): F[List[A]] =
+  def replicateA[A](n: Int, fa: => F[A]): F[List[A]] =
     sequence(List.fill(n)(fa))
 
   /**

--- a/tests/src/test/scala/cats/tests/ApplicativeTests.scala
+++ b/tests/src/test/scala/cats/tests/ApplicativeTests.scala
@@ -2,7 +2,9 @@ package cats
 package tests
 
 import cats.Applicative
-
+import scala.concurrent.Future
+import scala.concurrent.duration._
+import scala.concurrent.Await
 
 class ApplicativeCheck extends CatsSuite {
 
@@ -11,6 +13,21 @@ class ApplicativeCheck extends CatsSuite {
     val A = Applicative[Option]
     val fa = A.pure(1)
     A.replicateA(5, fa) should === (Some(List(1,1,1,1,1)))
+  }
 
+  test("replicateA evaluates the 'fa' argument by-name") {
+    import scala.concurrent.ExecutionContext.Implicits.global
+
+    val timeout = 5.seconds
+    val repetitions = 5
+    val A = Applicative[Future]
+
+    @volatile var n: Int = 0
+    def fut(): Future[Unit] = A.pure(n += 1)
+
+    def program: Future[List[Unit]] = A.replicateA(repetitions, fut())
+    Await.result(program, timeout)
+
+    n should === (repetitions)
   }
 }


### PR DESCRIPTION
Changes `Applicative.replicateA` such that the `fa` parameter is by-name instead of by-value.

```
def replicateA[A](n: Int, fa: F[A]): F[List[A]] = sequence(List.fill(n)(fa))    // before
def replicateA[A](n: Int, fa: => F[A]): F[List[A]] = sequence(List.fill(n)(fa)) // after
```

I think this change deserves some discussion, because in an ideal world, there should not be implicit side effects and therefore it should not matter whether `fa` is by-name or by-value.

However I recently encountered a problem with scala's `Future` and the available `Applicative` instance in `cats`:

```
import cats.Applicative
import cats.std.future._
import scala.concurrent.ExecutionContext.Implicits.global
import scala.concurrent._
import scala.concurrent.duration._

Await.result(Applicative[Future].replicateA(3,Future(println("Hello World"))), Duration.Inf)
```

Which results in the following output after `:paste` in the REPL:

```
Hello World
import cats.Applicative
import cats.std.future._
import scala.concurrent.ExecutionContext.Implicits.global
import scala.concurrent._
import scala.concurrent.duration._
f: scala.concurrent.Future[Unit]
res1: List[Unit] = List((), (), ())
```

As you can see, the `Hello World` is printed only once, because the argument to `replicateA`, `fa`, is evaluated **before** passing it to `List.fill` (which itself does use a by-name param), so `Hello World` is printed only once, during the evaluation of the arguments before calling `Applicative.replicateA`.

To fix this, I think we should change `replicateA` to take the second parameter by-name.  Any other suggestions?