### PR TITLE
Remove internal lazy val from Later.

### DIFF
--- a/bench/src/main/scala/cats/bench/TrampolineBench.scala
+++ b/bench/src/main/scala/cats/bench/TrampolineBench.scala
@@ -30,11 +30,12 @@ class TrampolineBench {
       y <- Trampoline.suspend(trampolineFib(n - 2))
     } yield x + y
 
-  // TailRec[A] only has .flatMap in 2.11.
-
+  // // TailRec[A] only has .flatMap in 2.11.
+  // import scala.util.control.TailCalls
+  // 
   // @Benchmark
   // def stdlib(): Int = stdlibFib(N).result
-  //
+  // 
   // def stdlibFib(n: Int): TailCalls.TailRec[Int] =
   //   if (n < 2) TailCalls.done(n) else for {
   //     x <- TailCalls.tailcall(stdlibFib(n - 1))

--- a/bench/src/main/scala/cats/bench/TrampolineBench.scala
+++ b/bench/src/main/scala/cats/bench/TrampolineBench.scala
@@ -32,7 +32,7 @@ class TrampolineBench {
 
   // // TailRec[A] only has .flatMap in 2.11.
   // import scala.util.control.TailCalls
-  // 
+  //
   // @Benchmark
   // def stdlib(): Int = stdlibFib(N).result
   // 

--- a/bench/src/main/scala/cats/bench/TrampolineBench.scala
+++ b/bench/src/main/scala/cats/bench/TrampolineBench.scala
@@ -35,7 +35,7 @@ class TrampolineBench {
   //
   // @Benchmark
   // def stdlib(): Int = stdlibFib(N).result
-  // 
+  //
   // def stdlibFib(n: Int): TailCalls.TailRec[Int] =
   //   if (n < 2) TailCalls.done(n) else for {
   //     x <- TailCalls.tailcall(stdlibFib(n - 1))

--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -3,6 +3,8 @@ package cats
 import scala.annotation.tailrec
 import cats.syntax.all._
 
+import java.io.{ Externalizable, ObjectOutput, ObjectInput }
+
 /**
  * Eval is a monad which controls evaluation.
  *
@@ -134,23 +136,57 @@ final case class Now[A](value: A) extends Eval[A] {
  * by the closure) will not be retained, and will be available for
  * garbage collection.
  */
-final class Later[A](f: () => A) extends Eval[A] {
-  private[this] var thunk: () => A = f
+final class Later[A](f: () => A) extends Eval[A] with Externalizable {
 
-  // The idea here is that `f` may have captured very large
-  // structures, but produce a very small result. In this case, once
-  // we've calculated a value, we would prefer to be able to free
-  // everything else.
-  //
-  // (For situations where `f` is small, but the output will be very
-  // expensive to store, consider using `Always`.)
-  lazy val value: A = {
-    val result = thunk()
-    thunk = null // scalastyle:off
-    result
-  }
+  // we use lock to prevent possible problems with someone else
+  // synchronizing on 'this'.
+  private[this] val lock = new Object()
+  private[this] var thunk: Function0[A] = f
+  private[this] var result: A = _
+
+  final def value: A =
+    if (thunk == null) {
+      result
+    } else lock.synchronized {
+      if (thunk == null) result else {
+        result = thunk()
+        thunk = null
+        result
+      }
+    }
 
   def memoize: Eval[A] = this
+
+  // everything below here is necessary to convince java to serialize
+  // these things.
+
+  def this() =
+    this(() => null.asInstanceOf[A])
+  
+  def writeExternal(out: ObjectOutput): Unit =
+    thunk match {
+      case null =>
+        out.writeObject(new Integer(1))
+        out.writeObject(result)
+      case t =>
+        out.writeObject(new Integer(0))
+        out.writeObject(t)
+    }
+
+  def readExternal(in: ObjectInput): Unit =
+    in.readObject() match {
+      case n: Integer =>
+        n.intValue match {
+          case 0 =>
+            thunk = in.readObject().asInstanceOf[Function0[A]]
+            result = null.asInstanceOf[A]
+          case 1 =>
+            thunk = null
+            result = in.readObject().asInstanceOf[A]
+        }
+      case x =>
+        throw new RuntimeException(s"expected integer, got $x")
+    }
 }
 
 object Later {

--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -141,7 +141,7 @@ final class Later[A](f: () => A) extends Eval[A] with Externalizable {
   // we use lock to prevent possible problems with someone else
   // synchronizing on 'this'.
   private[this] val lock = new Object()
-  private[this] var thunk: Function0[A] = f
+  @volatile private[this] var thunk: Function0[A] = f
   private[this] var result: A = _
 
   final def value: A =
@@ -162,7 +162,7 @@ final class Later[A](f: () => A) extends Eval[A] with Externalizable {
 
   def this() =
     this(() => null.asInstanceOf[A])
-  
+
   def writeExternal(out: ObjectOutput): Unit =
     thunk match {
       case null =>


### PR DESCRIPTION
This commit replaces the previous Later implementation
with one that is not based on Scala's lazy val encoding.

Concretely, this new implementation uses a private,
internal lock to avoid potential deadlocks that could
arise if other objects synchronized on a Later instance.
The possibility of this happening is relatively remote
but not impossible.

Performance seems to be equivalent to lazy vals in the
cases that were tested. An additional Object is
allocated, so Later instance may be slightly larger.

Is this a good idea? Should we stick with `lazy val`?
Should we synchronize on `this` to have smaller
instances? Should we be doing something else?