### PR TITLE
Add semiflatMap to OptionT and XorT

### DIFF
--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -25,6 +25,9 @@ final case class OptionT[F[_], A](value: F[Option[A]]) {
   def map[B](f: A => B)(implicit F: Functor[F]): OptionT[F, B] =
     OptionT(F.map(value)(_.map(f)))
 
+  def mapF[B](f: A => F[B])(implicit F: Monad[F]): OptionT[F, B] =
+    flatMap(a => OptionT.liftF(f(a)))
+
   def flatMap[B](f: A => OptionT[F, B])(implicit F: Monad[F]): OptionT[F, B] =
     flatMapF(a => f(a).value)
 

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -25,7 +25,7 @@ final case class OptionT[F[_], A](value: F[Option[A]]) {
   def map[B](f: A => B)(implicit F: Functor[F]): OptionT[F, B] =
     OptionT(F.map(value)(_.map(f)))
 
-  def mapF[B](f: A => F[B])(implicit F: Monad[F]): OptionT[F, B] =
+  def semiflatMap[B](f: A => F[B])(implicit F: Monad[F]): OptionT[F, B] =
     flatMap(a => OptionT.liftF(f(a)))
 
   def flatMap[B](f: A => OptionT[F, B])(implicit F: Monad[F]): OptionT[F, B] =

--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -85,7 +85,7 @@ final case class XorT[F[_], A, B](value: F[A Xor B]) {
 
   def map[D](f: B => D)(implicit F: Functor[F]): XorT[F, A, D] = bimap(identity, f)
 
-  def mapF[D](f: B => F[D])(implicit F: Monad[F]): XorT[F, A, D] =
+  def semiflatMap[D](f: B => F[D])(implicit F: Monad[F]): XorT[F, A, D] =
     flatMap(b => XorT.right[F, A, D](f(b)))
 
   def leftMap[C](f: A => C)(implicit F: Functor[F]): XorT[F, C, B] = bimap(f, identity)

--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -85,6 +85,9 @@ final case class XorT[F[_], A, B](value: F[A Xor B]) {
 
   def map[D](f: B => D)(implicit F: Functor[F]): XorT[F, A, D] = bimap(identity, f)
 
+  def mapF[D](f: B => F[D])(implicit F: Monad[F]): XorT[F, A, D] =
+    flatMap(b => XorT.right[F, A, D](f(b)))
+
   def leftMap[C](f: A => C)(implicit F: Functor[F]): XorT[F, C, B] = bimap(f, identity)
 
   def compare(that: XorT[F, A, B])(implicit o: Order[F[A Xor B]]): Int =

--- a/tests/src/test/scala/cats/tests/OptionTTests.scala
+++ b/tests/src/test/scala/cats/tests/OptionTTests.scala
@@ -149,9 +149,9 @@ class OptionTTests extends CatsSuite {
     }
   }
 
-  test("mapF consistent with value.flatMap+f+pure") {
+  test("semiflatMap consistent with value.flatMap+f+pure") {
     forAll { (o: OptionT[List, Int], f: Int => List[String]) =>
-      o.mapF(f) should === (OptionT(o.value.flatMap {
+      o.semiflatMap(f) should === (OptionT(o.value.flatMap {
         case None => List(None)
         case Some(a) => f(a).map(Some(_))
       }))

--- a/tests/src/test/scala/cats/tests/OptionTTests.scala
+++ b/tests/src/test/scala/cats/tests/OptionTTests.scala
@@ -149,6 +149,15 @@ class OptionTTests extends CatsSuite {
     }
   }
 
+  test("mapF consistent with value.flatMap+f+pure") {
+    forAll { (o: OptionT[List, Int], f: Int => List[String]) =>
+      o.mapF(f) should === (OptionT(o.value.flatMap {
+        case None => List(None)
+        case Some(a) => f(a).map(Some(_))
+      }))
+    }
+  }
+
   test("subflatMap consistent with value.map+flatMap") {
     forAll { (o: OptionT[List, Int], f: Int => Option[String]) =>
       o.subflatMap(f) should === (OptionT(o.value.map(_.flatMap(f))))

--- a/tests/src/test/scala/cats/tests/XorTTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTTests.scala
@@ -141,9 +141,9 @@ class XorTTests extends CatsSuite {
     }
   }
 
-  test("mapF consistent with value.flatMap+f+pure") {
+  test("semiflatMap consistent with value.flatMap+f+pure") {
     forAll { (xort: XorT[List, String, Int], f: Int => List[String]) =>
-      xort.mapF(f) should === (XorT(xort.value.flatMap {
+      xort.semiflatMap(f) should === (XorT(xort.value.flatMap {
         case l @ Xor.Left(_) => List(l)
         case Xor.Right(b) => f(b).map(Xor.right)
       }))

--- a/tests/src/test/scala/cats/tests/XorTTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTTests.scala
@@ -141,6 +141,15 @@ class XorTTests extends CatsSuite {
     }
   }
 
+  test("mapF consistent with value.flatMap+f+pure") {
+    forAll { (xort: XorT[List, String, Int], f: Int => List[String]) =>
+      xort.mapF(f) should === (XorT(xort.value.flatMap {
+        case l @ Xor.Left(_) => List(l)
+        case Xor.Right(b) => f(b).map(Xor.right)
+      }))
+    }
+  }
+
   test("subflatMap consistent with value.map+flatMap") {
     forAll { (xort: XorT[List, String, Int], f: Int => String Xor Double) =>
       xort.subflatMap(f) should === (XorT(xort.value.map(_.flatMap(f))))


### PR DESCRIPTION
Adds `mapF` to OptionT and XorT making it easier in the case where you have `XorT[F, A, B]` and `B => F[C]` to get `XorT[F, A, C]`. 

I'm not sure if the name `mapF` is appropriate or even if this belongs in cats but I've found something like this very useful recently.