### PR TITLE
correct the url to Data types à la carte

### DIFF
--- a/core/src/main/scala/cats/free/Inject.scala
+++ b/core/src/main/scala/cats/free/Inject.scala
@@ -7,7 +7,7 @@ import cats.data.Coproduct
 /**
   * Inject type class as described in "Data types a la carte" (Swierstra 2008).
   *
-  * @see [[http://www.staff.science.uu.nl/~swier004/Publications/DataTypesALaCarte.pdf]]
+  * @see [[http://www.staff.science.uu.nl/~swier004/publications/2008-jfp.pdf]]
   */
 sealed abstract class Inject[F[_], G[_]] {
   def inj[A](fa: F[A]): G[A]

--- a/docs/src/main/tut/freemonad.md
+++ b/docs/src/main/tut/freemonad.md
@@ -292,7 +292,7 @@ val result: (Map[String, Any], Option[Int]) = program.foldMap(pureCompiler).run(
 ## Composing Free monads ADTs.
 
 Real world applications often time combine different algebras.
-The `Inject` type class described by Swierstra in [Data types à la carte](http://www.staff.science.uu.nl/~swier004/Publications/DataTypesALaCarte.pdf)
+The `Inject` type class described by Swierstra in [Data types à la carte](http://www.staff.science.uu.nl/~swier004/publications/2008-jfp.pdf)
 lets us compose different algebras in the context of `Free`.
 
 Let's see a trivial example of unrelated ADT's getting composed as a `Coproduct` that can form a more complex program.


### PR DESCRIPTION
The URL to Data types à la carte seems to have changed to this URL http://www.staff.science.uu.nl/~swier004/publications/2008-jfp.pdf