### PR TITLE
Revert "Disable scaladoc during packaging for scala 2.10"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -233,12 +233,6 @@ lazy val publishSettings = Seq(
   scmInfo := Some(ScmInfo(url("https://github.com/typelevel/cats"), "scm:git:git@github.com:typelevel/cats.git")),
   autoAPIMappings := true,
   apiURL := Some(url("http://typelevel.org/cats/api/")),
-  publishArtifact in (Compile, packageDoc) := {
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, 10)) => false  // don't package scaladoc when publishing for 2.10
-      case _ => true
-    }
-  },
   pomExtra := (
     <developers>
       <developer>


### PR DESCRIPTION
Disabling docs for scala 2.10 can't be achieved by this change alone. Sonatype release requires javadoc jars, this is now blocking the 0.5.0 release. My proposal is that we revert this for now and find a more comprehensive solution for https://github.com/typelevel/cats/pull/898 later. I know it's kicking the can down the road, but this PR itself does not bring any value to 0.5.0, so I think it is sensible to not having it blocking the release. 

Update: #898 is not included in the 0.5.0 release. 