### PR TITLE
Add missing type parameters.

### DIFF
--- a/kernel/src/main/scala/cats/kernel/Order.scala
+++ b/kernel/src/main/scala/cats/kernel/Order.scala
@@ -134,7 +134,7 @@ abstract class OrderFunctions[O[T] <: Order[T]] extends PartialOrderFunctions[O]
     ev.max(x, y)
 }
 
-object Order extends OrderFunctions {
+object Order extends OrderFunctions[Order] {
 
   /**
    * Access an implicit `Order[A]`.

--- a/kernel/src/main/scala/cats/kernel/PartialOrder.scala
+++ b/kernel/src/main/scala/cats/kernel/PartialOrder.scala
@@ -134,7 +134,7 @@ abstract class PartialOrderFunctions[P[T] <: PartialOrder[T]] extends EqFunction
     ev.gt(x, y)
 }
 
-object PartialOrder extends PartialOrderFunctions {
+object PartialOrder extends PartialOrderFunctions[PartialOrder] {
 
   /**
    * Access an implicit `PartialOrder[A]`.


### PR DESCRIPTION
We had left out some type parameters in `cats.kernel` which leads to errors when trying to use those methods.