### PR TITLE
Add Apply.map2Eval and allow traverse laziness

### DIFF
--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -34,14 +34,45 @@ trait Apply[F[_]] extends Functor[F] with Cartesian[F] with ApplyArityFunctions[
     map(product(fa, fb)) { case (a, b) => f(a, b) }
 
   /**
+   * Similar to [[map2]] but uses [[Eval]] to allow for laziness in the `F[B]`
+   * argument. This can allow for "short-circuiting" of computations.
+   *
+   * NOTE: the default implementation of `map2Eval` does does not short-circuit
+   * computations. For data structures that can benefit from laziness, [[Apply]]
+   * instances should override this method.
+   *
+   * In the following example, `x.map2(bomb)(_ + _)` would result in an error,
+   * but `map2Eval` "short-circuits" the computation. `x` is `None` and thus the
+   * result of `bomb` doesn't even need to be evaluated in order to determine
+   * that the result of `map2Eval` should be `None`.
+   *
+   * {{{
+   * scala> import cats.{Eval, Later}
+   * scala> import cats.implicits._
+   * scala> val bomb: Eval[Option[Int]] = Later(sys.error("boom"))
+   * scala> val x: Option[Int] = None
+   * scala> x.map2Eval(bomb)(_ + _).value
+   * res0: Option[Int] = None
+   * }}}
+   */
+  def map2Eval[A, B, Z](fa: F[A], fb: Eval[F[B]])(f: (A, B) => Z): Eval[F[Z]] =
+    fb.map(fb => map2(fa, fb)(f))
+
+  /**
    * Two sequentially dependent Applys can be composed.
    *
    * The composition of Applys `F` and `G`, `F[G[x]]`, is also an Apply.
    *
-   * val ap = Apply[Option].compose[List]
-   * val x = Some(List(1, 2))
-   * val y = Some(List(10, 20))
-   * ap.map2(x, y)(_ + _) == Some(List(11, 12, 21, 22))
+   * Example:
+   * {{{
+   * scala> import cats.Apply
+   * scala> import cats.implicits._
+   * scala> val ap = Apply[Option].compose[List]
+   * scala> val x: Option[List[Int]] = Some(List(1, 2))
+   * scala> val y: Option[List[Int]] = Some(List(10, 20))
+   * scala> ap.map2(x, y)(_ + _)
+   * res0: Option[List[Int]] = Some(List(11, 21, 12, 22))
+   * }}}
    */
   def compose[G[_]](implicit GG: Apply[G]): Apply[Lambda[X => F[G[X]]]] =
     new CompositeApply[F, G] {

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -107,9 +107,9 @@ import simulacrum.typeclass
    * needed.
    */
   def traverse_[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
-    foldLeft(fa, G.pure(())) { (acc, a) =>
-      G.map2(acc, f(a)) { (_, _) => () }
-    }
+    foldRight(fa, Later(G.pure(()))) { (a, acc) =>
+      G.map2Eval(f(a), acc) { (_, _) => () }
+    }.value
 
   /**
    * Behaves like traverse_, but uses [[Unapply]] to find the

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -107,7 +107,7 @@ import simulacrum.typeclass
    * needed.
    */
   def traverse_[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
-    foldRight(fa, Later(G.pure(()))) { (a, acc) =>
+    foldRight(fa, Always(G.pure(()))) { (a, acc) =>
       G.map2Eval(f(a), acc) { (_, _) => () }
     }.value
 

--- a/core/src/main/scala/cats/Reducible.scala
+++ b/core/src/main/scala/cats/Reducible.scala
@@ -83,9 +83,16 @@ import simulacrum.typeclass
    * `A` values will be mapped into `G[B]` and combined using
    * `Applicative#map2`.
    *
-   * This method does the same thing as `Foldable#traverse_`.  The
-   * difference is that we only need `Apply[G]` here, since we don't
-   * need to call `Applicative#pure` for a starting value.
+   * This method is similar to [[Foldable.traverse_]]. There are two
+   * main differences:
+   *
+   * 1. We only need an [[Apply]] instance for `G` here, since we
+   * don't need to call [[Applicative.pure]] for a starting value.
+   * 2. This performs a strict left-associative traversal and thus
+   * must always traverse the entire data structure. Prefer
+   * [[Foldable.traverse_]] if you have an [[Applicative]] instance
+   * available for `G` and want to take advantage of short-circuiting
+   * the traversal.
    */
   def traverse1_[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: Apply[G]): G[Unit] =
     G.map(reduceLeftTo(fa)(f)((x, y) => G.map2(x, f(y))((_, b) => b)))(_ => ())
@@ -93,9 +100,9 @@ import simulacrum.typeclass
   /**
    * Sequence `F[G[A]]` using `Apply[G]`.
    *
-   * This method is similar to `Foldable#sequence_`. The difference is
-   * that we only need `Apply[G]` here, since we don't need to call
-   * `Applicative#pure` for a starting value.
+   * This method is similar to [[Foldable.sequence_]] but requires only
+   * an [[Apply]] instance for `G` instead of [[Applicative]]. See the
+   * [[traverse1_]] documentation for a description of the differences.
    */
   def sequence1_[G[_], A](fga: F[G[A]])(implicit G: Apply[G]): G[Unit] =
     G.map(reduceLeft(fga)((x, y) => G.map2(x, y)((_, b) => b)))(_ => ())

--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -170,7 +170,7 @@ trait OneAndLowPriority2 extends OneAndLowPriority1 {
   implicit def oneAndTraverse[F[_]](implicit F: Traverse[F]): Traverse[OneAnd[F, ?]] =
     new Traverse[OneAnd[F, ?]] {
       def traverse[G[_], A, B](fa: OneAnd[F, A])(f: (A) => G[B])(implicit G: Applicative[G]): G[OneAnd[F, B]] = {
-        G.map2Eval(f(fa.head), Later(F.traverse(fa.tail)(f)))(OneAnd(_, _)).value
+        G.map2Eval(f(fa.head), Always(F.traverse(fa.tail)(f)))(OneAnd(_, _)).value
       }
 
       def foldLeft[A, B](fa: OneAnd[F, A], b: B)(f: (B, A) => B): B = {

--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -170,9 +170,7 @@ trait OneAndLowPriority2 extends OneAndLowPriority1 {
   implicit def oneAndTraverse[F[_]](implicit F: Traverse[F]): Traverse[OneAnd[F, ?]] =
     new Traverse[OneAnd[F, ?]] {
       def traverse[G[_], A, B](fa: OneAnd[F, A])(f: (A) => G[B])(implicit G: Applicative[G]): G[OneAnd[F, B]] = {
-        val tail = F.traverse(fa.tail)(f)
-        val head = f(fa.head)
-        G.ap2[B, F[B], OneAnd[F, B]](G.pure(OneAnd(_, _)))(head, tail)
+        G.map2Eval(f(fa.head), Later(F.traverse(fa.tail)(f)))(OneAnd(_, _)).value
       }
 
       def foldLeft[A, B](fa: OneAnd[F, A], b: B)(f: (B, A) => B): B = {

--- a/core/src/main/scala/cats/std/list.scala
+++ b/core/src/main/scala/cats/std/list.scala
@@ -48,7 +48,7 @@ trait ListInstances extends cats.kernel.std.ListInstances {
       }
 
       def traverse[G[_], A, B](fa: List[A])(f: A => G[B])(implicit G: Applicative[G]): G[List[B]] =
-        foldRight[A, G[List[B]]](fa, Later(G.pure(List.empty))){ (a, lglb) =>
+        foldRight[A, G[List[B]]](fa, Always(G.pure(List.empty))){ (a, lglb) =>
           G.map2Eval(f(a), lglb)(_ :: _)
         }.value
 

--- a/core/src/main/scala/cats/std/list.scala
+++ b/core/src/main/scala/cats/std/list.scala
@@ -47,11 +47,10 @@ trait ListInstances extends cats.kernel.std.ListInstances {
         Eval.defer(loop(fa))
       }
 
-      def traverse[G[_], A, B](fa: List[A])(f: A => G[B])(implicit G: Applicative[G]): G[List[B]] = {
-        val gba = G.pure(Vector.empty[B])
-        val gbb = fa.foldLeft(gba)((buf, a) => G.map2(buf, f(a))(_ :+ _))
-        G.map(gbb)(_.toList)
-      }
+      def traverse[G[_], A, B](fa: List[A])(f: A => G[B])(implicit G: Applicative[G]): G[List[B]] =
+        foldRight[A, G[List[B]]](fa, Later(G.pure(List.empty))){ (a, lglb) =>
+          G.map2Eval(f(a), lglb)(_ :: _)
+        }.value
 
       override def exists[A](fa: List[A])(p: A => Boolean): Boolean =
         fa.exists(p)

--- a/core/src/main/scala/cats/std/map.scala
+++ b/core/src/main/scala/cats/std/map.scala
@@ -15,7 +15,7 @@ trait MapInstances extends cats.kernel.std.MapInstances {
     new Traverse[Map[K, ?]] with FlatMap[Map[K, ?]] {
 
       def traverse[G[_], A, B](fa: Map[K, A])(f: (A) => G[B])(implicit G: Applicative[G]): G[Map[K, B]] = {
-        val gba: Eval[G[Map[K, B]]] = Later(G.pure(Map.empty))
+        val gba: Eval[G[Map[K, B]]] = Always(G.pure(Map.empty))
         val gbb = Foldable.iterateRight(fa.iterator, gba){ (kv, lbuf) =>
           G.map2Eval(f(kv._2), lbuf)({ (b, buf) => buf + (kv._1 -> b)})
         }.value

--- a/core/src/main/scala/cats/std/map.scala
+++ b/core/src/main/scala/cats/std/map.scala
@@ -14,12 +14,11 @@ trait MapInstances extends cats.kernel.std.MapInstances {
   implicit def mapInstance[K]: Traverse[Map[K, ?]] with FlatMap[Map[K, ?]] =
     new Traverse[Map[K, ?]] with FlatMap[Map[K, ?]] {
 
-      def traverse[G[_] : Applicative, A, B](fa: Map[K, A])(f: (A) => G[B]): G[Map[K, B]] = {
-        val G = Applicative[G]
-        val gba = G.pure(Map.empty[K, B])
-        val gbb = fa.foldLeft(gba) { (buf, a) =>
-          G.map2(buf, f(a._2))({ case(x, y) => x + (a._1 -> y)})
-        }
+      def traverse[G[_], A, B](fa: Map[K, A])(f: (A) => G[B])(implicit G: Applicative[G]): G[Map[K, B]] = {
+        val gba: Eval[G[Map[K, B]]] = Later(G.pure(Map.empty))
+        val gbb = Foldable.iterateRight(fa.iterator, gba){ (kv, lbuf) =>
+          G.map2Eval(f(kv._2), lbuf)({ (b, buf) => buf + (kv._1 -> b)})
+        }.value
         G.map(gbb)(_.toMap)
       }
 

--- a/core/src/main/scala/cats/std/option.scala
+++ b/core/src/main/scala/cats/std/option.scala
@@ -21,6 +21,12 @@ trait OptionInstances extends cats.kernel.std.OptionInstances {
       override def map2[A, B, Z](fa: Option[A], fb: Option[B])(f: (A, B) => Z): Option[Z] =
         fa.flatMap(a => fb.map(b => f(a, b)))
 
+      override def map2Eval[A, B, Z](fa: Option[A], fb: Eval[Option[B]])(f: (A, B) => Z): Eval[Option[Z]] =
+        fa match {
+          case None => Now(None)
+          case Some(a) => fb.map(_.map(f(a, _)))
+        }
+
       def coflatMap[A, B](fa: Option[A])(f: Option[A] => B): Option[B] =
         if (fa.isDefined) Some(f(fa)) else None
 

--- a/core/src/main/scala/cats/std/stream.scala
+++ b/core/src/main/scala/cats/std/stream.scala
@@ -41,11 +41,8 @@ trait StreamInstances extends cats.kernel.std.StreamInstances {
         // We use foldRight to avoid possible stack overflows. Since
         // we don't want to return a Eval[_] instance, we call .value
         // at the end.
-        //
-        // (We don't worry about internal laziness because traverse
-        // has to evaluate the entire stream anyway.)
         foldRight(fa, Later(init)) { (a, lgsb) =>
-          lgsb.map(gsb => G.map2(f(a), gsb)(_ #:: _))
+          G.map2Eval(f(a), lgsb)(_ #:: _)
         }.value
       }
 

--- a/core/src/main/scala/cats/std/vector.scala
+++ b/core/src/main/scala/cats/std/vector.scala
@@ -45,7 +45,9 @@ trait VectorInstances extends cats.kernel.std.VectorInstances {
       }
 
       def traverse[G[_], A, B](fa: Vector[A])(f: A => G[B])(implicit G: Applicative[G]): G[Vector[B]] =
-        fa.foldLeft(G.pure(Vector.empty[B]))((buf, a) => G.map2(buf, f(a))(_ :+ _))
+      foldRight[A, G[Vector[B]]](fa, Later(G.pure(Vector.empty))){ (a, lgvb) =>
+        G.map2Eval(f(a), lgvb)(_ +: _)
+      }.value
 
       override def exists[A](fa: Vector[A])(p: A => Boolean): Boolean =
         fa.exists(p)

--- a/core/src/main/scala/cats/std/vector.scala
+++ b/core/src/main/scala/cats/std/vector.scala
@@ -45,7 +45,7 @@ trait VectorInstances extends cats.kernel.std.VectorInstances {
       }
 
       def traverse[G[_], A, B](fa: Vector[A])(f: A => G[B])(implicit G: Applicative[G]): G[Vector[B]] =
-      foldRight[A, G[Vector[B]]](fa, Later(G.pure(Vector.empty))){ (a, lgvb) =>
+      foldRight[A, G[Vector[B]]](fa, Always(G.pure(Vector.empty))){ (a, lgvb) =>
         G.map2Eval(f(a), lgvb)(_ +: _)
       }.value
 

--- a/tests/src/test/scala/cats/tests/EitherTests.scala
+++ b/tests/src/test/scala/cats/tests/EitherTests.scala
@@ -49,4 +49,10 @@ class EitherTests extends CatsSuite {
       show.show(e).nonEmpty should === (true)
     }
   }
+
+  test("map2Eval is lazy") {
+    val bomb: Eval[Either[String, Int]] = Later(sys.error("boom"))
+    val x: Either[String, Int] = Left("l")
+    x.map2Eval(bomb)(_ + _).value should === (x)
+  }
 }

--- a/tests/src/test/scala/cats/tests/OptionTests.scala
+++ b/tests/src/test/scala/cats/tests/OptionTests.scala
@@ -83,4 +83,9 @@ class OptionTests extends CatsSuite {
     // can't use `s.some should === (Some(null))` here, because it leads to NullPointerException
     s.some.exists(_ == null) should ===(true)
   }
+
+  test("map2Eval is lazy") {
+    val bomb: Eval[Option[Int]] = Later(sys.error("boom"))
+    none[Int].map2Eval(bomb)(_ + _).value should === (None)
+  }
 }

--- a/tests/src/test/scala/cats/tests/XorTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTests.scala
@@ -235,4 +235,10 @@ class XorTests extends CatsSuite {
     }
   }
 
+  test("map2Eval is lazy") {
+    val bomb: Eval[String Xor Int] = Later(sys.error("boom"))
+    val x = Xor.left[String, Int]("l")
+    x.map2Eval(bomb)(_ + _).value should === (x)
+  }
+
 }


### PR DESCRIPTION
Fixes #513.

I think this should solve the majority of use-cases for lazy traversal.
One thing I noticed is that both `reduceRightToOption` and `traverse1_`
(which uses the former) seem to be impossible to implement lazily such
that they allow for short-circuiting. At least I couldn't figure out a
way. I left a note in the `traverse1_` scaladoc, but in practice I don't
anticipate this being a problem, because at the cost of just having an
`Applicative` instance as opposed to `Apply`, you can use `traverse_`
which is sufficiently lazy.