### PR TITLE
Use Future#successful in pureEval when possible

### DIFF
--- a/core/src/main/scala/cats/std/future.scala
+++ b/core/src/main/scala/cats/std/future.scala
@@ -13,7 +13,10 @@ trait FutureInstances extends FutureInstances1 {
     new FutureCoflatMap with MonadError[Future, Throwable]{
       def pure[A](x: A): Future[A] = Future.successful(x)
 
-      override def pureEval[A](x: Eval[A]): Future[A] = Future(x.value)
+      override def pureEval[A](x: Eval[A]): Future[A] = x match {
+        case Now(x) => Future.successful(x)
+        case _ => Future(x.value)
+      }
 
       def flatMap[A, B](fa: Future[A])(f: A => Future[B]): Future[B] = fa.flatMap(f)
 


### PR DESCRIPTION
Since `Now` already has performed the work required to calculate the result value, we can lift the result into a Future using `Future#successful` instead of unwrapping the `Now` inside the block run by the `Future` (which potentially has to use another thread).