### PR TITLE
Add XorT#fromEither

### DIFF
--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -168,6 +168,13 @@ trait XorTFunctions {
     def apply[E, A](xor: Xor[E, A])(implicit F: Applicative[F]): XorT[F, E, A] =
       XorT(F.pure(xor))
   }
+
+  final def fromEither[F[_]]: FromEitherPartiallyApplied[F] = new FromEitherPartiallyApplied
+
+  final class FromEitherPartiallyApplied[F[_]] private[XorTFunctions] {
+    def apply[E, A](eit: Either[E,A])(implicit F: Applicative[F]): XorT[F, E, A] =
+      XorT(F.pure(Xor.fromEither(eit)))
+  }
 }
 
 private[data] abstract class XorTInstances extends XorTInstances1 {

--- a/tests/src/test/scala/cats/tests/XorTTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTTests.scala
@@ -70,6 +70,12 @@ class XorTTests extends CatsSuite {
     }
   }
 
+  test("fromEither") {
+    forAll { (either: Either[String, Int]) =>
+      Some(either.isLeft) should === (XorT.fromEither[Option](either).isLeft)
+    }
+  }
+
   test("isLeft negation of isRight") {
     forAll { (xort: XorT[List, String, Int]) =>
       xort.isLeft should === (xort.isRight.map(! _))


### PR DESCRIPTION
Adds the ability to call `XorT.fromEither` to lift from `Either[A,B]` .  This is sugar for the more verbose `x => XorT(Xor.fromEither(x))` and complements the ability to go from `XorT` to `Either` via `toEither`