### PR TITLE
Override reverse on reversed PartialOrder to return original instance

### DIFF
--- a/kernel-laws/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -32,6 +32,8 @@ class LawTests extends FunSuite with Discipline {
   laws[OrderLaws, Stream[HasEq[Int]]].check(_.eqv)
 
   laws[OrderLaws, Set[Int]].check(_.partialOrder)
+  laws[OrderLaws, Set[Int]]("reverse").check(_.partialOrder(PartialOrder[Set[Int]].reverse))
+  laws[OrderLaws, Set[Int]]("reverse.reverse").check(_.partialOrder(PartialOrder[Set[Int]].reverse.reverse))
   laws[OrderLaws, Option[HasPartialOrder[Int]]].check(_.partialOrder)
   laws[OrderLaws, List[HasPartialOrder[Int]]].check(_.partialOrder)
   laws[OrderLaws, Vector[HasPartialOrder[Int]]].check(_.partialOrder)
@@ -53,6 +55,8 @@ class LawTests extends FunSuite with Discipline {
   laws[OrderLaws, Vector[Int]].check(_.order)
   laws[OrderLaws, Stream[Int]].check(_.order)
   laws[OrderLaws, Int]("fromOrdering").check(_.order(Order.fromOrdering[Int]))
+  laws[OrderLaws, Int]("reverse").check(_.order(Order[Int].reverse))
+  laws[OrderLaws, Int]("reverse.reverse").check(_.order(Order[Int].reverse.reverse))
 
   laws[GroupLaws, String].check(_.monoid)
   laws[GroupLaws, Option[Int]].check(_.monoid)

--- a/kernel/src/main/scala/cats/kernel/PartialOrder.scala
+++ b/kernel/src/main/scala/cats/kernel/PartialOrder.scala
@@ -5,17 +5,17 @@ import scala.{specialized => sp}
 
 /**
  * The `PartialOrder` type class is used to define a partial ordering on some type `A`.
- * 
+ *
  * A partial order is defined by a relation <=, which obeys the following laws:
- * 
+ *
  * - x <= x (reflexivity)
  * - if x <= y and y <= x, then x = y (anti-symmetry)
  * - if x <= y and y <= z, then x <= z (transitivity)
- * 
+ *
  * To compute both <= and >= at the same time, we use a Double number
  * to encode the result of the comparisons x <= y and x >= y.
  * The truth table is defined as follows:
- * 
+ *
  * x <= y    x >= y      Double
  * true      true        = 0.0     (corresponds to x = y)
  * false     false       = NaN     (x and y cannot be compared)
@@ -41,7 +41,7 @@ trait PartialOrder[@sp A] extends Any with Eq[A] { self =>
    * - negative iff `x < y`
    * - zero     iff `x = y`
    * - positive iff `x > y`
-   */  
+   */
   def tryCompare(x: A, y: A): Option[Int] = {
     val c = partialCompare(x, y)
     if (isNaN(c)) None else Some(c.signum)
@@ -82,6 +82,8 @@ trait PartialOrder[@sp A] extends Any with Eq[A] { self =>
   def reverse: PartialOrder[A] =
     new PartialOrder[A] {
       def partialCompare(x: A, y: A): Double = self.partialCompare(y, x)
+
+      override def reverse: PartialOrder[A] = self
     }
 
   // The following may be overridden for performance:


### PR DESCRIPTION
Also add some law-checking for reversed and double-reversed
Order/PartialOrder instances.