### PR TITLE
Run kernel-law tests for JS as part of build

### DIFF
--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -28,7 +28,7 @@ fi
 sbt_cmd="sbt ++$TRAVIS_SCALA_VERSION"
 
 coverage="$sbt_cmd coverage validateJVM coverageReport && codecov"
-scala_js="$sbt_cmd macrosJS/compile coreJS/compile lawsJS/compile && $sbt_cmd testsJS/test && $sbt_cmd js/test"
+scala_js="$sbt_cmd macrosJS/compile coreJS/compile lawsJS/compile && $sbt_cmd kernelLawsJS/test && $sbt_cmd testsJS/test && $sbt_cmd js/test"
 scala_jvm="$sbt_cmd validateJVM"
 
 run_cmd="$coverage && $scala_js && $scala_jvm $publish_cmd"


### PR DESCRIPTION
This seems to have been missed in the build script