### PR TITLE
Add notes about kind-projector usage in docs

### DIFF
--- a/docs/src/main/tut/const.md
+++ b/docs/src/main/tut/const.md
@@ -134,6 +134,8 @@ is to take an `A` and return it right back (lifted into `Const`).
 Before we plug and play however, note that `modifyF` has a `Functor` constraint on `F[_]`. This means we need to
 define a `Functor` instance for `Const`, where the first type parameter is fixed.
 
+*Note*: the example below assumes usage of the [kind-projector compiler plugin](https://github.com/non/kind-projector) and will not compile if it is not being used in a project.
+
 ```tut:silent
 import cats.data.Const
 

--- a/docs/src/main/tut/freeapplicative.md
+++ b/docs/src/main/tut/freeapplicative.md
@@ -57,8 +57,11 @@ import cats.Id
 import cats.arrow.NaturalTransformation
 import cats.std.function._
 
+// a function that takes a string as input
+type FromString[A] = String => A
+
 val compiler =
-  new NaturalTransformation[ValidationOp, String => ?] {
+  new NaturalTransformation[ValidationOp, FromString] {
     def apply[A](fa: ValidationOp[A]): String => A =
       str =>
         fa match {
@@ -69,7 +72,7 @@ val compiler =
 ```
 
 ```tut
-val validator = prog.foldMap[String => ?](compiler)
+val validator = prog.foldMap[FromString](compiler)
 validator("1234")
 validator("12345")
 ```

--- a/docs/src/main/tut/freemonad.md
+++ b/docs/src/main/tut/freemonad.md
@@ -215,7 +215,7 @@ behavior, such as:
  - `Future[_]` for asynchronous computation
  - `List[_]` for gathering multiple results
  - `Option[_]` to support optional results
- - `Validated[_]` (or `Xor[E, ?]`) to support failure
+ - `Xor[E, ?]` to support failure
  - a pseudo-random monad to support non-determinism
  - and so on...
 

--- a/docs/src/main/tut/kleisli.md
+++ b/docs/src/main/tut/kleisli.md
@@ -120,7 +120,9 @@ instance, `Kleisli[F, A, B]` has a `Functor` instance so long as the chosen `F[_
 instance so long as the chosen `F[_]` does. The instances in Cats are laid out in a way such that implicit
 resolution will pick up the most specific instance it can (depending on the `F[_]`).
 
-An example of a `Monad` instance for `Kleisli` would be:
+An example of a `Monad` instance for `Kleisli` is shown below.
+
+*Note*: the example below assumes usage of the [kind-projector compiler plugin](https://github.com/non/kind-projector) and will not compile if it is not being used in a project.
 
 ```tut:silent
 import cats.syntax.flatMap._

--- a/docs/src/main/tut/monad.md
+++ b/docs/src/main/tut/monad.md
@@ -94,6 +94,8 @@ instructions on how to compose any outer monad (`F` in the following
 example) with a specific inner monad (`Option` in the following
 example).
 
+*Note*: the example below assumes usage of the [kind-projector compiler plugin](https://github.com/non/kind-projector) and will not compile if it is not being used in a project.
+
 ```tut:silent
 case class OptionT[F[_], A](value: F[Option[A]])
 

--- a/docs/src/main/tut/validated.md
+++ b/docs/src/main/tut/validated.md
@@ -185,6 +185,8 @@ Which can be defined in terms of `Apply#ap` and `Apply#map`, the very functions 
 
 Can we perhaps define an `Apply` instance for `Validated`? Better yet, can we define an `Applicative` instance?
 
+*Note*: the example below assumes usage of the [kind-projector compiler plugin](https://github.com/non/kind-projector) and will not compile if it is not being used in a project.
+
 ```tut:silent
 import cats.Applicative
 

--- a/docs/src/main/tut/xor.md
+++ b/docs/src/main/tut/xor.md
@@ -100,6 +100,8 @@ over `M[_] : Monad`).
 Since we only ever want the computation to continue in the case of `Xor.Right` (as captured
 by the right-bias nature), we fix the left type parameter and leave the right one free.
 
+*Note*: the example below assumes usage of the [kind-projector compiler plugin](https://github.com/non/kind-projector) and will not compile if it is not being used in a project.
+
 ```tut:silent
 import cats.Monad
 


### PR DESCRIPTION
Resolves #1033 although in all but one place, a simple type alias was
not possible.