### PR TITLE
Add updating site and release notes to release process

### DIFF
--- a/PROCESS.md
+++ b/PROCESS.md
@@ -87,7 +87,8 @@ does not account for conversations that occured on Github.
 Once the relevant documentation changes have been committed, new
 [release notes](https://github.com/typelevel/cats/releases) should be
 added. You can add a release by clicking the "Draft a new release" button
-on that page.
+on that page, or if the relevant release already exists, you can click
+"Edit release".
 
 The website should then be updated via `sbt docs/ghpagesPushSite`.
 

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -84,6 +84,13 @@ You can get a list of changes between release tags `v0.1.2` and
 messages is a good way to get a summary of what happened, although it
 does not account for conversations that occured on Github.
 
+Once the relevant documentation changes have been committed, new
+[release notes](https://github.com/typelevel/cats/releases) should be
+added. You can add a release by clicking the "Draft a new release" button
+on that page.
+
+The website should then be updated via `sbt docs/ghpagesPushSite`.
+
 ### Conclusion
 
 Ideally this document will evolve and grow as the project


### PR DESCRIPTION
At the Typelevel Summit in Philly, people brought up confusion around
the site not always being up to date with the latest release.

Also, we always seem to forget to update the release notes until
@travisbrown kindly volunteers to :)

cc @non @travisbrown