### PR TITLE
Add a link to the OptionT documentation from the monad docs.

### DIFF
--- a/docs/src/main/tut/monad.md
+++ b/docs/src/main/tut/monad.md
@@ -113,3 +113,4 @@ implicit def optionTMonad[F[_]](implicit F : Monad[F]) = {
 
 This sort of construction is called a monad transformer.
 
+Cats has an [`OptionT`](optiont.html) monad transformer, which adds a lot of useful functions to the simple implementation above.


### PR DESCRIPTION
The monad docs uses `OptionT` as an example about how to compose (some) monads, but doesn't include a link to the `OptionT` documentation.