### PR TITLE
Use pygments instead of rouge for syntax highlighting

### DIFF
--- a/docs/src/site/_config.yml
+++ b/docs/src/site/_config.yml
@@ -1,6 +1,6 @@
 name: Cats Documentation
 markdown: redcarpet
-highlighter: pygments
+highlighter: rouge
 baseurl: /cats
 apidocs: /cats/api/
 sources: https://github.com/typelevel/cats/blob/master/


### PR DESCRIPTION
It appears that GitHub is already using rouge instead of pygments for
the cats site, because it doesn't support pygments. This change is so I
stop getting the following email every time I push the cats website:

> You are attempting to use the 'pygments' highlighter, which is currently
> unsupported on GitHub Pages. Your site will use 'rouge' for highlighting
> instead. To suppress this warning, change the 'highlighter' value to
> 'rouge' in your '_config.yml' and ensure the 'pygments' key is unset.