### PR TITLE
Fixed a bug in the Order and PartialOrder instances for Tuple2+ where only the first element was used in comparisons

### DIFF
--- a/project/KernelBoiler.scala
+++ b/project/KernelBoiler.scala
@@ -147,13 +147,13 @@ object KernelBoiler {
         -  implicit def tuple${arity}Order[${`A..N`}](implicit ${constraints("Order")}): Order[${`(A..N)`}] =
         -    new Order[${`(A..N)`}] {
         -      def compare(x: ${`(A..N)`}, y: ${`(A..N)`}): Int =
-        -        ${binMethod("compare").find(_ != 0).getOrElse(0)}
+        -        ${binMethod("compare").mkString("Array(", ", ", ")")}.find(_ != 0).getOrElse(0)
         -    }
         -
         -  implicit def tuple${arity}PartialOrder[${`A..N`}](implicit ${constraints("PartialOrder")}): PartialOrder[${`(A..N)`}] =
         -    new PartialOrder[${`(A..N)`}] {
         -      def partialCompare(x: ${`(A..N)`}, y: ${`(A..N)`}): Double =
-        -        ${binMethod("partialCompare").find(_ != 0.0).getOrElse(0.0)}
+        -        ${binMethod("partialCompare").mkString("Array(", ", ", ")")}.find(_ != 0.0).getOrElse(0.0)
         -    }
         -
         -  implicit def tuple${arity}Semigroup[${`A..N`}](implicit ${constraints("Semigroup")}): Semigroup[${`(A..N)`}] =

--- a/tests/src/test/scala/cats/tests/TupleTests.scala
+++ b/tests/src/test/scala/cats/tests/TupleTests.scala
@@ -7,6 +7,19 @@ class TupleTests extends CatsSuite {
   checkAll("Tuple2", BitraverseTests[Tuple2].bitraverse[Option, Int, Int, Int, String, String, String])
   checkAll("Bitraverse[Tuple2]", SerializableTests.serializable(Bitraverse[Tuple2]))
 
+  test("eqv") {
+    val eq = Eq[(Int, Long)]
+    forAll { t: (Int, Long) => eq.eqv(t, t) should === (true) }
+    forAll { t: (Int, Long) => eq.eqv(t, t._1 -> (t._2 + 1)) should === (false) }
+  }
+
+  test("order") {
+    forAll { t: (Int, Int) =>
+      val u = t.swap
+      Order[(Int, Int)].compare(t, u) should === (scala.math.Ordering[(Int, Int)].compare(t, u))
+    }
+  }
+
   test("show") {
     (1, 2).show should === ("(1,2)")
 


### PR DESCRIPTION
Before this fix:

```
scala> import cats.implicits._
import cats.implicits._

scala> (1 -> 2) === (1 -> 3)
res0: Boolean = true

scala> import scala.reflect.runtime.universe._
import scala.reflect.runtime.universe._

scala> showCode(reify { (1 -> 2) === (1 -> 3) }.tree)
res1: String = implicits.eqSyntax(Predef.ArrowAssoc(1).->(2))(implicits.tuple2Order(implicits.intOrder, implicits.intOrder)).===(Predef.ArrowAssoc(1).->(3))
```

This is because we pick up the `Order[Tuple2[..]]` instance, which is erroneously defined like this:

```
  implicit def tuple2Order[A0, A1](implicit A0: Order[A0], A1: Order[A1]): Order[(A0, A1)] =
    new Order[(A0, A1)] {
      def compare(x: (A0, A1), y: (A0, A1)): Int =
        A0.compare(x._1, y._1)
    }
```

I think we should probably publish a 0.6.1 with this fix too as it is really nasty -- code compiles but values end up being report equal which aren't.

/cc @non 