### PR TITLE
Make Free.foldMap stack-safe.

### DIFF
--- a/free/src/test/scala/cats/free/FreeTests.scala
+++ b/free/src/test/scala/cats/free/FreeTests.scala
@@ -51,7 +51,7 @@ class FreeTests extends CatsSuite {
     fa should === (Free.pure[Option, Int](n))
   }
 
-  ignore("foldMap is stack safe") {
+  test("foldMap is stack safe") {
     trait FTestApi[A]
     case class TB(i: Int) extends FTestApi[Int]
 


### PR DESCRIPTION
Fixes #721.

The fix is now possible by strengthening constraints on the target monad from `Monad` to `MonadRec`.

This is not binary compatible, and will not be source compatible for users that used this with a non-`MonadRec` monad.