### PR TITLE
Make the usage of kind projections more consistent.

### DIFF
--- a/core/src/main/scala/cats/Alternative.scala
+++ b/core/src/main/scala/cats/Alternative.scala
@@ -3,7 +3,7 @@ package cats
 import simulacrum.typeclass
 
 @typeclass trait Alternative[F[_]] extends Applicative[F] with MonoidK[F] { self =>
-  override def compose[G[_]: Applicative]: Alternative[Lambda[A => F[G[A]]]] =
+  override def compose[G[_]: Applicative]: Alternative[λ[α => F[G[α]]]] =
     new ComposedAlternative[F, G] {
       val F = self
       val G = Applicative[G]

--- a/core/src/main/scala/cats/Applicative.scala
+++ b/core/src/main/scala/cats/Applicative.scala
@@ -44,7 +44,7 @@ import simulacrum.typeclass
   def sequence[G[_], A](as: G[F[A]])(implicit G: Traverse[G]): F[G[A]] =
     G.sequence(as)(this)
 
-  def compose[G[_]: Applicative]: Applicative[Lambda[A => F[G[A]]]] =
+  def compose[G[_]: Applicative]: Applicative[λ[α => F[G[α]]]] =
     new ComposedApplicative[F, G] {
       val F = self
       val G = Applicative[G]

--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -58,7 +58,7 @@ trait Apply[F[_]] extends Functor[F] with Cartesian[F] with ApplyArityFunctions[
   def map2Eval[A, B, Z](fa: F[A], fb: Eval[F[B]])(f: (A, B) => Z): Eval[F[Z]] =
     fb.map(fb => map2(fa, fb)(f))
 
-  def compose[G[_]: Apply]: Apply[Lambda[A => F[G[A]]]] =
+  def compose[G[_]: Apply]: Apply[λ[α => F[G[α]]]] =
     new ComposedApply[F, G] {
       val F = self
       val G = Apply[G]

--- a/core/src/main/scala/cats/Bifoldable.scala
+++ b/core/src/main/scala/cats/Bifoldable.scala
@@ -17,7 +17,7 @@ trait Bifoldable[F[_, _]] extends Any with Serializable { self =>
       (c: C, b: B) => C.combine(c, g(b))
     )
 
-  def compose[G[_, _]](implicit ev: Bifoldable[G]): Bifoldable[Lambda[(A, B) => F[G[A, B], G[A, B]]]] =
+  def compose[G[_, _]](implicit ev: Bifoldable[G]): Bifoldable[λ[(α, β) => F[G[α, β], G[α, β]]]] =
     new CompositeBifoldable[F, G] {
       val F = self
       val G = ev
@@ -28,7 +28,7 @@ object Bifoldable {
   def apply[F[_, _]](implicit F: Bifoldable[F]): Bifoldable[F] = F
 }
 
-trait CompositeBifoldable[F[_, _], G[_, _]] extends Bifoldable[Lambda[(A, B) => F[G[A, B], G[A, B]]]] {
+trait CompositeBifoldable[F[_, _], G[_, _]] extends Bifoldable[λ[(α, β) => F[G[α, β], G[α, β]]]] {
   implicit def F: Bifoldable[F]
   implicit def G: Bifoldable[G]
 

--- a/core/src/main/scala/cats/Bitraverse.scala
+++ b/core/src/main/scala/cats/Bitraverse.scala
@@ -14,7 +14,7 @@ trait Bitraverse[F[_, _]] extends Bifoldable[F] with Bifunctor[F] { self =>
     bitraverse(fab)(identity, identity)
 
   /** If F and G are both [[cats.Bitraverse]] then so is their composition F[G[_, _], G[_, _]] */
-  def compose[G[_, _]](implicit ev: Bitraverse[G]): Bitraverse[Lambda[(A, B) => F[G[A, B], G[A, B]]]] =
+  def compose[G[_, _]](implicit ev: Bitraverse[G]): Bitraverse[λ[(α, β) => F[G[α, β], G[α, β]]]] =
     new CompositeBitraverse[F, G] {
       val F = self
       val G = ev
@@ -29,7 +29,7 @@ object Bitraverse {
 }
 
 trait CompositeBitraverse[F[_, _], G[_, _]]
-    extends Bitraverse[Lambda[(A, B) => F[G[A, B], G[A, B]]]]
+    extends Bitraverse[λ[(α, β) => F[G[α, β], G[α, β]]]]
     with    CompositeBifoldable[F, G] {
   def F: Bitraverse[F]
   def G: Bitraverse[G]

--- a/core/src/main/scala/cats/Composed.scala
+++ b/core/src/main/scala/cats/Composed.scala
@@ -2,7 +2,7 @@ package cats
 
 import cats.functor._
 
-private[cats] trait ComposedInvariant[F[_], G[_]] extends Invariant[Lambda[A => F[G[A]]]] { outer =>
+private[cats] trait ComposedInvariant[F[_], G[_]] extends Invariant[λ[α => F[G[α]]]] { outer =>
   def F: Invariant[F]
   def G: Invariant[G]
 
@@ -10,7 +10,7 @@ private[cats] trait ComposedInvariant[F[_], G[_]] extends Invariant[Lambda[A => 
     F.imap(fga)(ga => G.imap(ga)(f)(g))(gb => G.imap(gb)(g)(f))
 }
 
-private[cats] trait ComposedFunctor[F[_], G[_]] extends Functor[Lambda[A => F[G[A]]]] with ComposedInvariant[F, G] { outer =>
+private[cats] trait ComposedFunctor[F[_], G[_]] extends Functor[λ[α => F[G[α]]]] with ComposedInvariant[F, G] { outer =>
   def F: Functor[F]
   def G: Functor[G]
 
@@ -18,7 +18,7 @@ private[cats] trait ComposedFunctor[F[_], G[_]] extends Functor[Lambda[A => F[G[
     F.map(fga)(ga => G.map(ga)(f))
 }
 
-private[cats] trait ComposedApply[F[_], G[_]] extends Apply[Lambda[A => F[G[A]]]] with ComposedFunctor[F, G] { outer =>
+private[cats] trait ComposedApply[F[_], G[_]] extends Apply[λ[α => F[G[α]]]] with ComposedFunctor[F, G] { outer =>
   def F: Apply[F]
   def G: Apply[G]
 
@@ -29,30 +29,30 @@ private[cats] trait ComposedApply[F[_], G[_]] extends Apply[Lambda[A => F[G[A]]]
     F.map2(fga, fgb)(G.product)
 }
 
-private[cats] trait ComposedApplicative[F[_], G[_]] extends Applicative[Lambda[A => F[G[A]]]] with ComposedApply[F, G] { outer =>
+private[cats] trait ComposedApplicative[F[_], G[_]] extends Applicative[λ[α => F[G[α]]]] with ComposedApply[F, G] { outer =>
   def F: Applicative[F]
   def G: Applicative[G]
 
   override def pure[A](x: A): F[G[A]] = F.pure(G.pure(x))
 }
 
-private[cats] trait ComposedSemigroupK[F[_], G[_]] extends SemigroupK[Lambda[A => F[G[A]]]] { outer =>
+private[cats] trait ComposedSemigroupK[F[_], G[_]] extends SemigroupK[λ[α => F[G[α]]]] { outer =>
   def F: SemigroupK[F]
 
   override def combineK[A](x: F[G[A]], y: F[G[A]]): F[G[A]] = F.combineK(x, y)
 }
 
-private[cats] trait ComposedMonoidK[F[_], G[_]] extends MonoidK[Lambda[A => F[G[A]]]] with ComposedSemigroupK[F, G] { outer =>
+private[cats] trait ComposedMonoidK[F[_], G[_]] extends MonoidK[λ[α => F[G[α]]]] with ComposedSemigroupK[F, G] { outer =>
   def F: MonoidK[F]
 
   override def empty[A]: F[G[A]] = F.empty
 }
 
-private[cats] trait ComposedAlternative[F[_], G[_]] extends Alternative[Lambda[A => F[G[A]]]] with ComposedApplicative[F, G] with ComposedMonoidK[F, G] { outer =>
+private[cats] trait ComposedAlternative[F[_], G[_]] extends Alternative[λ[α => F[G[α]]]] with ComposedApplicative[F, G] with ComposedMonoidK[F, G] { outer =>
   def F: Alternative[F]
 }
 
-private[cats] trait ComposedFoldable[F[_], G[_]] extends Foldable[Lambda[A => F[G[A]]]] { outer =>
+private[cats] trait ComposedFoldable[F[_], G[_]] extends Foldable[λ[α => F[G[α]]]] { outer =>
   def F: Foldable[F]
   def G: Foldable[G]
 
@@ -63,7 +63,7 @@ private[cats] trait ComposedFoldable[F[_], G[_]] extends Foldable[Lambda[A => F[
     F.foldRight(fga, lb)((ga, lb) => G.foldRight(ga, lb)(f))
 }
 
-private[cats] trait ComposedTraverse[F[_], G[_]] extends Traverse[Lambda[A => F[G[A]]]] with ComposedFoldable[F, G] with ComposedFunctor[F, G] { outer =>
+private[cats] trait ComposedTraverse[F[_], G[_]] extends Traverse[λ[α => F[G[α]]]] with ComposedFoldable[F, G] with ComposedFunctor[F, G] { outer =>
   def F: Traverse[F]
   def G: Traverse[G]
 
@@ -71,7 +71,7 @@ private[cats] trait ComposedTraverse[F[_], G[_]] extends Traverse[Lambda[A => F[
     F.traverse(fga)(ga => G.traverse(ga)(f))
 }
 
-private[cats] trait ComposedReducible[F[_], G[_]] extends Reducible[Lambda[A => F[G[A]]]] with ComposedFoldable[F, G] { outer =>
+private[cats] trait ComposedReducible[F[_], G[_]] extends Reducible[λ[α => F[G[α]]]] with ComposedFoldable[F, G] { outer =>
   def F: Reducible[F]
   def G: Reducible[G]
 
@@ -90,7 +90,7 @@ private[cats] trait ComposedReducible[F[_], G[_]] extends Reducible[Lambda[A => 
   }
 }
 
-private[cats] trait ComposedContravariant[F[_], G[_]] extends Functor[Lambda[A => F[G[A]]]] { outer =>
+private[cats] trait ComposedContravariant[F[_], G[_]] extends Functor[λ[α => F[G[α]]]] { outer =>
   def F: Contravariant[F]
   def G: Contravariant[G]
 
@@ -98,7 +98,7 @@ private[cats] trait ComposedContravariant[F[_], G[_]] extends Functor[Lambda[A =
     F.contramap(fga)(gb => G.contramap(gb)(f))
 }
 
-private[cats] trait ComposedContravariantCovariant[F[_], G[_]] extends Contravariant[Lambda[A => F[G[A]]]] { outer =>
+private[cats] trait ComposedContravariantCovariant[F[_], G[_]] extends Contravariant[λ[α => F[G[α]]]] { outer =>
   def F: Contravariant[F]
   def G: Functor[G]
 
@@ -106,7 +106,7 @@ private[cats] trait ComposedContravariantCovariant[F[_], G[_]] extends Contravar
     F.contramap(fga)(gb => G.map(gb)(f))
 }
 
-private[cats] trait ComposedCovariantContravariant[F[_], G[_]] extends Contravariant[Lambda[A => F[G[A]]]] { outer =>
+private[cats] trait ComposedCovariantContravariant[F[_], G[_]] extends Contravariant[λ[α => F[G[α]]]] { outer =>
   def F: Functor[F]
   def G: Contravariant[G]
 
@@ -114,7 +114,7 @@ private[cats] trait ComposedCovariantContravariant[F[_], G[_]] extends Contravar
     F.map(fga)(ga => G.contramap(ga)(f))
 }
 
-private[cats] trait ComposedInvariantCovariant[F[_], G[_]] extends Invariant[Lambda[A => F[G[A]]]] { outer =>
+private[cats] trait ComposedInvariantCovariant[F[_], G[_]] extends Invariant[λ[α => F[G[α]]]] { outer =>
   def F: Invariant[F]
   def G: Functor[G]
 
@@ -122,7 +122,7 @@ private[cats] trait ComposedInvariantCovariant[F[_], G[_]] extends Invariant[Lam
     F.imap(fga)(ga => G.map(ga)(f))(gb => G.map(gb)(g))
 }
 
-private[cats] trait ComposedInvariantContravariant[F[_], G[_]] extends Invariant[Lambda[A => F[G[A]]]] { outer =>
+private[cats] trait ComposedInvariantContravariant[F[_], G[_]] extends Invariant[λ[α => F[G[α]]]] { outer =>
   def F: Invariant[F]
   def G: Contravariant[G]
 

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -269,7 +269,7 @@ import simulacrum.typeclass
   def nonEmpty[A](fa: F[A]): Boolean =
     !isEmpty(fa)
 
-  def compose[G[_]: Foldable]: Foldable[Lambda[A => F[G[A]]]] =
+  def compose[G[_]: Foldable]: Foldable[λ[α => F[G[α]]]] =
     new ComposedFoldable[F, G] {
       val F = self
       val G = Foldable[G]

--- a/core/src/main/scala/cats/Functor.scala
+++ b/core/src/main/scala/cats/Functor.scala
@@ -39,13 +39,13 @@ import simulacrum.typeclass
    */
   def as[A, B](fa: F[A], b: B): F[B] = map(fa)(_ => b)
 
-  def compose[G[_]: Functor]: Functor[Lambda[A => F[G[A]]]] =
+  def compose[G[_]: Functor]: Functor[λ[α => F[G[α]]]] =
     new ComposedFunctor[F, G] {
       val F = self
       val G = Functor[G]
     }
 
-  override def composeContravariant[G[_]: Contravariant]: Contravariant[Lambda[A => F[G[A]]]] =
+  override def composeContravariant[G[_]: Contravariant]: Contravariant[λ[α => F[G[α]]]] =
     new ComposedCovariantContravariant[F, G] {
       val F = self
       val G = Contravariant[G]

--- a/core/src/main/scala/cats/MonoidK.scala
+++ b/core/src/main/scala/cats/MonoidK.scala
@@ -38,7 +38,7 @@ import simulacrum.typeclass
       def combine(x: F[A], y: F[A]): F[A] = self.combineK(x, y)
     }
 
-  override def compose[G[_]]: MonoidK[Lambda[A => F[G[A]]]] =
+  override def compose[G[_]]: MonoidK[λ[α => F[G[α]]]] =
     new ComposedMonoidK[F, G] {
       val F = self
     }

--- a/core/src/main/scala/cats/Reducible.scala
+++ b/core/src/main/scala/cats/Reducible.scala
@@ -107,7 +107,7 @@ import simulacrum.typeclass
   def sequence1_[G[_], A](fga: F[G[A]])(implicit G: Apply[G]): G[Unit] =
     G.map(reduceLeft(fga)((x, y) => G.map2(x, y)((_, b) => b)))(_ => ())
 
-  def compose[G[_]: Reducible]: Reducible[Lambda[A => F[G[A]]]] =
+  def compose[G[_]: Reducible]: Reducible[λ[α => F[G[α]]]] =
     new ComposedReducible[F, G] {
       val F = self
       val G = Reducible[G]

--- a/core/src/main/scala/cats/SemigroupK.scala
+++ b/core/src/main/scala/cats/SemigroupK.scala
@@ -36,7 +36,7 @@ import simulacrum.typeclass
       def combine(x: F[A], y: F[A]): F[A] = self.combineK(x, y)
     }
 
-  def compose[G[_]]: SemigroupK[Lambda[A => F[G[A]]]] =
+  def compose[G[_]]: SemigroupK[λ[α => F[G[α]]]] =
     new ComposedSemigroupK[F, G] {
       val F = self
     }

--- a/core/src/main/scala/cats/Traverse.scala
+++ b/core/src/main/scala/cats/Traverse.scala
@@ -49,7 +49,7 @@ import simulacrum.typeclass
   def sequenceU[GA](fga: F[GA])(implicit U: Unapply[Applicative,GA]): U.M[F[U.A]] =
     traverse(fga)(U.subst)(U.TC)
 
-  def compose[G[_]: Traverse]: Traverse[Lambda[A => F[G[A]]]] =
+  def compose[G[_]: Traverse]: Traverse[λ[α => F[G[α]]]] =
     new ComposedTraverse[F, G] {
       val F = self
       val G = Traverse[G]

--- a/core/src/main/scala/cats/data/Cokleisli.scala
+++ b/core/src/main/scala/cats/data/Cokleisli.scala
@@ -58,7 +58,7 @@ private[data] sealed abstract class CokleisliInstances extends CokleisliInstance
       fa.map(f)
   }
 
-  implicit def catsDataMonoidKForCokleisli[F[_]](implicit ev: Comonad[F]): MonoidK[Lambda[A => Cokleisli[F, A, A]]] =
+  implicit def catsDataMonoidKForCokleisli[F[_]](implicit ev: Comonad[F]): MonoidK[λ[α => Cokleisli[F, α, α]]] =
     new CokleisliMonoidK[F] { def F: Comonad[F] = ev }
 }
 
@@ -69,7 +69,7 @@ private[data] sealed abstract class CokleisliInstances0 {
   implicit def catsDataProfunctorForCokleisli[F[_]](implicit ev: Functor[F]): Profunctor[Cokleisli[F, ?, ?]] =
     new CokleisliProfunctor[F] { def F: Functor[F] = ev }
 
-  implicit def catsDataSemigroupKForCokleisli[F[_]](implicit ev: CoflatMap[F]): SemigroupK[Lambda[A => Cokleisli[F, A, A]]] =
+  implicit def catsDataSemigroupKForCokleisli[F[_]](implicit ev: CoflatMap[F]): SemigroupK[λ[α => Cokleisli[F, α, α]]] =
     new CokleisliSemigroupK[F] { def F: CoflatMap[F] = ev }
 }
 
@@ -118,13 +118,13 @@ private trait CokleisliProfunctor[F[_]] extends Profunctor[Cokleisli[F, ?, ?]] {
     fab.map(f)
 }
 
-private trait CokleisliSemigroupK[F[_]] extends SemigroupK[Lambda[A => Cokleisli[F, A, A]]] {
+private trait CokleisliSemigroupK[F[_]] extends SemigroupK[λ[α => Cokleisli[F, α, α]]] {
   implicit def F: CoflatMap[F]
 
   def combineK[A](a: Cokleisli[F, A, A], b: Cokleisli[F, A, A]): Cokleisli[F, A, A] = a compose b
 }
 
-private trait CokleisliMonoidK[F[_]] extends MonoidK[Lambda[A => Cokleisli[F, A, A]]] with CokleisliSemigroupK[F] {
+private trait CokleisliMonoidK[F[_]] extends MonoidK[λ[α => Cokleisli[F, α, α]]] with CokleisliSemigroupK[F] {
   implicit def F: Comonad[F]
 
   def empty[A]: Cokleisli[F, A, A] = Cokleisli(F.extract[A])

--- a/core/src/main/scala/cats/data/Func.scala
+++ b/core/src/main/scala/cats/data/Func.scala
@@ -32,33 +32,33 @@ object Func extends FuncInstances {
 }
 
 private[data] abstract class FuncInstances extends FuncInstances0 {
-  implicit def catsDataApplicativeForFunc[F[_], C](implicit FF: Applicative[F]): Applicative[Lambda[X => Func[F, C, X]]] =
+  implicit def catsDataApplicativeForFunc[F[_], C](implicit FF: Applicative[F]): Applicative[λ[α => Func[F, C, α]]] =
     new FuncApplicative[F, C] {
       def F: Applicative[F] = FF
     }
 }
 
 private[data] abstract class FuncInstances0 extends FuncInstances1 {
-  implicit def catsDataApplyForFunc[F[_], C](implicit FF: Apply[F]): Apply[Lambda[X => Func[F, C, X]]] =
+  implicit def catsDataApplyForFunc[F[_], C](implicit FF: Apply[F]): Apply[λ[α => Func[F, C, α]]] =
     new FuncApply[F, C] {
       def F: Apply[F] = FF
     }
 }
 
 private[data] abstract class FuncInstances1 {
-  implicit def catsDataFunctorForFunc[F[_], C](implicit FF: Functor[F]): Functor[Lambda[X => Func[F, C, X]]] =
+  implicit def catsDataFunctorForFunc[F[_], C](implicit FF: Functor[F]): Functor[λ[α => Func[F, C, α]]] =
     new FuncFunctor[F, C] {
       def F: Functor[F] = FF
     }
 }
 
-sealed trait FuncFunctor[F[_], C] extends Functor[Lambda[X => Func[F, C, X]]] {
+sealed trait FuncFunctor[F[_], C] extends Functor[λ[α => Func[F, C, α]]] {
   def F: Functor[F]
   override def map[A, B](fa: Func[F, C, A])(f: A => B): Func[F, C, B] =
     fa.map(f)(F)
 }
 
-sealed trait FuncApply[F[_], C] extends Apply[Lambda[X => Func[F, C, X]]] with FuncFunctor[F, C] {
+sealed trait FuncApply[F[_], C] extends Apply[λ[α => Func[F, C, α]]] with FuncFunctor[F, C] {
   def F: Apply[F]
   def ap[A, B](f: Func[F, C, A => B])(fa: Func[F, C, A]): Func[F, C, B] =
     Func.func(c => F.ap(f.run(c))(fa.run(c)))
@@ -66,7 +66,7 @@ sealed trait FuncApply[F[_], C] extends Apply[Lambda[X => Func[F, C, X]]] with F
     Func.func(c => F.product(fa.run(c), fb.run(c)))
 }
 
-sealed trait FuncApplicative[F[_], C] extends Applicative[Lambda[X => Func[F, C, X]]] with FuncApply[F, C] {
+sealed trait FuncApplicative[F[_], C] extends Applicative[λ[α => Func[F, C, α]]] with FuncApply[F, C] {
   def F: Applicative[F]
   def pure[A](a: A): Func[F, C, A] =
     Func.func(c => F.pure(a))
@@ -78,11 +78,11 @@ sealed trait FuncApplicative[F[_], C] extends Applicative[Lambda[X => Func[F, C,
 sealed abstract class AppFunc[F[_], A, B] extends Func[F, A, B] { self =>
   def F: Applicative[F]
 
-  def product[G[_]](g: AppFunc[G, A, B]): AppFunc[Lambda[X => Prod[F, G, X]], A, B] =
+  def product[G[_]](g: AppFunc[G, A, B]): AppFunc[λ[α => Prod[F, G, α]], A, B] =
     {
       implicit val FF: Applicative[F] = self.F
       implicit val GG: Applicative[G] = g.F
-      Func.appFunc[Lambda[X => Prod[F, G, X]], A, B]{
+      Func.appFunc[λ[α => Prod[F, G, α]], A, B]{
         a: A => Prod(self.run(a), g.run(a))
       }
     }
@@ -97,11 +97,10 @@ sealed abstract class AppFunc[F[_], A, B] extends Func[F, A, B] { self =>
   def andThen[G[_], C](g: AppFunc[G, B, C]): AppFunc[Nested[F, G, ?], A, C] =
     g.compose(self)
 
-  def map[C](f: B => C): AppFunc[F, A, C] =
-    {
-      implicit val FF: Applicative[F] = self.F
-      Func.appFunc(a => F.map(self.run(a))(f))
-    }
+  def map[C](f: B => C): AppFunc[F, A, C] = {
+    implicit val FF: Applicative[F] = self.F
+    Func.appFunc(a => F.map(self.run(a))(f))
+  }
 
   def traverse[G[_]](ga: G[A])(implicit GG: Traverse[G]): F[G[B]] =
     GG.traverse(ga)(self.run)(F)
@@ -110,13 +109,13 @@ sealed abstract class AppFunc[F[_], A, B] extends Func[F, A, B] { self =>
 object AppFunc extends AppFuncInstances
 
 private[data] abstract class AppFuncInstances {
-  implicit def appFuncApplicative[F[_], C](implicit FF: Applicative[F]): Applicative[Lambda[X => AppFunc[F, C, X]]] =
+  implicit def appFuncApplicative[F[_], C](implicit FF: Applicative[F]): Applicative[λ[α => AppFunc[F, C, α]]] =
     new AppFuncApplicative[F, C] {
       def F: Applicative[F] = FF
     }
 }
 
-private[data] sealed trait AppFuncApplicative[F[_], C] extends Applicative[Lambda[X => AppFunc[F, C, X]]] {
+private[data] sealed trait AppFuncApplicative[F[_], C] extends Applicative[λ[α => AppFunc[F, C, α]]] {
   def F: Applicative[F]
   override def map[A, B](fa: AppFunc[F, C, A])(f: A => B): AppFunc[F, C, B] =
     fa.map(f)

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -82,10 +82,10 @@ private[data] sealed abstract class KleisliInstances extends KleisliInstances0 {
   implicit def catsDataMonoidForKleisli[F[_], A, B](implicit M: Monoid[F[B]]): Monoid[Kleisli[F, A, B]] =
     new KleisliMonoid[F, A, B] { def FB: Monoid[F[B]] = M }
 
-  implicit def catsDataMonoidKForKleisli[F[_]](implicit M: Monad[F]): MonoidK[Lambda[A => Kleisli[F, A, A]]] =
+  implicit def catsDataMonoidKForKleisli[F[_]](implicit M: Monad[F]): MonoidK[λ[α => Kleisli[F, α, α]]] =
     new KleisliMonoidK[F] { def F: Monad[F] = M }
 
-  implicit val catsDataMonoidKForKleisliId: MonoidK[Lambda[A => Kleisli[Id, A, A]]] =
+  implicit val catsDataMonoidKForKleisliId: MonoidK[λ[α => Kleisli[Id, α, α]]] =
     catsDataMonoidKForKleisli[Id]
 
   implicit def catsDataArrowForKleisli[F[_]](implicit ev: Monad[F]): Arrow[Kleisli[F, ?, ?]] =
@@ -146,7 +146,7 @@ private[data] sealed abstract class KleisliInstances0 extends KleisliInstances1 
   implicit def catsDataSemigroupForKleisli[F[_], A, B](implicit M: Semigroup[F[B]]): Semigroup[Kleisli[F, A, B]] =
     new KleisliSemigroup[F, A, B] { def FB: Semigroup[F[B]] = M }
 
-  implicit def catsDataSemigroupKForKleisli[F[_]](implicit ev: FlatMap[F]): SemigroupK[Lambda[A => Kleisli[F, A, A]]] =
+  implicit def catsDataSemigroupKForKleisli[F[_]](implicit ev: FlatMap[F]): SemigroupK[λ[α => Kleisli[F, α, α]]] =
     new KleisliSemigroupK[F] { def F: FlatMap[F] = ev }
 
 }
@@ -252,13 +252,13 @@ private trait KleisliMonoid[F[_], A, B] extends Monoid[Kleisli[F, A, B]] with Kl
   override def empty = Kleisli[F, A, B](a => FB.empty)
 }
 
-private trait KleisliSemigroupK[F[_]] extends SemigroupK[Lambda[A => Kleisli[F, A, A]]] {
+private trait KleisliSemigroupK[F[_]] extends SemigroupK[λ[α => Kleisli[F, α, α]]] {
   implicit def F: FlatMap[F]
 
   override def combineK[A](a: Kleisli[F, A, A], b: Kleisli[F, A, A]): Kleisli[F, A, A] = a compose b
 }
 
-private trait KleisliMonoidK[F[_]] extends MonoidK[Lambda[A => Kleisli[F, A, A]]] with KleisliSemigroupK[F] {
+private trait KleisliMonoidK[F[_]] extends MonoidK[λ[α => Kleisli[F, α, α]]] with KleisliSemigroupK[F] {
   implicit def F: Monad[F]
 
   override def empty[A]: Kleisli[F, A, A] = Kleisli(F.pure[A])

--- a/core/src/main/scala/cats/data/Prod.scala
+++ b/core/src/main/scala/cats/data/Prod.scala
@@ -11,7 +11,7 @@ final case class Prod[F[_], G[_], A](first: F[A], second: G[A])
 object Prod extends ProdInstances
 
 private[data] sealed abstract class ProdInstances extends ProdInstances0 {
-  implicit def catsDataAlternativeForProd[F[_], G[_]](implicit FF: Alternative[F], GG: Alternative[G]): Alternative[Lambda[X => Prod[F, G, X]]] = new ProdAlternative[F, G] {
+  implicit def catsDataAlternativeForProd[F[_], G[_]](implicit FF: Alternative[F], GG: Alternative[G]): Alternative[λ[α => Prod[F, G, α]]] = new ProdAlternative[F, G] {
     def F: Alternative[F] = FF
     def G: Alternative[G] = GG
   }
@@ -23,47 +23,47 @@ private[data] sealed abstract class ProdInstances extends ProdInstances0 {
 }
 
 private[data] sealed abstract class ProdInstances0 extends ProdInstances1 {
-  implicit def catsDataMonoidKForProd[F[_], G[_]](implicit FF: MonoidK[F], GG: MonoidK[G]): MonoidK[Lambda[X => Prod[F, G, X]]] = new ProdMonoidK[F, G] {
+  implicit def catsDataMonoidKForProd[F[_], G[_]](implicit FF: MonoidK[F], GG: MonoidK[G]): MonoidK[λ[α => Prod[F, G, α]]] = new ProdMonoidK[F, G] {
     def F: MonoidK[F] = FF
     def G: MonoidK[G] = GG
   }
 }
 
 private[data] sealed abstract class ProdInstances1 extends ProdInstances2 {
-  implicit def catsDataSemigroupKForProd[F[_], G[_]](implicit FF: SemigroupK[F], GG: SemigroupK[G]): SemigroupK[Lambda[X => Prod[F, G, X]]] = new ProdSemigroupK[F, G] {
+  implicit def catsDataSemigroupKForProd[F[_], G[_]](implicit FF: SemigroupK[F], GG: SemigroupK[G]): SemigroupK[λ[α => Prod[F, G, α]]] = new ProdSemigroupK[F, G] {
     def F: SemigroupK[F] = FF
     def G: SemigroupK[G] = GG
   }
 }
 
 private[data] sealed abstract class ProdInstances2 extends ProdInstances3 {
-  implicit def catsDataApplicativeForProd[F[_], G[_]](implicit FF: Applicative[F], GG: Applicative[G]): Applicative[Lambda[X => Prod[F, G, X]]] = new ProdApplicative[F, G] {
+  implicit def catsDataApplicativeForProd[F[_], G[_]](implicit FF: Applicative[F], GG: Applicative[G]): Applicative[λ[α => Prod[F, G, α]]] = new ProdApplicative[F, G] {
     def F: Applicative[F] = FF
     def G: Applicative[G] = GG
   }
 }
 
 private[data] sealed abstract class ProdInstances3 extends ProdInstances4 {
-  implicit def catsDataApplyForProd[F[_], G[_]](implicit FF: Apply[F], GG: Apply[G]): Apply[Lambda[X => Prod[F, G, X]]] = new ProdApply[F, G] {
+  implicit def catsDataApplyForProd[F[_], G[_]](implicit FF: Apply[F], GG: Apply[G]): Apply[λ[α => Prod[F, G, α]]] = new ProdApply[F, G] {
     def F: Apply[F] = FF
     def G: Apply[G] = GG
   }
 }
 
 private[data] sealed abstract class ProdInstances4 {
-  implicit def catsDataFunctorForProd[F[_], G[_]](implicit FF: Functor[F], GG: Functor[G]): Functor[Lambda[X => Prod[F, G, X]]] = new ProdFunctor[F, G] {
+  implicit def catsDataFunctorForProd[F[_], G[_]](implicit FF: Functor[F], GG: Functor[G]): Functor[λ[α => Prod[F, G, α]]] = new ProdFunctor[F, G] {
     def F: Functor[F] = FF
     def G: Functor[G] = GG
   }
 }
 
-sealed trait ProdFunctor[F[_], G[_]] extends Functor[Lambda[X => Prod[F, G, X]]] {
+sealed trait ProdFunctor[F[_], G[_]] extends Functor[λ[α => Prod[F, G, α]]] {
   def F: Functor[F]
   def G: Functor[G]
   override def map[A, B](fa: Prod[F, G, A])(f: A => B): Prod[F, G, B] = Prod(F.map(fa.first)(f), G.map(fa.second)(f))
 }
 
-sealed trait ProdApply[F[_], G[_]] extends Apply[Lambda[X => Prod[F, G, X]]] with ProdFunctor[F, G] {
+sealed trait ProdApply[F[_], G[_]] extends Apply[λ[α => Prod[F, G, α]]] with ProdFunctor[F, G] {
   def F: Apply[F]
   def G: Apply[G]
   def ap[A, B](f: Prod[F, G, A => B])(fa: Prod[F, G, A]): Prod[F, G, B] =
@@ -72,27 +72,27 @@ sealed trait ProdApply[F[_], G[_]] extends Apply[Lambda[X => Prod[F, G, X]]] wit
     Prod(F.product(fa.first, fb.first), G.product(fa.second, fb.second))
 }
 
-sealed trait ProdApplicative[F[_], G[_]] extends Applicative[Lambda[X => Prod[F, G, X]]] with ProdApply[F, G] {
+sealed trait ProdApplicative[F[_], G[_]] extends Applicative[λ[α => Prod[F, G, α]]] with ProdApply[F, G] {
   def F: Applicative[F]
   def G: Applicative[G]
   def pure[A](a: A): Prod[F, G, A] = Prod(F.pure(a), G.pure(a))
 }
 
-sealed trait ProdSemigroupK[F[_], G[_]] extends SemigroupK[Lambda[X => Prod[F, G, X]]] {
+sealed trait ProdSemigroupK[F[_], G[_]] extends SemigroupK[λ[α => Prod[F, G, α]]] {
   def F: SemigroupK[F]
   def G: SemigroupK[G]
   override def combineK[A](x: Prod[F, G, A], y: Prod[F, G, A]): Prod[F, G, A] =
     Prod(F.combineK(x.first, y.first), G.combineK(x.second, y.second))
 }
 
-sealed trait ProdMonoidK[F[_], G[_]] extends MonoidK[Lambda[X => Prod[F, G, X]]] with ProdSemigroupK[F, G] {
+sealed trait ProdMonoidK[F[_], G[_]] extends MonoidK[λ[α => Prod[F, G, α]]] with ProdSemigroupK[F, G] {
   def F: MonoidK[F]
   def G: MonoidK[G]
   override def empty[A]: Prod[F, G, A] =
     Prod(F.empty[A], G.empty[A])
 }
 
-sealed trait ProdAlternative[F[_], G[_]] extends Alternative[Lambda[X => Prod[F, G, X]]]
+sealed trait ProdAlternative[F[_], G[_]] extends Alternative[λ[α => Prod[F, G, α]]]
   with ProdApplicative[F, G] with ProdMonoidK[F, G] {
   def F: Alternative[F]
   def G: Alternative[G]

--- a/core/src/main/scala/cats/functor/Bifunctor.scala
+++ b/core/src/main/scala/cats/functor/Bifunctor.scala
@@ -25,7 +25,7 @@ trait Bifunctor[F[_, _]] extends Any with Serializable { self =>
   def rightMap[A,B,C](fab: F[A, B])(f: B => C): F[A,C] = bimap(fab)(identity, f)
 
   /** The composition of two Bifunctors is itself a Bifunctor */
-  def compose[G[_, _]](implicit G0: Bifunctor[G]): Bifunctor[Lambda[(A, B) => F[G[A, B], G[A, B]]]] =
+  def compose[G[_, _]](implicit G0: Bifunctor[G]): Bifunctor[λ[(α, β) => F[G[α, β], G[α, β]]]] =
     new CompositeBifunctor[F, G] {
       val F = self
       val G = G0
@@ -37,7 +37,7 @@ object Bifunctor {
 }
 
 trait CompositeBifunctor[F[_, _], G[_, _]]
-    extends Bifunctor[Lambda[(A, B) => F[G[A, B], G[A, B]]]] {
+    extends Bifunctor[λ[(A, B) => F[G[A, B], G[A, B]]]] {
   def F: Bifunctor[F]
   def G: Bifunctor[G]
 

--- a/core/src/main/scala/cats/functor/Contravariant.scala
+++ b/core/src/main/scala/cats/functor/Contravariant.scala
@@ -10,13 +10,13 @@ import simulacrum.typeclass
   def contramap[A, B](fa: F[A])(f: B => A): F[B]
   override def imap[A, B](fa: F[A])(f: A => B)(fi: B => A): F[B] = contramap(fa)(fi)
 
-  def compose[G[_]: Contravariant]: Functor[Lambda[A => F[G[A]]]] =
+  def compose[G[_]: Contravariant]: Functor[λ[α => F[G[α]]]] =
     new ComposedContravariant[F, G] {
       val F = self
       val G = Contravariant[G]
     }
 
-  override def composeFunctor[G[_]: Functor]: Contravariant[Lambda[A => F[G[A]]]] =
+  override def composeFunctor[G[_]: Functor]: Contravariant[λ[α => F[G[α]]]] =
     new ComposedContravariantCovariant[F, G] {
       val F = self
       val G = Functor[G]

--- a/core/src/main/scala/cats/functor/Invariant.scala
+++ b/core/src/main/scala/cats/functor/Invariant.scala
@@ -9,19 +9,19 @@ import simulacrum.typeclass
 @typeclass trait Invariant[F[_]] { self =>
   def imap[A, B](fa: F[A])(f: A => B)(g: B => A): F[B]
 
-  def compose[G[_]: Invariant]: Invariant[Lambda[A => F[G[A]]]] =
+  def compose[G[_]: Invariant]: Invariant[λ[α => F[G[α]]]] =
     new ComposedInvariant[F, G] {
       val F = self
       val G = Invariant[G]
     }
 
-  def composeFunctor[G[_]: Functor]: Invariant[Lambda[A => F[G[A]]]] =
+  def composeFunctor[G[_]: Functor]: Invariant[λ[α => F[G[α]]]] =
     new ComposedInvariantCovariant[F, G] {
       val F = self
       val G = Functor[G]
     }
 
-  def composeContravariant[G[_]: Contravariant]: Invariant[Lambda[A => F[G[A]]]] =
+  def composeContravariant[G[_]: Contravariant]: Invariant[λ[α => F[G[α]]]] =
     new ComposedInvariantContravariant[F, G] {
       val F = self
       val G = Contravariant[G]

--- a/core/src/main/scala/cats/std/function.scala
+++ b/core/src/main/scala/cats/std/function.scala
@@ -74,7 +74,7 @@ private[std] sealed trait Function1Instances extends Function1Instances0 {
   implicit def catsStdMonoidForFunction1[A,B](implicit M: Monoid[B]): Monoid[A => B] =
     new Function1Monoid[A, B] { def B: Monoid[B] = M }
 
-  implicit val catsStdMonoidKForFunction1: MonoidK[Lambda[A => A => A]] =
+  implicit val catsStdMonoidKForFunction1: MonoidK[λ[α => α => α]] =
     new Function1MonoidK {}
 }
 
@@ -82,7 +82,7 @@ private[std] sealed trait Function1Instances0 {
   implicit def catsStdSemigroupForFunction1[A,B](implicit S: Semigroup[B]): Semigroup[A => B] =
     new Function1Semigroup[A, B] { def B: Semigroup[B] = S }
 
-  implicit val catsStdSemigroupKForFunction1: SemigroupK[Lambda[A => A => A]] =
+  implicit val catsStdSemigroupKForFunction1: SemigroupK[λ[α => α => α]] =
     new Function1SemigroupK {}
 }
 
@@ -100,11 +100,11 @@ private[std] sealed trait Function1Monoid[A, B] extends Monoid[A => B] with Func
   override def empty: A => B = _ => B.empty
 }
 
-private[std] sealed trait Function1SemigroupK extends SemigroupK[Lambda[A => A => A]] {
+private[std] sealed trait Function1SemigroupK extends SemigroupK[λ[α => α => α]] {
   override def combineK[A](x: A => A, y: A => A): A => A = x compose y
 }
 
-private[std] sealed trait Function1MonoidK extends MonoidK[Lambda[A => A => A]] with Function1SemigroupK {
+private[std] sealed trait Function1MonoidK extends MonoidK[λ[α => α => α]] with Function1SemigroupK {
   override def empty[A]: A => A = identity[A]
 }
 

--- a/free/src/main/scala/cats/free/FreeApplicative.scala
+++ b/free/src/main/scala/cats/free/FreeApplicative.scala
@@ -27,7 +27,7 @@ sealed abstract class FreeApplicative[F[_], A] extends Product with Serializable
   /** Interprets/Runs the sequence of operations using the semantics of Applicative G
     * Tail recursive only if G provides tail recursive interpretation (ie G is FreeMonad)
     */
-  final def foldMap[G[_]](f: FunctionK[F,G])(implicit G: Applicative[G]): G[A] =
+  final def foldMap[G[_]](f: FunctionK[F, G])(implicit G: Applicative[G]): G[A] =
     this match {
       case Pure(a) => G.pure(a)
       case Ap(pivot, fn) => G.map2(f(pivot), fn.foldMap(f))((a, g) => g(a))
@@ -40,7 +40,7 @@ sealed abstract class FreeApplicative[F[_], A] extends Product with Serializable
     foldMap(FunctionK.id[F])
 
   /** Interpret this algebra into another FreeApplicative */
-  final def compile[G[_]](f: FunctionK[F,G]): FA[G, A] =
+  final def compile[G[_]](f: FunctionK[F, G]): FA[G, A] =
     foldMap[FA[G, ?]] {
       new FunctionK[F, FA[G, ?]] {
         def apply[B](fa: F[B]): FA[G, B] = lift(f(fa))
@@ -48,7 +48,7 @@ sealed abstract class FreeApplicative[F[_], A] extends Product with Serializable
     }
 
   /** Interpret this algebra into a Monoid */
-  final def analyze[M:Monoid](f: FunctionK[F,λ[α => M]]): M =
+  final def analyze[M:Monoid](f: FunctionK[F, λ[α => M]]): M =
     foldMap[Const[M, ?]](new (FunctionK[F,Const[M, ?]]) {
       def apply[X](x: F[X]): Const[M,X] = Const(f(x))
     }).getConst

--- a/free/src/test/scala/cats/free/FreeApplicativeTests.scala
+++ b/free/src/test/scala/cats/free/FreeApplicativeTests.scala
@@ -126,7 +126,7 @@ class FreeApplicativeTests extends CatsSuite {
 
     val z = Apply[Dsl].map2(x, y)((_, _) => ())
 
-    val asString: FunctionK[Id,λ[α => String]] = new FunctionK[Id,λ[α => String]] {
+    val asString: FunctionK[Id, λ[α => String]] = new FunctionK[Id, λ[α => String]] {
       def apply[A](a: A): String = a.toString
     }
 

--- a/tests/src/test/scala/cats/tests/CokleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/CokleisliTests.scala
@@ -59,15 +59,14 @@ class CokleisliTests extends SlowCatsSuite {
     {
       implicit val cokleisliMonoidK = Cokleisli.catsDataMonoidKForCokleisli[NonEmptyList]
       checkAll("Cokleisli[NonEmptyList, Int, Int]", MonoidKTests[CokleisliNELE].monoidK[Int])
-      checkAll("MonoidK[Lambda[A => Cokleisli[NonEmptyList, A, A]]]", SerializableTests.serializable(cokleisliMonoidK))
+      checkAll("MonoidK[λ[α => Cokleisli[NonEmptyList, α, α]]]", SerializableTests.serializable(cokleisliMonoidK))
     }
 
     {
       implicit val cokleisliSemigroupK = Cokleisli.catsDataSemigroupKForCokleisli[NonEmptyList]
       checkAll("Cokleisli[NonEmptyList, Int, Int]", SemigroupKTests[CokleisliNELE].semigroupK[Int])
-      checkAll("SemigroupK[Lambda[A => Cokleisli[NonEmptyList, A, A]]]", SerializableTests.serializable(cokleisliSemigroupK))
+      checkAll("SemigroupK[λ[α => Cokleisli[NonEmptyList, α, α]]]", SerializableTests.serializable(cokleisliSemigroupK))
     }
-
   }
 
   test("contramapValue with Id consistent with lmap"){

--- a/tests/src/test/scala/cats/tests/FunctionTests.scala
+++ b/tests/src/test/scala/cats/tests/FunctionTests.scala
@@ -36,9 +36,9 @@ class FunctionTests extends CatsSuite {
 
   checkAll("Function1[String, Int]", GroupLaws[Function1[String, Int]].monoid)
 
-  checkAll("Function1[Int, Int]", MonoidKTests[Lambda[A => A => A]].semigroupK[Int])
-  checkAll("SemigroupK[Lambda[A => A => A]", SerializableTests.serializable(catsStdSemigroupKForFunction1))
+  checkAll("Function1[Int, Int]", MonoidKTests[λ[α => α => α]].semigroupK[Int])
+  checkAll("SemigroupK[λ[α => α => α]", SerializableTests.serializable(catsStdSemigroupKForFunction1))
 
-  checkAll("Function1[Int, Int]", MonoidKTests[Lambda[A => A => A]].monoidK[Int])
-  checkAll("MonoidK[Lambda[A => A => A]", SerializableTests.serializable(catsStdMonoidKForFunction1))
+  checkAll("Function1[Int, Int]", MonoidKTests[λ[α => α => α]].monoidK[Int])
+  checkAll("MonoidK[λ[α => α => α]", SerializableTests.serializable(catsStdMonoidKForFunction1))
 }

--- a/tests/src/test/scala/cats/tests/KleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/KleisliTests.scala
@@ -93,14 +93,14 @@ class KleisliTests extends CatsSuite {
 
   {
     implicit val catsDataMonoidKForKleisli = Kleisli.catsDataMonoidKForKleisli[Option]
-    checkAll("Kleisli[Option, Int, Int]", MonoidKTests[Lambda[A => Kleisli[Option, A, A]]].monoidK[Int])
-    checkAll("MonoidK[Lambda[A => Kleisli[Option, A, A]]]", SerializableTests.serializable(catsDataMonoidKForKleisli))
+    checkAll("Kleisli[Option, Int, Int]", MonoidKTests[λ[α => Kleisli[Option, α, α]]].monoidK[Int])
+    checkAll("MonoidK[λ[α => Kleisli[Option, α, α]]]", SerializableTests.serializable(catsDataMonoidKForKleisli))
   }
 
   {
     implicit val catsDataSemigroupKForKleisli = Kleisli.catsDataSemigroupKForKleisli[Option]
-    checkAll("Kleisli[Option, Int, Int]", SemigroupKTests[Lambda[A => Kleisli[Option, A, A]]].semigroupK[Int])
-    checkAll("SemigroupK[Lambda[A => Kleisli[Option, A, A]]]", SerializableTests.serializable(catsDataSemigroupKForKleisli))
+    checkAll("Kleisli[Option, Int, Int]", SemigroupKTests[λ[α => Kleisli[Option, α, α]]].semigroupK[Int])
+    checkAll("SemigroupK[λ[α => Kleisli[Option, α, α]]]", SerializableTests.serializable(catsDataSemigroupKForKleisli))
   }
 
   checkAll("Kleisli[Option, ?, Int]", ContravariantTests[Kleisli[Option, ?, Int]].contravariant[Int, Int, Int])
@@ -155,14 +155,14 @@ class KleisliTests extends CatsSuite {
     Monad[Kleisli[List, Int, ?]]
     MonadReader[Kleisli[List, Int, ?], Int]
     Monoid[Kleisli[List, Int, String]]
-    MonoidK[Lambda[A => Kleisli[List, A, A]]]
+    MonoidK[λ[α => Kleisli[List, α, α]]]
     Arrow[Kleisli[List, ?, ?]]
     Choice[Kleisli[List, ?, ?]]
     Split[Kleisli[List, ?, ?]]
     Strong[Kleisli[List, ?, ?]]
     FlatMap[Kleisli[List, Int, ?]]
     Semigroup[Kleisli[List, Int, String]]
-    SemigroupK[Lambda[A => Kleisli[List, A, A]]]
+    SemigroupK[λ[α => Kleisli[List, α, α]]]
 
     // F is Id
     Functor[Kleisli[Id, Int, ?]]
@@ -171,14 +171,14 @@ class KleisliTests extends CatsSuite {
     Monad[Kleisli[Id, Int, ?]]
     MonadReader[Kleisli[Id, Int, ?], Int]
     Monoid[Kleisli[Id, Int, String]]
-    MonoidK[Lambda[A => Kleisli[Id, A, A]]]
+    MonoidK[λ[α => Kleisli[Id, α, α]]]
     Arrow[Kleisli[Id, ?, ?]]
     Choice[Kleisli[Id, ?, ?]]
     Split[Kleisli[Id, ?, ?]]
     Strong[Kleisli[Id, ?, ?]]
     FlatMap[Kleisli[Id, Int, ?]]
     Semigroup[Kleisli[Id, Int, String]]
-    SemigroupK[Lambda[A => Kleisli[Id, A, A]]]
+    SemigroupK[λ[α => Kleisli[Id, α, α]]]
 
     // using Reader alias instead of Kleisli with Id as F
     Functor[Reader[Int, ?]]
@@ -187,14 +187,14 @@ class KleisliTests extends CatsSuite {
     Monad[Reader[Int, ?]]
     MonadReader[Reader[Int, ?], Int]
     Monoid[Reader[Int, String]]
-    MonoidK[Lambda[A => Reader[A, A]]]
+    MonoidK[λ[α => Reader[α, α]]]
     Arrow[Reader[?, ?]]
     Choice[Reader[?, ?]]
     Split[Reader[?, ?]]
     Strong[Reader[?, ?]]
     FlatMap[Reader[Int, ?]]
     Semigroup[Reader[Int, String]]
-    SemigroupK[Lambda[A => Reader[A, A]]]
+    SemigroupK[λ[α => Reader[α, α]]]
 
     // using IntReader alias instead of Kleisli with Id as F and A as Int
     type IntReader[A] = Reader[Int, A]

--- a/tests/src/test/scala/cats/tests/ProdTests.scala
+++ b/tests/src/test/scala/cats/tests/ProdTests.scala
@@ -7,11 +7,11 @@ import cats.laws.discipline.arbitrary._
 
 class ProdTests extends CatsSuite {
   implicit val iso = CartesianTests.Isomorphisms.invariant[Prod[Option, List, ?]]
-  checkAll("Prod[Option, List, Int]", CartesianTests[Lambda[X => Prod[Option, List, X]]].cartesian[Int, Int, Int])
-  checkAll("Cartesian[Prod[Option, List, Int]]", SerializableTests.serializable(Cartesian[Lambda[X => Prod[Option, List, X]]]))
+  checkAll("Prod[Option, List, Int]", CartesianTests[λ[α => Prod[Option, List, α]]].cartesian[Int, Int, Int])
+  checkAll("Cartesian[Prod[Option, List, Int]]", SerializableTests.serializable(Cartesian[λ[α => Prod[Option, List, α]]]))
 
-  checkAll("Prod[Option, List, Int]", AlternativeTests[Lambda[X => Prod[Option, List, X]]].alternative[Int, Int, Int])
-  checkAll("Alternative[Prod[Option, List, Int]]", SerializableTests.serializable(Alternative[Lambda[X => Prod[Option, List, X]]]))
+  checkAll("Prod[Option, List, Int]", AlternativeTests[λ[α => Prod[Option, List, α]]].alternative[Int, Int, Int])
+  checkAll("Alternative[Prod[Option, List, Int]]", SerializableTests.serializable(Alternative[λ[α => Prod[Option, List, α]]]))
 
   {
     implicit val monoidK = ListWrapper.monoidK

--- a/tests/src/test/scala/cats/tests/TransLiftTests.scala
+++ b/tests/src/test/scala/cats/tests/TransLiftTests.scala
@@ -23,17 +23,16 @@ class TransLiftTests extends CatsSuite {
   }
 
   test("transLift for XorT, OptionT, WriterT requires only Functor") {
-    val d: XorT[JustFunctor, Int, Int]    = JustFunctor(1).liftT[({type λ[α[_], β] = XorT[α, Int, β]})#λ]
+    val d: XorT[JustFunctor, Int, Int]    = JustFunctor(1).liftT[λ[(α[_], β) => XorT[α, Int, β]]]
     val c: OptionT[JustFunctor, Int]      = JustFunctor(1).liftT[OptionT]
-    val a: WriterT[JustFunctor, Int, Int] = JustFunctor(1).liftT[({type λ[α[_], β] = WriterT[α, Int, β]})#λ]
-
+    val a: WriterT[JustFunctor, Int, Int] = JustFunctor(1).liftT[λ[(α[_], β) => WriterT[α, Int, β]]]
   }
 
   test("transLift for StateT requires Applicative Functor") {
-    val f: StateT[JustAp, Int, Int]  = JustAp(1).liftT[({type λ[α[_], β] = StateT[α, Int, β]})#λ]
+    val f: StateT[JustAp, Int, Int] = JustAp(1).liftT[λ[(α[_], β) => StateT[α, Int, β]]]
   }
 
-  test("transLift for, Kleisli doesn't require anything of the wrapped value"){
-    val e: Kleisli[NoTypeclass, Int, Int] = NoTypeclass(1).liftT[({type λ[α[_], β] = Kleisli[α, Int, β]})#λ]
+  test("transLift for Kleisli doesn't require anything of the wrapped value"){
+    val e: Kleisli[NoTypeclass, Int, Int] = NoTypeclass(1).liftT[λ[(α[_], β) => Kleisli[α, Int, β]]]
   }
 }


### PR DESCRIPTION
Like @InTheNow said in #1069: it's probably better to be consistent in our kind projection syntax.

Since the `Lambda` syntax was used quite a lot more than the `λ` syntax, I changed the occurrences of the last to the first.

I have also replaced the last type lambdas in `TransLiftTests` by kind projections.