### PR TITLE
Provide concise .toString for free structures.

### DIFF
--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -156,4 +156,5 @@ sealed abstract class Free[S[_], A] extends Product with Serializable {
 
   final def compile[T[_]](f: FunctionK[S,T]): Free[T, A] = mapSuspension(f)
 
+  override def toString(): String = "Free(...)"
 }

--- a/free/src/main/scala/cats/free/FreeApplicative.scala
+++ b/free/src/main/scala/cats/free/FreeApplicative.scala
@@ -60,6 +60,8 @@ sealed abstract class FreeApplicative[F[_], A] extends Product with Serializable
         def apply[B](fa: F[B]): Free[F, B] = Free.liftF(fa)
       }
     }
+
+  override def toString(): String = "FreeApplicative(...)"
 }
 
 object FreeApplicative {

--- a/free/src/test/scala/cats/free/FreeApplicativeTests.scala
+++ b/free/src/test/scala/cats/free/FreeApplicativeTests.scala
@@ -28,6 +28,12 @@ class FreeApplicativeTests extends CatsSuite {
   checkAll("FreeApplicative[Option, ?]", ApplicativeTests[FreeApplicative[Option, ?]].applicative[Int, Int, Int])
   checkAll("Monad[FreeApplicative[Option, ?]]", SerializableTests.serializable(Applicative[FreeApplicative[Option, ?]]))
 
+  test("toString is stack-safe") {
+    val r = FreeApplicative.pure[List, Int](333)
+    val rr = (1 to 1000000).foldLeft(r)((r, _) => r.map(_ + 1))
+    rr.toString.length should be > 0
+  }
+
   test("FreeApplicative#fold") {
     val n = 2
     val o1 = Option(1)

--- a/free/src/test/scala/cats/free/FreeTests.scala
+++ b/free/src/test/scala/cats/free/FreeTests.scala
@@ -18,6 +18,12 @@ class FreeTests extends CatsSuite {
   checkAll("Free[Option, ?]", MonadRecTests[Free[Option, ?]].monadRec[Int, Int, Int])
   checkAll("MonadRec[Free[Option, ?]]", SerializableTests.serializable(MonadRec[Free[Option, ?]]))
 
+  test("toString is stack-safe") {
+    val r = Free.pure[List, Int](333)
+    val rr = (1 to 1000000).foldLeft(r)((r, _) => r.map(_ + 1))
+    rr.toString.length should be > 0
+  }
+
   test("mapSuspension id"){
     forAll { x: Free[List, Int] =>
       x.mapSuspension(FunctionK.id[List]) should === (x)


### PR DESCRIPTION
Previously calling .toString on a Free value would traverse
the entire ADT of case classes. In some cases this would
actually cause a stack overflow in the printing code. It
also represented a (small) law violation (you could use the
output to distinguish x and x.map(identity) in some cases).

This change replaces the output with opaque "Free(...)"
and "FreeApplicative(...)" strings.