### PR TITLE
Adding a way to create a Kleisli with just F[B]

### DIFF
--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -67,7 +67,7 @@ object Kleisli extends KleisliInstances with KleisliFunctions
 
 private[data] sealed trait KleisliFunctions {
 
-  def pureF[F[_], A, B](x: F[B])(implicit F: Applicative[F]): Kleisli[F, A, B] =
+  def pureF[F[_], A, B](x: F[B]): Kleisli[F, A, B] =
     Kleisli(_ => x)
 
   def pure[F[_], A, B](x: B)(implicit F: Applicative[F]): Kleisli[F, A, B] =

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -67,7 +67,7 @@ object Kleisli extends KleisliInstances with KleisliFunctions
 
 private[data] sealed trait KleisliFunctions {
 
-  def const[F[_], A, B](x: F[B]): Kleisli[F, A, B] =
+  def lift[F[_], A, B](x: F[B]): Kleisli[F, A, B] =
     Kleisli(_ => x)
 
   def pure[F[_], A, B](x: B)(implicit F: Applicative[F]): Kleisli[F, A, B] =
@@ -124,7 +124,7 @@ private[data] sealed abstract class KleisliInstances extends KleisliInstances0 {
     new TransLift[Kleisli[?[_], A, ?]] {
       type TC[M[_]] = Trivial
 
-      def liftT[M[_], B](ma: M[B])(implicit ev: Trivial): Kleisli[M, A, B] = Kleisli.const(ma)
+      def liftT[M[_], B](ma: M[B])(implicit ev: Trivial): Kleisli[M, A, B] = Kleisli.lift(ma)
     }
 
   implicit def catsDataApplicativeErrorForKleisli[F[_], A, E](implicit AE: ApplicativeError[F, E]): ApplicativeError[Kleisli[F, A, ?], E]

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -67,7 +67,7 @@ object Kleisli extends KleisliInstances with KleisliFunctions
 
 private[data] sealed trait KleisliFunctions {
 
-  def pureF[F[_], A, B](x: F[B]): Kleisli[F, A, B] =
+  def const[F[_], A, B](x: F[B]): Kleisli[F, A, B] =
     Kleisli(_ => x)
 
   def pure[F[_], A, B](x: B)(implicit F: Applicative[F]): Kleisli[F, A, B] =
@@ -124,7 +124,7 @@ private[data] sealed abstract class KleisliInstances extends KleisliInstances0 {
     new TransLift[Kleisli[?[_], A, ?]] {
       type TC[M[_]] = Trivial
 
-      def liftT[M[_], B](ma: M[B])(implicit ev: Trivial): Kleisli[M, A, B] = Kleisli[M, A, B](a => ma)
+      def liftT[M[_], B](ma: M[B])(implicit ev: Trivial): Kleisli[M, A, B] = Kleisli.const(ma)
     }
 
   implicit def catsDataApplicativeErrorForKleisli[F[_], A, E](implicit AE: ApplicativeError[F, E]): ApplicativeError[Kleisli[F, A, ?], E]

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -67,6 +67,9 @@ object Kleisli extends KleisliInstances with KleisliFunctions
 
 private[data] sealed trait KleisliFunctions {
 
+  def pureF[F[_], A, B](x: F[B])(implicit F: Applicative[F]): Kleisli[F, A, B] =
+    Kleisli(_ => x)
+
   def pure[F[_], A, B](x: B)(implicit F: Applicative[F]): Kleisli[F, A, B] =
     Kleisli(_ => F.pure(x))
 


### PR DESCRIPTION
I'm new to Kleislis and found myself wanting a function like this. Scalaz has a `.liftKleisli` function, but I wasn't sure what would be preferred: `Kleisli.pureF(fa)` or `fa.liftKleisli`.