### PR TITLE
Fix Inject instance and reduceRightToOption null behavior

### DIFF
--- a/core/src/main/scala/cats/Reducible.scala
+++ b/core/src/main/scala/cats/Reducible.scala
@@ -75,7 +75,7 @@ import simulacrum.typeclass
    * Overriden from `Foldable[_]` for efficiency.
    */
   override def reduceRightToOption[A, B](fa: F[A])(f: A => B)(g: (A, Eval[B]) => Eval[B]): Eval[Option[B]] =
-    reduceRightTo(fa)(f)(g).map(Option(_))
+    reduceRightTo(fa)(f)(g).map(Some(_))
 
   /**
    * Traverse `F[A]` using `Apply[G]`.

--- a/free/src/main/scala/cats/free/Inject.scala
+++ b/free/src/main/scala/cats/free/Inject.scala
@@ -27,7 +27,7 @@ private[free] sealed abstract class InjectInstances {
     new Inject[F, Coproduct[F, G, ?]] {
       def inj[A](fa: F[A]): Coproduct[F, G, A] = Coproduct.leftc(fa)
 
-      def prj[A](ga: Coproduct[F, G, A]): Option[F[A]] = ga.run.fold(Option(_), _ => None)
+      def prj[A](ga: Coproduct[F, G, A]): Option[F[A]] = ga.run.fold(Some(_), _ => None)
     }
 
   implicit def rightInjectInstance[F[_], G[_], H[_]](implicit I: Inject[F, G]): Inject[F, Coproduct[H, G, ?]] =

--- a/free/src/main/scala/cats/free/Inject.scala
+++ b/free/src/main/scala/cats/free/Inject.scala
@@ -20,7 +20,7 @@ private[free] sealed abstract class InjectInstances {
     new Inject[F, F] {
       def inj[A](fa: F[A]): F[A] = fa
 
-      def prj[A](ga: F[A]): Option[F[A]] = Option(ga)
+      def prj[A](ga: F[A]): Option[F[A]] = Some(ga)
     }
 
   implicit def leftInjectInstance[F[_], G[_]]: Inject[F, Coproduct[F, G, ?]] =

--- a/free/src/test/scala/cats/free/InjectTests.scala
+++ b/free/src/test/scala/cats/free/InjectTests.scala
@@ -101,10 +101,4 @@ class InjectTests extends CatsSuite {
     }
   }
 
-  test("null identity") {
-    val listIntNull = null.asInstanceOf[List[Int]]
-    Inject.reflexiveInjectInstance[List].inj[Int](listIntNull) should ===(listIntNull)
-    Inject.reflexiveInjectInstance[List].prj[Int](listIntNull) should ===(Some(listIntNull))
-  }
-
 }

--- a/free/src/test/scala/cats/free/InjectTests.scala
+++ b/free/src/test/scala/cats/free/InjectTests.scala
@@ -101,4 +101,10 @@ class InjectTests extends CatsSuite {
     }
   }
 
+  test("null identity") {
+    val listIntNull = null.asInstanceOf[List[Int]]
+    Inject.reflexiveInjectInstance[List].inj[Int](listIntNull) should ===(listIntNull)
+    Inject.reflexiveInjectInstance[List].prj[Int](listIntNull) should ===(Some(listIntNull))
+  }
+
 }


### PR DESCRIPTION
`Inject.prj(null)` with the provided reflexive Inject instance (`Inject[F, F]`) returns None, but `Inject.inj(null)` returns null. I am fairly sure that inj and prj should be mutual inverses, this fixes that. It works the same way now as in Scalaz.