### PR TITLE
Enforce kind projection style using Scalastyle

### DIFF
--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -64,4 +64,10 @@
    <parameter name="ignoreOverride">false</parameter>
   </parameters>
  </check>
+ <check level="error" class="org.scalastyle.file.RegexChecker" enabled="true" customId="kind.projector.lambda">
+  <parameters>
+   <parameter name="regex">Lambda\[</parameter>
+  </parameters>
+  <customMessage><![CDATA[Use Greek characters in a kind projection (λ[α => ...]).]]></customMessage>
+ </check>
 </scalastyle>


### PR DESCRIPTION
Now Scalastyle is working again, I have added the Scalastyle rule I mentioned in #1092 to make sure the `Lambda[...]` style is not use are used.