### PR TITLE
Simplify the constraint on Xor/XorT/Ior to[] by using Alternative

### DIFF
--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -45,8 +45,8 @@ sealed abstract class Ior[+A, +B] extends Product with Serializable {
   final def toOption: Option[B] = right
   final def toList: List[B] = right.toList
 
-  final def to[F[_], BB >: B](implicit monoidKF: MonoidK[F], applicativeF: Applicative[F]): F[BB] =
-    fold(_ => monoidKF.empty, applicativeF.pure, (_, b) => applicativeF.pure(b))
+  final def to[F[_], BB >: B](implicit F: Alternative[F]): F[BB] =
+    fold(_ => F.empty, F.pure, (_, b) => F.pure(b))
 
   final def swap: B Ior A = fold(Ior.right, Ior.left, (a, b) => Ior.both(b, a))
 

--- a/core/src/main/scala/cats/data/Xor.scala
+++ b/core/src/main/scala/cats/data/Xor.scala
@@ -78,8 +78,8 @@ sealed abstract class Xor[+A, +B] extends Product with Serializable {
   def withValidated[AA,BB](f: Validated[A,B] => Validated[AA,BB]): AA Xor BB =
     f(toValidated).toXor
 
-  def to[F[_], BB >: B](implicit monoidKF: MonoidK[F], applicativeF: Applicative[F]): F[BB] =
-    fold(_ => monoidKF.empty, applicativeF.pure)
+  def to[F[_], BB >: B](implicit F: Alternative[F]): F[BB] =
+    fold(_ => F.empty, F.pure)
 
   def bimap[C, D](fa: A => C, fb: B => D): C Xor D = this match {
     case Xor.Left(a) => Xor.Left(fa(a))

--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -57,8 +57,8 @@ final case class XorT[F[_], A, B](value: F[A Xor B]) {
 
   def toOption(implicit F: Functor[F]): OptionT[F, B] = OptionT(F.map(value)(_.toOption))
 
-  def to[G[_]](implicit functorF: Functor[F], monoidKG: MonoidK[G], applicativeG: Applicative[G]): F[G[B]] =
-    functorF.map(value)(_.to[G, B])
+  def to[G[_]](implicit F: Functor[F], G: Alternative[G]): F[G[B]] =
+    F.map(value)(_.to[G, B])
 
   def collectRight(implicit F: MonadCombine[F]): F[B] =
     F.flatMap(value)(_.to[F, B])


### PR DESCRIPTION
Replace seperate constraints `MonoidK` and `Applicative` with `Alternative`.