### PR TITLE
Syntax for Cartesian operations with tuples

### DIFF
--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -40,6 +40,7 @@ trait AllSyntax
     with TransLiftSyntax
     with TraverseFilterSyntax
     with TraverseSyntax
+    with TupleSyntax
     with ValidatedSyntax
     with WriterSyntax
     with XorSyntax

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -39,6 +39,7 @@ package object syntax {
   object transLift extends TransLiftSyntax
   object traverse extends TraverseSyntax
   object traverseFilter extends TraverseFilterSyntax
+  object tuple extends TupleSyntax
   object validated extends ValidatedSyntax
   object writer extends WriterSyntax
   object xor extends XorSyntax

--- a/core/src/main/scala/cats/syntax/tuple.scala
+++ b/core/src/main/scala/cats/syntax/tuple.scala
@@ -1,0 +1,4 @@
+package cats
+package syntax
+
+trait TupleSyntax extends TupleCartesianSyntax

--- a/tests/src/test/scala/cats/tests/SyntaxTests.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxTests.scala
@@ -257,6 +257,39 @@ object SyntaxTests extends AllInstances with AllSyntax {
     val pfegea = mock[PartialFunction[E, G[A]]]
     val gea4 = ga.recoverWith(pfegea)
   }
+
+  def testTupleArity[F[_]: Apply : Cartesian, G[_]: Contravariant : Cartesian, H[_]: Invariant : Cartesian, A, B, C, D, E, Z] = {
+    val tfabc = mock[(F[A], F[B], F[C])]
+    val fa = mock[F[A]]
+    val fb = mock[F[B]]
+    val fc = mock[F[C]]
+    val f = mock[(A, B, C) => Z]
+    val ff = mock[F[(A, B, C) => Z]]
+
+    tfabc map3 f
+    (fa, fb, fc) map3 f
+    (fa, fb, fc) apWith ff
+
+    val tgabc = mock[(G[A], G[B])]
+    val ga = mock[G[A]]
+    val gb = mock[G[B]]
+    val g = mock[Z => (A, B)]
+
+    tgabc contramap2 g
+    (ga, gb) contramap2 g
+
+    val thabcde = mock[(H[A], H[B], H[C], H[D], H[E])]
+    val ha = mock[H[A]]
+    val hb = mock[H[B]]
+    val hc = mock[H[C]]
+    val hd = mock[H[D]]
+    val he = mock[H[E]]
+    val f5 = mock[(A, B, C, D, E) => Z]
+    val g5 = mock[Z => (A, B, C, D, E)]
+
+    thabcde.imap5(f5)(g5)
+    (ha, hb, hc, hd, he).imap5(f5)(g5)
+  }
 }
 
 /**


### PR DESCRIPTION
Generates
```scala
trait TupleAritySyntax {
  private[syntax] final class Tuple1Ops[F[_], A0](t1: Tuple1[F[A0]]) {
    def map[Z](f: (A0) => Z)(implicit functor: Functor[F]): F[Z] = functor.map(t1._1)(f)
    def contramap[Z](f: Z => (A0))(implicit contravariant: Contravariant[F]): F[Z] = contravariant.contramap(t1._1)(f)
    def imap[Z](f: (A0) => Z)(g: Z => (A0))(implicit invariant: Invariant[F]): F[Z] = invariant.imap(t1._1)(f)(g)
  }
  implicit def tuple1Syntax[F[_], A0](t1: Tuple1[F[A0]]): Tuple1Ops[F, A0] = new Tuple1Ops(t1)
  private[syntax] final class Tuple2Ops[F[_], A0, A1](t2: Tuple2[F[A0], F[A1]]) {
    def map2[Z](f: (A0, A1) => Z)(implicit functor: Functor[F], cartesian: Cartesian[F]): F[Z] = Cartesian.map2(t2._1, t2._2)(f)
    def contramap2[Z](f: Z => (A0, A1))(implicit contravariant: Contravariant[F], cartesian: Cartesian[F]): F[Z] = Cartesian.contramap2(t2._1, t2._2)(f)
    def imap2[Z](f: (A0, A1) => Z)(g: Z => (A0, A1))(implicit invariant: Invariant[F], cartesian: Cartesian[F]): F[Z] = Cartesian.imap2(t2._1, t2._2)(f)(g)
  }
  implicit def tuple2Syntax[F[_], A0, A1](t2: Tuple2[F[A0], F[A1]]): Tuple2Ops[F, A0, A1] = new Tuple2Ops(t2)

  // etc.
}
```

Things I'm not sure about:
* `map2`, `map3`, etc. or just `map`?
* is there any compiler-related ceremony that I need to do with the syntax classes? (extends AnyVal?)
* is it worth generating tests too (as per #383)?