### PR TITLE
`foldLeftM` without `Free`.

### DIFF
--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -254,23 +254,4 @@ object Free {
           case Right(b) => pure(b)
         }
     }
-
-  /**
-   * Perform a stack-safe monadic fold from the source context `F`
-   * into the target monad `G`.
-   *
-   * This method can express short-circuiting semantics. Even when
-   * `fa` is an infinite structure, this method can potentially
-   * terminate if the `foldRight` implementation for `F` and the
-   * `tailRecM` implementation for `G` are sufficiently lazy.
-   */
-  def foldLeftM[F[_]: Foldable, G[_]: Monad, A, B](fa: F[A], z: B)(f: (B, A) => G[B]): G[B] =
-    unsafeFoldLeftM[F, Free[G, ?], A, B](fa, z) { (b, a) =>
-      Free.liftF(f(b, a))
-    }.runTailRec
-
-  private def unsafeFoldLeftM[F[_], G[_], A, B](fa: F[A], z: B)(f: (B, A) => G[B])(implicit F: Foldable[F], G: Monad[G]): G[B] =
-    F.foldRight(fa, Always((w: B) => G.pure(w))) { (a, lb) =>
-      Always((w: B) => G.flatMap(f(w, a))(lb.value))
-    }.value.apply(z)
 }

--- a/free/src/test/scala/cats/free/FreeTests.scala
+++ b/free/src/test/scala/cats/free/FreeTests.scala
@@ -90,25 +90,6 @@ class FreeTests extends CatsSuite {
     assert(res == List(112358))
   }
 
-  test(".foldLeftM") {
-    // you can see .foldLeftM traversing the entire structure by
-    // changing the constant argument to .take and observing the time
-    // this test takes.
-    val ns = Stream.from(1).take(1000)
-    val res = Free.foldLeftM[Stream, Either[Int, ?], Int, Int](ns, 0) { (sum, n) =>
-      if (sum >= 2) Either.left(sum) else Either.right(sum + n)
-    }
-    assert(res == Either.left(3))
-  }
-
-  test(".foldLeftM short-circuiting") {
-    val ns = Stream.continually(1)
-    val res = Free.foldLeftM[Stream, Either[Int, ?], Int, Int](ns, 0) { (sum, n) =>
-      if (sum >= 100000) Either.left(sum) else Either.right(sum + n)
-    }
-    assert(res == Either.left(100000))
-  }
-
   sealed trait Test1Algebra[A]
 
   case class Test1[A](value : Int, f: Int => A) extends Test1Algebra[A]


### PR DESCRIPTION
This is an implementation of `foldLeftM` without using `Free`. Instead, it introduces an auxiliary structure

``` scala
case class Source[A](uncons: () => Option[(A, Source[A])])
```

and a conversion from any foldable `F[A]` to `Source[A]`, which provides lazy access to elements of `F[A]`.

It still uses `foldRight`, but I think there is a better separation of concerns here, because `G` is not involved in the `foldRight` at all.

~~I didn't bother to move this out of `Free.scala`, but `Free` is not used here at all.~~ I moved the implementation to `Foldable`.

Funny enough, if I make `Source` extend `AnyVal`, it crashes the compiler with a `StackOverflowError` ([SI-9600](https://issues.scala-lang.org/browse/SI-9600)).
