### PR TITLE
Fix contramap signature in Contravariant doc page

### DIFF
--- a/docs/src/main/tut/contravariant.md
+++ b/docs/src/main/tut/contravariant.md
@@ -11,7 +11,7 @@ The `Contravariant` type class is for functors that define a `contramap`
 function with the following type:
 
 ```scala
-def contramap[A, B](f: B => A): F[A] => F[B]
+def contramap[A, B](fa: F[A])(f: B => A): F[B]
 ```
 
 It looks like regular (also called `Covariant`) [`Functor`](functor.html)'s `map`,


### PR DESCRIPTION
I think I have spotted a typo in the docs. Find the actual function definition [here](https://github.com/typelevel/cats/blob/f592db84facd88d51d3f64e0e309f320878b8c52/core/src/main/scala/cats/functor/Contravariant.scala#L10).