### PR TITLE
Add Xor.toTry

### DIFF
--- a/core/src/main/scala/cats/data/Xor.scala
+++ b/core/src/main/scala/cats/data/Xor.scala
@@ -69,6 +69,8 @@ sealed abstract class Xor[+A, +B] extends Product with Serializable {
 
   def toList: List[B] = fold(_ => Nil, _ :: Nil)
 
+  def toTry(implicit ev: A <:< Throwable): Try[B] = fold(a => Failure(ev(a)), Success(_))
+
   def toValidated: Validated[A,B] = fold(Validated.Invalid.apply, Validated.Valid.apply)
 
   /** Returns a [[ValidatedNel]] representation of this disjunction with the `Left` value

--- a/tests/src/test/scala/cats/tests/XorTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTests.scala
@@ -204,6 +204,14 @@ class XorTests extends CatsSuite {
     }
   }
 
+  test("toTry then fromTry is identity") {
+    implicit def eqTh: Eq[Throwable] = Eq.allEqual
+
+    forAll { (x: Throwable Xor String) =>
+      Xor.fromTry(x.toTry) should === (x)
+    }
+  }
+
   test("isLeft consistency") {
     forAll { (x: Int Xor String) =>
       x.isLeft should === (x.toEither.isLeft)


### PR DESCRIPTION
Add a method to convert an `Xor` to a `Try`, since `Try` is very commonly used in existing libraries.