### PR TITLE
Add ApplySemigroup and ApplicativeMonoid

### DIFF
--- a/core/src/main/scala/cats/Applicative.scala
+++ b/core/src/main/scala/cats/Applicative.scala
@@ -50,3 +50,7 @@ import simulacrum.typeclass
       val G = Applicative[G]
     }
 }
+
+abstract class ApplicativeMonoid[F[_], A](f: Applicative[F], monoid: Monoid[A]) extends ApplySemigroup(f, monoid) with Monoid[F[A]] {
+  def empty: F[A] = f.pure(monoid.empty)
+}

--- a/core/src/main/scala/cats/Applicative.scala
+++ b/core/src/main/scala/cats/Applicative.scala
@@ -51,6 +51,11 @@ import simulacrum.typeclass
     }
 }
 
-abstract class ApplicativeMonoid[F[_], A](f: Applicative[F], monoid: Monoid[A]) extends ApplySemigroup(f, monoid) with Monoid[F[A]] {
+object Applicative {
+  def monoid[F[_], A](implicit f: Applicative[F], monoid: Monoid[A]): Monoid[F[A]] =
+    new ApplicativeMonoid[F, A](f, monoid)
+}
+
+private[cats] class ApplicativeMonoid[F[_], A](f: Applicative[F], monoid: Monoid[A]) extends ApplySemigroup(f, monoid) with Monoid[F[A]] {
   def empty: F[A] = f.pure(monoid.empty)
 }

--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -65,7 +65,12 @@ trait Apply[F[_]] extends Functor[F] with Cartesian[F] with ApplyArityFunctions[
     }
 }
 
-abstract class ApplySemigroup[F[_], A](f: Apply[F], sg: Semigroup[A]) extends Semigroup[F[A]] {
+object Apply {
+  def semigroup[F[_], A](implicit f: Apply[F], sg: Semigroup[A]): Semigroup[F[A]] =
+    new ApplySemigroup[F, A](f, sg)
+}
+
+private[cats] class ApplySemigroup[F[_], A](f: Apply[F], sg: Semigroup[A]) extends Semigroup[F[A]] {
   def combine(a: F[A], b: F[A]): F[A] =
     f.map2(a, b)(sg.combine)
 }

--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -64,3 +64,8 @@ trait Apply[F[_]] extends Functor[F] with Cartesian[F] with ApplyArityFunctions[
       val G = Apply[G]
     }
 }
+
+abstract class ApplySemigroup[F[_], A](f: Apply[F], sg: Semigroup[A]) extends Semigroup[F[A]] {
+  def combine(a: F[A], b: F[A]): F[A] =
+    f.map2(a, b)(sg.combine)
+}

--- a/core/src/main/scala/cats/std/future.scala
+++ b/core/src/main/scala/cats/std/future.scala
@@ -1,7 +1,6 @@
 package cats
 package std
 
-import cats.syntax.all._
 import cats.data.Xor
 
 import scala.util.control.NonFatal
@@ -51,12 +50,8 @@ private[cats] abstract class FutureCoflatMap(implicit ec: ExecutionContext) exte
   def coflatMap[A, B](fa: Future[A])(f: Future[A] => B): Future[B] = Future(f(fa))
 }
 
-private[cats] class FutureSemigroup[A: Semigroup](implicit ec: ExecutionContext) extends Semigroup[Future[A]] {
-  def combine(fx: Future[A], fy: Future[A]): Future[A] =
-    (fx zip fy).map { case (x, y) => x |+| y }
-}
+private[cats] class FutureSemigroup[A: Semigroup](implicit ec: ExecutionContext)
+  extends ApplySemigroup[Future, A](future.catsStdInstancesForFuture, implicitly)
 
-private[cats] class FutureMonoid[A](implicit A: Monoid[A], ec: ExecutionContext) extends FutureSemigroup[A] with Monoid[Future[A]] {
-  def empty: Future[A] =
-    Future.successful(A.empty)
-}
+private[cats] class FutureMonoid[A](implicit A: Monoid[A], ec: ExecutionContext)
+  extends ApplicativeMonoid[Future, A](future.catsStdInstancesForFuture, implicitly)

--- a/core/src/main/scala/cats/std/try.scala
+++ b/core/src/main/scala/cats/std/try.scala
@@ -1,7 +1,6 @@
 package cats
 package std
 
-import cats.syntax.all._
 import cats.data.Xor
 import TryInstances.castFailure
 
@@ -122,14 +121,6 @@ private[cats] abstract class TryCoflatMap extends CoflatMap[Try] {
   def coflatMap[A, B](ta: Try[A])(f: Try[A] => B): Try[B] = Try(f(ta))
 }
 
-private[cats] class TrySemigroup[A: Semigroup] extends Semigroup[Try[A]] {
-  def combine(fx: Try[A], fy: Try[A]): Try[A] =
-    for {
-      x <- fx
-      y <- fy
-    } yield x |+| y
-}
+private[cats] class TrySemigroup[A: Semigroup] extends ApplySemigroup[Try, A](try_.catsStdInstancesForTry, implicitly)
 
-private[cats] class TryMonoid[A](implicit A: Monoid[A]) extends TrySemigroup[A] with Monoid[Try[A]] {
-  def empty: Try[A] = Success(A.empty)
-}
+private[cats] class TryMonoid[A](implicit A: Monoid[A]) extends ApplicativeMonoid[Try, A](try_.catsStdInstancesForTry, implicitly)


### PR DESCRIPTION
these are always lawful. The generalization to `Group` may not be (see Try, Failure has no inverse) or `Semilattice` (`Apply.map2(a, a)(_._1)` might not be idempotent, but if it is, we can add Band and Semilattice.