### PR TITLE
Add Kailuo Wang as a Cats maintainer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ The current maintainers (people who can merge pull requests) are:
  * [milessabin](https://github.com/milessabin) Miles Sabin
  * [fthomas](https://github.com/fthomas) Frank Thomas
  * [julien-truffaut](https://github.com/julien-truffaut) Julien Truffaut
+ * [kailuowang](https://github.com/kailuowang) Kailuo Wang
 
 We are currently following a practice of requiring at least two
 sign-offs to merge PRs (and for large or contentious issues we may


### PR DESCRIPTION
This add Kailuo to the maintainers list in the README. I've already invited him as a collaborator via Github.