### PR TITLE
Add monoid syntax

### DIFF
--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -23,6 +23,7 @@ trait AllSyntax
     with ListSyntax
     with MonadCombineSyntax
     with MonadFilterSyntax
+    with MonoidSyntax
     with OptionSyntax
     with OrderSyntax
     with PartialOrderSyntax

--- a/core/src/main/scala/cats/syntax/monoid.scala
+++ b/core/src/main/scala/cats/syntax/monoid.scala
@@ -1,0 +1,12 @@
+package cats
+package syntax
+
+trait MonoidSyntax extends SemigroupSyntax {
+  // TODO: use simulacrum instances eventually
+  implicit def catsSyntaxMonoid[A: Monoid](a: A): MonoidOps[A] =
+    new MonoidOps[A](a)
+}
+
+final class MonoidOps[A: Monoid](lhs: A) {
+  def isEmpty(implicit eq: Eq[A]): Boolean = Monoid[A].isEmpty(lhs)(eq)
+}

--- a/tests/src/test/scala/cats/tests/SyntaxTests.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxTests.scala
@@ -40,6 +40,12 @@ class SyntaxTests extends AllInstances with AllSyntax {
     val z: A = x |-| y
   }
 
+  def testMonoid[A: Monoid]: Unit = {
+    val x = mock[A]
+    implicit val y = mock[Eq[A]]
+    val z: Boolean = x.isEmpty
+  }
+
   def testEq[A: Eq]: Unit = {
     val x = mock[A]
     val y = mock[A]


### PR DESCRIPTION
This resolves #1124 

There are a couple of questions

- in `Group` and `SemiGroup` the comment `// TODO: use simulacrum instances eventually` has been made. I have copied this so all 3 can be changed at the same time. Is that the right thing to do here? I'm happy to use simulacrum if not

- in implementing `isEmpty` I originally attempted to use `Ops.binOp` but couldn't get it to work with my implicit `Eq`. Should I be using that here?

Sorry they are such basic questions, this is my first attempt at contributing to Cats and I'm trying to find my feet!