### PR TITLE
Removed nesting in project structure listing

### DIFF
--- a/docs/src/main/tut/freemonad.md
+++ b/docs/src/main/tut/freemonad.md
@@ -461,10 +461,10 @@ From a computational point of view, `Free` recursive structure can be
 seen as a sequence of operations.
 
  - `Pure` returns an `A` value and ends the entire computation.
-- `Suspend` is a continuation; it suspends the current computation
-  with the suspension functor `F` (which can represent a command for
-  example) and hands control to the caller. `A` represents a value
-  bound to this computation.
+ - `Suspend` is a continuation; it suspends the current computation
+   with the suspension functor `F` (which can represent a command for
+   example) and hands control to the caller. `A` represents a value
+   bound to this computation.
 
 Please note this `Free` construction has the interesting quality of
 _encoding_ the recursion on the heap instead of the stack as classic

--- a/docs/src/site/index.md
+++ b/docs/src/site/index.md
@@ -88,7 +88,7 @@ In an attempt to be more modular, Cats is broken up into a number of sub-project
 * *core* - contains type class definitions (e.g. Functor, Applicative, Monad), essential datatypes, and
   type class instances for those datatypes and standard library types
 * *laws* - laws for the type classes, used to validate type class instances
- * *cats-free* - free structures such as the free monad, and supporting type classes.
+* *cats-free* - free structures such as the free monad, and supporting type classes.
 * *tests* - tests that check type class instances with laws from *laws*
 * *docs* - The source for this website
 


### PR DESCRIPTION
Is the project structure listing necessary at all given that nearly identical info is provided at the beginning?