### PR TITLE
Add list syntax object

### DIFF
--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -22,6 +22,7 @@ package object syntax {
   object functor extends FunctorSyntax
   object group extends GroupSyntax
   object invariant extends InvariantSyntax
+  object list extends ListSyntax
   object monadCombine extends MonadCombineSyntax
   object monadFilter extends MonadFilterSyntax
   object option extends OptionSyntax


### PR DESCRIPTION
Currently `import cats.syntax._` brings in the list syntax but there is
no object to import only the list syntax.