### PR TITLE
Adjust documentation to change from algebra to cats-kernel.

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ Cats will be designed to use modern *best practices*:
  * [scalacheck](http://scalacheck.org) for property-based testing
  * [discipline](https://github.com/typelevel/discipline) for encoding and testing laws
  * [kind-projector](https://github.com/non/kind-projector) for type lambda syntax
- * [algebra](https://github.com/non/algebra) for shared algebraic structures
  * ...and of course a pure functional subset of the Scala language.
 
 (We also plan to support [Miniboxing](http://scala-miniboxing.org) in a branch.)

--- a/docs/src/main/tut/contravariant.md
+++ b/docs/src/main/tut/contravariant.md
@@ -20,7 +20,7 @@ but with the `f` transformation reversed.
 Generally speaking, if you have some context `F[A]` for type `A`,
 and you can get an `A` value out of a `B` value — `Contravariant` allows you to get the `F[B]` context for `B`.
 
-Examples of `Contravariant` instances are [`Show`](show.html) and `scala.math.Ordering` (along with `algebra.Order`).
+Examples of `Contravariant` instances are [`Show`](show.html) and `scala.math.Ordering` (along with `cats.kernel.Order`).
 
 ## Contravariant instance for Show.
 

--- a/docs/src/main/tut/monoid.md
+++ b/docs/src/main/tut/monoid.md
@@ -2,8 +2,8 @@
 layout: default
 title:  "Monoid"
 section: "typeclasses"
-source: "https://github.com/non/algebra/blob/master/core/src/main/scala/algebra/Monoid.scala"
-
+source: "kernel/src/main/scala/cats/kernel/Monoid.scala"
+scaladoc: "#cats.kernel.Monoid"
 ---
 # Monoid
 
@@ -70,10 +70,7 @@ l.foldMap(i => (i, i.toString)) // do both of the above in one pass, hurrah!
 -------------------------------------------------------------------------------
  
 N.B.
-Cats does not define a `Monoid` type class itself, it uses the [`Monoid`
-trait](https://github.com/non/algebra/blob/master/core/src/main/scala/algebra/Monoid.scala)
-which is defined in the [algebra project](https://github.com/non/algebra) on 
-which it depends. The [`cats` package object](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/package.scala)
-defines type aliases to the `Monoid` from algebra, so that you can
-`import cats.Monoid`. Also the `Monoid` instance for tuple is also [implemented in algebra](https://github.com/non/algebra/blob/v0.4.2/project/Boilerplate.scala#L80-L217), 
-cats merely provides it through [inheritance](https://github.com/typelevel/cats/blob/v0.5.0/core/src/main/scala/cats/std/tuple.scala). 
+Cats defines  the `Monoid` type class in cats-kernel. The [`cats` package object](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/package.scala)
+defines type aliases to the `Monoid` from cats-kernel, so that you can
+`import cats.Monoid`. Also the `Monoid` instance for tuple is also [implemented in cats-kernel](https://github.com/typelevel/cats/blob/master/project/KernelBoiler.scala), 
+cats merely provides it through [inheritance](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/std/tuple.scala).

--- a/docs/src/main/tut/semigroup.md
+++ b/docs/src/main/tut/semigroup.md
@@ -2,8 +2,8 @@
 layout: default
 title:  "Semigroup"
 section: "typeclasses"
-source: "https://github.com/non/algebra/blob/master/core/src/main/scala/algebra/Semigroup.scala"
-
+source: "kernel/src/main/scala/cats/kernel/Semigroup.scala"
+scaladoc: "#cats.kernel.Semigroup"
 ---
 # Semigroup
 
@@ -93,9 +93,6 @@ None |+| Some(1)
 ```
 
 N.B.
-Cats does not define a `Semigroup` type class itself, it uses the [`Semigroup`
-trait](https://github.com/non/algebra/blob/master/core/src/main/scala/algebra/Semigroup.scala)
-which is defined in the [algebra project](https://github.com/non/algebra) on 
-which it depends. The [`cats` package object](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/package.scala)
-defines type aliases to the `Semigroup` from algebra, so that you can
+Cats defines the `Semigroup` type class in cats-kernel. The [`cats` package object](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/package.scala)
+defines type aliases to the `Semigroup` from cats-kernel, so that you can
 `import cats.Semigroup`.

--- a/docs/src/main/tut/semigroupk.md
+++ b/docs/src/main/tut/semigroupk.md
@@ -7,52 +7,7 @@ scaladoc: "#cats.SemigroupK"
 ---
 # SemigroupK
 
-Before introducing a `SemigroupK`, it makes sense to talk about what a
-`Semigroup` is. A semigroup for some given type `A` has a single operation
-(which we will call `combine`), which takes two values of type `A`, and
-returns a value of type `A`. This operation must be guaranteed to be
-associative. That is to say that:
-
-```scala
-((a combine b) combine c)
-```
-
-must be the same as
-
-```scala
-(a combine (b combine c))
-```
-
-for all possible values of `a`, `b`, `c`.
-
-Cats does not define a `Semigroup` type class itself. Instead, we use the
-[`Semigroup`
-trait](https://github.com/non/algebra/blob/master/core/src/main/scala/algebra/Semigroup.scala)
-which is defined in the [algebra
-project](https://github.com/non/algebra). The [`cats` package
-object](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/package.scala)
-defines type aliases to the `Semigroup` from algebra, so that you can
-`import cats.semigroup`.
-
-There are instances of `Semigroup` defined for many types found in the
-scala common library:
-
-```tut:silent
-import cats._
-import cats.implicits._
-```
-
-Examples.
-
-```tut:book
-Semigroup[Int].combine(1, 2)
-Semigroup[List[Int]].combine(List(1,2,3), List(4,5,6))
-Semigroup[Option[Int]].combine(Option(1), Option(2))
-Semigroup[Option[Int]].combine(Option(1), None)
-Semigroup[Int => Int].combine({(x: Int) => x + 1},{(x: Int) => x * 10}).apply(6)
-```
-
-`SemigroupK` has a very similar structure to `Semigroup`, the difference
+`SemigroupK` has a very similar structure to [`Semigroup`](semigroup.html), the difference
 is that `SemigroupK` operates on type constructors of one argument. So, for
 example, whereas you can find a `Semigroup` for types which are fully
 specified like `Int` or `List[Int]` or `Option[Int]`, you will find
@@ -63,6 +18,13 @@ takes a concrete type, like `Int`, and returns a concrete type:
 `List[Int]`. This pattern would also be referred to having `kind: * ->
 *`, whereas `Int` would have kind `*` and `Map` would have kind `*,* -> *`,
 and, in fact, the `K` in `SemigroupK` stands for `Kind`.
+
+First some imports.
+
+```tut:silent
+import cats._
+import cats.implicits._
+```
 
 For `List`, the `Semigroup` instance's `combine` operation and the `SemigroupK`
 instance's `combineK` operation are both list concatenation:

--- a/docs/src/site/colophon.md
+++ b/docs/src/site/colophon.md
@@ -17,7 +17,6 @@ integrating them into your own projects.
  * [scalacheck](http://scalacheck.org) for property-based testing
  * [discipline](https://github.com/typelevel/discipline) for encoding and testing laws
  * [kind-projector](https://github.com/non/kind-projector) for type lambda syntax
- * [algebra](https://github.com/non/algebra) for algebraic structures shared between Cats, [Spire](https://github.com/non/spire), and [Algebird](https://github.com/twitter/algebird)
  * [tut](https://github.com/tpolecat/tut) type-checked example code makes sure that our examples stay in sync with the rest of our source
 
 There are other libraries that aim to foster Functional Programming in the Scala programming language which Cats has a relationship to:


### PR DESCRIPTION
Remove / change some links to algebra in the documentation.

Removed the introduction about `Semigroup` in the `SemigroupK` documentation since it was a duplicate of the `Semigroup` documentation.