### PR TITLE
Reduce size of arbitrary ListWrappers

### DIFF
--- a/tests/src/test/scala/cats/tests/ListWrapper.scala
+++ b/tests/src/test/scala/cats/tests/ListWrapper.scala
@@ -4,8 +4,7 @@ package tests
 import cats.functor.Invariant
 import cats.std.list._
 
-import org.scalacheck.Arbitrary
-import org.scalacheck.Arbitrary.arbitrary
+import org.scalacheck.{Arbitrary, Gen}
 
 /** This data type exists purely for testing.
   *
@@ -120,8 +119,12 @@ object ListWrapper {
 
   def monoid[A]: Monoid[ListWrapper[A]] = monadCombine.algebra[A]
 
-  implicit def listWrapperArbitrary[A: Arbitrary]: Arbitrary[ListWrapper[A]] =
-    Arbitrary(arbitrary[List[A]].map(ListWrapper.apply))
+  implicit def listWrapperArbitrary[A](implicit A: Arbitrary[A]): Arbitrary[ListWrapper[A]] =
+    Arbitrary(
+      for {
+        size <- Gen.chooseNum(0, 3)
+        list <- Gen.listOfN(size, A.arbitrary)
+      } yield ListWrapper(list))
 
   implicit def listWrapperEq[A: Eq]: Eq[ListWrapper[A]] = Eq.by(_.list)
 }


### PR DESCRIPTION
This is an experiment in response to #957. If this doesn't have much of
an effect on build times, then I think we can go ahead and close out
that ticket, since we are no longer seeing build timeouts. I suspect it
won't make much of a difference, because we already have changed to a
more performant JS environment and have reduced the scalacheck size
configuration in CatSuite.