### PR TITLE
Add gitbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ TAGS
 *.sublime-project
 *.sublime-workspace
 tests.iml
+node_modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -161,7 +161,8 @@ Write about checking laws
 
 ## Contributing documentation
 
-### source for the documentation
+### Source for the documentation
+
 The documentation for this website is stored alongside the source, in the [docs subproject](https://github.com/typelevel/cats/tree/master/docs).
 
 * The source for the static pages is in `docs/src/site`
@@ -188,6 +189,10 @@ run `sbt docs/makeSite`
 4. Navigate to http://localhost:4000/cats/ in your browser
 
 5. Make changes to your site, and run `sbt makeSite` to regenerate the site. The changes should be reflected as soon as you run `makeSite`.
+
+### Generating the book
+
+run `bash scripts/build-book.sh`
 
 ### Compiler verified documentation
 

--- a/docs/src/main/tut/SUMMARY.md
+++ b/docs/src/main/tut/SUMMARY.md
@@ -1,0 +1,36 @@
+- [Typeclasses](typeclasses.md)
+
+    - [Applicative](applicative.md)
+    - [Apply](apply.md)
+    - [Contravariant](contravariant.md)
+    - [Faq](faq.md)
+    - [Foldable](foldable.md)
+    - [Functor](functor.md)
+    - [Id](id.md)
+    - [Invariant](invariant.md)
+    - [Monad](monad.md)
+    - [Monoid](monoid.md)
+    - [Monoidk](monoidk.md)
+    - [Semigroup](semigroup.md)
+    - [Semigroupk](semigroupk.md)
+    - [Traverse](traverse.md)
+
+- Data Types
+
+    - [Const](const.md)
+    - [Freeapplicative](freeapplicative.md)
+    - [Freemonad](freemonad.md)
+    - [Kleisli](kleisli.md)
+    - [Oneand](oneand.md)
+    - [Optiont](optiont.md)
+    - [State](state.md)
+    - [Validated](validated.md)
+    - [Xor](xor.md)
+
+- [Contributing](CONTRIBUTING.md)
+
+- [Process](PROCESS.md)
+
+- [Authors](AUTHORS.md)
+
+- [Changes](CHANGES.md)

--- a/docs/src/main/tut/monadcombine.md
+++ b/docs/src/main/tut/monadcombine.md
@@ -1,9 +1,0 @@
----
-layout: default
-title:  "MonadCombine"
-section: "typeclasses"
-source: "core/src/main/scala/cats/MonadCombine.scala"
-scaladoc: "#cats.MonadCombine"
----
-# MonadCombine
-

--- a/docs/src/main/tut/monadfilter.md
+++ b/docs/src/main/tut/monadfilter.md
@@ -1,9 +1,0 @@
----
-layout: default
-title:  "MonadFilter"
-section: "typeclasses"
-source: "core/src/main/scala/cats/MonadFilter.scala"
-scaladoc: "#cats.MonadFilter"
----
-# MonadFilter
-

--- a/docs/src/main/tut/show.md
+++ b/docs/src/main/tut/show.md
@@ -1,9 +1,0 @@
----
-layout: default
-title:  "Show"
-section: "typeclasses"
-source: "core/src/main/scala/cats/Show.scala"
-scaladoc: "#cats.Show"
----
-# Show
-

--- a/scripts/build-book.sh
+++ b/scripts/build-book.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -eux
+
+gitbook="node_modules/gitbook-cli/bin/gitbook.js"
+tut="docs/target/scala-2.11/tut"
+
+# Brings AUTHORS.md, CHANGES.md, ...
+cp *.md $tut/
+
+# This removes badges from the README.
+# Because badges are in svg, leaving them adds an extra (heavy) dependeny on `svgexport`
+echo -e "# [Cats](https://github.com/typelevel/cats) \n$(sed -ne '/Overview/,$p' README.md)" \
+  > $tut/README.md
+
+if ! test -e $gitbook; then
+  npm install gitbook
+  npm install gitbook-cli
+  sudo apt-get install -y calibre # Required for ebook stuff
+fi
+
+$gitbook build $tut book
+$gitbook pdf   $tut book/ebook.pdf
+$gitbook epub  $tut book/ebook.epub
+$gitbook mobi  $tut book/ebook.mobi
+
+exit 0


### PR DESCRIPTION
This PR contributes a shell script to compile cats documentation as a gitbook. Fix #1125.

Here are previews of the result in [html](http://olivierblanvillain.github.io/cats/book/), [epub](http://olivierblanvillain.github.io/cats/book/ebook.epub), [mobi](http://olivierblanvillain.github.io/cats/book/ebook.mobi) and [pdf](http://olivierblanvillain.github.io/cats/book/ebook.pdf).

If this becomes the default way to read cats documentation, I should probably be incorporated to / replace http://typelevel.org/cats/.
