### PR TITLE
Add syntax to create a XorT from an F[A] and from a Xor.

### DIFF
--- a/core/src/main/scala/cats/data/Xor.scala
+++ b/core/src/main/scala/cats/data/Xor.scala
@@ -19,6 +19,9 @@ import scala.util.{Failure, Success, Try}
  * `flatMap` apply only in the context of the "right" case. This right bias makes [[Xor]] more convenient to use
  * than `scala.Either` in a monadic context. Methods such as `swap`, and `leftMap` provide functionality
  * that `scala.Either` exposes through left projections.
+ *
+ * Some additional [[Xor]] methods can be found in [[Xor.XorOps XorOps]]. These methods are not defined on [[Xor]] itself because
+ * [[Xor]] is covariant in its types `A` and `B`.
  */
 sealed abstract class Xor[+A, +B] extends Product with Serializable {
 
@@ -188,6 +191,20 @@ sealed abstract class Xor[+A, +B] extends Product with Serializable {
 object Xor extends XorInstances with XorFunctions {
   final case class Left[+A](a: A) extends (A Xor Nothing)
   final case class Right[+B](b: B) extends (Nothing Xor B)
+
+  final implicit class XorOps[A, B](val value: A Xor B) extends AnyVal {
+    /**
+     * Transform the `Xor` into a [[XorT]] while lifting it into the specified Applicative.
+     *
+     * {{{
+     * scala> import cats.implicits._
+     * scala> val x: Xor[String, Int] = Xor.right(3)
+     * scala> x.toXorT[Option]
+     * res0: cats.data.XorT[Option, String, Int] = XorT(Some(Right(3)))
+     * }}}
+     */
+    def toXorT[F[_]: Applicative]: XorT[F, A, B] = XorT.fromXor(value)
+  }
 }
 
 private[data] sealed abstract class XorInstances extends XorInstances1 {

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -13,6 +13,7 @@ trait AllSyntax
     with ComonadSyntax
     with ComposeSyntax
     with ContravariantSyntax
+    with CoproductSyntax
     with EitherSyntax
     with EqSyntax
     with FlatMapSyntax
@@ -37,7 +38,7 @@ trait AllSyntax
     with StrongSyntax
     with TransLiftSyntax
     with TraverseSyntax
-    with XorSyntax
     with ValidatedSyntax
-    with CoproductSyntax
     with WriterSyntax
+    with XorSyntax
+    with XorTSyntax

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -36,7 +36,8 @@ package object syntax {
   object strong extends StrongSyntax
   object transLift extends TransLiftSyntax
   object traverse extends TraverseSyntax
-  object xor extends XorSyntax
   object validated extends ValidatedSyntax
   object writer extends WriterSyntax
+  object xor extends XorSyntax
+  object xort extends XorTSyntax
 }

--- a/core/src/main/scala/cats/syntax/xort.scala
+++ b/core/src/main/scala/cats/syntax/xort.scala
@@ -1,0 +1,39 @@
+package cats
+package syntax
+
+import cats.data.XorT
+
+trait XorTSyntax extends XorTSyntax1 {
+  implicit def catsSyntaxXorT[F[_]: Functor, A](fa: F[A]): XorTFunctorOps[F, A] = new XorTFunctorOps(fa)
+}
+
+private[syntax] trait XorTSyntax1 {
+  implicit def catsSyntaxUXorT[FA](fa: FA)(implicit U: Unapply[Functor, FA]): XorTFunctorOps[U.M, U.A] =
+    new XorTFunctorOps[U.M, U.A](U.subst(fa))(U.TC)
+}
+
+final class XorTFunctorOps[F[_]: Functor, A](val fa: F[A]) {
+  /**
+   * Lift this `F[A]` into a `XorT[F, A, R]`.
+   *
+   * {{{
+   * scala> import cats.implicits._
+   * scala> val oa: Option[String] = Some("boo")
+   * scala> oa.leftXorT[Int]
+   * res0: cats.data.XorT[Option,String,Int] = XorT(Some(Left(boo)))
+   * }}}
+   */
+  def leftXorT[R]: XorT[F, A, R] = XorT.left(fa)
+
+  /**
+   * Lift this `F[A]` into a `XorT[F, L, A]`.
+   *
+   * {{{
+   * scala> import cats.implicits._
+   * scala> val oa: Option[Int] = Some(1)
+   * scala> oa.rightXorT[String]
+   * res0: cats.data.XorT[Option,String,Int] = XorT(Some(Right(1)))
+   * }}}
+   */
+  def rightXorT[L]: XorT[F, L, A] = XorT.right(fa)
+}

--- a/tests/src/test/scala/cats/tests/XorTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTests.scala
@@ -219,6 +219,7 @@ class XorTests extends CatsSuite {
       x.isLeft should === (x.toList.isEmpty)
       x.isLeft should === (x.toValidated.isInvalid)
       x.isLeft should === (x.toValidatedNel.isInvalid)
+      Option(x.isLeft) should === (x.toXorT[Option].isLeft)
     }
   }
 


### PR DESCRIPTION
I have added syntax to create a `XorT` from a 

- `F[A]` :  `fa.leftXorT` and `fa.rightXorT` and which use `XorT.left` and `XorT.right`
- `Xor` : `xor.toXorT` (which was suggested by @ceedubs in #1078)

The last one is a little bit difficult:
- If I define it on `Xor` I need to work around the covariance of `A` and `B` in `Xor` versus the invariance in `XorT`, so you would need to write `xor.toXorT[F, A, B]`. 
- I have also defined `toXorT` (currently `toXorT2` in `syntax.xor`) as a syntax function on `Xor` so you can write `xor.toXorT[F]`. But it's probably not expected that there are syntax functions for a data type defined in cats itself (at least I couldn't think of / find an earlier precedent).

I prefer the syntax function because it is nicer/easier to use, but it would probably be more difficult to find, since it won't be in the `Xor` scaladoc. WDYT ?