### PR TITLE
Add mima for kernel

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -203,9 +203,9 @@ lazy val kernel = crossProject.crossType(CrossType.Pure)
   .settings(scoverageSettings: _*)
   .settings(sourceGenerators in Compile <+= (sourceManaged in Compile).map(KernelBoiler.gen))
   .jsSettings(commonJsSettings:_*)
-  .jvmSettings(commonJvmSettings:_*)
+  .jvmSettings((commonJvmSettings ++ (mimaPreviousArtifacts := Set("org.typelevel" %% "cats-kernel" % "0.6.0"))):_*)
 
-lazy val kernelJVM = kernel.jvm
+lazy val kernelJVM = kernel.jvm 
 lazy val kernelJS = kernel.js
 
 lazy val kernelLaws = crossProject.crossType(CrossType.Pure)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,7 @@
 addSbtPlugin("com.eed3si9n"         % "sbt-unidoc"            % "0.3.2")
 addSbtPlugin("com.github.gseitz"    % "sbt-release"           % "1.0.0")
 addSbtPlugin("com.jsuereth"         % "sbt-pgp"               % "1.0.0")
+addSbtPlugin("com.typesafe"         % "sbt-mima-plugin"       % "0.1.9")
 addSbtPlugin("com.typesafe.sbt"     % "sbt-ghpages"           % "0.5.3")
 addSbtPlugin("com.typesafe.sbt"     % "sbt-site"              % "0.8.1")
 addSbtPlugin("org.tpolecat"         % "tut-plugin"            % "0.4.2")


### PR DESCRIPTION
This adds mima for kernel, but it does not pass, so it is not added to travis yet.

As discussed when moving kernel from algebra, the thinking was we could be more conservative there. I would like to turn this on after the next release (I guess 0.7.0) and I hope we can be conservative with kernel updates so that algebra is not too tightly coupled to cats.