### PR TITLE
Add toNested to OptionT and XorT.

### DIFF
--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -105,6 +105,25 @@ final case class OptionT[F[_], A](value: F[Option[A]]) {
   def foldRight[B](lb: Eval[B])(f: (A, Eval[B]) => Eval[B])(implicit F: Foldable[F]): Eval[B] =
     F.compose(optionInstance).foldRight(value, lb)(f)
 
+  /**
+   * Transform this `OptionT[F, A]` into a `[[Nested]][F, Option, A]`.
+   *
+   * An example where `toNested` can be used, is to get the `Apply.ap` function with the
+   * behavior from the composed `Apply` instances from `F` and `Option`, which is
+   * inconsistent with the behavior of the `ap` from `Monad` of `OptionT`.
+   *
+   * {{{
+   * scala> import cats.implicits._
+   * scala> import cats.data.OptionT
+   * scala> val ff: OptionT[List, Int => String] =
+   *      |   OptionT(List(Option(_.toString), None))
+   * scala> val fa: OptionT[List, Int] = OptionT(List(Option(1), Option(2)))
+   * scala> ff.ap(fa)
+   * res0: OptionT[List,String] = OptionT(List(Some(1), Some(2), None))
+   * scala> OptionT(ff.toNested.ap(fa.toNested).value)
+   * res1: OptionT[List,String] = OptionT(List(Some(1), Some(2), None, None))
+   * }}}
+   */
   def toNested: Nested[F, Option, A] = Nested(value)
 }
 
@@ -122,8 +141,8 @@ object OptionT extends OptionTInstances {
   /**
    * Transforms an `Option` into an `OptionT`, lifted into the specified `Applicative`.
    *
-   * Note: The return type is a FromOptionPartiallyApplied[F], which has an apply method
-   * on it, allowing you to call fromOption like this:
+   * Note: The return type is a `FromOptionPartiallyApplied[F]`, which has an apply method
+   * on it, allowing you to call `fromOption` like this:
    * {{{
    * scala> import cats.implicits._
    * scala> val o: Option[Int] = Some(2)
@@ -142,7 +161,6 @@ object OptionT extends OptionTInstances {
 
   /**
    * Lifts the `F[A]` Functor into an `OptionT[F, A]`.
-   *
    */
   def liftF[F[_], A](fa: F[A])(implicit F: Functor[F]): OptionT[F, A] = OptionT(F.map(fa)(Some(_)))
 }

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -104,6 +104,8 @@ final case class OptionT[F[_], A](value: F[Option[A]]) {
 
   def foldRight[B](lb: Eval[B])(f: (A, Eval[B]) => Eval[B])(implicit F: Foldable[F]): Eval[B] =
     F.compose(optionInstance).foldRight(value, lb)(f)
+
+  def toNested: Nested[F, Option, A] = Nested(value)
 }
 
 object OptionT extends OptionTInstances {

--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -175,6 +175,32 @@ final case class XorT[F[_], A, B](value: F[A Xor B]) {
 
   def show(implicit show: Show[F[A Xor B]]): String = show.show(value)
 
+  /**
+   * Transform this `XorT[F, A, B]` into a `[[Nested]][F, A Xor ?, B]`.
+   *
+   * An example where `toNested` can be used, is to get the `Apply.ap` function with the
+   * behavior from the composed `Apply` instances from `F` and `Xor[A, ?]`, which is
+   * inconsistent with the behavior of the `ap` from `Monad` of `XorT`.
+   *
+   * {{{
+   * scala> import cats.data.{Nested, Xor, XorT}
+   * scala> import cats.implicits._
+   * scala> val ff: XorT[List, String, Int => String] =
+   *      |   XorT(List(Xor.right(_.toString), Xor.left("error")))
+   * scala> val fa: XorT[List, String, Int] =
+   *      |   XorT(List(Xor.right(1), Xor.right(2)))
+   * scala> type ErrorOr[A] = String Xor A
+   * scala> type ListErrorOr[A] = Nested[List, ErrorOr, A]
+   * scala> ff.ap(fa)
+   * res0: XorT[List,String,String] = XorT(List(Right(1), Right(2), Left(error)))
+   * scala> XorT((ff.toNested: ListErrorOr[Int => String]).ap(fa.toNested: ListErrorOr[Int]).value)
+   * res1: XorT[List,String,String] = XorT(List(Right(1), Right(2), Left(error), Left(error)))
+   * }}}
+   *
+   * Note that we need the `ErrorOr` type alias above because otherwise we can't use the
+   * syntax function `ap` on `Nested[List, A Xor ?, B]`. This won't be needed after cats has
+   * decided [[https://github.com/typelevel/cats/issues/1073 how to handle the SI-2712 fix]].
+   */
   def toNested: Nested[F, A Xor ?, B] = Nested[F, A Xor ?, B](value)
 }
 

--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -174,6 +174,8 @@ final case class XorT[F[_], A, B](value: F[A Xor B]) {
     XorT(F.map(value)(xor => f(xor.toValidated).toXor))
 
   def show(implicit show: Show[F[A Xor B]]): String = show.show(value)
+
+  def toNested: Nested[F, A Xor ?, B] = Nested[F, A Xor ?, B](value)
 }
 
 object XorT extends XorTInstances with XorTFunctions


### PR DESCRIPTION
I have added `toNested` to `OptionT` and `XorT` like I mentioned in #1107.

This among other things makes it possible to use the "applicative `ap`" (called `app` in Scalaz) which is inconsistent the `ap` it gets from the monad instances of `OptionT` or `XorT` (see #1106).

```scala
import cats.implicits._
import cats.data.OptionT

val ff: OptionT[List, Int => String] = 
  OptionT(List(Option(_.toString), none[Int => String]))
val fa: OptionT[List, Int] = 
  OptionT(List(1.some, 2.some))

ff.ap(fa)
// OptionT[List,String] = OptionT(List(Some(1), Some(2), None))

OptionT(ff.toNested.ap(fa.toNested).value)
// OptionT[List,String] = OptionT(List(Some(1), Some(2), None, None))
```

The `toNested` for `XorT` is currently not that useful because we are not able to get the implicits for `Nested[F, A Xor ?, B]`, but it works with the SI-2712 fix : 

```scala
import cats.data.{Xor, XorT}
import cats.implicits._

val ff2: XorT[List, String, Int => String] = 
  XorT(List(Xor.right(_.toString), "error".left))
val fa2: XorT[List, String, Int] = 
  XorT(List(1.right, 2.right))

ff2.ap(fa2)
// XorT[List,String,String] = XorT(List(Right(1), Right(2), Left(error)))

XorT(ff2.toNested.ap(fa2.toNested).value)
// XorT[List,String,String] = XorT(List(Right(1), Right(2), Left(error), Left(error)))
```
---

In #1107 I also suggested that we could simplify some functions like `foldLeft` by using the one from `Nested`, but I benchmarked `optiont.foldLeft(0)(_ + _)` (the current implementation) vs `optiont.toNested.foldLeft(0)(_ + _)` and the one using `toNested` is quite a bit slower : 

```
[info] Benchmark                    Mode  Cnt         Score         Error  Units
[info] ToNestedBench.compose       thrpt   10  58633849.651 ±  646010.783  ops/s
[info] ToNestedBench.nestedDetour  thrpt   10  39380592.834 ± 4962640.124  ops/s
```

Even though a `foldLeft` implementation with `toNested` would like slightly nicer, I am not sure it's worth the performance hit ? (This doesn't feel that important, but if someone wants to voice their opinion ...)

```scala
F.compose(optionInstance).foldLeft(value, b)(f)
toNested.foldLeft(value, b)(f)
```
---

I am not sure which tests to add (I could check for consistency for `map`, `traverse`, ... ?)