### PR TITLE
Backport tuple order fix for 0.6.x

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -150,6 +150,9 @@ lazy val catsJVM = project.in(file(".catsJVM"))
   .settings(moduleName := "cats")
   .settings(catsSettings)
   .settings(commonJvmSettings)
+  // mima complains about the .catsJVM directory not existing for this module.
+  // It should be fine to not run it on this module since it's just an aggregate.
+  .settings(mimaReportBinaryIssues := {})
   .aggregate(macrosJVM, kernelJVM, kernelLawsJVM, coreJVM, lawsJVM, freeJVM, testsJVM, docs, bench)
   .dependsOn(macrosJVM, kernelJVM, kernelLawsJVM, coreJVM, lawsJVM, freeJVM, testsJVM % "test-internal -> test", bench % "compile-internal;test-internal -> test")
 

--- a/project/KernelBoiler.scala
+++ b/project/KernelBoiler.scala
@@ -147,13 +147,13 @@ object KernelBoiler {
         -  implicit def tuple${arity}Order[${`A..N`}](implicit ${constraints("Order")}): Order[${`(A..N)`}] =
         -    new Order[${`(A..N)`}] {
         -      def compare(x: ${`(A..N)`}, y: ${`(A..N)`}): Int =
-        -        ${binMethod("compare").find(_ != 0).getOrElse(0)}
+        -        ${binMethod("compare").mkString("Array(", ", ", ")")}.find(_ != 0).getOrElse(0)
         -    }
         -
         -  implicit def tuple${arity}PartialOrder[${`A..N`}](implicit ${constraints("PartialOrder")}): PartialOrder[${`(A..N)`}] =
         -    new PartialOrder[${`(A..N)`}] {
         -      def partialCompare(x: ${`(A..N)`}, y: ${`(A..N)`}): Double =
-        -        ${binMethod("partialCompare").find(_ != 0.0).getOrElse(0.0)}
+        -        ${binMethod("partialCompare").mkString("Array(", ", ", ")")}.find(_ != 0.0).getOrElse(0.0)
         -    }
         -
         -  implicit def tuple${arity}Semigroup[${`A..N`}](implicit ${constraints("Semigroup")}): Semigroup[${`(A..N)`}] =

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,7 @@
 addSbtPlugin("com.eed3si9n"         % "sbt-unidoc"            % "0.3.2")
 addSbtPlugin("com.github.gseitz"    % "sbt-release"           % "1.0.0")
 addSbtPlugin("com.jsuereth"         % "sbt-pgp"               % "1.0.0")
+addSbtPlugin("com.typesafe"         % "sbt-mima-plugin"       % "0.1.9")
 addSbtPlugin("com.typesafe.sbt"     % "sbt-ghpages"           % "0.5.3")
 addSbtPlugin("com.typesafe.sbt"     % "sbt-site"              % "0.8.1")
 addSbtPlugin("org.tpolecat"         % "tut-plugin"            % "0.4.0")

--- a/tests/src/test/scala/cats/tests/TupleTests.scala
+++ b/tests/src/test/scala/cats/tests/TupleTests.scala
@@ -7,6 +7,19 @@ class TupleTests extends CatsSuite {
   checkAll("Tuple2", BitraverseTests[Tuple2].bitraverse[Option, Int, Int, Int, String, String, String])
   checkAll("Bitraverse[Tuple2]", SerializableTests.serializable(Bitraverse[Tuple2]))
 
+  test("eqv") {
+    val eq = Eq[(Int, Long)]
+    forAll { t: (Int, Long) => eq.eqv(t, t) should === (true) }
+    forAll { t: (Int, Long) => eq.eqv(t, t._1 -> (t._2 + 1)) should === (false) }
+  }
+
+  test("order") {
+    forAll { t: (Int, Int) =>
+      val u = t.swap
+      Order[(Int, Int)].compare(t, u) should === (scala.math.Ordering[(Int, Int)].compare(t, u))
+    }
+  }
+
   test("show") {
     (1, 2).show should === ("(1,2)")
 


### PR DESCRIPTION
This PR (which is against the `series/0.6.x` branch that I just created) does a couple of things:
- Backport the tuple order fix from #1062 
- Add a binary compatibility check to all published modules (since we will want to maintain binary compatibility within the 0.6.x series)

I will largely unavailable for a little over a week, but I thought that if I got this branch set up someone else (@non?) might be able to get a 0.6.1 published with the fix for this pretty nasty bug.

cc @mpilquist and @travisbrown who have both expressed interest in getting this backported for a 0.6.1 release.