### PR TITLE
Add Is constructor for Leibniz equality

### DIFF
--- a/core/src/main/scala/cats/eq/Is.scala
+++ b/core/src/main/scala/cats/eq/Is.scala
@@ -1,5 +1,7 @@
 package cats.eq
 
+import cats.Id
+
 /**
   * A value of `A Is B` witnesses that the types `A` and `B` are the same.
   * You can use this value to coerce `A` into `B` and therefore `A Is B` is
@@ -30,6 +32,13 @@ abstract class Is[A, B] {
 
   final def lift[F[_]]: F[A] Is F[B] =
     subst[λ[α => F[A] Is F[α]]](Is.refl)
+
+  /**
+    * Substitution on identity brings about a direct coercion function of the
+    * same form that `=:=` provides.
+    */
+  def coerce: A => B =
+    subst[Id]
 }
 
 object Is {
@@ -43,13 +52,6 @@ object Is {
   implicit def refl[A]: A Is A = new Is[A, A] {
     def subst[F[_]](fa: F[A]): F[A] = fa
   }
-
-  /**
-    * In order to furnish `A Is B` values as their coercions we provide an
-    * implicit conversion to the coercion function.
-    */
-  implicit def witness[A, B](t: A Is B): A => B =
-    t.subst[A => ?](identity)
 
   /**
     * A value `A Is B` is always sufficient to produce a similar `Predef.=:=`

--- a/core/src/main/scala/cats/eq/Is.scala
+++ b/core/src/main/scala/cats/eq/Is.scala
@@ -3,61 +3,64 @@ package cats.eq
 import cats.Id
 
 /**
- * A value of `A Is B` witnesses that the types `A` and `B` are the same.
- * You can use this value to coerce `A` into `B` and therefore `A Is B` is
- * similar in feel to `A =:= B`; however, `A Is B` has more computational
- * content and offers greater functionality.
+ * A value of `A Is B` is proof that the types `A` and `B` are the same. More
+ * powerfully, it asserts that they have the same meaning in all type
+ * contexts. This can be a more powerful assertion than `A =:= B` and is more
+ * easily used in manipulation of types while avoiding (potentially
+ * erroneous) coercions.
  *
- * `A Is B` is also known as Leibniz equality and represents computationally
- * the idea that two things are equal if they take equal values on all
- * predicates. In other words, `A` equals `B` when for all predicates `P[_]`
- * we have that `P[A]` implies `P[B]` and visa versa. `A Is B` represents
- * this idea computationally providing exploitable structure to our equalities.
- *
- * The heart of `A Is B` is the `subst` method which converts values `F[A]`
- * into values `F[B]` for any `F[_]`. Creative choices of `F` enable type
- * equalities to be substituted into many more complex type expressions.
+ * `A Is B` is also known as Leibniz equality.
  */
 abstract class Is[A, B] {
   def subst[F[_]](fa: F[A]): F[B]
 
-  final def andThen[C](next: B Is C): A Is C =
+  @inline final def andThen[C](next: B Is C): A Is C =
     next.subst[A Is ?](this)
 
-  final def compose[C](prev: C Is A): C Is B =
+  @inline final def compose[C](prev: C Is A): C Is B =
     prev andThen this
 
-  final def from: B Is A =
+  @inline final def from: B Is A =
     this.subst[? Is A](Is.refl)
 
-  final def lift[F[_]]: F[A] Is F[B] =
+  @inline final def lift[F[_]]: F[A] Is F[B] =
     subst[λ[α => F[A] Is F[α]]](Is.refl)
 
   /**
    * Substitution on identity brings about a direct coercion function of the
    * same form that `=:=` provides.
    */
-  def coerce: A => B =
-    subst[Id]
+  @inline final def coerce(a: A): B =
+    subst[Id](a)
 }
 
 object Is {
+
+  /**
+   * In truth, "all values of `A Is B` are `refl`". `reflAny` is that
+   * single value.
+   */
+  private[this] val reflAny = new Is[Any, Any] {
+    def subst[F[_]](fa: F[Any]) = fa
+  }
 
   /**
    * In normal circumstances the only `Is` value which is available is the
    * computational identity `A Is A` at all types `A`. These "self loops"
    * generate all of the behavior of equality and also ensure that at its
    * heart `A Is B` is always just an identity relation.
+   *
+   * Implementation note: all values of `refl` return the same (private)
+   * instance at whatever type is appropriate to save on allocations.
    */
-  implicit def refl[A]: A Is A = new Is[A, A] {
-    def subst[F[_]](fa: F[A]): F[A] = fa
-  }
+  implicit def refl[A]: A Is A =
+    reflAny.asInstanceOf
 
   /**
    * A value `A Is B` is always sufficient to produce a similar `Predef.=:=`
    * value.
    */
-  implicit def scalaEq[A, B](t: A Is B): A =:= B =
+  implicit def predefEq[A, B](t: A Is B): A =:= B =
     t.subst[A =:= ?](implicitly[A =:= A])
 
 }

--- a/core/src/main/scala/cats/eq/Is.scala
+++ b/core/src/main/scala/cats/eq/Is.scala
@@ -3,21 +3,21 @@ package cats.eq
 import cats.Id
 
 /**
-  * A value of `A Is B` witnesses that the types `A` and `B` are the same.
-  * You can use this value to coerce `A` into `B` and therefore `A Is B` is
-  * similar in feel to `A =:= B`; however, `A Is B` has more computational
-  * content and offers greater functionality.
-  *
-  * `A Is B` is also known as Leibniz equality and represents computationally
-  * the idea that two things are equal if they take equal values on all
-  * predicates. In other words, `A` equals `B` when for all predicates `P[_]`
-  * we have that `P[A]` implies `P[B]` and visa versa. `A Is B` represents
-  * this idea computationally providing exploitable structure to our equalities.
-  *
-  * The heart of `A Is B` is the `subst` method which converts values `F[A]`
-  * into values `F[B]` for any `F[_]`. Creative choices of `F` enable type
-  * equalities to be substituted into many more complex type expressions.
-  */
+ * A value of `A Is B` witnesses that the types `A` and `B` are the same.
+ * You can use this value to coerce `A` into `B` and therefore `A Is B` is
+ * similar in feel to `A =:= B`; however, `A Is B` has more computational
+ * content and offers greater functionality.
+ *
+ * `A Is B` is also known as Leibniz equality and represents computationally
+ * the idea that two things are equal if they take equal values on all
+ * predicates. In other words, `A` equals `B` when for all predicates `P[_]`
+ * we have that `P[A]` implies `P[B]` and visa versa. `A Is B` represents
+ * this idea computationally providing exploitable structure to our equalities.
+ *
+ * The heart of `A Is B` is the `subst` method which converts values `F[A]`
+ * into values `F[B]` for any `F[_]`. Creative choices of `F` enable type
+ * equalities to be substituted into many more complex type expressions.
+ */
 abstract class Is[A, B] {
   def subst[F[_]](fa: F[A]): F[B]
 
@@ -34,9 +34,9 @@ abstract class Is[A, B] {
     subst[λ[α => F[A] Is F[α]]](Is.refl)
 
   /**
-    * Substitution on identity brings about a direct coercion function of the
-    * same form that `=:=` provides.
-    */
+   * Substitution on identity brings about a direct coercion function of the
+   * same form that `=:=` provides.
+   */
   def coerce: A => B =
     subst[Id]
 }
@@ -44,19 +44,19 @@ abstract class Is[A, B] {
 object Is {
 
   /**
-    * In normal circumstances the only `Is` value which is available is the
-    * computational identity `A Is A` at all types `A`. These "self loops"
-    * generate all of the behavior of equality and also ensure that at its
-    * heart `A Is B` is always just an identity relation.
-    */
+   * In normal circumstances the only `Is` value which is available is the
+   * computational identity `A Is A` at all types `A`. These "self loops"
+   * generate all of the behavior of equality and also ensure that at its
+   * heart `A Is B` is always just an identity relation.
+   */
   implicit def refl[A]: A Is A = new Is[A, A] {
     def subst[F[_]](fa: F[A]): F[A] = fa
   }
 
   /**
-    * A value `A Is B` is always sufficient to produce a similar `Predef.=:=`
-    * value.
-    */
+   * A value `A Is B` is always sufficient to produce a similar `Predef.=:=`
+   * value.
+   */
   implicit def scalaEq[A, B](t: A Is B): A =:= B =
     t.subst[A =:= ?](implicitly[A =:= A])
 

--- a/core/src/main/scala/cats/eq/Is.scala
+++ b/core/src/main/scala/cats/eq/Is.scala
@@ -61,3 +61,4 @@ object Is {
     t.subst[A =:= ?](implicitly[A =:= A])
 
 }
+

--- a/core/src/main/scala/cats/eq/Is.scala
+++ b/core/src/main/scala/cats/eq/Is.scala
@@ -1,0 +1,61 @@
+package cats.eq
+
+/**
+  * A value of `A Is B` witnesses that the types `A` and `B` are the same.
+  * You can use this value to coerce `A` into `B` and therefore `A Is B` is
+  * similar in feel to `A =:= B`; however, `A Is B` has more computational
+  * content and offers greater functionality.
+  *
+  * `A Is B` is also known as Leibniz equality and represents computationally
+  * the idea that two things are equal if they take equal values on all
+  * predicates. In other words, `A` equals `B` when for all predicates `P[_]`
+  * we have that `P[A]` implies `P[B]` and visa versa. `A Is B` represents
+  * this idea computationally providing exploitable structure to our equalities.
+  *
+  * The heart of `A Is B` is the `subst` method which converts values `F[A]`
+  * into values `F[B]` for any `F[_]`. Creative choices of `F` enable type
+  * equalities to be substituted into many more complex type expressions.
+  */
+abstract class Is[A, B] {
+  def subst[F[_]](fa: F[A]): F[B]
+
+  final def andThen[C](next: B Is C): A Is C =
+    next.subst[A Is ?](this)
+
+  final def compose[C](prev: C Is A): C Is B =
+    prev andThen this
+
+  final def from: B Is A =
+    this.subst[? Is A](Is.refl)
+
+  final def lift[F[_]]: F[A] Is F[B] =
+    subst[λ[α => F[A] Is F[α]]](Is.refl)
+}
+
+object Is {
+
+  /**
+    * In normal circumstances the only `Is` value which is available is the
+    * computational identity `A Is A` at all types `A`. These "self loops"
+    * generate all of the behavior of equality and also ensure that at its
+    * heart `A Is B` is always just an identity relation.
+    */
+  implicit def refl[A]: A Is A = new Is[A, A] {
+    def subst[F[_]](fa: F[A]): F[A] = fa
+  }
+
+  /**
+    * In order to furnish `A Is B` values as their coercions we provide an
+    * implicit conversion to the coercion function.
+    */
+  implicit def witness[A, B](t: A Is B): A => B =
+    t.subst[A => ?](identity)
+
+  /**
+    * A value `A Is B` is always sufficient to produce a similar `Predef.=:=`
+    * value.
+    */
+  implicit def scalaEq[A, B](t: A Is B): A =:= B =
+    t.subst[A =:= ?](implicitly[A =:= A])
+
+}

--- a/core/src/main/scala/cats/evidence/Is.scala
+++ b/core/src/main/scala/cats/evidence/Is.scala
@@ -89,9 +89,9 @@ object Is {
 
   /**
    * It can be convenient to convert a `Predef.=:=` value into an `Is` value.
-   * This is not strictly valid as while it is almost certainly true that `A
-   * =:= B` implies `A Is B` it is not the case that you can create evidence
-   * of `A Is B` except via a coercion. Use responsibly.
+   * This is not strictly valid as while it is almost certainly true that
+   * `A =:= B` implies `A Is B` it is not the case that you can create
+   * evidence of `A Is B` except via a coercion. Use responsibly.
    */
   @inline def unsafeFromPredef[A, B](eq: A =:= B): A Is B =
     reflAny.asInstanceOf[A Is B]

--- a/core/src/main/scala/cats/evidence/Is.scala
+++ b/core/src/main/scala/cats/evidence/Is.scala
@@ -1,4 +1,4 @@
-package cats.eq
+package cats.evidence
 
 import cats.Id
 

--- a/core/src/main/scala/cats/evidence/Is.scala
+++ b/core/src/main/scala/cats/evidence/Is.scala
@@ -71,11 +71,11 @@ object Is {
     reflAny.asInstanceOf[A Is A]
 
   /**
-    * It can be convenient to convert a `Predef.=:=` value into an `Is` value.
-    * This is not strictly valid as while it is almost certainly true that `A
-    * =:= B` implies `A Is B` it is not the case that you can create evidence
-    * of `A Is B` except via a coercion. Use responsibly.
-    */
+   * It can be convenient to convert a `Predef.=:=` value into an `Is` value.
+   * This is not strictly valid as while it is almost certainly true that `A
+   * =:= B` implies `A Is B` it is not the case that you can create evidence
+   * of `A Is B` except via a coercion. Use responsibly.
+   */
   def unsafeFromPredef[A, B](eq: A =:= B): A Is B =
     reflAny.asInstanceOf[A Is B]
 

--- a/core/src/main/scala/cats/evidence/Is.scala
+++ b/core/src/main/scala/cats/evidence/Is.scala
@@ -63,5 +63,14 @@ object Is {
   implicit def refl[A]: A Is A =
     reflAny.asInstanceOf[A Is A]
 
+  /**
+    * It can be convenient to convert a `Predef.=:=` value into an `Is` value.
+    * This is not strictly valid as while it is almost certainly true that `A
+    * =:= B` implies `A Is B` it is not the case that you can create evidence
+    * of `A Is B` except via a coercion. Use responsibly.
+    */
+  def unsafeFromPredef[A, B](eq: A =:= B): A Is B =
+    reflAny.asInstanceOf[A Is B]
+
 }
 

--- a/core/src/main/scala/cats/evidence/Is.scala
+++ b/core/src/main/scala/cats/evidence/Is.scala
@@ -21,15 +21,32 @@ abstract class Is[A, B] extends Serializable {
    */
   def substitute[F[_]](fa: F[A]): F[B]
 
+  /**
+    * `Is` is transitive and therefore values of `Is` can be composed in a
+    * chain much like functions. See also `compose`.
+    */
   @inline final def andThen[C](next: B Is C): A Is C =
     next.substitute[A Is ?](this)
 
+  /**
+    * `Is` is transitive and therefore values of `Is` can be composed in a
+    * chain much like functions. See also `andThen`.
+    */
   @inline final def compose[C](prev: C Is A): C Is B =
     prev andThen this
 
-  @inline final def from: B Is A =
+  /**
+    * `Is` is symmetric and therefore can be flipped around. Flipping is its
+    * own inverse, so `x.flip.flip == x`.
+    */
+  @inline final def flip: B Is A =
     this.substitute[? Is A](Is.refl)
 
+  /**
+    * Sometimes for more complex substitutions it helps the typechecker to
+    * wrap one layer of `F[_]` context around the types you're equating
+    * before substitution.
+    */
   @inline final def lift[F[_]]: F[A] Is F[B] =
     substitute[λ[α => F[A] Is F[α]]](Is.refl)
 

--- a/core/src/main/scala/cats/evidence/Is.scala
+++ b/core/src/main/scala/cats/evidence/Is.scala
@@ -67,7 +67,7 @@ object Is {
    * Implementation note: all values of `refl` return the same (private)
    * instance at whatever type is appropriate to save on allocations.
    */
-  implicit def refl[A]: A Is A =
+  @inline implicit def refl[A]: A Is A =
     reflAny.asInstanceOf[A Is A]
 
   /**
@@ -76,7 +76,7 @@ object Is {
    * =:= B` implies `A Is B` it is not the case that you can create evidence
    * of `A Is B` except via a coercion. Use responsibly.
    */
-  def unsafeFromPredef[A, B](eq: A =:= B): A Is B =
+  @inline def unsafeFromPredef[A, B](eq: A =:= B): A Is B =
     reflAny.asInstanceOf[A Is B]
 
 }

--- a/core/src/main/scala/cats/evidence/Is.scala
+++ b/core/src/main/scala/cats/evidence/Is.scala
@@ -32,6 +32,13 @@ abstract class Is[A, B] extends Serializable {
    */
   @inline final def coerce(a: A): B =
     subst[Id](a)
+
+  /**
+    * A value `A Is B` is always sufficient to produce a similar `Predef.=:=`
+    * value.
+    */
+  @inline final def predefEq: A =:= B =
+    subst[A =:= ?](implicitly[A =:= A])
 }
 
 object Is {
@@ -55,13 +62,6 @@ object Is {
    */
   implicit def refl[A]: A Is A =
     reflAny.asInstanceOf[A Is A]
-
-  /**
-   * A value `A Is B` is always sufficient to produce a similar `Predef.=:=`
-   * value.
-   */
-  implicit def predefEq[A, B](t: A Is B): A =:= B =
-    t.subst[A =:= ?](implicitly[A =:= A])
 
 }
 

--- a/core/src/main/scala/cats/evidence/Is.scala
+++ b/core/src/main/scala/cats/evidence/Is.scala
@@ -54,7 +54,7 @@ object Is {
    * instance at whatever type is appropriate to save on allocations.
    */
   implicit def refl[A]: A Is A =
-    reflAny.asInstanceOf
+    reflAny.asInstanceOf[A Is A]
 
   /**
    * A value `A Is B` is always sufficient to produce a similar `Predef.=:=`

--- a/core/src/main/scala/cats/evidence/Is.scala
+++ b/core/src/main/scala/cats/evidence/Is.scala
@@ -11,7 +11,7 @@ import cats.Id
  *
  * `A Is B` is also known as Leibniz equality.
  */
-abstract class Is[A, B] {
+abstract class Is[A, B] extends Serializable {
   def subst[F[_]](fa: F[A]): F[B]
 
   @inline final def andThen[C](next: B Is C): A Is C =

--- a/core/src/main/scala/cats/evidence/package.scala
+++ b/core/src/main/scala/cats/evidence/package.scala
@@ -1,0 +1,5 @@
+package cats
+
+package object evidence {
+  type Leibniz[A, B] = cats.evidence.Is[A, B]
+}

--- a/tests/src/test/scala/cats/tests/EvidenceTests.scala
+++ b/tests/src/test/scala/cats/tests/EvidenceTests.scala
@@ -1,0 +1,19 @@
+package cats.tests
+
+import cats.evidence._
+
+class EvidenceTests extends CatsSuite {
+
+  test("Is / Leibniz") {
+
+    def cast1[A, B](as: List[A])(implicit ev: A Is B): List[B] =
+      ev.substitute(as)
+    cast1[Int, Int](1 :: 2 :: 3 :: Nil)
+
+    def cast2[A, B](as: List[A])(implicit ev: Leibniz[A, B]): List[B] =
+      ev.substitute(as)
+    cast2[Int, Int](1 :: 2 :: 3 :: Nil)
+
+  }
+
+}


### PR DESCRIPTION
(See #1177 for initial discussion)

This PR adds Leibniz type equality under the name `A Is B`. Leibniz equality is an improvement over `Predef.=:=` as it can be substituted into type expressions and as it has more computational meaning. Both of these add power and convenience to `Is` which makes it appealing for certain kinds of pure functional work. I am, for instance, using a local version of this in a [Cats-based lens library I'm working on](https://github.com/tel/scala-telescope) to implement a generalized `Equality[S, T, A, B]` optic at the base of the optical hierarchy. It also shows up nicely for making GADTs with more computational integrity.

This is my first Cats contribution so there's probably a lot missing—please let me know how to continue to develop it.
## Questions
- I've simplified the Scalaz version back to one they used previously which appears to not play as nicely with subtyping. I'm not sure if this is a good idea... but it's undeniable that this version is clearer.
- Is `Is` a good name? Also possible are `TEq`, `Leib`, and `Leibniz`. I like `Is` since it's very direct.
- How can I better document this?
- What is the right way to add tests?
- What methods or companion object functions are missing? Are there any I have right now that are suspect?
## Before we can land
- [X] Rename `cats.eq` to `cats.evidence`
- [ ] Decide about design to maximize allocation and inlining
- [ ] Determine whether or not to include `def fromPredef[A, B](eq: A =:= B): A Is B`
  - **Pros** greater convenience
  - **Cons** not strictly valid in a constructive sense; may be possible to generate invalid inferences?
- [ ] Add equality tests at the type level by porting some notion of Shapeless's `illtyped` macro
- [ ] Add basic tests showing design of implicits working without imports
- [ ] Add basic tests to show that methods don't throw
- [ ] Tests that we aren't reallocating
- [x] Decide what to call `from` ({`from`, `reverse`, `flip`, `mirror`, `symm`, `inverse`})
- [ ] Determine the appropriate `@inline` design
## Implicits spec
- [ ] `refl` is available whenever there is an implicit need for `A Is A` without extra imports
