### PR TITLE
Add Peter Neyens as a maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The current maintainers (people who can merge pull requests) are:
  * [rossabaker](https://github.com/rossabaker) Ross Baker
  * [travisbrown](https://github.com/travisbrown) Travis Brown
  * [adelbertc](https://github.com/adelbertc) Adelbert Chang
+ * [peterneyens](https://github.com/peterneyens) Peter Neyens
  * [tpolecat](https://github.com/tpolecat) Rob Norris
  * [stew](https://github.com/stew) Mike O'Connor
  * [non](https://github.com/non) Erik Osheim


### PR DESCRIPTION
@peterneyens has been quite active with Cats in the past 3 months. Peter has contributed a significant change set over a number of PRs, has always taken feedback well and addressed it quickly, and has provided helpful and friendly feedback on others' PRs.

Thanks a bunch, @peterneyens. Please give a 👍 if you'd like to be added as a maintainer.

_If anyone has reason to believe that this candidate's conduct does not align with typelevel's [code of conduct](http://typelevel.org/conduct.html) or goal of an inclusive, welcoming and safe environment; please contact a typelevel member (contact information is provided at the bottom of the code of conduct) via email or private Gitter message._