### PR TITLE
Add johnynek as a maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ The current maintainers (people who can merge pull requests) are:
 
  * [ceedubs](https://github.com/ceedubs) Cody Allen
  * [rossabaker](https://github.com/rossabaker) Ross Baker
+ * [johnynek](https://github.com/johnynek) P. Oscar Boykin
  * [travisbrown](https://github.com/travisbrown) Travis Brown
  * [adelbertc](https://github.com/adelbertc) Adelbert Chang
  * [tpolecat](https://github.com/tpolecat) Rob Norris


### PR DESCRIPTION
@johnynek's Cats contributions started fairly recently, but @johnynek was a big part of the algebra effort that led to cats-kernel and has contributed some nice changes and feedback since the creation of cats-kernel. Like @non, @johnynek is a person who is performance-conscious, and I think that Cats could benefit from this area of knowledge/awareness.

@johnynek thanks for the great work. Add a 👍 if you would like to be added as a maintainer.

_If anyone has reason to believe that this candidate's conduct does not align with typelevel's [code of conduct](http://typelevel.org/conduct.html) or goal of an inclusive, welcoming and safe environment; please contact a typelevel member (contact information is provided at the bottom of the code of conduct) via email or private Gitter message._