### PR TITLE
Implement Reducible.reduceM

### DIFF
--- a/core/src/main/scala/cats/Reducible.scala
+++ b/core/src/main/scala/cats/Reducible.scala
@@ -60,6 +60,12 @@ import simulacrum.typeclass
   def reduceLeftTo[A, B](fa: F[A])(f: A => B)(g: (B, A) => B): B
 
   /**
+   *  Monadic variant of [[reduceLeftTo]]
+   */
+  def reduceLeftM[G[_], A, B](fa: F[A])(f: A => G[B])(g: (B, A) => G[B])(implicit G: FlatMap[G]): G[B] =
+    reduceLeftTo(fa)(f)((gb, a) => G.flatMap(gb)(g(_, a)))
+
+  /**
    * Overriden from Foldable[_] for efficiency.
    */
   override def reduceLeftToOption[A, B](fa: F[A])(f: A => B)(g: (B, A) => B): Option[B] =

--- a/tests/src/test/scala/cats/tests/ReducibleTests.scala
+++ b/tests/src/test/scala/cats/tests/ReducibleTests.scala
@@ -1,0 +1,18 @@
+package cats
+package tests
+
+class ReducibleTestsAdditional extends CatsSuite {
+
+  test("Reducible[NonEmptyList].reduceLeftM stack safety") {
+    def nonzero(acc: Long, x: Long): Option[Long] =
+      if (x == 0) None else Some(acc + x)
+
+    val n = 100000L
+    val expected = n*(n+1)/2
+    val actual = (1L to n).toList.toNel.flatMap(_.reduceLeftM(Option.apply)(nonzero))
+    actual should === (Some(expected))
+  }
+
+}
+
+


### PR DESCRIPTION
`foldM` for nonempty collections. First mention: https://gitter.im/typelevel/cats?at=5781d3f33eaf66535e62da69