### PR TITLE
[Do not merge] Separate Bitraverse hierarchy default implementations

### DIFF
--- a/core/src/main/scala/cats/Bifoldable.scala
+++ b/core/src/main/scala/cats/Bifoldable.scala
@@ -16,26 +16,26 @@ trait Bifoldable[F[_, _]] extends Any with Serializable {
   def compose[G[_, _]](implicit ev: Bifoldable[G]): Bifoldable[λ[(α, β) => F[G[α, β], G[α, β]]]]
 }
 
-trait DefaultBifoldable[F[_, _]] extends Bifoldable[F] { self =>
-
-  def bifoldMap[A, B, C](fab: F[A, B])(f: A => C, g: B => C)(implicit C: Monoid[C]): C =
-    bifoldLeft(fab, C.empty)(
-      (c: C, a: A) => C.combine(c, f(a)),
-      (c: C, b: B) => C.combine(c, g(b))
-    )
-
-  def compose[G[_, _]](implicit ev: Bifoldable[G]): Bifoldable[λ[(α, β) => F[G[α, β], G[α, β]]]] =
-    new ComposedBifoldable[F, G] {
-      val F = self
-      val G = ev
-    }
-}
-
 object Bifoldable {
   def apply[F[_, _]](implicit F: Bifoldable[F]): Bifoldable[F] = F
+
+  trait Default[F[_, _]] extends Bifoldable[F] { self =>
+
+    def bifoldMap[A, B, C](fab: F[A, B])(f: A => C, g: B => C)(implicit C: Monoid[C]): C =
+      bifoldLeft(fab, C.empty)(
+        (c: C, a: A) => C.combine(c, f(a)),
+        (c: C, b: B) => C.combine(c, g(b))
+      )
+
+    def compose[G[_, _]](implicit ev: Bifoldable[G]): Bifoldable[λ[(α, β) => F[G[α, β], G[α, β]]]] =
+      new ComposedBifoldable[F, G] {
+        val F = self
+        val G = ev
+      }
+  }
 }
 
-private[cats] trait ComposedBifoldable[F[_, _], G[_, _]] extends DefaultBifoldable[λ[(α, β) => F[G[α, β], G[α, β]]]] {
+private[cats] trait ComposedBifoldable[F[_, _], G[_, _]] extends Bifoldable.Default[λ[(α, β) => F[G[α, β], G[α, β]]]] {
   implicit def F: Bifoldable[F]
   implicit def G: Bifoldable[G]
 

--- a/core/src/main/scala/cats/Bitraverse.scala
+++ b/core/src/main/scala/cats/Bitraverse.scala
@@ -9,7 +9,31 @@ trait Bitraverse[F[_, _]] extends Bifoldable[F] with Bifunctor[F] {
   /** Traverse each side of the structure with the given functions */
   def bitraverse[G[_]: Applicative, A, B, C, D](fab: F[A, B])(f: A => G[C], g: B => G[D]): G[F[C, D]]
 
-  /** Sequence each side of the structure with the given functions */
+  /**
+   * Sequence each side of the structure with the given functions.
+   *
+   * Example:
+   * {{{
+   * scala> import cats.data.Xor
+   * scala> import cats.implicits._
+   *
+   * scala> val rightSome: Option[String] Xor Option[Int] = Xor.right(Some(3))
+   * scala> rightSome.bisequence
+   * res0: Option[String Xor Int] = Some(Right(3))
+   *
+   * scala> val rightNone: Option[String] Xor Option[Int] = Xor.right(None)
+   * scala> rightNone.bisequence
+   * res0: Option[String Xor Int] = None
+   *
+   * scala> val leftSome: Option[String] Xor Option[Int] = Xor.left(Some("foo"))
+   * scala> leftSome.bisequence
+   * res0: Option[String Xor Int] = Some(Left(foo))
+   *
+   * scala> val leftNone: Option[String] Xor Option[Int] = Xor.left(None)
+   * scala> leftNone.bisequence
+   * res0: Option[String Xor Int] = None
+   * }}}
+   */
   def bisequence[G[_]: Applicative, A, B](fab: F[G[A], G[B]]): G[F[A, B]]
 
   /** If F and G are both [[cats.Bitraverse]] then so is their composition F[G[_, _], G[_, _]] */

--- a/core/src/main/scala/cats/Bitraverse.scala
+++ b/core/src/main/scala/cats/Bitraverse.scala
@@ -1,19 +1,26 @@
 package cats
 
-import cats.functor.{Bifunctor, ComposedBifunctor}
+import cats.functor.{Bifunctor, ComposedBifunctor, DefaultBifunctor}
 
 /**
  *  A type class abstracting over types that give rise to two independent [[cats.Traverse]]s.
  */
-trait Bitraverse[F[_, _]] extends Bifoldable[F] with Bifunctor[F] { self =>
+trait Bitraverse[F[_, _]] extends Bifoldable[F] with Bifunctor[F] {
   /** Traverse each side of the structure with the given functions */
   def bitraverse[G[_]: Applicative, A, B, C, D](fab: F[A, B])(f: A => G[C], g: B => G[D]): G[F[C, D]]
 
   /** Sequence each side of the structure with the given functions */
+  def bisequence[G[_]: Applicative, A, B](fab: F[G[A], G[B]]): G[F[A, B]]
+
+  /** If F and G are both [[cats.Bitraverse]] then so is their composition F[G[_, _], G[_, _]] */
+  def compose[G[_, _]](implicit ev: Bitraverse[G]): Bitraverse[λ[(α, β) => F[G[α, β], G[α, β]]]]
+}
+
+trait DefaultBitraverse[F[_, _]] extends Bitraverse[F] with DefaultBifoldable[F] with DefaultBifunctor[F] { self =>
+
   def bisequence[G[_]: Applicative, A, B](fab: F[G[A], G[B]]): G[F[A, B]] =
     bitraverse(fab)(identity, identity)
 
-  /** If F and G are both [[cats.Bitraverse]] then so is their composition F[G[_, _], G[_, _]] */
   def compose[G[_, _]](implicit ev: Bitraverse[G]): Bitraverse[λ[(α, β) => F[G[α, β], G[α, β]]]] =
     new ComposedBitraverse[F, G] {
       val F = self
@@ -29,7 +36,7 @@ object Bitraverse {
 }
 
 private[cats] trait ComposedBitraverse[F[_, _], G[_, _]]
-    extends Bitraverse[λ[(α, β) => F[G[α, β], G[α, β]]]]
+    extends DefaultBitraverse[λ[(α, β) => F[G[α, β], G[α, β]]]]
     with    ComposedBifoldable[F, G]
     with    ComposedBifunctor[F, G] {
   def F: Bitraverse[F]

--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -71,7 +71,7 @@ private[data] sealed abstract class ConstInstances extends ConstInstances0 {
   }
 
   implicit val catsDataBifoldableForConst: Bifoldable[Const] =
-    new Bifoldable[Const] {
+    new DefaultBifoldable[Const] {
       def bifoldLeft[A, B, C](fab: Const[A, B], c: C)(f: (C, A) => C, g: (C, B) => C): C =
         f(c, fab.getConst)
 

--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -71,7 +71,7 @@ private[data] sealed abstract class ConstInstances extends ConstInstances0 {
   }
 
   implicit val catsDataBifoldableForConst: Bifoldable[Const] =
-    new DefaultBifoldable[Const] {
+    new Bifoldable.Default[Const] {
       def bifoldLeft[A, B, C](fab: Const[A, B], c: C)(f: (C, A) => C, g: (C, B) => C): C =
         f(c, fab.getConst)
 

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -1,7 +1,7 @@
 package cats
 package data
 
-import cats.functor.Bifunctor
+import cats.functor.{Bifunctor, DefaultBifunctor}
 
 /** Represents a right-biased disjunction that is either an `A`, or a `B`, or both an `A` and a `B`.
  *
@@ -146,7 +146,7 @@ private[data] sealed abstract class IorInstances extends IorInstances0 {
   }
 
   implicit def catsDataBifunctorForIor: Bifunctor[Ior] =
-    new Bifunctor[Ior] {
+    new DefaultBifunctor[Ior] {
       override def bimap[A, B, C, D](fab: A Ior B)(f: A => C, g: B => D): C Ior D = fab.bimap(f, g)
     }
 }

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -1,7 +1,7 @@
 package cats
 package data
 
-import cats.functor.{Bifunctor, DefaultBifunctor}
+import cats.functor.Bifunctor
 
 /** Represents a right-biased disjunction that is either an `A`, or a `B`, or both an `A` and a `B`.
  *
@@ -146,7 +146,7 @@ private[data] sealed abstract class IorInstances extends IorInstances0 {
   }
 
   implicit def catsDataBifunctorForIor: Bifunctor[Ior] =
-    new DefaultBifunctor[Ior] {
+    new Bifunctor.Default[Ior] {
       override def bimap[A, B, C, D](fab: A Ior B)(f: A => C, g: B => D): C Ior D = fab.bimap(f, g)
     }
 }

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -259,7 +259,7 @@ private[data] sealed abstract class ValidatedInstances extends ValidatedInstance
   }
 
   implicit val catsDataBitraverseForValidated: Bitraverse[Validated] =
-    new DefaultBitraverse[Validated] {
+    new Bitraverse.Default[Validated] {
       def bitraverse[G[_], A, B, C, D](fab: Validated[A, B])(f: A => G[C], g: B => G[D])(implicit G: Applicative[G]): G[Validated[C, D]] =
         fab match {
           case Invalid(a) => G.map(f(a))(Validated.invalid)

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -259,7 +259,7 @@ private[data] sealed abstract class ValidatedInstances extends ValidatedInstance
   }
 
   implicit val catsDataBitraverseForValidated: Bitraverse[Validated] =
-    new Bitraverse[Validated] {
+    new DefaultBitraverse[Validated] {
       def bitraverse[G[_], A, B, C, D](fab: Validated[A, B])(f: A => G[C], g: B => G[D])(implicit G: Applicative[G]): G[Validated[C, D]] =
         fab match {
           case Invalid(a) => G.map(f(a))(Validated.invalid)

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -2,7 +2,7 @@ package cats
 package data
 
 import cats.kernel.instances.tuple._
-import cats.functor.{Bifunctor, Contravariant, DefaultBifunctor}
+import cats.functor.{Bifunctor, Contravariant}
 
 final case class WriterT[F[_], L, V](run: F[(L, V)]) {
   def written(implicit functorF: Functor[F]): F[L] =
@@ -64,7 +64,7 @@ private[data] sealed abstract class WriterTInstances extends WriterTInstances0 {
     catsDataEqForWriterT[Id, L, V]
 
   implicit def catsDataBifunctorForWriterT[F[_]:Functor]: Bifunctor[WriterT[F, ?, ?]] =
-    new DefaultBifunctor[WriterT[F, ?, ?]] {
+    new Bifunctor.Default[WriterT[F, ?, ?]] {
       def bimap[A, B, C, D](fab: WriterT[F, A, B])(f: A => C, g: B => D): WriterT[F, C, D] =
         fab.bimap(f, g)
     }

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -2,7 +2,7 @@ package cats
 package data
 
 import cats.kernel.instances.tuple._
-import cats.functor.{Bifunctor, Contravariant}
+import cats.functor.{Bifunctor, Contravariant, DefaultBifunctor}
 
 final case class WriterT[F[_], L, V](run: F[(L, V)]) {
   def written(implicit functorF: Functor[F]): F[L] =
@@ -64,7 +64,7 @@ private[data] sealed abstract class WriterTInstances extends WriterTInstances0 {
     catsDataEqForWriterT[Id, L, V]
 
   implicit def catsDataBifunctorForWriterT[F[_]:Functor]: Bifunctor[WriterT[F, ?, ?]] =
-    new Bifunctor[WriterT[F, ?, ?]] {
+    new DefaultBifunctor[WriterT[F, ?, ?]] {
       def bimap[A, B, C, D](fab: WriterT[F, A, B])(f: A => C, g: B => D): WriterT[F, C, D] =
         fab.bimap(f, g)
     }

--- a/core/src/main/scala/cats/data/Xor.scala
+++ b/core/src/main/scala/cats/data/Xor.scala
@@ -235,7 +235,7 @@ private[data] sealed abstract class XorInstances extends XorInstances1 {
     }
 
   implicit val catsDataBitraverseForXor: Bitraverse[Xor] =
-    new DefaultBitraverse[Xor] {
+    new Bitraverse.Default[Xor] {
       def bitraverse[G[_], A, B, C, D](fab: Xor[A, B])(f: A => G[C], g: B => G[D])(implicit G: Applicative[G]): G[Xor[C, D]] =
         fab match {
           case Xor.Left(a) => G.map(f(a))(Xor.left)

--- a/core/src/main/scala/cats/data/Xor.scala
+++ b/core/src/main/scala/cats/data/Xor.scala
@@ -235,7 +235,7 @@ private[data] sealed abstract class XorInstances extends XorInstances1 {
     }
 
   implicit val catsDataBitraverseForXor: Bitraverse[Xor] =
-    new Bitraverse[Xor] {
+    new DefaultBitraverse[Xor] {
       def bitraverse[G[_], A, B, C, D](fab: Xor[A, B])(f: A => G[C], g: B => G[D])(implicit G: Applicative[G]): G[Xor[C, D]] =
         fab match {
           case Xor.Left(a) => G.map(f(a))(Xor.left)

--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -1,7 +1,7 @@
 package cats
 package data
 
-import cats.functor.Bifunctor
+import cats.functor.{Bifunctor, DefaultBifunctor}
 
 /**
  * Transformer for `Xor`, allowing the effect of an arbitrary type constructor `F` to be combined with the
@@ -238,7 +238,7 @@ private[data] abstract class XorTInstances extends XorTInstances1 {
     functor.Contravariant[Show].contramap(sh)(_.value)
 
   implicit def catsDataBifunctorForXorT[F[_]](implicit F: Functor[F]): Bifunctor[XorT[F, ?, ?]] =
-    new Bifunctor[XorT[F, ?, ?]] {
+    new DefaultBifunctor[XorT[F, ?, ?]] {
       override def bimap[A, B, C, D](fab: XorT[F, A, B])(f: A => C, g: B => D): XorT[F, C, D] = fab.bimap(f, g)
     }
 
@@ -401,7 +401,7 @@ private[data] sealed trait XorTTraverse[F[_], L] extends Traverse[XorT[F, L, ?]]
     fa traverse f
 }
 
-private[data] sealed trait XorTBifoldable[F[_]] extends Bifoldable[XorT[F, ?, ?]] {
+private[data] sealed trait XorTBifoldable[F[_]] extends DefaultBifoldable[XorT[F, ?, ?]] {
   implicit def F0: Foldable[F]
 
   def bifoldLeft[A, B, C](fab: XorT[F, A, B], c: C)(f: (C, A) => C, g: (C, B) => C): C =
@@ -411,7 +411,7 @@ private[data] sealed trait XorTBifoldable[F[_]] extends Bifoldable[XorT[F, ?, ?]
     F0.foldRight(fab.value, c)( (axb, acc) => Bifoldable[Xor].bifoldRight(axb, acc)(f, g))
 }
 
-private[data] sealed trait XorTBitraverse[F[_]] extends Bitraverse[XorT[F, ?, ?]] with XorTBifoldable[F] {
+private[data] sealed trait XorTBitraverse[F[_]] extends DefaultBitraverse[XorT[F, ?, ?]] with XorTBifoldable[F] {
   override implicit def F0: Traverse[F]
 
   override def bitraverse[G[_], A, B, C, D](fab: XorT[F, A, B])(f: A => G[C], g: B => G[D])(implicit G: Applicative[G]): G[XorT[F, C, D]] =

--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -1,7 +1,7 @@
 package cats
 package data
 
-import cats.functor.{Bifunctor, DefaultBifunctor}
+import cats.functor.Bifunctor
 
 /**
  * Transformer for `Xor`, allowing the effect of an arbitrary type constructor `F` to be combined with the
@@ -238,7 +238,7 @@ private[data] abstract class XorTInstances extends XorTInstances1 {
     functor.Contravariant[Show].contramap(sh)(_.value)
 
   implicit def catsDataBifunctorForXorT[F[_]](implicit F: Functor[F]): Bifunctor[XorT[F, ?, ?]] =
-    new DefaultBifunctor[XorT[F, ?, ?]] {
+    new Bifunctor.Default[XorT[F, ?, ?]] {
       override def bimap[A, B, C, D](fab: XorT[F, A, B])(f: A => C, g: B => D): XorT[F, C, D] = fab.bimap(f, g)
     }
 
@@ -401,7 +401,7 @@ private[data] sealed trait XorTTraverse[F[_], L] extends Traverse[XorT[F, L, ?]]
     fa traverse f
 }
 
-private[data] sealed trait XorTBifoldable[F[_]] extends DefaultBifoldable[XorT[F, ?, ?]] {
+private[data] sealed trait XorTBifoldable[F[_]] extends Bifoldable.Default[XorT[F, ?, ?]] {
   implicit def F0: Foldable[F]
 
   def bifoldLeft[A, B, C](fab: XorT[F, A, B], c: C)(f: (C, A) => C, g: (C, B) => C): C =
@@ -411,7 +411,7 @@ private[data] sealed trait XorTBifoldable[F[_]] extends DefaultBifoldable[XorT[F
     F0.foldRight(fab.value, c)( (axb, acc) => Bifoldable[Xor].bifoldRight(axb, acc)(f, g))
 }
 
-private[data] sealed trait XorTBitraverse[F[_]] extends DefaultBitraverse[XorT[F, ?, ?]] with XorTBifoldable[F] {
+private[data] sealed trait XorTBitraverse[F[_]] extends Bitraverse.Default[XorT[F, ?, ?]] with XorTBifoldable[F] {
   override implicit def F0: Traverse[F]
 
   override def bitraverse[G[_], A, B, C, D](fab: XorT[F, A, B])(f: A => G[C], g: B => G[D])(implicit G: Applicative[G]): G[XorT[F, C, D]] =

--- a/core/src/main/scala/cats/functor/Bifunctor.scala
+++ b/core/src/main/scala/cats/functor/Bifunctor.scala
@@ -10,6 +10,15 @@ trait Bifunctor[F[_, _]] extends Any with Serializable {
   /**
    * The quintessential method of the Bifunctor trait, it applies a
    * function to each "side" of the bifunctor.
+   *
+   * Example:
+   * {{{
+   * scala> import cats.implicits._
+   *
+   * scala> val x: (List[String], Int) = (List("foo", "bar"), 3)
+   * scala> x.bimap(_.headOption, _.toLong + 1)
+   * res0: (Option[String], Long) = (Some(foo),4)
+   * }}}
    */
   def bimap[A, B, C, D](fab: F[A, B])(f: A => C, g: B => D): F[C, D]
 

--- a/core/src/main/scala/cats/functor/Bifunctor.scala
+++ b/core/src/main/scala/cats/functor/Bifunctor.scala
@@ -27,25 +27,25 @@ trait Bifunctor[F[_, _]] extends Any with Serializable {
   def compose[G[_, _]](implicit G0: Bifunctor[G]): Bifunctor[λ[(α, β) => F[G[α, β], G[α, β]]]]
 }
 
-trait DefaultBifunctor[F[_, _]] extends Bifunctor[F] { self =>
-
-  def leftMap[A, B, C](fab: F[A, B])(f: A => C): F[C, B] = bimap(fab)(f, identity)
-
-  def rightMap[A, B, C](fab: F[A, B])(f: B => C): F[A, C] = bimap(fab)(identity, f)
-
-  def compose[G[_, _]](implicit G0: Bifunctor[G]): Bifunctor[λ[(α, β) => F[G[α, β], G[α, β]]]] =
-    new ComposedBifunctor[F, G] {
-      val F = self
-      val G = G0
-    }
-}
-
 object Bifunctor {
   def apply[F[_, _]](implicit ev: Bifunctor[F]): Bifunctor[F] = ev
+
+  trait Default[F[_, _]] extends Bifunctor[F] { self =>
+
+    def leftMap[A, B, C](fab: F[A, B])(f: A => C): F[C, B] = bimap(fab)(f, identity)
+
+    def rightMap[A, B, C](fab: F[A, B])(f: B => C): F[A, C] = bimap(fab)(identity, f)
+
+    def compose[G[_, _]](implicit G0: Bifunctor[G]): Bifunctor[λ[(α, β) => F[G[α, β], G[α, β]]]] =
+      new ComposedBifunctor[F, G] {
+        val F = self
+        val G = G0
+      }
+  }
 }
 
 private[cats] trait ComposedBifunctor[F[_, _], G[_, _]]
-    extends DefaultBifunctor[λ[(A, B) => F[G[A, B], G[A, B]]]] {
+    extends Bifunctor.Default[λ[(A, B) => F[G[A, B], G[A, B]]]] {
   def F: Bifunctor[F]
   def G: Bifunctor[G]
 

--- a/core/src/main/scala/cats/functor/Bifunctor.scala
+++ b/core/src/main/scala/cats/functor/Bifunctor.scala
@@ -5,7 +5,7 @@ package functor
  * A type class of types which give rise to two independent, covariant
  * functors.
  */
-trait Bifunctor[F[_, _]] extends Any with Serializable { self =>
+trait Bifunctor[F[_, _]] extends Any with Serializable {
 
   /**
    * The quintessential method of the Bifunctor trait, it applies a
@@ -13,18 +13,26 @@ trait Bifunctor[F[_, _]] extends Any with Serializable { self =>
    */
   def bimap[A, B, C, D](fab: F[A, B])(f: A => C, g: B => D): F[C, D]
 
-  // derived methods
   /**
    * apply a function to the "left" functor
    */
-  def leftMap[A, B, C](fab: F[A, B])(f: A => C): F[C, B] = bimap(fab)(f, identity)
+  def leftMap[A, B, C](fab: F[A, B])(f: A => C): F[C, B]
 
   /**
    * apply a function ro the "right" functor
    */
-  def rightMap[A, B, C](fab: F[A, B])(f: B => C): F[A, C] = bimap(fab)(identity, f)
+  def rightMap[A, B, C](fab: F[A, B])(f: B => C): F[A, C]
 
   /** The composition of two Bifunctors is itself a Bifunctor */
+  def compose[G[_, _]](implicit G0: Bifunctor[G]): Bifunctor[λ[(α, β) => F[G[α, β], G[α, β]]]]
+}
+
+trait DefaultBifunctor[F[_, _]] extends Bifunctor[F] { self =>
+
+  def leftMap[A, B, C](fab: F[A, B])(f: A => C): F[C, B] = bimap(fab)(f, identity)
+
+  def rightMap[A, B, C](fab: F[A, B])(f: B => C): F[A, C] = bimap(fab)(identity, f)
+
   def compose[G[_, _]](implicit G0: Bifunctor[G]): Bifunctor[λ[(α, β) => F[G[α, β], G[α, β]]]] =
     new ComposedBifunctor[F, G] {
       val F = self
@@ -37,7 +45,7 @@ object Bifunctor {
 }
 
 private[cats] trait ComposedBifunctor[F[_, _], G[_, _]]
-    extends Bifunctor[λ[(A, B) => F[G[A, B], G[A, B]]]] {
+    extends DefaultBifunctor[λ[(A, B) => F[G[A, B], G[A, B]]]] {
   def F: Bifunctor[F]
   def G: Bifunctor[G]
 

--- a/core/src/main/scala/cats/functor/Bifunctor.scala
+++ b/core/src/main/scala/cats/functor/Bifunctor.scala
@@ -54,7 +54,7 @@ object Bifunctor {
 }
 
 private[cats] trait ComposedBifunctor[F[_, _], G[_, _]]
-    extends Bifunctor.Default[λ[(A, B) => F[G[A, B], G[A, B]]]] {
+    extends Bifunctor.Default[λ[(α, β) => F[G[α, β], G[α, β]]]] {
   def F: Bifunctor[F]
   def G: Bifunctor[G]
 

--- a/core/src/main/scala/cats/instances/either.scala
+++ b/core/src/main/scala/cats/instances/either.scala
@@ -6,7 +6,7 @@ import cats.data.Xor
 
 trait EitherInstances extends EitherInstances1 {
   implicit val catsStdBitraverseForEither: Bitraverse[Either] =
-    new Bitraverse[Either] {
+    new DefaultBitraverse[Either] {
       def bitraverse[G[_], A, B, C, D](fab: Either[A, B])(f: A => G[C], g: B => G[D])(implicit G: Applicative[G]): G[Either[C, D]] =
         fab match {
           case Left(a) => G.map(f(a))(Left(_))

--- a/core/src/main/scala/cats/instances/either.scala
+++ b/core/src/main/scala/cats/instances/either.scala
@@ -6,7 +6,7 @@ import cats.data.Xor
 
 trait EitherInstances extends EitherInstances1 {
   implicit val catsStdBitraverseForEither: Bitraverse[Either] =
-    new DefaultBitraverse[Either] {
+    new Bitraverse.Default[Either] {
       def bitraverse[G[_], A, B, C, D](fab: Either[A, B])(f: A => G[C], g: B => G[D])(implicit G: Applicative[G]): G[Either[C, D]] =
         fab match {
           case Left(a) => G.map(f(a))(Left(_))

--- a/core/src/main/scala/cats/instances/tuple.scala
+++ b/core/src/main/scala/cats/instances/tuple.scala
@@ -5,7 +5,7 @@ trait TupleInstances extends Tuple2Instances with cats.kernel.instances.TupleIns
 
 sealed trait Tuple2Instances {
   implicit val catsStdBitraverseForTuple2: Bitraverse[Tuple2] =
-    new DefaultBitraverse[Tuple2] {
+    new Bitraverse.Default[Tuple2] {
       def bitraverse[G[_]: Applicative, A, B, C, D](fab: (A, B))(f: A => G[C], g: B => G[D]): G[(C, D)] =
         Applicative[G].tuple2(f(fab._1), g(fab._2))
 

--- a/core/src/main/scala/cats/instances/tuple.scala
+++ b/core/src/main/scala/cats/instances/tuple.scala
@@ -5,7 +5,7 @@ trait TupleInstances extends Tuple2Instances with cats.kernel.instances.TupleIns
 
 sealed trait Tuple2Instances {
   implicit val catsStdBitraverseForTuple2: Bitraverse[Tuple2] =
-    new Bitraverse[Tuple2] {
+    new DefaultBitraverse[Tuple2] {
       def bitraverse[G[_]: Applicative, A, B, C, D](fab: (A, B))(f: A => G[C], g: B => G[D]): G[(C, D)] =
         Applicative[G].tuple2(f(fab._1), g(fab._2))
 


### PR DESCRIPTION
This is a first-step for #992. I've started with the Bitraverse type
hierarchy because it's not a very deep one. The idea is that we would
continue this effort for other type class hierarchies.

I am not particularly fond of the `DefaultX` naming convention, but it was the least bad of the ones I could think of. I'm open to other ideas.
