### PR TITLE
Update docs for version 0.6.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## Version 0.6.1
 
-> 2016 July 16
+> 2016 July 14
 
 Version 0.6.1 is a patch release compatible with 0.6.0.
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,17 @@
+## Version 0.6.1
+
+> 2016 July 16
+
+Version 0.6.1 is a patch release compatible with 0.6.0.
+
+It contains one bug fix:
+
+* [#1062](https://github.com/typelevel/cats/pull/1173/commits/8dd682771557274a61f1e773df0f999b44a9819d): Fixed a bug in the Order and PartialOrder instances for Tuple2+ where only the first element was used in comparisons
+
+It also contains a change to the build:
+
+* [#1173](https://github.com/typelevel/cats/pull/1173/commits/5531d1ac7a6807c1842cd4b5b599173b14b652a9): Add binary compatibility check to all published modules
+
 ## Version 0.6.0
 
 > 2016 May 19

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To get started with SBT, simply add the following to your `build.sbt`
 file:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats" % "0.6.0"
+libraryDependencies += "org.typelevel" %% "cats" % "0.6.1"
 ```
 
 This will pull in all of Cats' modules. If you only require some

--- a/docs/src/site/index.md
+++ b/docs/src/site/index.md
@@ -21,7 +21,7 @@ Cats is currently available for Scala 2.10 and 2.11.
 
 To get started with SBT, simply add the following to your build.sbt file:
 
-    libraryDependencies += "org.typelevel" %% "cats" % "0.6.0"
+    libraryDependencies += "org.typelevel" %% "cats" % "0.6.1"
 
 This will pull in all of Cats' modules. If you only require some
 functionality, you can pick-and-choose from amongst these modules


### PR DESCRIPTION
This shouldn't be merged until version 0.6.1 is released.

Currently I don't have permission to publish to Sonatype for cats, so for now I'm hoping that @non (or someone else -- maybe @travisbrown or @kailuowang or @mpilquist ?) can publish the release (off of the `series/0.6.x` branch). Hopefully by the time we are ready for the next release I can get the necessary permissions. I've guessed Saturday as the release date in the changelog but we can definitely change that depending on when it actually gets released :)

Note: there's a little bit of strangeness in that we need to make these changes to the master branch since that's the README that people see, but it kind of seems like these changes should also live on the `series/0.6.x` branch. However, the `0.6.x` branch was made off of the [v0.6.0 tag](https://github.com/typelevel/cats/releases/tag/v0.6.0) which doesn't actually include the release notes for the 0.6.0 release. I'm inclined to not worry about updating the documentation on the 0.6.0 branch and just make a manual adjustment to the suggested version number in `index.md` on the `gh-pages` branch. Hopefully we can form a better system for the next release.