### PR TITLE
Change dependency version to 0.6.1 on website

### DIFF
--- a/index.md
+++ b/index.md
@@ -21,7 +21,7 @@ Cats is currently available for Scala 2.10 and 2.11.
 
 To get started with SBT, simply add the following to your build.sbt file:
 
-    libraryDependencies += "org.typelevel" %% "cats" % "0.6.0"
+    libraryDependencies += "org.typelevel" %% "cats" % "0.6.1"
 
 This will pull in all of Cats' modules. If you only require some
 functionality, you can pick-and-choose from amongst these modules


### PR DESCRIPTION
This is a change directly to the `gh-pages` branch. Normally this would be taken care of by publishing the whole site for a new release, but we currently don't have a great setup for doing this outside of the `master` branch.

We should wait until 0.6.1 has synced to maven central before merging this.