### PR TITLE
fix memory problem when running sbt with forking all tests and doc ge…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,6 +63,7 @@ lazy val commonSettings = Seq(
     compilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full),
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.6.3")
   ),
+  fork in test := true,
   parallelExecution in Test := false,
   scalacOptions in (Compile, doc) := (scalacOptions in (Compile, doc)).value.filter(_ != "-Xfatal-warnings"),
   // workaround for https://github.com/scalastyle/scalastyle-sbt-plugin/issues/47
@@ -137,6 +138,8 @@ lazy val docSettings = Seq(
   site.addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), "api"),
   site.addMappingsToSiteDir(tut, "_tut"),
   ghpagesNoJekyll := false,
+  fork in tut := true,
+  fork in (ScalaUnidoc, unidoc) := true,
   siteMappings += file("CONTRIBUTING.md") -> "contributing.md",
   scalacOptions in (ScalaUnidoc, unidoc) ++= Seq(
     "-Xfatal-warnings",
@@ -361,7 +364,7 @@ addCommandAlias("validateJVM", ";scalastyle;buildJVM;makeSite")
 
 addCommandAlias("validateJS", ";macrosJS/compile;kernelJS/compile;coreJS/compile;kernelLawsJS/compile;lawsJS/compile;kernelLawsJS/test;testsJS/test;js/test")
 
-addCommandAlias("validate", ";validateJS;validateJVM")
+addCommandAlias("validate", ";clean;validateJS;validateJVM")
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Base Build Settings - Should not need to edit below this line.

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -29,5 +29,5 @@ sbt_cmd="sbt ++$TRAVIS_SCALA_VERSION"
 
 coverage="$sbt_cmd coverage validateJVM coverageReport && codecov"
 
-run_cmd="$coverage && $sbt_cmd validate"
+run_cmd="$coverage && $sbt_cmd validate $publish_cmd"
 eval $run_cmd

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -28,8 +28,6 @@ fi
 sbt_cmd="sbt ++$TRAVIS_SCALA_VERSION"
 
 coverage="$sbt_cmd coverage validateJVM coverageReport && codecov"
-scala_js="$sbt_cmd macrosJS/compile coreJS/compile lawsJS/compile && $sbt_cmd kernelLawsJS/test && $sbt_cmd testsJS/test && $sbt_cmd js/test"
-scala_jvm="$sbt_cmd validateJVM"
 
-run_cmd="$coverage && $scala_js && $scala_jvm $publish_cmd"
+run_cmd="$coverage && $sbt_cmd validate"
 eval $run_cmd

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -29,5 +29,5 @@ sbt_cmd="sbt ++$TRAVIS_SCALA_VERSION"
 
 coverage="$sbt_cmd coverage validateJVM coverageReport && codecov"
 
-run_cmd="$coverage && $sbt_cmd validate $publish_cmd"
+run_cmd="$coverage && $sbt_cmd validate && $sbt_cmd $publish_cmd"
 eval $run_cmd


### PR DESCRIPTION
Right now running aggregated task such as `validate` or `release` in a single sbt session usually causes out of memory crash.
Forking some heavy tasks such as `tests` and `scalaUnidoc` seems to help. 
Noticed that it is able to run `validate` on travis now. 