### PR TITLE
Prefix instead of suffix unsafe methods with 'unsafe'

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -15,14 +15,14 @@ final case class NonEmptyVector[A] private (toVector: Vector[A]) {
     toVector.lift(i)
 
   /** Gets the element at the index, or throws an exception if none exists */
-  def getUnsafe(i: Int): A = toVector(i)
+  def unsafeGet(i: Int): A = toVector(i)
 
   /** Updates the element at the index, if it exists */
   def updated(i: Int, a: A): Option[NonEmptyVector[A]] =
     if (toVector.isDefinedAt(i)) Some(NonEmptyVector(toVector.updated(i, a))) else None
 
   /** Updates the element at the index, or throws an exeption if none exists */
-  def updatedUnsafe(i: Int, a: A):
+  def unsafeUpdated(i: Int, a: A):
       NonEmptyVector[A] = NonEmptyVector(toVector.updated(i, a))
 
   def head: A = toVector.head
@@ -188,7 +188,7 @@ private[data] sealed trait NonEmptyVectorInstances {
           case Xor.Left(a) => go(f(a).concat(v.tail))
           }
         go(f(a))
-        NonEmptyVector.fromVectorUnsafe(buf.result())
+        NonEmptyVector.unsafeFromVector(buf.result())
       }
     }
 
@@ -220,7 +220,7 @@ object NonEmptyVector extends NonEmptyVectorInstances {
   def fromVector[A](vector: Vector[A]): Option[NonEmptyVector[A]] =
     if (vector.isEmpty) None else Some(new NonEmptyVector(vector))
 
-  def fromVectorUnsafe[A](vector: Vector[A]): NonEmptyVector[A] =
+  def unsafeFromVector[A](vector: Vector[A]): NonEmptyVector[A] =
     if (vector.nonEmpty) NonEmptyVector(vector)
     else throw new IllegalArgumentException("Cannot create NonEmptyVector from empty vector")
 }

--- a/tests/src/test/scala/cats/tests/NonEmptyVectorTests.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyVectorTests.scala
@@ -160,9 +160,9 @@ class NonEmptyVectorTests extends CatsSuite {
     NonEmptyVector.fromVector(Vector.empty[Int]) should === (Option.empty[NonEmptyVector[Int]])
   }
 
-  test("fromVectorUnsafe throws an exception when the input vector is empty") {
+  test("unsafeFromVector throws an exception when the input vector is empty") {
     val _ = intercept[IllegalArgumentException] {
-      NonEmptyVector.fromVectorUnsafe(Vector.empty[Int])
+      NonEmptyVector.unsafeFromVector(Vector.empty[Int])
     }
   }
 
@@ -191,11 +191,11 @@ class NonEmptyVectorTests extends CatsSuite {
     }
   }
 
-  test("NonEmptyVector#getUnsafe throws an exception when the element does not exist") {
+  test("NonEmptyVector#unsafeGet throws an exception when the element does not exist") {
     forAll{ (nonEmptyVector: NonEmptyVector[Int]) =>
       val size = nonEmptyVector.toVector.size
       val _ = intercept[IndexOutOfBoundsException] {
-        nonEmptyVector.getUnsafe(size)
+        nonEmptyVector.unsafeGet(size)
       }
     }
   }
@@ -207,11 +207,11 @@ class NonEmptyVectorTests extends CatsSuite {
     }
   }
 
-  test("NonEmptyVector#updatedUnsafe throws an exception when the element does not exist") {
+  test("NonEmptyVector#unsafeUpdated throws an exception when the element does not exist") {
     forAll { (nonEmptyVector: NonEmptyVector[Int], element: Int) =>
       val size = nonEmptyVector.toVector.size
       val _ = intercept[IndexOutOfBoundsException] {
-        nonEmptyVector.updatedUnsafe(size, element)
+        nonEmptyVector.unsafeUpdated(size, element)
       }
     }
   }


### PR DESCRIPTION
Prefixing seems to be the more common pattern, so here ya go

Examples:
FS2: https://github.com/functional-streams-for-scala/fs2/search?utf8=%E2%9C%93&q=unsafe
Our own `Free`: https://github.com/typelevel/cats/blob/a4b4091d04a8ad4736713037a0fb6d58c23468cf/free/src/main/scala/cats/free/Free.scala#L224
Haskell: https://hackage.haskell.org/package/base-4.9.0.0/docs/System-IO-Unsafe.html