### PR TITLE
Remove MonadFilter.filterM

### DIFF
--- a/core/src/main/scala/cats/MonadFilter.scala
+++ b/core/src/main/scala/cats/MonadFilter.scala
@@ -15,7 +15,4 @@ import simulacrum.typeclass
 
   def filter[A](fa: F[A])(f: A => Boolean): F[A] =
     flatMap(fa)(a => if (f(a)) pure(a) else empty[A])
-
-  def filterM[A](fa: F[A])(f: A => F[Boolean]): F[A] =
-    flatMap(fa)(a => flatMap(f(a))(b => if (b) pure(a) else empty[A]))
 }


### PR DESCRIPTION
Resolves #1054.

This simply removes `MonadFilter.filterM` to prevent confusion due to
this `filterM` being different than that from Haskell or Scalaz.

This version of `filterM` doesn't seem particularly useful to me. The
only type that comes to mind for which this might be useful is `Option`,
and it's pretty easy to come up with a more straightforward
implementation for the `Option` case. A more general solution for
`filterM` is provided by #1148, but so far there doesn't seem to be any
interest in that proposal, so I don't want it to hold up resolving #1054.