### PR TITLE
Change format of NonEmptyVector.show

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -21,7 +21,11 @@ final case class NonEmptyVector[A] private (toVector: Vector[A]) {
   def updated(i: Int, a: A): Option[NonEmptyVector[A]] =
     if (toVector.isDefinedAt(i)) Some(NonEmptyVector(toVector.updated(i, a))) else None
 
-  /** Updates the element at the index, or throws an exeption if none exists */
+  /**
+   * Updates the element at the index, or throws an exception if none exists
+   *
+   * @throws IndexOutOfBoundsException if `i` does not satisfy `0 <= i < length`.
+   */
   def updatedUnsafe(i: Int, a: A):
       NonEmptyVector[A] = NonEmptyVector(toVector.updated(i, a))
 
@@ -40,8 +44,8 @@ final case class NonEmptyVector[A] private (toVector: Vector[A]) {
   def concat(other: NonEmptyVector[A]): NonEmptyVector[A] = NonEmptyVector(toVector ++ other.toVector)
 
   /**
-    * Alias for concat
-    */
+   * Alias for concat
+   */
   def ++(other: NonEmptyVector[A]): NonEmptyVector[A] = concat(other)
 
   /**
@@ -50,8 +54,8 @@ final case class NonEmptyVector[A] private (toVector: Vector[A]) {
   def concat(other: Vector[A]): NonEmptyVector[A] = NonEmptyVector(toVector ++ other)
 
   /**
-    * Alias for concat
-    */
+   * Alias for concat
+   */
   def ++(other: Vector[A]): NonEmptyVector[A] = concat(other)
 
   /**
@@ -123,7 +127,9 @@ final case class NonEmptyVector[A] private (toVector: Vector[A]) {
    * universal .toString method.
    */
   def show(implicit A: Show[A]): String =
-    s"NonEmptyVector(${Show[Vector[A]].show(toVector)})"
+    s"NonEmpty${Show[Vector[A]].show(toVector)}"
+
+  def length: Int = toVector.length
 }
 
 private[data] sealed trait NonEmptyVectorInstances {
@@ -138,7 +144,7 @@ private[data] sealed trait NonEmptyVectorInstances {
 
       override def split[A](fa: NonEmptyVector[A]): (A, Vector[A]) = (fa.head, fa.tail)
 
-      override def size[A](fa: NonEmptyVector[A]): Long = 1 + fa.tail.size.toLong
+      override def size[A](fa: NonEmptyVector[A]): Long = fa.length.toLong
 
       override def reduceLeft[A](fa: NonEmptyVector[A])(f: (A, A) => A): A =
         fa.reduceLeft(f)
@@ -167,7 +173,7 @@ private[data] sealed trait NonEmptyVectorInstances {
       def extract[A](fa: NonEmptyVector[A]): A = fa.head
 
       def traverse[G[_], A, B](fa: NonEmptyVector[A])(f: (A) => G[B])(implicit G: Applicative[G]): G[NonEmptyVector[B]] =
-      G.map2Eval(f(fa.head), Always(Traverse[Vector].traverse(fa.tail)(f)))(NonEmptyVector(_, _)).value
+        G.map2Eval(f(fa.head), Always(Traverse[Vector].traverse(fa.tail)(f)))(NonEmptyVector(_, _)).value
 
 
       override def foldLeft[A, B](fa: NonEmptyVector[A], b: B)(f: (B, A) => B): B =

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -22,9 +22,8 @@ final case class NonEmptyVector[A] private (toVector: Vector[A]) {
     if (toVector.isDefinedAt(i)) Some(NonEmptyVector(toVector.updated(i, a))) else None
 
   /**
-   * Updates the element at the index, or throws an exception if none exists
-   *
-   * @throws IndexOutOfBoundsException if `i` does not satisfy `0 <= i < length`.
+   * Updates the element at the index, or throws an `IndexOutOfBoundsException`
+   * if none exists (if `i` does not satisfy `0 <= i < length`).
    */
   def updatedUnsafe(i: Int, a: A):
       NonEmptyVector[A] = NonEmptyVector(toVector.updated(i, a))

--- a/tests/src/test/scala/cats/tests/NonEmptyVectorTests.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyVectorTests.scala
@@ -67,8 +67,11 @@ class NonEmptyVectorTests extends CatsSuite {
   }
 
   test("Show is formatted correctly") {
-    val nonEmptyVector = NonEmptyVector("Test", Vector.empty)
-    nonEmptyVector.show should === ("NonEmptyVector(Vector(Test))")
+    val v1 = NonEmptyVector("Test", Vector.empty)
+    v1.show should === ("NonEmptyVector(Test)")
+
+    val v2 = NonEmptyVector("foo", "bar", "baz")
+    v2.show should === ("NonEmptyVector(foo, bar, baz)")
   }
 
   test("Creating NonEmptyVector + toVector is identity") {


### PR DESCRIPTION
This follows up on several small suggestions from comments in #1137. The
only meaningful modification is changing the format of `show` from
something like `NonEmptyVector(Vector(1, 2, 3))` to something like
`NonEmptyVector(1, 2, 3)`.

I've also added a `length` method to `NonEmptyVector`.