### PR TITLE
Make some Writer improvements

### DIFF
--- a/core/src/main/scala/cats/MonadWriter.scala
+++ b/core/src/main/scala/cats/MonadWriter.scala
@@ -12,7 +12,7 @@ trait MonadWriter[F[_], W] extends Monad[F] {
   def pass[A](fa: F[(W => W, A)]): F[A]
 
   /** Lift the log into the effect */
-  def tell(w: W): F[Unit] = writer((w, ()))
+  def write(w: W): F[Unit] = writer((w, ()))
 
   /** Pair the value with an inspection of the accumulator */
   def listens[A, B](fa: F[A])(f: W => B): F[(B, A)] =

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -3,8 +3,12 @@ package data
 
 import cats.kernel.instances.tuple._
 import cats.functor.{Bifunctor, Contravariant}
+import cats.syntax.semigroup._
 
 final case class WriterT[F[_], L, V](run: F[(L, V)]) {
+  def write(l: L)(implicit functorF: Functor[F], semigroupL: Semigroup[L]): WriterT[F, L, V] =
+    mapWritten(_ |+| l)
+
   def written(implicit functorF: Functor[F]): F[L] =
     functorF.map(run)(_._1)
 
@@ -244,6 +248,8 @@ private[data] sealed trait WriterTMonadWriter[F[_], L] extends MonadWriter[Write
 
   def pass[A](fa: WriterT[F, L, (L => L, A)]): WriterT[F, L, A] =
     WriterT(F0.flatMap(fa.value) { case (f, a) => F0.map(fa.written)(l => (f(l), a)) })
+
+  override def write(l: L): WriterT[F, L, Unit] = WriterT.write(l)
 }
 
 private[data] sealed trait WriterTSemigroupK[F[_], L] extends SemigroupK[WriterT[F, L, ?]] {
@@ -299,7 +305,7 @@ trait WriterTFunctions {
   def put[F[_], L, V](v: V)(l: L)(implicit applicativeF: Applicative[F]): WriterT[F, L, V] =
     WriterT.putT[F, L, V](applicativeF.pure(v))(l)
 
-  def tell[F[_], L](l: L)(implicit applicativeF: Applicative[F]): WriterT[F, L, Unit] =
+  def write[F[_], L](l: L)(implicit applicativeF: Applicative[F]): WriterT[F, L, Unit] =
     WriterT.put[F, L, Unit](())(l)
 
   def value[F[_], L, V](v: V)(implicit applicativeF: Applicative[F], monoidL: Monoid[L]): WriterT[F, L, V] =

--- a/core/src/main/scala/cats/data/package.scala
+++ b/core/src/main/scala/cats/data/package.scala
@@ -38,7 +38,11 @@ package object data {
 
   type Writer[L, V] = WriterT[Id, L, V]
   object Writer {
-    def apply[L, V](l: L, v: V): WriterT[Id, L, V] = WriterT[Id, L, V]((l, v))
+    def apply[L, V](l: L, v: V): Writer[L, V] = WriterT[Id, L, V]((l, v))
+
+    def value[L:Monoid, V](v: V): Writer[L, V] = WriterT.value(v)
+
+    def write[L](l: L): Writer[L, Unit] = WriterT.write(l)
   }
 
   type State[S, A] = StateT[Eval, S, A]

--- a/laws/src/main/scala/cats/laws/MonadWriterLaws.scala
+++ b/laws/src/main/scala/cats/laws/MonadWriterLaws.scala
@@ -7,14 +7,14 @@ trait MonadWriterLaws[F[_], W] extends MonadLaws[F] {
   def monadWriterWriterPure[A](a: A)(implicit W: Monoid[W]): IsEq[F[A]] =
     F.writer((W.empty, a)) <-> F.pure(a)
 
-  def monadWriterTellFusion(x: W, y: W)(implicit W: Monoid[W]): IsEq[F[Unit]] =
-    F.flatMap(F.tell(x))(_ => F.tell(y)) <-> F.tell(W.combine(x, y))
+  def monadWriterWriteFusion(x: W, y: W)(implicit W: Monoid[W]): IsEq[F[Unit]] =
+    F.flatMap(F.write(x))(_ => F.write(y)) <-> F.write(W.combine(x, y))
 
   def monadWriterListenPure[A](a: A)(implicit W: Monoid[W]): IsEq[F[(W, A)]] =
     F.listen(F.pure(a)) <-> F.pure((W.empty, a))
 
   def monadWriterListenWriter[A](aw: (W, A)): IsEq[F[(W, A)]] =
-    F.listen(F.writer(aw)) <-> F.map(F.tell(aw._1))(_ => aw)
+    F.listen(F.writer(aw)) <-> F.map(F.write(aw._1))(_ => aw)
 }
 
 object MonadWriterLaws {

--- a/laws/src/main/scala/cats/laws/discipline/MonadWriterTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadWriterTests.scala
@@ -31,7 +31,7 @@ trait MonadWriterTests[F[_], W] extends MonadTests[F] {
       def parents = Seq(monad[A, B, C])
       def props = Seq(
         "monadWriter writer pure" -> forAll(laws.monadWriterWriterPure[A] _),
-        "monadWriter tell fusion" -> forAll(laws.monadWriterTellFusion _),
+        "monadWriter write fusion" -> forAll(laws.monadWriterWriteFusion _),
         "monadWriter listen pure" -> forAll(laws.monadWriterListenPure[A] _),
         "monadWriter listen writer" -> forAll(laws.monadWriterListenWriter[A] _)
       )

--- a/tests/src/test/scala/cats/tests/WriterTTests.scala
+++ b/tests/src/test/scala/cats/tests/WriterTTests.scala
@@ -12,7 +12,7 @@ import cats.kernel.laws.OrderLaws
 class WriterTTests extends CatsSuite {
   type Logged[A] = Writer[ListWrapper[Int], A]
 
-  // we have a lot of generated lists of lists in these tests. We have to write
+  // we have a lot of generated lists of lists in these tests. We have to tell
   // Scalacheck to calm down a bit so we don't hit memory and test duration
   // issues.
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =

--- a/tests/src/test/scala/cats/tests/WriterTTests.scala
+++ b/tests/src/test/scala/cats/tests/WriterTTests.scala
@@ -77,6 +77,14 @@ class WriterTTests extends CatsSuite {
     w2.write("bar") should === (Writer("foobar", 3))
   }
 
+  test("MonadWriter's write is consistent with write") {
+    type Logged[A] = Writer[String, A]
+    val w = MonadWriter[Logged, String]
+    val x = w.write("foo")
+    x should === (Writer.write("foo"))
+    x should === (Writer("foo", ()))
+  }
+
   test("write instantiates a Writer") {
     Writer.write("foo").written should === ("foo")
   }

--- a/tests/src/test/scala/cats/tests/WriterTTests.scala
+++ b/tests/src/test/scala/cats/tests/WriterTTests.scala
@@ -12,7 +12,7 @@ import cats.kernel.laws.OrderLaws
 class WriterTTests extends CatsSuite {
   type Logged[A] = Writer[ListWrapper[Int], A]
 
-  // we have a lot of generated lists of lists in these tests. We have to tell
+  // we have a lot of generated lists of lists in these tests. We have to write
   // Scalacheck to calm down a bit so we don't hit memory and test duration
   // issues.
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
@@ -47,9 +47,9 @@ class WriterTTests extends CatsSuite {
     }
   }
 
-  test("tell + written is identity") {
+  test("write + written is identity") {
     forAll { (i: Int) =>
-      WriterT.tell[Id, Int](i).written should === (i)
+      WriterT.write[Id, Int](i).written should === (i)
     }
   }
 
@@ -68,6 +68,17 @@ class WriterTTests extends CatsSuite {
   test("show") {
     val writerT: WriterT[Id, List[String], String] = WriterT.put("foo")(List("Some log message"))
     writerT.show should === ("(List(Some log message),foo)")
+  }
+
+  test("write appends to log") {
+    val w1: Writer[String, Int] = Writer.value(3)
+    val w2 = w1.write("foo")
+    w2 should === (Writer("foo", 3))
+    w2.write("bar") should === (Writer("foobar", 3))
+  }
+
+  test("write instantiates a Writer") {
+    Writer.write("foo").written should === ("foo")
   }
 
   {


### PR DESCRIPTION
These are some changes based on a [Gitter conversation](https://gitter.im/typelevel/cats?at=5788d4739f79ee4f2bb479a0).
Well at least some of them are. Others just seemed right to me.

* Add a `write` method to `WriterT` to easily append to the log.
  * This is the main item inspired by the Gitter conversation.
* Change `tell` to `write`.
  * This seems more consistent to me, because we have used `MonadWriter` as opposed to `MonadTell`.
* Add helper `Writer.value` and `Writer.write` instantiation methods.