### PR TITLE
Add Contravariant instance for Eq and test Show instance.

### DIFF
--- a/core/src/main/scala/cats/functor/Contravariant.scala
+++ b/core/src/main/scala/cats/functor/Contravariant.scala
@@ -29,7 +29,22 @@ import simulacrum.typeclass
     }
 }
 
-object Contravariant {
+object Contravariant extends KernelContravariantInstances
+
+/**
+ * Convariant instances for types that are housed in cats.kernel and therefore
+ * can't have instances for this type class in their companion objects.
+ */
+private[functor] sealed trait KernelContravariantInstances {
+  implicit val catsFunctorContravariantForEq: Contravariant[Eq] =
+    new Contravariant[Eq] {
+      /** Derive a `Eq` for `B` given a `Eq[A]` and a function `B => A`.
+       *
+       * Note: resulting instances are law-abiding only when the functions used are injective (represent a one-to-one mapping)
+       */
+      def contramap[A, B](fa: Eq[A])(f: B => A): Eq[B] = fa.on(f)
+    }
+
   implicit val catsFunctorContravariantForPartialOrder: Contravariant[PartialOrder] =
     new Contravariant[PartialOrder] {
       /** Derive a `PartialOrder` for `B` given a `PartialOrder[A]` and a function `B => A`.

--- a/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
@@ -83,6 +83,11 @@ object arbitrary extends ArbitraryInstances0 {
   implicit def catsLawsArbitraryForFn0[A: Arbitrary]: Arbitrary[() => A] =
     Arbitrary(getArbitrary[A].map(() => _))
 
+  implicit def catsLawsArbitraryForEq[A: Arbitrary]: Arbitrary[Eq[A]] =
+    Arbitrary(Gen.oneOf(
+      new Eq[A] { def eqv(x: A, y: A) = true },
+      new Eq[A] { def eqv(x: A, y: A) = false }))
+
   implicit def catsLawsArbitraryForPartialOrder[A: Arbitrary]: Arbitrary[PartialOrder[A]] =
     Arbitrary(Gen.oneOf(
       PartialOrder.from[A]((_: A, _: A) => Double.NaN),

--- a/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
@@ -84,9 +84,7 @@ object arbitrary extends ArbitraryInstances0 {
     Arbitrary(getArbitrary[A].map(() => _))
 
   implicit def catsLawsArbitraryForEq[A: Arbitrary]: Arbitrary[Eq[A]] =
-    Arbitrary(Gen.oneOf(
-      new Eq[A] { def eqv(x: A, y: A) = true },
-      new Eq[A] { def eqv(x: A, y: A) = false }))
+    Arbitrary(new Eq[A] { def eqv(x: A, y: A) = x.hashCode == y.hashCode })
 
   implicit def catsLawsArbitraryForPartialOrder[A: Arbitrary]: Arbitrary[PartialOrder[A]] =
     Arbitrary(Gen.oneOf(

--- a/laws/src/main/scala/cats/laws/discipline/Eq.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Eq.scala
@@ -32,6 +32,22 @@ object eq {
   }
 
   /**
+   * Create an approximation of Eq[Eq[A]] by generating 100 values for A
+   * and comparing the application of the two eqv functions
+   */
+  implicit def catsLawsEqForEq[A](implicit arbA: Arbitrary[(A, A)], booleanEq: Eq[Boolean]): Eq[Eq[A]] = new Eq[Eq[A]] {
+    def eqv(f: Eq[A], g: Eq[A]): Boolean = {
+      val samples = List.fill(100)(arbA.arbitrary.sample).collect {
+        case Some(a) => a
+        case None => sys.error("Could not generate arbitrary values to compare two Eq[A]")
+      }
+      samples.forall {
+        case (l, r) => booleanEq.eqv(f.eqv(l, r), g.eqv(l, r))
+      }
+    }
+  }
+
+  /**
    * Create an approximation of Eq[PartialOrder[A]] by generating 100 values for A
    * and comparing the application of the two compare functions
    */

--- a/laws/src/main/scala/cats/laws/discipline/Eq.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Eq.scala
@@ -35,14 +35,14 @@ object eq {
    * Create an approximation of Eq[Eq[A]] by generating 100 values for A
    * and comparing the application of the two eqv functions
    */
-  implicit def catsLawsEqForEq[A](implicit arbA: Arbitrary[(A, A)], booleanEq: Eq[Boolean]): Eq[Eq[A]] = new Eq[Eq[A]] {
+  implicit def catsLawsEqForEq[A](implicit arbA: Arbitrary[(A, A)]): Eq[Eq[A]] = new Eq[Eq[A]] {
     def eqv(f: Eq[A], g: Eq[A]): Boolean = {
       val samples = List.fill(100)(arbA.arbitrary.sample).collect {
         case Some(a) => a
         case None => sys.error("Could not generate arbitrary values to compare two Eq[A]")
       }
       samples.forall {
-        case (l, r) => booleanEq.eqv(f.eqv(l, r), g.eqv(l, r))
+        case (l, r) => f.eqv(l, r) == g.eqv(l, r)
       }
     }
   }
@@ -67,14 +67,14 @@ object eq {
    * Create an approximation of Eq[Order[A]] by generating 100 values for A
    * and comparing the application of the two compare functions
    */
-  implicit def catsLawsEqForOrder[A](implicit arbA: Arbitrary[(A, A)], intEq: Eq[Int]): Eq[Order[A]] = new Eq[Order[A]] {
+  implicit def catsLawsEqForOrder[A](implicit arbA: Arbitrary[(A, A)]): Eq[Order[A]] = new Eq[Order[A]] {
     def eqv(f: Order[A], g: Order[A]): Boolean = {
       val samples = List.fill(100)(arbA.arbitrary.sample).collect {
         case Some(a) => a
         case None => sys.error("Could not generate arbitrary values to compare two Order[A]")
       }
       samples.forall {
-        case (l, r) => intEq.eqv(f.compare(l, r), g.compare(l, r))
+        case (l, r) => f.compare(l, r) == g.compare(l, r)
       }
     }
   }

--- a/tests/src/test/scala/cats/tests/KernelContravariantTests.scala
+++ b/tests/src/test/scala/cats/tests/KernelContravariantTests.scala
@@ -7,6 +7,9 @@ import cats.laws.discipline.{ContravariantTests, SerializableTests}
 import cats.laws.discipline.eq._
 
 class KernelContravariantTests extends CatsSuite {
+  checkAll("Contravariant[Eq]", ContravariantTests[Eq].contravariant[Int, Int, Int])
+  checkAll("Contravariant[Eq]", SerializableTests.serializable(Contravariant[Eq]))
+
   checkAll("Contravariant[PartialOrder]", ContravariantTests[PartialOrder].contravariant[Int, Int, Int])
   checkAll("Contravariant[PartialOrder]", SerializableTests.serializable(Contravariant[PartialOrder]))
 

--- a/tests/src/test/scala/cats/tests/ShowTests.scala
+++ b/tests/src/test/scala/cats/tests/ShowTests.scala
@@ -1,0 +1,12 @@
+package cats
+package tests
+
+import cats.functor.Contravariant
+import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.{ContravariantTests, SerializableTests}
+import cats.laws.discipline.eq._
+
+class ShowTests extends CatsSuite {
+  checkAll("Contravariant[Show]", ContravariantTests[Show].contravariant[Int, Int, Int])
+  checkAll("Contravariant[Show]", SerializableTests.serializable(Contravariant[Show]))
+}


### PR DESCRIPTION
As far I can tell this seemed to be the only missing `Contravariant` instance.

 #579 also mentioned `StateT`, but I think only an `IndexedStateT` would have a `Contravariant` (that's also why there is no `Profunctor` instance, see #1067).

I don't think it is possible to test the instance for `Eq`, since `CovariantTests` would need an `Arbitrary[Eq[A]]` and an `Eq[Eq[A]]` ?