### PR TITLE
Put liftT on the companion object of XorT

### DIFF
--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -223,7 +223,7 @@ trait XorTFunctions {
    * Alias for [[XorT.right]]
    * {{{
    * scala> import cats.data.XorT
-   * scala> import cats.instances.option._
+   * scala> import cats.implicits._
    * scala> val o: Option[Int] = Some(3)
    * scala> val n: Option[Int] = None
    * scala> XorT.liftT(o)

--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -210,7 +210,11 @@ final case class XorT[F[_], A, B](value: F[A Xor B]) {
   def toNested: Nested[F, A Xor ?, B] = Nested[F, A Xor ?, B](value)
 }
 
-object XorT extends XorTInstances with XorTFunctions
+object XorT extends XorTInstances with XorTFunctions {
+
+  def liftT[M[_]: Functor, E, A](ma: M[A]): XorT[M, E, A] = XorT(Functor[M].map(ma)(Xor.right))
+
+}
 
 trait XorTFunctions {
   final def left[F[_], A, B](fa: F[A])(implicit F: Functor[F]): XorT[F, A, B] = XorT(F.map(fa)(Xor.left))
@@ -280,7 +284,7 @@ private[data] abstract class XorTInstances extends XorTInstances1 {
       type TC[M[_]] = Functor[M]
 
       def liftT[M[_]: Functor, A](ma: M[A]): XorT[M, E, A] =
-        XorT(Functor[M].map(ma)(Xor.right))
+        XorT.liftT(ma)
     }
 
   implicit def catsMonoidForXorT[F[_], L, A](implicit F: Monoid[F[L Xor A]]): Monoid[XorT[F, L, A]] =

--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -220,9 +220,9 @@ trait XorTFunctions {
   final def pure[F[_], A, B](b: B)(implicit F: Applicative[F]): XorT[F, A, B] = right(F.pure(b))
 
   /**
-   * Alias for XorT.right
+   * Alias for [[XorT.right]]
    */
-  final def liftT[F[_], A, B](fb: F[B])(implicit F: Functor[F]): XorT[F, A, B] = right(fb)
+  final def liftT[F[_], A, B](fb: F[B]): XorT[F, A, B] = right(fb)
 
   /** Transforms an `Xor` into an `XorT`, lifted into the specified `Applicative`.
    *

--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -221,8 +221,18 @@ trait XorTFunctions {
 
   /**
    * Alias for [[XorT.right]]
+   * {{{
+   * scala> import cats.data.XorT
+   * scala> import cats.instances.option._
+   * scala> val o: Option[Int] = Some(3)
+   * scala> val n: Option[Int] = None
+   * scala> XorT.liftT(o)
+   * res0: cats.data.XorT[Option,Nothing,Int] = XorT(Some(Right(3)))
+   * scala> XorT.liftT(n)
+   * res1: cats.data.XorT[Option,Nothing,Int] = XorT(None)
+   * }}}
    */
-  final def liftT[F[_], A, B](fb: F[B]): XorT[F, A, B] = right(fb)
+  final def liftT[F[_], A, B](fb: F[B])(implicit F: Functor[F]): XorT[F, A, B] = right(fb)
 
   /** Transforms an `Xor` into an `XorT`, lifted into the specified `Applicative`.
    *

--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -210,11 +210,7 @@ final case class XorT[F[_], A, B](value: F[A Xor B]) {
   def toNested: Nested[F, A Xor ?, B] = Nested[F, A Xor ?, B](value)
 }
 
-object XorT extends XorTInstances with XorTFunctions {
-
-  def liftT[M[_]: Functor, E, A](ma: M[A]): XorT[M, E, A] = XorT(Functor[M].map(ma)(Xor.right))
-
-}
+object XorT extends XorTInstances with XorTFunctions
 
 trait XorTFunctions {
   final def left[F[_], A, B](fa: F[A])(implicit F: Functor[F]): XorT[F, A, B] = XorT(F.map(fa)(Xor.left))
@@ -222,6 +218,11 @@ trait XorTFunctions {
   final def right[F[_], A, B](fb: F[B])(implicit F: Functor[F]): XorT[F, A, B] = XorT(F.map(fb)(Xor.right))
 
   final def pure[F[_], A, B](b: B)(implicit F: Applicative[F]): XorT[F, A, B] = right(F.pure(b))
+
+  /**
+   * Alias for XorT.right
+   */
+  final def liftT[F[_], A, B](fb: F[B])(implicit F: Functor[F]): XorT[F, A, B] = right(fb)
 
   /** Transforms an `Xor` into an `XorT`, lifted into the specified `Applicative`.
    *


### PR DESCRIPTION
I found it useful to have liftT available to me for wrapping values in XorT.  I couldn't figure out what test should be added in this case, but if anyone has any examples or suggestions I'd love to add one.  