### PR TITLE
Adding leftWiden to XorT

### DIFF
--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -93,6 +93,8 @@ final case class XorT[F[_], A, B](value: F[A Xor B]) {
 
   def leftMap[C](f: A => C)(implicit F: Functor[F]): XorT[F, C, B] = bimap(f, identity)
 
+  def leftWiden[AA >: A](implicit F: Functor[F]): XorT[F, AA, B] = leftMap(a => a)
+
   def compare(that: XorT[F, A, B])(implicit o: Order[F[A Xor B]]): Int =
     o.compare(value, that.value)
 

--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -93,8 +93,6 @@ final case class XorT[F[_], A, B](value: F[A Xor B]) {
 
   def leftMap[C](f: A => C)(implicit F: Functor[F]): XorT[F, C, B] = bimap(f, identity)
 
-  def leftWiden[AA >: A](implicit F: Functor[F]): XorT[F, AA, B] = leftMap(a => a)
-
   def compare(that: XorT[F, A, B])(implicit o: Order[F[A Xor B]]): Int =
     o.compare(value, that.value)
 

--- a/core/src/main/scala/cats/functor/Bifunctor.scala
+++ b/core/src/main/scala/cats/functor/Bifunctor.scala
@@ -30,6 +30,20 @@ trait Bifunctor[F[_, _]] extends Any with Serializable { self =>
       val F = self
       val G = G0
     }
+
+  /**
+   * Widens A into a supertype AA.
+   * Example:
+   * {{{
+   * scala> import cats.data.Xor
+   * scala> import cats.implicits._
+   * scala> sealed trait Foo
+   * scala> case object Bar extends Foo
+   * scala> val x1: Xor[Bar.type, Int] = Xor.left(Bar)
+   * scala> val x2: Xor[Foo, Int] = x1.leftWiden
+   * }}}
+   */
+  def leftWiden[A, B, AA >: A](fab: F[A, B]): F[AA, B] = fab.asInstanceOf[F[AA, B]]
 }
 
 object Bifunctor {

--- a/core/src/main/scala/cats/functor/Bifunctor.scala
+++ b/core/src/main/scala/cats/functor/Bifunctor.scala
@@ -19,11 +19,6 @@ trait Bifunctor[F[_, _]] extends Any with Serializable { self =>
    */
   def leftMap[A, B, C](fab: F[A, B])(f: A => C): F[C, B] = bimap(fab)(f, identity)
 
-  /**
-   * apply a function ro the "right" functor
-   */
-  def rightMap[A, B, C](fab: F[A, B])(f: B => C): F[A, C] = bimap(fab)(identity, f)
-
   /** The composition of two Bifunctors is itself a Bifunctor */
   def compose[G[_, _]](implicit G0: Bifunctor[G]): Bifunctor[λ[(α, β) => F[G[α, β], G[α, β]]]] =
     new ComposedBifunctor[F, G] {

--- a/core/src/main/scala/cats/syntax/bifunctor.scala
+++ b/core/src/main/scala/cats/syntax/bifunctor.scala
@@ -15,4 +15,6 @@ final class BifunctorOps[F[_, _], A, B](fab: F[A, B])(implicit F: Bifunctor[F]) 
   def leftMap[C](f: A => C): F[C, B] = F.leftMap(fab)(f)
 
   def rightMap[D](f: B => D): F[A, D] = F.rightMap(fab)(f)
+
+  def leftWiden[AA >: A]: F[AA, B] = F.leftWiden(fab)
 }

--- a/core/src/main/scala/cats/syntax/bifunctor.scala
+++ b/core/src/main/scala/cats/syntax/bifunctor.scala
@@ -14,7 +14,5 @@ final class BifunctorOps[F[_, _], A, B](fab: F[A, B])(implicit F: Bifunctor[F]) 
 
   def leftMap[C](f: A => C): F[C, B] = F.leftMap(fab)(f)
 
-  def rightMap[D](f: B => D): F[A, D] = F.rightMap(fab)(f)
-
   def leftWiden[AA >: A]: F[AA, B] = F.leftWiden(fab)
 }

--- a/laws/src/main/scala/cats/laws/BifunctorLaws.scala
+++ b/laws/src/main/scala/cats/laws/BifunctorLaws.scala
@@ -19,15 +19,8 @@ trait BifunctorLaws[F[_, _]] {
   def bifunctorLeftMapIdentity[A, B](fa: F[A, B]): IsEq[F[A, B]] =
     fa.leftMap(identity) <-> fa
 
-  def bifunctorRightMapIdentity[A, B](fa: F[A, B]): IsEq[F[A, B]] =
-    fa.rightMap(identity) <-> fa
-
   def bifunctorLeftMapComposition[A, B, C, D](fa: F[A, B], f: A => C, g: C => D): IsEq[F[D, B]] = {
     fa.leftMap(f).leftMap(g) <-> fa.leftMap(f andThen g)
-  }
-
-  def bifunctorRightMapComposition[A, B, C, D](fa: F[A, B], f: B => C, g: C => D): IsEq[F[A, D]] = {
-    fa.rightMap(f).rightMap(g) <-> fa.rightMap(f andThen g)
   }
 
 }

--- a/laws/src/main/scala/cats/laws/discipline/BifunctorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/BifunctorTests.scala
@@ -27,9 +27,7 @@ trait BifunctorTests[F[_, _]] extends Laws {
       "Bifunctor Identity" -> forAll(laws.bifunctorIdentity[A, B] _),
       "Bifunctor associativity" -> forAll(laws.bifunctorComposition[A, A2, A3, B, B2, B3] _),
       "Bifunctor leftMap Identity" -> forAll(laws.bifunctorLeftMapIdentity[A, B] _),
-      "Bifunctor rightMap Identity" -> forAll(laws.bifunctorRightMapIdentity[A, B] _),
-      "Bifunctor leftMap associativity" -> forAll(laws.bifunctorLeftMapComposition[A, B, A2, A3] _),
-      "Bifunctor rightMap associativity" -> forAll(laws.bifunctorRightMapComposition[A, B, B2, B3] _)
+      "Bifunctor leftMap associativity" -> forAll(laws.bifunctorLeftMapComposition[A, B, A2, A3] _)
     )
   }
 }


### PR DESCRIPTION
Adding a `leftWiden` method to `XorT`, as `XorT` is invariant on errors, as referenced in #556 