### PR TITLE
Add distinct method to NonEmptyList and NonEmptyVector.

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -5,6 +5,7 @@ import cats.instances.list._
 import cats.syntax.order._
 
 import scala.annotation.tailrec
+import scala.collection.immutable.TreeSet
 import scala.collection.mutable.ListBuffer
 
 /**
@@ -104,6 +105,20 @@ final case class NonEmptyList[A](head: A, tail: List[A]) {
 
   def show(implicit A: Show[A]): String =
     toList.iterator.map(A.show).mkString("NonEmptyList(", ", ", ")")
+
+  /**
+   * Remove duplicates. Duplicates are checked using `Order[_]` instance.
+   */
+  def distinct(implicit O: Order[A]): NonEmptyList[A] = {
+    implicit val ord = O.toOrdering
+
+    val buf = ListBuffer.empty[A]
+    tail.foldLeft(TreeSet(head)) { (elementsSoFar, a) =>
+      if (elementsSoFar(a)) elementsSoFar else { buf += a; elementsSoFar + a }
+    }
+
+    NonEmptyList(head, buf.toList)
+  }
 
   override def toString: String = s"NonEmpty$toList"
 }

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -2,7 +2,7 @@ package cats
 package data
 
 import scala.annotation.tailrec
-import scala.collection.immutable.VectorBuilder
+import scala.collection.immutable.{TreeSet, VectorBuilder}
 import cats.instances.vector._
 
 /**
@@ -129,6 +129,20 @@ final case class NonEmptyVector[A] private (toVector: Vector[A]) {
     s"NonEmpty${Show[Vector[A]].show(toVector)}"
 
   def length: Int = toVector.length
+
+  /**
+   * Remove duplicates. Duplicates are checked using `Order[_]` instance.
+   */
+  def distinct(implicit O: Order[A]): NonEmptyVector[A] = {
+    implicit val ord = O.toOrdering
+
+    val buf = Vector.newBuilder[A]
+    tail.foldLeft(TreeSet(head)) { (elementsSoFar, a) =>
+      if (elementsSoFar(a)) elementsSoFar else { buf += a; elementsSoFar + a }
+    }
+
+    NonEmptyVector(head, buf.result())
+  }
 }
 
 private[data] sealed trait NonEmptyVectorInstances {

--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -2,7 +2,6 @@ package cats
 package data
 
 import scala.annotation.tailrec
-import scala.collection.GenSeqLike
 import scala.collection.mutable.Builder
 import cats.instances.stream._
 
@@ -93,14 +92,6 @@ final case class OneAnd[F[_], A](head: A, tail: F[A]) {
    */
   def show(implicit A: Show[A], FA: Show[F[A]]): String =
     s"OneAnd(${A.show(head)}, ${FA.show(tail)})"
-
-  /**
-   * Remove duplicates. Duplicates are checked using universal equality provided by .equals.
-   */
-  def distinct(implicit ev: F[A] <:< GenSeqLike[A, F[A]]): OneAnd[F, A] = {
-    val newTail = ev(tail).filter(_ != head).distinct
-    OneAnd(head, newTail)
-  }
 }
 
 private[data] sealed trait OneAndInstances extends OneAndLowPriority2 {

--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -2,6 +2,7 @@ package cats
 package data
 
 import scala.annotation.tailrec
+import scala.collection.GenSeqLike
 import scala.collection.mutable.Builder
 import cats.instances.stream._
 
@@ -92,6 +93,14 @@ final case class OneAnd[F[_], A](head: A, tail: F[A]) {
    */
   def show(implicit A: Show[A], FA: Show[F[A]]): String =
     s"OneAnd(${A.show(head)}, ${FA.show(tail)})"
+
+  /**
+   * Remove duplicates. Duplicates are checked using universal equality provided by .equals.
+   */
+  def distinct(implicit ev: F[A] <:< GenSeqLike[A, F[A]]): OneAnd[F, A] = {
+    val newTail = ev(tail).filter(_ != head).distinct
+    OneAnd(head, newTail)
+  }
 }
 
 private[data] sealed trait OneAndInstances extends OneAndLowPriority2 {

--- a/tests/src/test/scala/cats/tests/NonEmptyListTests.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyListTests.scala
@@ -178,6 +178,12 @@ class NonEmptyListTests extends CatsSuite {
       (i :: nel).toList should === (i :: nel.toList)
     }
   }
+
+  test("NonEmptyList#distinct is consistent with List#distinct") {
+    forAll { nel: NonEmptyList[Int] =>
+      nel.distinct.toList should === (nel.toList.distinct)
+    }
+  }
 }
 
 class ReducibleNonEmptyListCheck extends ReducibleCheck[NonEmptyList]("NonEmptyList") {

--- a/tests/src/test/scala/cats/tests/NonEmptyVectorTests.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyVectorTests.scala
@@ -218,6 +218,12 @@ class NonEmptyVectorTests extends CatsSuite {
       }
     }
   }
+
+  test("NonEmptyVector#distinct is consistent with Vector#distinct") {
+    forAll { nonEmptyVector: NonEmptyVector[Int] =>
+      nonEmptyVector.distinct.toVector should === (nonEmptyVector.toVector.distinct)
+    }
+  }
 }
 
 class ReducibleNonEmptyVectorCheck extends ReducibleCheck[NonEmptyVector]("NonEmptyVector") {


### PR DESCRIPTION
Hello.

Does it make sense to have `distinct` method on `NonEmptyList`? If this is something that could be accepted I might work on unit tests for this.

The implementation is based on universal equality to compare values. Using `Eq` would require a typeclass for getting hash codes and some `Set` implementation that would use those.