### PR TITLE
Updated broken link on OptionT docs

### DIFF
--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -9,7 +9,7 @@ import instances.option.{catsStdInstancesForOption => optionInstance}
  *
  * It may also be said that `OptionT` is a monad transformer for `Option`.
  *
- * For more information, see the [[http://non.github.io/cats/tut/optiont.html documentation]].
+ * For more information, see the [[http://typelevel.org/cats/tut/optiont.html documentation]].
  */
 final case class OptionT[F[_], A](value: F[Option[A]]) {
 


### PR DESCRIPTION
Updates a broken link on the `OptionT` scaladoc comments.
@ceedubs 