### PR TITLE
Additional test to ensure that semantics of apply on NonEmptyVector remains as expected

### DIFF
--- a/tests/src/test/scala/cats/tests/NonEmptyVectorTests.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyVectorTests.scala
@@ -254,10 +254,13 @@ class NonEmptyVectorTests extends CatsSuite {
     }
   }
 
-  test("Cannot create a new NonEmptyVector from apply with an empty vector") {
+  test("Cannot create a new NonEmptyVector[Int] from apply with a Vector[Int]") {
     "val bad: NonEmptyVector[Int] = NonEmptyVector(Vector(1))" shouldNot compile
   }
 
+  test("Cannot create a new NonEmptyVector[Int] from apply with a an empty Vector") {
+    "val bad: NonEmptyVector[Int] = NonEmptyVector(Vector())" shouldNot compile
+  }
 }
 
 class ReducibleNonEmptyVectorCheck extends ReducibleCheck[NonEmptyVector]("NonEmptyVector") {

--- a/tests/src/test/scala/cats/tests/NonEmptyVectorTests.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyVectorTests.scala
@@ -259,7 +259,7 @@ class NonEmptyVectorTests extends CatsSuite {
   }
 
   test("Cannot create a new NonEmptyVector[Int] from apply with a an empty Vector") {
-    "val bad: NonEmptyVector[Int] = NonEmptyVector(Vector())" shouldNot compile
+    "val bad: NonEmptyVector[Int] = NonEmptyVector(Vector.empty[Int])" shouldNot compile
   }
 }
 


### PR DESCRIPTION
@kailuowang @ceedubs - Apologies I didn't get back to the [comment](https://github.com/typelevel/cats/pull/1212#discussion_r72367628) by @kailuowang on the test name prior to the PR being merged.

Here is a follow up to address the text of the test. I have renamed it a different way than was suggested, and I have also added an additional test.

The original intent of the test was that it was a test to ensure that supplying a` Vector[Int]` to the `apply` method could not result in a `NonEmptyVector[Int] `(rather it should result in a `NonEmptyVector[Vector[Int]]`. 

As noted in #1214, supplying an empty `Vector[Int] `to apply was causing an empty `NonEmptyVector[Int]` to be created. The new test more explicitly verifies that this cannot happen.

These might be overkill as far as test goes, but given #1214, I figured the tests would be useful. Let me know what you think.