### PR TITLE
[Do not merge] Don't run stack-safety tests for JS

### DIFF
--- a/free/src/test/scala/cats/free/FreeApplicativeTests.scala
+++ b/free/src/test/scala/cats/free/FreeApplicativeTests.scala
@@ -28,7 +28,7 @@ class FreeApplicativeTests extends CatsSuite {
   checkAll("FreeApplicative[Option, ?]", ApplicativeTests[FreeApplicative[Option, ?]].applicative[Int, Int, Int])
   checkAll("Applicative[FreeApplicative[Option, ?]]", SerializableTests.serializable(Applicative[FreeApplicative[Option, ?]]))
 
-  test("toString is stack-safe") {
+  slowTest("toString is stack-safe") {
     val r = FreeApplicative.pure[List, Int](333)
     val rr = (1 to 1000000).foldLeft(r)((r, _) => r.map(_ + 1))
     rr.toString.length should be > 0

--- a/free/src/test/scala/cats/free/FreeTests.scala
+++ b/free/src/test/scala/cats/free/FreeTests.scala
@@ -18,7 +18,7 @@ class FreeTests extends CatsSuite {
   checkAll("Free[Option, ?]", MonadRecTests[Free[Option, ?]].monadRec[Int, Int, Int])
   checkAll("MonadRec[Free[Option, ?]]", SerializableTests.serializable(MonadRec[Free[Option, ?]]))
 
-  test("toString is stack-safe") {
+  slowTest("toString is stack-safe") {
     val r = Free.pure[List, Int](333)
     val rr = (1 to 1000000).foldLeft(r)((r, _) => r.map(_ + 1))
     rr.toString.length should be > 0
@@ -50,14 +50,14 @@ class FreeTests extends CatsSuite {
     }
   }
 
-  test("tailRecM is stack safe") {
+  slowTest("tailRecM is stack safe") {
     val n = 50000
     val fa = MonadRec[Free[Option, ?]].tailRecM(0)(i =>
       Free.pure[Option, Int Xor Int](if (i < n) Xor.Left(i+1) else Xor.Right(i)))
     fa should === (Free.pure[Option, Int](n))
   }
 
-  test("foldMap is stack safe") {
+  slowTest("foldMap is stack safe") {
     trait FTestApi[A]
     case class TB(i: Int) extends FTestApi[Int]
 

--- a/tests/src/test/scala/cats/tests/CatsSuite.scala
+++ b/tests/src/test/scala/cats/tests/CatsSuite.scala
@@ -43,6 +43,19 @@ trait CatsSuite extends FunSuite with Matchers with GeneratorDrivenPropertyCheck
   // with scalactic's equality
   override def catsSyntaxEq[A: Eq](a: A): EqOps[A] = new EqOps[A](a)
 
+  /**
+   * Declare a test that will not run in scala.js tests.
+   *
+   * In general, we want our tests to run in all target environments, but
+   * certain tests (especially those with heavy trampolining) seem to be leading
+   * to resource issues in the JS builds, causing them to sporadically fail.
+   *
+   * See https://github.com/typelevel/cats/issues/1242
+   */
+  def slowTest(testName: String)(testFun: => Unit): Unit =
+    if (Platform.isJs) ()
+    else test(testName)(testFun)
+
   def even(i: Int): Boolean = i % 2 == 0
 
   val evenPf: PartialFunction[Int, Int] = { case i if even(i) => i }

--- a/tests/src/test/scala/cats/tests/FoldableTests.scala
+++ b/tests/src/test/scala/cats/tests/FoldableTests.scala
@@ -107,7 +107,7 @@ class FoldableTestsAdditional extends CatsSuite {
     larger.value should === (large.map(_ + 1))
   }
 
-  test("Foldable[List].foldM stack safety") {
+  slowTest("Foldable[List].foldM stack safety") {
     def nonzero(acc: Long, x: Long): Option[Long] =
       if (x == 0) None else Some(acc + x)
 

--- a/tests/src/test/scala/cats/tests/MonadRecInstancesTests.scala
+++ b/tests/src/test/scala/cats/tests/MonadRecInstancesTests.scala
@@ -10,39 +10,39 @@ class MonadRecInstancesTests extends CatsSuite {
     res should === (M.pure(n))
   }
 
-  test("tailRecM stack-safety for Id") {
+  slowTest("tailRecM stack-safety for Id") {
     tailRecMStackSafety[Id]
   }
 
-  test("tailRecM stack-safety for Option") {
+  slowTest("tailRecM stack-safety for Option") {
     tailRecMStackSafety[Option]
   }
 
-  test("tailRecM stack-safety for OptionT") {
+  slowTest("tailRecM stack-safety for OptionT") {
     tailRecMStackSafety[OptionT[Option, ?]]
   }
 
-  test("tailRecM stack-safety for Either") {
+  slowTest("tailRecM stack-safety for Either") {
     tailRecMStackSafety[Either[String, ?]]
   }
 
-  test("tailRecM stack-safety for Xor") {
+  slowTest("tailRecM stack-safety for Xor") {
     tailRecMStackSafety[String Xor ?]
   }
 
-  test("tailRecM stack-safety for XorT") {
+  slowTest("tailRecM stack-safety for XorT") {
     tailRecMStackSafety[XorT[Option, String, ?]]
   }
 
-  test("tailRecM stack-safety for List") {
+  slowTest("tailRecM stack-safety for List") {
     tailRecMStackSafety[List]
   }
 
-  test("tailRecM stack-safety for Eval") {
+  slowTest("tailRecM stack-safety for Eval") {
     tailRecMStackSafety[Eval]
   }
 
-  test("tailRecM stack-safety for StateT") {
+  slowTest("tailRecM stack-safety for StateT") {
     import StateTTests._ // import implicit Eq[StateT[...]]
     tailRecMStackSafety[StateT[Option, Int, ?]]
   }

--- a/tests/src/test/scala/cats/tests/ReducibleTests.scala
+++ b/tests/src/test/scala/cats/tests/ReducibleTests.scala
@@ -5,7 +5,7 @@ import org.scalacheck.Arbitrary
 
 class ReducibleTestsAdditional extends CatsSuite {
 
-  test("Reducible[NonEmptyList].reduceLeftM stack safety") {
+  slowTest("Reducible[NonEmptyList].reduceLeftM stack safety") {
     def nonzero(acc: Long, x: Long): Option[Long] =
       if (x == 0) None else Some(acc + x)
 
@@ -20,7 +20,7 @@ class ReducibleTestsAdditional extends CatsSuite {
 abstract class ReducibleCheck[F[_]: Reducible](name: String)(implicit ArbFInt: Arbitrary[F[Int]]) extends FoldableCheck[F](name) {
   def range(start: Long, endInclusive: Long): F[Long]
 
-  test(s"Reducible[$name].reduceLeftM stack safety") {
+  slowTest(s"Reducible[$name].reduceLeftM stack safety") {
     def nonzero(acc: Long, x: Long): Option[Long] =
       if (x == 0) None else Some(acc + x)
 

--- a/tests/src/test/scala/cats/tests/StateTTests.scala
+++ b/tests/src/test/scala/cats/tests/StateTTests.scala
@@ -15,7 +15,7 @@ class StateTTests extends CatsSuite {
     add1.run(1).value should === (2 -> 1)
   }
 
-  test("traversing state is stack-safe"){
+  slowTest("traversing state is stack-safe"){
     val ns = (0 to 100000).toList
     val x = ns.traverseU(_ => add1)
     x.runS(0).value should === (100001)


### PR DESCRIPTION
This is a shot in the dark attempting to fix #1242.

The idea is that we can mark certain tests as slow and not run them when
running JS tests. Currently I've done this for all of the stack-safety
tests that I can find.

I don't really like this solution, but currently almost every PR is
resulting in a failed build, which is really problematic. One thing that
we could do is get rid of the `Platform.isJs` branch of the `slowTest`
implementation locally just before a release to make sure that these
tests all pass on JS. I think we only really run into these issues on
Travis CI.