### PR TITLE
A different approach to try fix the build

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,9 +1,10 @@
 # see https://weblogs.java.net/blog/kcpeppe/archive/2013/12/11/case-study-jvm-hotspot-flags
 -Dfile.encoding=UTF8
 -Xms1G
--Xmx3G
+-Xmx4G
+-XX:MaxMetaspaceSize=512m
 -XX:MaxPermSize=512M
--XX:ReservedCodeCacheSize=250M
+-XX:ReservedCodeCacheSize=256M
 -XX:+TieredCompilation
 -XX:-UseGCOverheadLimit
 # effectively adds GC to Perm space


### PR DESCRIPTION
The hypothesis is that our memory footprint increased, the scalajs build failed due to it although the error message isn't obvious.