### PR TITLE
Split build tasks on travis fixes #1242

### DIFF
--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -29,5 +29,10 @@ sbt_cmd="sbt ++$TRAVIS_SCALA_VERSION"
 
 coverage="$sbt_cmd coverage validateJVM coverageReport && codecov"
 
-run_cmd="$coverage && $sbt_cmd validate && $sbt_cmd $publish_cmd"
+
+scala_js="$sbt_cmd macrosJS/compile coreJS/compile lawsJS/compile && $sbt_cmd kernelLawsJS/test && $sbt_cmd testsJS/test && $sbt_cmd js/test"		
+scala_jvm="$sbt_cmd validateJVM"		
+  		  
+run_cmd="$coverage && $scala_js && $scala_jvm $publish_cmd"
+
 eval $run_cmd


### PR DESCRIPTION
I believe the frequent scalajs build failure is caused by out of memory, So splitting the tasks helped. This is verified by #1254 which passes two builds consecutively.

Update: thanks to @mikejcurry in his comment [here](https://github.com/typelevel/cats/pull/1258#issuecomment-237067035)  I understand we are at the upper bound of memory available on travis, i.e. we can't increase jvm memory to solve this problem. 