### PR TITLE
Add MonadRec for Future and reinstate Future tests for JVM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -175,8 +175,8 @@ lazy val catsJVM = project.in(file(".catsJVM"))
   .settings(moduleName := "cats")
   .settings(catsSettings)
   .settings(commonJvmSettings)
-  .aggregate(macrosJVM, kernelJVM, kernelLawsJVM, coreJVM, lawsJVM, freeJVM, testsJVM, docs, bench)
-  .dependsOn(macrosJVM, kernelJVM, kernelLawsJVM, coreJVM, lawsJVM, freeJVM, testsJVM % "test-internal -> test", bench % "compile-internal;test-internal -> test")
+  .aggregate(macrosJVM, kernelJVM, kernelLawsJVM, coreJVM, lawsJVM, freeJVM, testsJVM, jvm, docs, bench)
+  .dependsOn(macrosJVM, kernelJVM, kernelLawsJVM, coreJVM, lawsJVM, freeJVM, testsJVM % "test-internal -> test", jvm, bench % "compile-internal;test-internal -> test")
 
 lazy val catsJS = project.in(file(".catsJS"))
   .settings(moduleName := "cats")
@@ -290,6 +290,13 @@ lazy val js = project
   .settings(commonJsSettings:_*)
   .enablePlugins(ScalaJSPlugin)
 
+// cats-jvm is JVM-only
+lazy val jvm = project
+  .dependsOn(macrosJVM, coreJVM, testsJVM % "test-internal -> test")
+  .settings(moduleName := "cats-jvm")
+  .settings(catsSettings:_*)
+  .settings(commonJvmSettings:_*)
+
 lazy val publishSettings = Seq(
   homepage := Some(url("https://github.com/typelevel/cats")),
   licenses := Seq("MIT" -> url("http://opensource.org/licenses/MIT")),
@@ -358,7 +365,7 @@ lazy val publishSettings = Seq(
 ) ++ credentialSettings ++ sharedPublishSettings ++ sharedReleaseProcess
 
 // These aliases serialise the build for the benefit of Travis-CI.
-addCommandAlias("buildJVM", ";macrosJVM/compile;coreJVM/compile;kernelLawsJVM/compile;lawsJVM/compile;freeJVM/compile;kernelLawsJVM/test;coreJVM/test;testsJVM/test;freeJVM/test;bench/test")
+addCommandAlias("buildJVM", ";macrosJVM/compile;coreJVM/compile;kernelLawsJVM/compile;lawsJVM/compile;freeJVM/compile;kernelLawsJVM/test;coreJVM/test;testsJVM/test;freeJVM/test;jvm/test;bench/test")
 
 addCommandAlias("validateJVM", ";scalastyle;buildJVM;makeSite")
 

--- a/core/src/main/scala/cats/instances/future.scala
+++ b/core/src/main/scala/cats/instances/future.scala
@@ -14,6 +14,10 @@ trait FutureInstances extends FutureInstances1 {
 
       def flatMap[A, B](fa: Future[A])(f: A => Future[B]): Future[B] = fa.flatMap(f)
 
+      /**
+       * Note that while this implementation will not compile with `@tailrec`,
+       * it is in fact stack-safe.
+       */
       final def tailRecM[B, C](b: B)(f: B => Future[(B Xor C)]): Future[C] =
         f(b).flatMap {
           case Xor.Left(b1) => tailRecM(b1)(f)

--- a/jvm/src/test/scala/cats/tests/FutureTests.scala
+++ b/jvm/src/test/scala/cats/tests/FutureTests.scala
@@ -1,26 +1,17 @@
 package cats
-package js
+package jvm
 package tests
 
 import cats.data.Xor
 import cats.laws.discipline._
-import cats.js.instances.Await
-import cats.js.instances.future.futureComonad
 import cats.tests.CatsSuite
 
-import scala.concurrent.Future
+import scala.concurrent.{Await, Future}
 import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
-
-// https://issues.scala-lang.org/browse/SI-7934
-@deprecated("", "")
-class DeprecatedForwarder {
-  implicit def runNow = scala.scalajs.concurrent.JSExecutionContext.Implicits.runNow
-}
-object DeprecatedForwarder extends DeprecatedForwarder
-import DeprecatedForwarder.runNow
 
 class FutureTests extends CatsSuite {
   val timeout = 3.seconds
@@ -39,13 +30,10 @@ class FutureTests extends CatsSuite {
   implicit val throwableEq: Eq[Throwable] =
     Eq.fromUniversalEquals
 
-  implicit val comonad: Comonad[Future] = futureComonad(timeout)
-
   // Need non-fatal Throwables for Future recoverWith/handleError
   implicit val nonFatalArbitrary: Arbitrary[Throwable] =
     Arbitrary(arbitrary[Exception].map(identity))
 
-  checkAll("Future[Int]", MonadErrorTests[Future, Throwable].monadError[Int, Int, Int])
-  checkAll("Future[Int]", ComonadTests[Future].comonad[Int, Int, Int])
+  checkAll("Future with Throwable", MonadErrorTests[Future, Throwable].monadError[Int, Int, Int])
   checkAll("Future", MonadRecTests[Future].monadRec[Int, Int, Int])
 }


### PR DESCRIPTION
This PR adds a new `MonadRec` instance for `Future` (as discussed on [Gitter](https://gitter.im/typelevel/cats?at=57a2073cc915a0e426b91de1)). The implementation of `tailRecM` is not literally tail recursive, but it is stack-safe.

I've also reinstated the `jvm` module that was removed in #1018, since it looks like the removal of the `MonadError` laws checking there wasn't intentional, and since I need a place to put the `MonadRec` laws checking for `Future`.