### PR TITLE
add catchNonFatal to MonadError

### DIFF
--- a/core/src/main/scala/cats/ApplicativeError.scala
+++ b/core/src/main/scala/cats/ApplicativeError.scala
@@ -80,7 +80,7 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
    * Often E is Throwable. Here we try to call pure or catch
    * and raise.
    */
-  def catchNonFatal[A](a: => A)(implicit ev: Throwable =:= E): F[A] =
+  def catchNonFatal[A](a: => A)(implicit ev: Throwable <:< E): F[A] =
     try pure(a)
     catch {
       case NonFatal(e) => raiseError(e)
@@ -90,7 +90,7 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
    * Often E is Throwable. Here we try to call pure or catch
    * and raise
    */
-  def catchNonFatalEval[A](a: Eval[A])(implicit ev: Throwable =:= E): F[A] =
+  def catchNonFatalEval[A](a: Eval[A])(implicit ev: Throwable <:< E): F[A] =
     try pure(a.value)
     catch {
       case NonFatal(e) => raiseError(e)
@@ -99,7 +99,7 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
   /**
    * If the error type is Throwable, we can convert from a scala.util.Try
    */
-  def fromTry[A](t: Try[A])(implicit ev: Throwable =:= E): F[A] =
+  def fromTry[A](t: Try[A])(implicit ev: Throwable <:< E): F[A] =
     t match {
       case Success(a) => pure(a)
       case Failure(e) => raiseError(e)

--- a/tests/src/test/scala/cats/tests/TryTests.scala
+++ b/tests/src/test/scala/cats/tests/TryTests.scala
@@ -30,6 +30,26 @@ class TryTests extends CatsSuite {
     }
   }
 
+  test("tryCatch works") {
+    forAll { e: Either[String, Int] =>
+      val str = e.fold(identity, _.toString)
+      val res = MonadError[Try, Throwable].tryCatch(str.toInt)
+      // the above shuold just never cause an uncaught exception
+      // this is a somewhat bogus test:
+      res should not be (null)
+    }
+  }
+
+  test("tryCatchEval works") {
+    forAll { e: Either[String, Int] =>
+      val str = e.fold(identity, _.toString)
+      val res = MonadError[Try, Throwable].tryCatchEval(Eval.later(str.toInt))
+      // the above shuold just never cause an uncaught exception
+      // this is a somewhat bogus test:
+      res should not be (null)
+    }
+  }
+
   // The following tests check laws which are a different formulation of
   // laws that are checked. Since these laws are more or less duplicates of
   // existing laws, we don't check them for all types that have the relevant

--- a/tests/src/test/scala/cats/tests/TryTests.scala
+++ b/tests/src/test/scala/cats/tests/TryTests.scala
@@ -51,7 +51,7 @@ class TryTests extends CatsSuite {
   }
   test("fromTry works") {
     forAll { t: Try[Int] =>
-      (MonadError[Try, Throwable].fromTry(t)) should === t
+      (MonadError[Try, Throwable].fromTry(t)) should === (t)
     }
   }
 

--- a/tests/src/test/scala/cats/tests/TryTests.scala
+++ b/tests/src/test/scala/cats/tests/TryTests.scala
@@ -34,7 +34,7 @@ class TryTests extends CatsSuite {
     forAll { e: Either[String, Int] =>
       val str = e.fold(identity, _.toString)
       val res = MonadError[Try, Throwable].catchNonFatal(str.toInt)
-      // the above shuold just never cause an uncaught exception
+      // the above should just never cause an uncaught exception
       // this is a somewhat bogus test:
       res should not be (null)
     }
@@ -44,7 +44,7 @@ class TryTests extends CatsSuite {
     forAll { e: Either[String, Int] =>
       val str = e.fold(identity, _.toString)
       val res = MonadError[Try, Throwable].catchNonFatalEval(Eval.later(str.toInt))
-      // the above shuold just never cause an uncaught exception
+      // the above should just never cause an uncaught exception
       // this is a somewhat bogus test:
       res should not be (null)
     }

--- a/tests/src/test/scala/cats/tests/TryTests.scala
+++ b/tests/src/test/scala/cats/tests/TryTests.scala
@@ -30,23 +30,28 @@ class TryTests extends CatsSuite {
     }
   }
 
-  test("tryCatch works") {
+  test("catchNonFatal works") {
     forAll { e: Either[String, Int] =>
       val str = e.fold(identity, _.toString)
-      val res = MonadError[Try, Throwable].tryCatch(str.toInt)
+      val res = MonadError[Try, Throwable].catchNonFatal(str.toInt)
       // the above shuold just never cause an uncaught exception
       // this is a somewhat bogus test:
       res should not be (null)
     }
   }
 
-  test("tryCatchEval works") {
+  test("catchNonFatalEval works") {
     forAll { e: Either[String, Int] =>
       val str = e.fold(identity, _.toString)
-      val res = MonadError[Try, Throwable].tryCatchEval(Eval.later(str.toInt))
+      val res = MonadError[Try, Throwable].catchNonFatalEval(Eval.later(str.toInt))
       // the above shuold just never cause an uncaught exception
       // this is a somewhat bogus test:
       res should not be (null)
+    }
+  }
+  test("fromTry works") {
+    forAll { t: Try[Int] =>
+      (MonadError[Try, Throwable].fromTry(t)) should === t
     }
   }
 


### PR DESCRIPTION
This method seems really convenient for many common `MonadError` cases.

It is somewhat limited due to requiring `Throwable`, we could put it on the `MonadError` object rather than instance, and we could introduce a new typeclass `Catchable[M]`?

I think this covers 90% of the cases without adding too much complexity.