### PR TITLE
Add syntax import objects for FunctorFilter and TraverseFilter

### DIFF
--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -19,6 +19,7 @@ package object syntax {
   object flatMap extends FlatMapSyntax
   object foldable extends FoldableSyntax
   object functor extends FunctorSyntax
+  object functorFilter extends FunctorFilterSyntax
   object group extends GroupSyntax
   object invariant extends InvariantSyntax
   object list extends ListSyntax
@@ -37,6 +38,7 @@ package object syntax {
   object strong extends StrongSyntax
   object transLift extends TransLiftSyntax
   object traverse extends TraverseSyntax
+  object traverseFilter extends TraverseFilterSyntax
   object validated extends ValidatedSyntax
   object writer extends WriterSyntax
   object xor extends XorSyntax

--- a/tests/src/test/scala/cats/tests/SyntaxTests.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxTests.scala
@@ -23,7 +23,7 @@ import cats.functor.{Invariant, Contravariant}
  *
  * None of these tests should ever run, or do any runtime checks.
  */
-class SyntaxTests extends AllInstances with AllSyntax {
+object SyntaxTests extends AllInstances with AllSyntax {
 
   // pretend we have a value of type A
   def mock[A]: A = ???
@@ -256,5 +256,28 @@ class SyntaxTests extends AllInstances with AllSyntax {
 
     val pfegea = mock[PartialFunction[E, G[A]]]
     val gea4 = ga.recoverWith(pfegea)
+  }
+}
+
+/**
+ * Similar to [[SyntaxTests]] but doesn't automatically include all
+ * instances/syntax, so that piecemeal imports can be tested.
+ */
+object AdHocSyntaxTests {
+  import SyntaxTests.mock
+
+  def testFunctorFilterSyntax[F[_]:FunctorFilter, A]: Unit = {
+    import cats.syntax.functorFilter._
+
+    val fa = mock[F[A]]
+    val filtered = fa.mapFilter(_ => None)
+  }
+
+  def testTraverseFilterSyntax[F[_]:TraverseFilter, G[_]: Applicative, A, B]: Unit = {
+    import cats.syntax.traverseFilter._
+
+    val fa = mock[F[A]]
+    val f = mock[A => G[Option[B]]]
+    val filtered = fa.traverseFilter(f)
   }
 }


### PR DESCRIPTION
This is something that I missed on #1225.

@travisbrown this might be something that we want to make it into 0.7.0.