### PR TITLE
Some attribution work

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -99,8 +99,9 @@ possible:
  * yilinwei
  * Zach Abbott
 
-Cats has been heavily inspired by [Scalaz](https://github.com/scalaz/scalaz),
-and some Cats code is only a slightly modified version of code originating in
+Cats has been heavily inspired by many libraries, including [Scalaz](https://github.com/scalaz/scalaz),
+Haskell's [Prelude](https://hackage.haskell.org/package/base-4.9.0.0/docs/Prelude.html), and others.
+In particular, some Cats code is only a slightly modified version of code originating in
 Scalaz. Therefore, we'd also like to credit and thank all of the
 [Scalaz contributors](https://github.com/scalaz/scalaz/graphs/contributors) for
 their work.

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -31,6 +31,7 @@ possible:
  * Binh Nguyen
  * Bobby Rauchenberg
  * Brendan McAdams
+ * Brian McKenna
  * Cody Allen
  * Colt Frederickson
  * Dale Wijnand
@@ -97,6 +98,12 @@ possible:
  * Yosef Fertel
  * yilinwei
  * Zach Abbott
+
+Cats has been heavily inspired by [scalaz](https://github.com/scalaz/scalaz),
+and some Cats code is only a slightly modified version of code originating in
+scalaz. Therefore, we'd also like to credit and thank all of the
+[scalaz contributors](https://github.com/scalaz/scalaz/graphs/contributors) for
+their work.
 
 We've tried to include everyone, but if you've made a contribution to
 Cats and are not listed, please feel free to open an issue or pull

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -99,10 +99,10 @@ possible:
  * yilinwei
  * Zach Abbott
 
-Cats has been heavily inspired by [scalaz](https://github.com/scalaz/scalaz),
+Cats has been heavily inspired by [Scalaz](https://github.com/scalaz/scalaz),
 and some Cats code is only a slightly modified version of code originating in
-scalaz. Therefore, we'd also like to credit and thank all of the
-[scalaz contributors](https://github.com/scalaz/scalaz/graphs/contributors) for
+Scalaz. Therefore, we'd also like to credit and thank all of the
+[Scalaz contributors](https://github.com/scalaz/scalaz/graphs/contributors) for
 their work.
 
 We've tried to include everyone, but if you've made a contribution to

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,6 +131,12 @@ Write about type class methods on data structures as described in https://github
 
 Write about https://github.com/typelevel/cats/pull/36#issuecomment-72892359
 
+### Attributions
+
+If your contribution has been derived from or inspired by other work, please
+state this in its ScalaDoc comment and provide proper attribution. When
+possible, include the original authors' names and a link to the original work.
+
 ### Write tests
 
 - Tests for cats-core go into the tests module, under the `cats.tests` package.

--- a/core/src/main/scala/cats/FlatMapRec.scala
+++ b/core/src/main/scala/cats/FlatMapRec.scala
@@ -9,6 +9,10 @@ import cats.data.Xor
  *
  * Based on Phil Freeman's
  * [[http://functorial.com/stack-safety-for-free/index.pdf Stack Safety for Free]].
+ *
+ * This Scala implementation of `FlatMapRec` and its usages are derived from
+ * [[https://github.com/scalaz/scalaz/blob/series/7.3.x/core/src/main/scala/scalaz/BindRec.scala scalaz's BindRec]],
+ * originally written by Brian McKenna.
  */
 @typeclass trait FlatMapRec[F[_]] extends FlatMap[F] {
 

--- a/core/src/main/scala/cats/FlatMapRec.scala
+++ b/core/src/main/scala/cats/FlatMapRec.scala
@@ -11,7 +11,7 @@ import cats.data.Xor
  * [[http://functorial.com/stack-safety-for-free/index.pdf Stack Safety for Free]].
  *
  * This Scala implementation of `FlatMapRec` and its usages are derived from
- * [[https://github.com/scalaz/scalaz/blob/series/7.3.x/core/src/main/scala/scalaz/BindRec.scala scalaz's BindRec]],
+ * [[https://github.com/scalaz/scalaz/blob/series/7.3.x/core/src/main/scala/scalaz/BindRec.scala Scalaz's BindRec]],
  * originally written by Brian McKenna.
  */
 @typeclass trait FlatMapRec[F[_]] extends FlatMap[F] {

--- a/core/src/main/scala/cats/NotNull.scala
+++ b/core/src/main/scala/cats/NotNull.scala
@@ -9,7 +9,7 @@ package cats
  *
  * This trait is used along with ambiguous implicits to achieve the goal of
  * preventing inference of `Null`. This ambiguous implicit trick has been used
- * in the Scala community for some time. [[https://gist.github.com/milessabin/de58f3ba7024d51dcc1a] Here]
+ * in the Scala community for some time. [[https://gist.github.com/milessabin/de58f3ba7024d51dcc1a Here]]
  * is an early example of such a trick being used in a similar way to prevent a
  * `Nothing` type.
  */

--- a/core/src/main/scala/cats/NotNull.scala
+++ b/core/src/main/scala/cats/NotNull.scala
@@ -8,7 +8,7 @@ package cats
  * parameter is omitted.
  *
  * `NotNull`, its implementation, and its usages are derived from
- * [[https://github.com/scalaz/scalaz/blob/series/7.3.x/core/src/main/scala/scalaz/NotNothing.scala scalaz's NotNothing]],
+ * [[https://github.com/scalaz/scalaz/blob/series/7.3.x/core/src/main/scala/scalaz/NotNothing.scala Scalaz's NotNothing]],
  * originally written by Brian McKenna.
  */
 sealed trait NotNull[A]

--- a/core/src/main/scala/cats/NotNull.scala
+++ b/core/src/main/scala/cats/NotNull.scala
@@ -7,9 +7,11 @@ package cats
  * This can be useful in preventing `Null` from being inferred when a type
  * parameter is omitted.
  *
- * `NotNull`, its implementation, and its usages are derived from
- * [[https://github.com/scalaz/scalaz/blob/series/7.3.x/core/src/main/scala/scalaz/NotNothing.scala Scalaz's NotNothing]],
- * originally written by Brian McKenna.
+ * This trait is used along with ambiguous implicits to achieve the goal of
+ * preventing inference of `Null`. This ambiguous implicit trick has been used
+ * in the Scala community for some time. [[https://gist.github.com/milessabin/de58f3ba7024d51dcc1a] Here]
+ * is an early example of such a trick being used in a similar way to prevent a
+ * `Nothing` type.
  */
 sealed trait NotNull[A]
 

--- a/core/src/main/scala/cats/NotNull.scala
+++ b/core/src/main/scala/cats/NotNull.scala
@@ -6,6 +6,10 @@ package cats
  *
  * This can be useful in preventing `Null` from being inferred when a type
  * parameter is omitted.
+ *
+ * `NotNull`, its implementation, and its usages are derived from
+ * [[https://github.com/scalaz/scalaz/blob/series/7.3.x/core/src/main/scala/scalaz/NotNothing.scala scalaz's NotNothing]],
+ * originally written by Brian McKenna.
  */
 sealed trait NotNull[A]
 

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -354,6 +354,10 @@ trait ValidatedFunctions {
    * scala> Validated.catchOnly[NumberFormatException] { "foo".toInt }
    * res0: Validated[NumberFormatException, Int] = Invalid(java.lang.NumberFormatException: For input string: "foo")
    * }}}
+   *
+   * This method and its usage of [[NotNull]] are inspired by and derived from
+   * the `fromTryCatchThrowable` method [[https://github.com/scalaz/scalaz/pull/746/files contributed]]
+   * to Scalaz by Brian McKenna.
    */
   def catchOnly[T >: Null <: Throwable]: CatchOnlyPartiallyApplied[T] = new CatchOnlyPartiallyApplied[T]
 

--- a/core/src/main/scala/cats/data/Xor.scala
+++ b/core/src/main/scala/cats/data/Xor.scala
@@ -322,6 +322,10 @@ trait XorFunctions {
    * scala> Xor.catchOnly[NumberFormatException] { "foo".toInt }
    * res0: Xor[NumberFormatException, Int] = Left(java.lang.NumberFormatException: For input string: "foo")
    * }}}
+   *
+   * This method and its usage of [[NotNull]] are inspired by and derived from
+   * the `fromTryCatchThrowable` method [[https://github.com/scalaz/scalaz/pull/746/files contributed]]
+   * to Scalaz by Brian McKenna.
    */
   def catchOnly[T >: Null <: Throwable]: CatchOnlyPartiallyApplied[T] =
     new CatchOnlyPartiallyApplied[T]


### PR DESCRIPTION
This is inspired by #1275. It doesn't include a CLA, and there is
most likely more work that should be done with respect to attribution,
but I'm hoping that this is a step in the right direction.

I've added a link to the scalaz contributors page within AUTHORS.md.
I'm not sure who all out of that should and would want to be directly listed
in the authors page for Cats. I've explicitly added Brian McKenna to the
authors page, as my understanding of [this
tweet](https://twitter.com/puffnfresh/status/762901748772057088) is that
he would like to be on there.

@puffnfresh, if you care to, please let me know if there is any way that I could improve this.