### PR TITLE
Add val alias for FunctionK

### DIFF
--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -7,6 +7,7 @@ import cats.data.Xor
 package object cats {
 
   type ~>[F[_], G[_]] = arrow.FunctionK[F, G]
+  val ~> = arrow.FunctionK
 
   type ⊥ = Nothing
   type ⊤ = Any


### PR DESCRIPTION
I find myself wanting to use the identity instance of FunctionK via `~>.id`. This can be achieved with an import `import cats.arrow.{ FunctionK ⇒ ~> }`, but an alias to the object would be a bit more convenient.
