### PR TITLE
Eliminate macro build noise.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,7 @@ lazy val kernelSettings = Seq(
 ) ++ warnUnusedImport
 
 lazy val commonSettings = Seq(
+  incOptions := incOptions.value.withLogRecompileOnMacro(false),
   scalacOptions ++= commonScalacOptions,
   resolvers ++= Seq(
     "bintray/non" at "http://dl.bintray.com/non/maven",


### PR DESCRIPTION
SBT 0.13.12 added a warning about recompilation due to incremental build cache invalidation in the presence of macros. This is enabled by default.

Whilst in many ways laudable, this introduces a lot of unhelpful build noise in projects which define macros. Fortunately there is an SBT incremental build option to disable this warning. The PR adds that option to the Cats build.

More info on the warning can be found [here](https://github.com/sbt/sbt/issues/2654).