### PR TITLE
Drastically speed up Monoid[Map[K, V]] instance.

### DIFF
--- a/bench/src/main/scala/cats/bench/MapMonoidBench.scala
+++ b/bench/src/main/scala/cats/bench/MapMonoidBench.scala
@@ -1,0 +1,59 @@
+package cats.bench
+
+//import cats.instances.list._
+import cats.instances.int._
+import cats.instances.map._
+
+import scalaz.std.anyVal._
+//import scalaz.std.list._
+import scalaz.std.map._
+
+import org.openjdk.jmh.annotations.{ Benchmark, Scope, State }
+
+@State(Scope.Benchmark)
+class MapMonoidBench {
+
+  val words: List[String] =
+    for {
+      c <- List("a", "b", "c", "d", "e")
+      t <- 1 to 100
+    } yield c * t
+
+  val maps: List[Map[String, Int]] = (words ++ words).map(s => Map(s -> 1))
+
+  @Benchmark def combineAllCats: Map[String, Int] =
+    cats.Monoid[Map[String, Int]].combineAll(maps)
+
+  @Benchmark def combineCats: Map[String, Int] =
+    maps.foldLeft(Map.empty[String, Int]) {
+      case (acc, m) => cats.Monoid[Map[String, Int]].combine(acc, m)
+    }
+
+  @Benchmark def combineScalaz: Map[String, Int] =
+    maps.foldLeft(Map.empty[String, Int]) {
+      case (acc, m) => scalaz.Monoid[Map[String, Int]].append(acc, m)
+    }
+
+  @Benchmark def combineDirect: Map[String, Int] =
+    maps.foldLeft(Map.empty[String, Int]) {
+      case (acc, m) => m.foldLeft(acc) {
+        case (m, (k, v)) => m.updated(k, v + m.getOrElse(k, 0))
+      }
+    }
+
+  @Benchmark def combineGeneric: Map[String, Int] =
+    combineMapsGeneric[String, Int](maps, 0, _ + _)
+
+  def combineMapsGeneric[K, V](maps: List[Map[K, V]], z: V, f: (V, V) => V): Map[K, V] =
+    maps.foldLeft(Map.empty[K, V]) {
+      case (acc, m) => m.foldLeft(acc) {
+        case (m, (k, v)) => m.updated(k, f(v, m.getOrElse(k, z)))
+      }
+    }
+
+  @Benchmark def foldMapCats: Map[String, Int] =
+    cats.Foldable[List].foldMap(maps)(identity)
+
+  @Benchmark def foldMapScalaz: Map[String, Int] =
+    scalaz.Foldable[List].foldMap(maps)(identity)
+}

--- a/bench/src/main/scala/cats/bench/MapMonoidBench.scala
+++ b/bench/src/main/scala/cats/bench/MapMonoidBench.scala
@@ -1,11 +1,11 @@
 package cats.bench
 
-//import cats.instances.list._
+import cats.instances.list._
 import cats.instances.int._
 import cats.instances.map._
 
 import scalaz.std.anyVal._
-//import scalaz.std.list._
+import scalaz.std.list._
 import scalaz.std.map._
 
 import org.openjdk.jmh.annotations.{ Benchmark, Scope, State }

--- a/build.sbt
+++ b/build.sbt
@@ -281,6 +281,8 @@ lazy val bench = project.dependsOn(macrosJVM, coreJVM, freeJVM, lawsJVM)
   .settings(catsSettings)
   .settings(noPublishSettings)
   .settings(commonJvmSettings)
+  .settings(libraryDependencies ++= Seq(
+    "org.scalaz" %% "scalaz-core" % "7.2.5"))
   .enablePlugins(JmhPlugin)
 
 // cats-js is JS-only

--- a/kernel/src/main/scala/cats/kernel/Monoid.scala
+++ b/kernel/src/main/scala/cats/kernel/Monoid.scala
@@ -34,6 +34,9 @@ trait Monoid[@sp(Int, Long, Float, Double) A] extends Any with Semigroup[A] {
    */
   def combineAll(as: TraversableOnce[A]): A =
     as.foldLeft(empty)(combine)
+
+  override def combineAllOption(as: TraversableOnce[A]): Option[A] =
+    if (as.isEmpty) None else Some(combineAll(as))
 }
 
 abstract class MonoidFunctions[M[T] <: Monoid[T]] extends SemigroupFunctions[M] {

--- a/kernel/src/main/scala/cats/kernel/instances/StaticMethods.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/StaticMethods.scala
@@ -5,34 +5,12 @@ import scala.collection.mutable
 
 object StaticMethods {
 
-  def initMutableMap[K, V](m: Map[K, V]): mutable.Map[K, V] = {
-    val result = mutable.Map.empty[K, V]
-    m.foreach { case (k, v) => result(k) = v }
-    result
-  }
-
-  def wrapMutableMap[K, V](m: mutable.Map[K, V]): Map[K, V] =
-    new WrappedMutableMap(m)
-
   private[kernel] class WrappedMutableMap[K, V](m: mutable.Map[K, V]) extends Map[K, V] {
     override def size: Int = m.size
     def get(k: K): Option[V] = m.get(k)
     def iterator: Iterator[(K, V)] = m.iterator
     def +[V2 >: V](kv: (K, V2)): Map[K, V2] = m.toMap + kv
     def -(key: K): Map[K, V] = m.toMap - key
-  }
-
-  // the caller should arrange so that the smaller map is the first
-  // argument, and the larger map is the second.
-  def addMap[K, V](small: Map[K, V], big: Map[K, V])(f: (V, V) => V): Map[K, V] = {
-    val m = initMutableMap(big)
-    small.foreach { case (k, v1) =>
-      m(k) = m.get(k) match {
-        case Some(v2) => f(v1, v2)
-        case None => v1
-      }
-    }
-    wrapMutableMap(m)
   }
 
   // scalastyle:off return

--- a/kernel/src/main/scala/cats/kernel/instances/StaticMethods.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/StaticMethods.scala
@@ -1,5 +1,5 @@
 package cats.kernel
-package instances.util
+package instances
 
 import scala.collection.mutable
 

--- a/kernel/src/main/scala/cats/kernel/instances/StaticMethods.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/StaticMethods.scala
@@ -5,6 +5,9 @@ import scala.collection.mutable
 
 object StaticMethods {
 
+  def wrapMutableMap[K, V](m: mutable.Map[K, V]): Map[K, V] =
+    new WrappedMutableMap(m)
+
   private[kernel] class WrappedMutableMap[K, V](m: mutable.Map[K, V]) extends Map[K, V] {
     override def size: Int = m.size
     def get(k: K): Option[V] = m.get(k)

--- a/kernel/src/main/scala/cats/kernel/instances/map.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/map.scala
@@ -47,6 +47,6 @@ class MapMonoid[K, V](implicit V: Semigroup[V]) extends Monoid[Map[K, V]]  {
         m.updated(k, Semigroup.maybeCombine(m.get(k), v))
       }
     }
-    new StaticMethods.WrappedMutableMap(acc)
+    StaticMethods.wrapMutableMap(acc)
   }
 }

--- a/kernel/src/main/scala/cats/kernel/instances/map.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/map.scala
@@ -47,6 +47,6 @@ class MapMonoid[K, V](implicit V: Semigroup[V]) extends Monoid[Map[K, V]]  {
         m.updated(k, Semigroup.maybeCombine(m.get(k), v))
       }
     }
-    StaticMethods.wrapMutableMap(acc)
+    new StaticMethods.WrappedMutableMap(acc)
   }
 }

--- a/kernel/src/main/scala/cats/kernel/instances/stream.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/stream.scala
@@ -1,8 +1,6 @@
 package cats.kernel
 package instances
 
-import cats.kernel.instances.util.StaticMethods
-
 package object stream extends StreamInstances
 
 trait StreamInstances extends StreamInstances1 {

--- a/kernel/src/main/scala/cats/kernel/instances/vector.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/vector.scala
@@ -1,8 +1,6 @@
 package cats.kernel
 package instances
 
-import cats.kernel.instances.util.StaticMethods
-
 package object vector extends VectorInstances
 
 trait VectorInstances extends VectorInstances1 {


### PR DESCRIPTION
This commit fixes a number of problems I introduced with cats-kernel.

 1. Map's monoid was not overriding combineAll
 2. It was also doing the wrong thing for combine
 3. Monoid should have overridden combineAllOption

The performance for map's `combine` is 150x faster after this commit,
and `combineAll` is 780x faster. Rather than focusing on how good
these speed ups are, I want to apologize for how bad the
implementations were previously. The new `combine` is competitive with
other implementations, and `combineAll` is about x5 faster than the
equivalent code using combine.

(All figures using before/after numbers for the given benchmark.)

Thanks to Adelbert and Travis for noticing this problem. Also thanks
to Travis for producing this benchmark! Finally, thanks to Oscar for
helping me look at and fix this issue.