### PR TITLE
Revert "Port #1215 to EitherT"

### DIFF
--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -218,21 +218,6 @@ trait EitherTFunctions {
 
   final def pure[F[_], A, B](b: B)(implicit F: Applicative[F]): EitherT[F, A, B] = right(F.pure(b))
 
-  /**
-   * Alias for [[right]]
-   * {{{
-   * scala> import cats.data.EitherT
-   * scala> import cats.implicits._
-   * scala> val o: Option[Int] = Some(3)
-   * scala> val n: Option[Int] = None
-   * scala> EitherT.liftT(o)
-   * res0: cats.data.EitherT[Option,Nothing,Int] = EitherT(Some(Right(3)))
-   * scala> EitherT.liftT(n)
-   * res1: cats.data.EitherT[Option,Nothing,Int] = EitherT(None)
-   * }}}
-   */
-  final def liftT[F[_], A, B](fb: F[B])(implicit F: Functor[F]): EitherT[F, A, B] = right(fb)
-
   /** Transforms an `Either` into an `EitherT`, lifted into the specified `Applicative`.
    *
    * Note: The return type is a FromEitherPartiallyApplied[F], which has an apply method
@@ -287,7 +272,7 @@ private[data] abstract class EitherTInstances extends EitherTInstances1 {
       type TC[M[_]] = Functor[M]
 
       def liftT[M[_]: Functor, A](ma: M[A]): EitherT[M, E, A] =
-        EitherT.liftT(ma)
+        EitherT(Functor[M].map(ma)(Either.right))
     }
 
   implicit def catsMonoidForEitherT[F[_], L, A](implicit F: Monoid[F[Either[L, A]]]): Monoid[EitherT[F, L, A]] =


### PR DESCRIPTION
Reverts typelevel/cats#1301. I think this needs to be done before we can revert #1289—GitHub is saying "Sorry, this pull request couldn’t be reverted automatically. It may have already been reverted, or the content may have changed since it was merged." when I try to open a revert PR there.