### PR TITLE
Remove references to Monad from CoflatMap doc

### DIFF
--- a/core/src/main/scala/cats/CoflatMap.scala
+++ b/core/src/main/scala/cats/CoflatMap.scala
@@ -11,15 +11,14 @@ import simulacrum.typeclass
 
   /**
    * `coflatMap` is the dual of `flatMap` on `FlatMap`. It applies
-   * a value in a Monadic context to a function that takes a value
+   * a value in a context to a function that takes a value
    * in a context and returns a normal value.
    *
    * Example:
    * {{{
    * scala> import cats.implicits._
-   * scala> import cats.Monad
    * scala> import cats.CoflatMap
-   * scala> val fa = Monad[Option].pure(3)
+   * scala> val fa = Some(3)
    * scala> def f(a: Option[Int]): Int = a match {
    *      | case Some(x) => 2 * x
    *      | case None => 0 }
@@ -36,9 +35,8 @@ import simulacrum.typeclass
    * Example:
    * {{{
    * scala> import cats.implicits._
-   * scala> import cats.Monad
    * scala> import cats.CoflatMap
-   * scala> val fa = Monad[Option].pure(3)
+   * scala> val fa = Some(3)
    * fa: Option[Int] = Some(3)
    * scala> CoflatMap[Option].coflatten(fa)
    * res0: Option[Option[Int]] = Some(Some(3))


### PR DESCRIPTION
Apologies in advance for this, if I had the ability to label this PR, it would definitely be something along the lines of 'nitpick'.

The doc for `coflatMap` states that the value is in a Monadic context, which can be confusing, because:
- there is no Monad constraint on the context (the example being a Monad is incidental) 
- the context is *more likely* to be a Comonad