### PR TITLE
Partial revert of #1289

### DIFF
--- a/core/src/main/scala/cats/ApplicativeError.scala
+++ b/core/src/main/scala/cats/ApplicativeError.scala
@@ -1,6 +1,6 @@
 package cats
 
-import cats.data.EitherT
+import cats.data.{Xor, XorT}
 import scala.util.{ Failure, Success, Try }
 import scala.util.control.NonFatal
 
@@ -37,21 +37,21 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
   def handleError[A](fa: F[A])(f: E => A): F[A] = handleErrorWith(fa)(f andThen pure)
 
   /**
-   * Handle errors by turning them into [[scala.util.Either]] values.
+   * Handle errors by turning them into [[cats.data.Xor]] values.
    *
    * If there is no error, then an `scala.util.Right` value will be returned instead.
    *
    * All non-fatal errors should be handled by this method.
    */
-  def attempt[A](fa: F[A]): F[Either[E, A]] = handleErrorWith(
-    map(fa)(Right(_): Either[E, A])
-  )(e => pure(Left(e)))
+  def attempt[A](fa: F[A]): F[Xor[E, A]] = handleErrorWith(
+    map(fa)(Xor.Right(_): Xor[E, A])
+  )(e => pure(Xor.Left(e)))
 
   /**
-   * Similar to [[attempt]], but wraps the result in a [[cats.data.EitherT]] for
+   * Similar to [[attempt]], but wraps the result in a [[cats.data.XorT]] for
    * convenience.
    */
-  def attemptT[A](fa: F[A]): EitherT[F, E, A] = EitherT(attempt(fa))
+  def attemptT[A](fa: F[A]): XorT[F, E, A] = XorT(attempt(fa))
 
   /**
    * Recover from certain errors by mapping them to an `A` value.

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -207,7 +207,7 @@ import simulacrum.typeclass
   /**
    * Behaves like traverse_, but uses [[Unapply]] to find the
    * [[Applicative]] instance for `G` - used when `G` is a
-   * type constructor with two or more parameters such as [[scala.util.Either]]
+   * type constructor with two or more parameters such as `scala.util.Either`
    *
    * {{{
    * scala> import cats.implicits._
@@ -251,7 +251,7 @@ import simulacrum.typeclass
   /**
    * Behaves like sequence_, but uses [[Unapply]] to find the
    * [[Applicative]] instance for `G` - used when `G` is a
-   * type constructor with two or more parameters such as [[scala.util.Either]]
+   * type constructor with two or more parameters such as `scala.util.Either`
    *
    * {{{
    * scala> import cats.implicits._

--- a/core/src/main/scala/cats/arrow/Choice.scala
+++ b/core/src/main/scala/cats/arrow/Choice.scala
@@ -1,6 +1,7 @@
 package cats
 package arrow
 
+import cats.data.Xor
 import simulacrum.typeclass
 
 @typeclass trait Choice[F[_, _]] extends Category[F] {
@@ -11,19 +12,20 @@ import simulacrum.typeclass
    *
    * Example:
    * {{{
+   * scala> import cats.data.Xor
    * scala> import cats.implicits._
    * scala> val b: Boolean => String = _ + " is a boolean"
    * scala> val i: Int => String =  _ + " is an integer"
-   * scala> val f: (Either[Boolean, Int]) => String = Choice[Function1].choice(b, i)
+   * scala> val f: Xor[Boolean, Int] => String = Choice[Function1].choice(b, i)
    *
-   * scala> f(Right(3))
+   * scala> f(Xor.Right(3))
    * res0: String = 3 is an integer
    *
-   * scala> f(Left(false))
+   * scala> f(Xor.Left(false))
    * res0: String = false is a boolean
    * }}}
    */
-  def choice[A, B, C](f: F[A, C], g: F[B, C]): F[Either[A, B], C]
+  def choice[A, B, C](f: F[A, C], g: F[B, C]): F[Xor[A, B], C]
 
   /**
    * An `F` that, given a source `A` on either the right or left side, will
@@ -31,15 +33,16 @@ import simulacrum.typeclass
    *
    * Example:
    * {{{
+   * scala> import cats.data.Xor
    * scala> import cats.implicits._
-   * scala> val f: (Either[Int, Int]) => Int = Choice[Function1].codiagonal[Int]
+   * scala> val f: (Xor[Int, Int]) => Int = Choice[Function1].codiagonal[Int]
    *
-   * scala> f(Right(3))
+   * scala> f(Xor.Right(3))
    * res0: Int = 3
    *
-   * scala> f(Left(3))
+   * scala> f(Xor.Left(3))
    * res1: Int = 3
    * }}}
    */
-  def codiagonal[A]: F[Either[A, A], A] = choice(id, id)
+  def codiagonal[A]: F[Xor[A, A], A] = choice(id, id)
 }

--- a/core/src/main/scala/cats/arrow/FunctionK.scala
+++ b/core/src/main/scala/cats/arrow/FunctionK.scala
@@ -1,7 +1,7 @@
 package cats
 package arrow
 
-import cats.data. Coproduct
+import cats.data.{Coproduct, Xor}
 
 trait FunctionK[F[_], G[_]] extends Serializable { self =>
   def apply[A](fa: F[A]): G[A]
@@ -17,8 +17,8 @@ trait FunctionK[F[_], G[_]] extends Serializable { self =>
   def or[H[_]](h: FunctionK[H, G]): FunctionK[Coproduct[F, H, ?], G] =
     new FunctionK[Coproduct[F, H, ?], G] {
       def apply[A](fa: Coproduct[F, H, A]): G[A] = fa.run match {
-        case Left(ff) => self(ff)
-        case Right(gg) => h(gg)
+        case Xor.Left(ff) => self(ff)
+        case Xor.Right(gg) => h(gg)
       }
     }
 }

--- a/core/src/main/scala/cats/data/Coproduct.scala
+++ b/core/src/main/scala/cats/data/Coproduct.scala
@@ -3,13 +3,12 @@ package data
 
 import cats.arrow.FunctionK
 import cats.functor.Contravariant
-import cats.syntax.either._
 
-/** `F` on the left and `G` on the right of [[scala.util.Either]].
+/** `F` on the left and `G` on the right of [[cats.data.Xor]].
  *
- * @param run The underlying [[scala.util.Either]].
+ * @param run The underlying [[cats.data.Xor]].
  */
-final case class Coproduct[F[_], G[_], A](run: Either[F[A], G[A]]) {
+final case class Coproduct[F[_], G[_], A](run: Xor[F[A], G[A]]) {
 
   import Coproduct._
 
@@ -87,17 +86,17 @@ final case class Coproduct[F[_], G[_], A](run: Either[F[A], G[A]]) {
 object Coproduct extends CoproductInstances {
 
   def leftc[F[_], G[_], A](x: F[A]): Coproduct[F, G, A] =
-    Coproduct(Left(x))
+    Coproduct(Xor.Left(x))
 
   def rightc[F[_], G[_], A](x: G[A]): Coproduct[F, G, A] =
-    Coproduct(Right(x))
+    Coproduct(Xor.Right(x))
 
   final class CoproductLeft[G[_]] private[Coproduct] {
-    def apply[F[_], A](fa: F[A]): Coproduct[F, G, A] = Coproduct(Left(fa))
+    def apply[F[_], A](fa: F[A]): Coproduct[F, G, A] = Coproduct(Xor.Left(fa))
   }
 
   final class CoproductRight[F[_]] private[Coproduct] {
-    def apply[G[_], A](ga: G[A]): Coproduct[F, G, A] = Coproduct(Right(ga))
+    def apply[G[_], A](ga: G[A]): Coproduct[F, G, A] = Coproduct(Xor.Right(ga))
   }
 
   def left[G[_]]: CoproductLeft[G] = new CoproductLeft[G]
@@ -107,7 +106,7 @@ object Coproduct extends CoproductInstances {
 
 private[data] sealed abstract class CoproductInstances3 {
 
-  implicit def catsDataEqForCoproduct[F[_], G[_], A](implicit E: Eq[Either[F[A], G[A]]]): Eq[Coproduct[F, G, A]] =
+  implicit def catsDataEqForCoproduct[F[_], G[_], A](implicit E: Eq[Xor[F[A], G[A]]]): Eq[Coproduct[F, G, A]] =
     Eq.by(_.run)
 
   implicit def catsDataFunctorForCoproduct[F[_], G[_]](implicit F0: Functor[F], G0: Functor[G]): Functor[Coproduct[F, G, ?]] =

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -393,7 +393,7 @@ private[data] trait EitherTMonadError[F[_], L] extends MonadError[EitherT[F, L, 
       case r @ Right(_) => F.pure(r)
     })
   def raiseError[A](e: L): EitherT[F, L, A] = EitherT.left(F.pure(e))
-  override def attempt[A](fla: EitherT[F, L, A]): EitherT[F, L, Either[L, A]] = EitherT.right(fla.value)
+  override def attempt[A](fla: EitherT[F, L, A]): EitherT[F, L, Xor[L, A]] = EitherT.right(F.map(fla.value)(_.toXor))
   override def recover[A](fla: EitherT[F, L, A])(pf: PartialFunction[L, A]): EitherT[F, L, A] =
     fla.recover(pf)
   override def recoverWith[A](fla: EitherT[F, L, A])(pf: PartialFunction[L, EitherT[F, L, A]]): EitherT[F, L, A] =

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -11,14 +11,14 @@ import scala.annotation.tailrec
  *  - `[[Ior.Right Right]][B]`
  *  - `[[Ior.Both Both]][A, B]`
  *
- * `A [[Ior]] B` is similar to `Either[A, B]`, except that it can represent the simultaneous presence of
+ * `A [[Ior]] B` is similar to `Xor[A, B]`, except that it can represent the simultaneous presence of
  * an `A` and a `B`. It is right-biased so methods such as `map` and `flatMap` operate on the
  * `B` value. Some methods, like `flatMap`, handle the presence of two [[Ior.Both Both]] values using a
- * `[[Semigroup]][A]`, while other methods, like [[toEither]], ignore the `A` value in a [[Ior.Both Both]].
+ * `[[Semigroup]][A]`, while other methods, like [[toXor]], ignore the `A` value in a [[Ior.Both Both]].
  *
- * `A [[Ior]] B` is isomorphic to `Either[Either[A, B], (A, B)]`, but provides methods biased toward `B`
+ * `A [[Ior]] B` is isomorphic to `Xor[Xor[A, B], (A, B)]`, but provides methods biased toward `B`
  * values, regardless of whether the `B` values appear in a [[Ior.Right Right]] or a [[Ior.Both Both]].
- * The isomorphic [[scala.util.Either]] form can be accessed via the [[unwrap]] method.
+ * The isomorphic [[cats.data.Xor]] form can be accessed via the [[unwrap]] method.
  */
 sealed abstract class Ior[+A, +B] extends Product with Serializable {
 
@@ -36,10 +36,10 @@ sealed abstract class Ior[+A, +B] extends Product with Serializable {
   final def right: Option[B] = fold(_ => None, b => Some(b), (_, b) => Some(b))
   final def onlyLeft: Option[A] = fold(a => Some(a), _ => None, (_, _) => None)
   final def onlyRight: Option[B] = fold(_ => None, b => Some(b), (_, _) => None)
-  final def onlyLeftOrRight: Option[Either[A, B]] = fold(a => Some(Left(a)), b => Some(Right(b)), (_, _) => None)
+  final def onlyLeftOrRight: Option[Xor[A, B]] = fold(a => Some(Xor.Left(a)), b => Some(Xor.Right(b)), (_, _) => None)
   final def onlyBoth: Option[(A, B)] = fold(_ => None, _ => None, (a, b) => Some((a, b)))
   final def pad: (Option[A], Option[B]) = fold(a => (Some(a), None), b => (None, Some(b)), (a, b) => (Some(a), Some(b)))
-  final def unwrap: Either[Either[A, B], (A, B)] = fold(a => Left(Left(a)), b => Left(Right(b)), (a, b) => Right((a, b)))
+  final def unwrap: Xor[Xor[A, B], (A, B)] = fold(a => Xor.Left(Xor.Left(a)), b => Xor.Left(Xor.Right(b)), (a, b) => Xor.Right((a, b)))
 
   final def toXor: A Xor B = fold(Xor.left, Xor.right, (_, b) => Xor.right(b))
   final def toEither: Either[A, B] = fold(Left(_), Right(_), (_, b) => Right(b))

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -101,7 +101,7 @@ private[data] sealed abstract class KleisliInstances extends KleisliInstances0 {
     new Choice[Kleisli[F, ?, ?]] {
       def id[A]: Kleisli[F, A, A] = Kleisli(ev.pure(_))
 
-      def choice[A, B, C](f: Kleisli[F, A, C], g: Kleisli[F, B, C]): Kleisli[F, Either[A, B], C] =
+      def choice[A, B, C](f: Kleisli[F, A, C], g: Kleisli[F, B, C]): Kleisli[F, Xor[A, B], C] =
         Kleisli(_.fold(f.run, g.run))
 
       def compose[A, B, C](f: Kleisli[F, B, C], g: Kleisli[F, A, B]): Kleisli[F, A, C] =

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -86,11 +86,11 @@ final case class OptionT[F[_], A](value: F[Option[A]]) {
         case None => default
       })
 
-  def toRight[L](left: => L)(implicit F: Functor[F]): EitherT[F, L, A] =
-    EitherT(cata(Left(left), Right.apply))
+  def toRight[L](left: => L)(implicit F: Functor[F]): XorT[F, L, A] =
+    XorT(cata(Xor.Left(left), Xor.Right.apply))
 
-  def toLeft[R](right: => R)(implicit F: Functor[F]): EitherT[F, A, R] =
-    EitherT(cata(Right(right), Left.apply))
+  def toLeft[R](right: => R)(implicit F: Functor[F]): XorT[F, A, R] =
+    XorT(cata(Xor.Right(right), Xor.Left.apply))
 
   def show(implicit F: Show[F[Option[A]]]): String = F.show(value)
 

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -80,11 +80,11 @@ sealed abstract class Validated[+E, +A] extends Product with Serializable {
   def toXor: Xor[E, A] = fold(Xor.Left.apply, Xor.Right.apply)
 
   /**
-   * Convert to an Either, apply a function, convert back.  This is handy
-   * when you want to use the Monadic properties of the Either type.
+   * Convert to an Xor, apply a function, convert back.  This is handy
+   * when you want to use the Monadic properties of the Xor type.
    */
-  def withEither[EE, B](f: Either[E, A] => Either[EE, B]): Validated[EE, B] =
-    Validated.fromEither(f(toEither))
+  def withXor[EE, B](f: Xor[E, A] => Xor[EE, B]): Validated[EE, B] =
+    Validated.fromXor(f(toXor))
 
   /**
    * Validated is a [[functor.Bifunctor]], this method applies one of the
@@ -390,6 +390,11 @@ trait ValidatedFunctions {
    * Converts an `Either[A, B]` to an `Validated[A, B]`.
    */
   def fromEither[A, B](e: Either[A, B]): Validated[A, B] = e.fold(invalid, valid)
+
+  /**
+   * Converts an `Xor[A, B]` to an `Validated[A, B]`.
+   */
+  def fromXor[A, B](e: Xor[A, B]): Validated[A, B] = e.fold(invalid, valid)
 
   /**
    * Converts an `Option[B]` to an `Validated[A, B]`, where the provided `ifNone` values is returned on

--- a/core/src/main/scala/cats/data/Xor.scala
+++ b/core/src/main/scala/cats/data/Xor.scala
@@ -278,7 +278,7 @@ private[data] sealed abstract class XorInstances extends XorInstances1 {
       override def map[B, C](fa: A Xor B)(f: B => C): A Xor C = fa.map(f)
       override def map2Eval[B, C, Z](fb: A Xor B, fc: Eval[A Xor C])(f: (B, C) => Z): Eval[A Xor Z] =
         fb.map2Eval(fc)(f)
-      override def attempt[B](fab: A Xor B): A Xor (Either[A, B]) = Xor.right(fab.toEither)
+      override def attempt[B](fab: A Xor B): A Xor (Xor[A, B]) = Xor.right(fab)
       override def recover[B](fab: A Xor B)(pf: PartialFunction[A, B]): A Xor B =
         fab recover pf
       override def recoverWith[B](fab: A Xor B)(pf: PartialFunction[A, A Xor B]): A Xor B =

--- a/core/src/main/scala/cats/data/XorT.scala
+++ b/core/src/main/scala/cats/data/XorT.scala
@@ -403,7 +403,7 @@ private[data] trait XorTMonadError[F[_], L] extends MonadError[XorT[F, L, ?], L]
       case r @ Xor.Right(_) => F.pure(r)
     })
   def raiseError[A](e: L): XorT[F, L, A] = XorT.left(F.pure(e))
-  override def attempt[A](fla: XorT[F, L, A]): XorT[F, L, Either[L, A]] = XorT.right(fla.toEither)
+  override def attempt[A](fla: XorT[F, L, A]): XorT[F, L, Xor[L, A]] = XorT.right(fla.value)
   override def recover[A](fla: XorT[F, L, A])(pf: PartialFunction[L, A]): XorT[F, L, A] =
     fla.recover(pf)
   override def recoverWith[A](fla: XorT[F, L, A])(pf: PartialFunction[L, XorT[F, L, A]]): XorT[F, L, A] =

--- a/core/src/main/scala/cats/instances/either.scala
+++ b/core/src/main/scala/cats/instances/either.scala
@@ -1,6 +1,7 @@
 package cats
 package instances
 
+import cats.data.Xor
 import cats.syntax.EitherUtil
 import cats.syntax.either._
 import scala.annotation.tailrec
@@ -71,7 +72,7 @@ trait EitherInstances extends EitherInstances1 {
       def foldRight[B, C](fa: Either[A, B], lc: Eval[C])(f: (B, Eval[C]) => Eval[C]): Eval[C] =
         fa.fold(_ => lc, b => f(b, lc))
 
-      override def attempt[B](fab: Either[A, B]): Either[A, Either[A, B]] = Right(fab)
+      override def attempt[B](fab: Either[A, B]): Either[A, Xor[A, B]] = Right(fab.toXor)
       override def recover[B](fab: Either[A, B])(pf: PartialFunction[A, B]): Either[A, B] =
         fab recover pf
       override def recoverWith[B](fab: Either[A, B])(pf: PartialFunction[A, Either[A, B]]): Either[A, B] =

--- a/core/src/main/scala/cats/instances/function.scala
+++ b/core/src/main/scala/cats/instances/function.scala
@@ -2,6 +2,7 @@ package cats
 package instances
 
 import cats.arrow.{Arrow, Choice}
+import cats.data.Xor
 import cats.functor.Contravariant
 import annotation.tailrec
 
@@ -70,10 +71,10 @@ private[instances] sealed trait Function1Instances extends Function1Instances0 {
 
   implicit val catsStdInstancesForFunction1: Choice[Function1] with Arrow[Function1] =
     new Choice[Function1] with Arrow[Function1] {
-      def choice[A, B, C](f: A => C, g: B => C): Either[A, B] => C =
+      def choice[A, B, C](f: A => C, g: B => C): Xor[A, B] => C =
         _ match {
-          case Left(a)  => f(a)
-          case Right(b) => g(b)
+          case Xor.Left(a)  => f(a)
+          case Xor.Right(b) => g(b)
         }
 
       def lift[A, B](f: A => B): A => B = f

--- a/core/src/main/scala/cats/instances/future.scala
+++ b/core/src/main/scala/cats/instances/future.scala
@@ -1,6 +1,7 @@
 package cats
 package instances
 
+import cats.data.Xor
 import scala.util.control.NonFatal
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -27,8 +28,8 @@ trait FutureInstances extends FutureInstances1 {
       def raiseError[A](e: Throwable): Future[A] = Future.failed(e)
       override def handleError[A](fea: Future[A])(f: Throwable => A): Future[A] = fea.recover { case t => f(t) }
 
-      override def attempt[A](fa: Future[A]): Future[Either[Throwable, A]] =
-        (fa.map(a => Right[Throwable, A](a))) recover { case NonFatal(t) => Left(t) }
+      override def attempt[A](fa: Future[A]): Future[Xor[Throwable, A]] =
+        (fa.map(a => Xor.Right(a))) recover { case NonFatal(t) => Xor.Left(t) }
 
       override def recover[A](fa: Future[A])(pf: PartialFunction[Throwable, A]): Future[A] = fa.recover(pf)
 

--- a/core/src/main/scala/cats/instances/try.scala
+++ b/core/src/main/scala/cats/instances/try.scala
@@ -3,6 +3,7 @@ package instances
 
 import TryInstances.castFailure
 
+import cats.data.Xor
 import scala.util.control.NonFatal
 import scala.util.{Failure, Success, Try}
 import scala.annotation.tailrec
@@ -66,8 +67,8 @@ trait TryInstances extends TryInstances1 {
       override def handleError[A](ta: Try[A])(f: Throwable => A): Try[A] =
         ta.recover { case t => f(t) }
 
-      override def attempt[A](ta: Try[A]): Try[Either[Throwable, A]] =
-        (ta.map(a => Right[Throwable, A](a))) recover { case NonFatal(t) => Left(t) }
+      override def attempt[A](ta: Try[A]): Try[Xor[Throwable, A]] =
+        (ta.map(a => Xor.Right(a))) recover { case NonFatal(t) => Xor.Left(t) }
 
       override def recover[A](ta: Try[A])(pf: PartialFunction[Throwable, A]): Try[A] =
         ta.recover(pf)

--- a/core/src/main/scala/cats/syntax/applicativeError.scala
+++ b/core/src/main/scala/cats/syntax/applicativeError.scala
@@ -1,7 +1,7 @@
 package cats
 package syntax
 
-import cats.data.EitherT
+import cats.data.{Xor, XorT}
 
 trait ApplicativeErrorSyntax {
   implicit def catsSyntaxApplicativeErrorId[E](e: E): ApplicativeErrorIdOps[E] =
@@ -24,10 +24,10 @@ final class ApplicativeErrorOps[F[_], E, A](fa: F[A])(implicit F: ApplicativeErr
   def handleErrorWith(f: E => F[A]): F[A] =
     F.handleErrorWith(fa)(f)
 
-  def attempt: F[Either[E, A]] =
+  def attempt: F[Xor[E, A]] =
     F.attempt(fa)
 
-  def attemptT: EitherT[F, E, A] =
+  def attemptT: XorT[F, E, A] =
     F.attemptT(fa)
 
   def recover(pf: PartialFunction[E, A]): F[A] =

--- a/docs/src/main/tut/validated.md
+++ b/docs/src/main/tut/validated.md
@@ -314,19 +314,17 @@ val houseNumber = config.parse[Int]("house_number").andThen{ n =>
 The `withXor` method allows you to temporarily turn a `Validated` instance into an `Xor` instance and apply it to a function.
 
 ```tut:silent
-import cats.syntax.either._ // get Either#flatMap
-
-def positive(field: String, i: Int): Either[ConfigError, Int] = {
-  if (i >= 0) Right(i)
-  else Left(ParseError(field))
+def positive(field: String, i: Int): Xor[ConfigError, Int] = {
+  if (i >= 0) Xor.Right(i)
+  else Xor.Left(ParseError(field))
 }
 ```
 
 Thus.
 
 ```tut:book
-val houseNumber = config.parse[Int]("house_number").withEither{ either: Either[ConfigError, Int] =>
-  either.flatMap{ i =>
+val houseNumber = config.parse[Int]("house_number").withXor { xor: Xor[ConfigError, Int] =>
+  xor.flatMap{ i =>
     positive("house_number", i)
   }
 }

--- a/free/src/test/scala/cats/free/InjectTests.scala
+++ b/free/src/test/scala/cats/free/InjectTests.scala
@@ -2,6 +2,7 @@ package cats
 package free
 
 import cats.arrow.FunctionK
+import cats.data.Xor
 import cats.tests.CatsSuite
 import cats.data.Coproduct
 import org.scalacheck._
@@ -91,13 +92,13 @@ class InjectTests extends CatsSuite {
 
   test("apply in left") {
     forAll { (y: Test1[Int]) =>
-      Inject[Test1Algebra, T].inj(y) == Coproduct(Left(y)) should ===(true)
+      Inject[Test1Algebra, T].inj(y) == Coproduct(Xor.Left(y)) should ===(true)
     }
   }
 
   test("apply in right") {
     forAll { (y: Test2[Int]) =>
-      Inject[Test2Algebra, T].inj(y) == Coproduct(Right(y)) should ===(true)
+      Inject[Test2Algebra, T].inj(y) == Coproduct(Xor.Right(y)) should ===(true)
     }
   }
 

--- a/laws/src/main/scala/cats/laws/ApplicativeErrorLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplicativeErrorLaws.scala
@@ -1,7 +1,7 @@
 package cats
 package laws
 
-import cats.data.EitherT
+import cats.data.{Xor, XorT}
 
 // Taken from http://functorial.com/psc-pages/docs/Control/Monad/Error/Class/index.html
 trait ApplicativeErrorLaws[F[_], E] extends ApplicativeLaws[F] {
@@ -19,11 +19,11 @@ trait ApplicativeErrorLaws[F[_], E] extends ApplicativeLaws[F] {
   def handleErrorPure[A](a: A, f: E => A): IsEq[F[A]] =
     F.handleError(F.pure(a))(f) <-> F.pure(a)
 
-  def raiseErrorAttempt(e: E): IsEq[F[Either[E, Unit]]] =
-    F.attempt(F.raiseError[Unit](e)) <-> F.pure(Left(e))
+  def raiseErrorAttempt(e: E): IsEq[F[Xor[E, Unit]]] =
+    F.attempt(F.raiseError[Unit](e)) <-> F.pure(Xor.Left(e))
 
-  def pureAttempt[A](a: A): IsEq[F[Either[E, A]]] =
-    F.attempt(F.pure(a)) <-> F.pure(Right(a))
+  def pureAttempt[A](a: A): IsEq[F[Xor[E, A]]] =
+    F.attempt(F.pure(a)) <-> F.pure(Xor.Right(a))
 
   def handleErrorWithConsistentWithRecoverWith[A](fa: F[A], f: E => F[A]): IsEq[F[A]] =
     F.handleErrorWith(fa)(f) <-> F.recoverWith(fa)(PartialFunction(f))
@@ -34,8 +34,8 @@ trait ApplicativeErrorLaws[F[_], E] extends ApplicativeLaws[F] {
   def recoverConsistentWithRecoverWith[A](fa: F[A], pf: PartialFunction[E, A]): IsEq[F[A]] =
     F.recover(fa)(pf) <-> F.recoverWith(fa)(pf andThen F.pure)
 
-  def attemptConsistentWithAttemptT[A](fa: F[A]): IsEq[EitherT[F, E, A]] =
-    EitherT(F.attempt(fa)) <-> F.attemptT(fa)
+  def attemptConsistentWithAttemptT[A](fa: F[A]): IsEq[XorT[F, E, A]] =
+    XorT(F.attempt(fa)) <-> F.attemptT(fa)
 }
 
 object ApplicativeErrorLaws {

--- a/laws/src/main/scala/cats/laws/ChoiceLaws.scala
+++ b/laws/src/main/scala/cats/laws/ChoiceLaws.scala
@@ -2,6 +2,7 @@ package cats
 package laws
 
 import cats.arrow.Choice
+import cats.data.Xor
 import cats.syntax.compose._
 
 /**
@@ -10,7 +11,7 @@ import cats.syntax.compose._
 trait ChoiceLaws[F[_, _]] extends CategoryLaws[F] {
   implicit override def F: Choice[F]
 
-  def choiceCompositionDistributivity[A, B, C, D](fac: F[A, C], fbc: F[B, C], fcd: F[C, D]): IsEq[F[Either[A, B], D]] =
+  def choiceCompositionDistributivity[A, B, C, D](fac: F[A, C], fbc: F[B, C], fcd: F[C, D]): IsEq[F[Xor[A, B], D]] =
     (F.choice(fac, fbc) andThen fcd) <-> F.choice(fac andThen fcd, fbc andThen fcd)
 }
 

--- a/laws/src/main/scala/cats/laws/discipline/ApplicativeErrorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ApplicativeErrorTests.scala
@@ -2,7 +2,7 @@ package cats
 package laws
 package discipline
 
-import cats.data.EitherT
+import cats.data.{Xor, XorT}
 import cats.laws.discipline.CartesianTests.Isomorphisms
 import cats.laws.discipline.arbitrary._
 import org.scalacheck.{Arbitrary, Prop}
@@ -22,9 +22,9 @@ trait ApplicativeErrorTests[F[_], E] extends ApplicativeTests[F] {
     EqFB: Eq[F[B]],
     EqFC: Eq[F[C]],
     EqE: Eq[E],
-    EqFEitherEU: Eq[F[Either[E, Unit]]],
-    EqFEitherEA: Eq[F[Either[E, A]]],
-    EqEitherTFEA: Eq[EitherT[F, E, A]],
+    EqFEitherEU: Eq[F[Xor[E, Unit]]],
+    EqFEitherEA: Eq[F[Xor[E, A]]],
+    EqEitherTFEA: Eq[XorT[F, E, A]],
     EqFABC: Eq[F[(A, B, C)]],
     iso: Isomorphisms[F]
   ): RuleSet = {

--- a/laws/src/main/scala/cats/laws/discipline/ChoiceTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ChoiceTests.scala
@@ -3,6 +3,7 @@ package laws
 package discipline
 
 import cats.arrow.Choice
+import cats.data.Xor
 import org.scalacheck.Arbitrary
 import org.scalacheck.Prop._
 
@@ -16,7 +17,7 @@ trait ChoiceTests[F[_, _]] extends CategoryTests[F] {
     ArbFCD: Arbitrary[F[C, D]],
     EqFAB: Eq[F[A, B]],
     EqFAD: Eq[F[A, D]],
-    EqFEitherABD: Eq[F[Either[A, B], D]]
+    EqFEitherABD: Eq[F[Xor[A, B], D]]
   ): RuleSet =
     new DefaultRuleSet(
       name = "choice",

--- a/laws/src/main/scala/cats/laws/discipline/MonadErrorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadErrorTests.scala
@@ -2,7 +2,7 @@ package cats
 package laws
 package discipline
 
-import cats.data.EitherT
+import cats.data.{Xor, XorT}
 import cats.laws.discipline.CartesianTests.Isomorphisms
 import org.scalacheck.{Arbitrary, Prop}
 import org.scalacheck.Prop.forAll
@@ -21,9 +21,9 @@ trait MonadErrorTests[F[_], E] extends ApplicativeErrorTests[F, E] with MonadTes
     EqFB: Eq[F[B]],
     EqFC: Eq[F[C]],
     EqE: Eq[E],
-    EqFEitherEU: Eq[F[Either[E, Unit]]],
-    EqFEitherEA: Eq[F[Either[E, A]]],
-    EqEitherTFEA: Eq[EitherT[F, E, A]],
+    EqFEitherEU: Eq[F[Xor[E, Unit]]],
+    EqFEitherEA: Eq[F[Xor[E, A]]],
+    EqEitherTFEA: Eq[XorT[F, E, A]],
     EqFABC: Eq[F[(A, B, C)]],
     iso: Isomorphisms[F]
   ): RuleSet = {

--- a/tests/src/test/scala/cats/tests/ApplicativeErrorTests.scala
+++ b/tests/src/test/scala/cats/tests/ApplicativeErrorTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.data.EitherT
+import cats.data.{Xor, XorT}
 
 class ApplicativeErrorCheck extends CatsSuite {
   val failed: Option[Int] =
@@ -19,12 +19,12 @@ class ApplicativeErrorCheck extends CatsSuite {
     failed.handleErrorWith(_ => Some(7)) should === (Some(7))
   }
 
-  test("attempt syntax creates a wrapped Either") {
-    failed.attempt should === (Option(Left(())))
+  test("attempt syntax creates a wrapped Xor") {
+    failed.attempt should === (Option(Xor.Left(())))
   }
 
-  test("attemptT syntax creates an EitherT") {
-    failed.attemptT should === (EitherT[Option, Unit, Int](Option(Left(()))))
+  test("attemptT syntax creates an XorT") {
+    failed.attemptT should === (XorT[Option, Unit, Int](Option(Xor.Left(()))))
   }
 
   test("recover syntax transforms an error to a success") {

--- a/tests/src/test/scala/cats/tests/CoproductTests.scala
+++ b/tests/src/test/scala/cats/tests/CoproductTests.scala
@@ -53,9 +53,9 @@ class CoproductTests extends CatsSuite {
     }
   }
 
-  test("toValidated + toEither is identity") {
+  test("toValidated + toXor is identity") {
     forAll { (x: Coproduct[Option, List, Int]) =>
-      x.toValidated.toEither should === (x.run)
+      x.toValidated.toXor should === (x.run)
     }
   }
 }

--- a/tests/src/test/scala/cats/tests/EitherTTests.scala
+++ b/tests/src/test/scala/cats/tests/EitherTTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.data.EitherT
+import cats.data.{EitherT, Xor, XorT}
 import cats.functor.Bifunctor
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
@@ -46,8 +46,8 @@ class EitherTTests extends CatsSuite {
   {
     //if a Monad is defined
     implicit val F = ListWrapper.monad
-    implicit val eq0 = EitherT.catsDataEqForEitherT[ListWrapper, String, Either[String, Int]]
-    implicit val eq1 = EitherT.catsDataEqForEitherT[EitherT[ListWrapper, String, ?], String, Int](eq0)
+    implicit val eq0 = EitherT.catsDataEqForEitherT[ListWrapper, String, Xor[String, Int]]
+    implicit val eq1 = XorT.catsDataEqForXorT[EitherT[ListWrapper, String, ?], String, Int](eq0)
 
     Functor[EitherT[ListWrapper, String, ?]]
     Applicative[EitherT[ListWrapper, String, ?]]

--- a/tests/src/test/scala/cats/tests/EitherTests.scala
+++ b/tests/src/test/scala/cats/tests/EitherTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.data.EitherT
+import cats.data.XorT
 import cats.laws.discipline._
 import cats.kernel.laws.{GroupLaws, OrderLaws}
 import scala.util.Try
@@ -14,7 +14,7 @@ class EitherTests extends CatsSuite {
   checkAll("Either[Int, Int]", CartesianTests[Either[Int, ?]].cartesian[Int, Int, Int])
   checkAll("Cartesian[Either[Int, ?]]", SerializableTests.serializable(Cartesian[Either[Int, ?]]))
 
-  implicit val eq0 = EitherT.catsDataEqForEitherT[Either[Int, ?], Int, Int]
+  implicit val eq0 = XorT.catsDataEqForXorT[Either[Int, ?], Int, Int]
 
   checkAll("Either[Int, Int]", MonadErrorTests[Either[Int, ?], Int].monadError[Int, Int, Int])
   checkAll("MonadError[Either[Int, ?]]", SerializableTests.serializable(MonadError[Either[Int, ?], Int]))

--- a/tests/src/test/scala/cats/tests/IorTests.scala
+++ b/tests/src/test/scala/cats/tests/IorTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.data.Ior
+import cats.data.{Ior, Xor}
 import cats.laws.discipline.{BifunctorTests, TraverseTests, MonadTests, SerializableTests, CartesianTests}
 import cats.laws.discipline.arbitrary._
 import org.scalacheck.Arbitrary._
@@ -34,7 +34,7 @@ class IorTests extends CatsSuite {
 
   test("onlyLeftOrRight") {
     forAll { (i: Int Ior String) =>
-      i.onlyLeft.map(Left(_)).orElse(i.onlyRight.map(Right(_))) should === (i.onlyLeftOrRight)
+      i.onlyLeft.map(Xor.Left(_)).orElse(i.onlyRight.map(Xor.Right(_))) should === (i.onlyLeftOrRight)
     }
   }
 

--- a/tests/src/test/scala/cats/tests/KleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/KleisliTests.scala
@@ -2,7 +2,7 @@ package cats
 package tests
 
 import cats.arrow.{Arrow, Choice, Split, FunctionK}
-import cats.data.{EitherT, Kleisli, Reader}
+import cats.data.{Kleisli, Reader, XorT}
 import cats.functor.{Contravariant, Strong}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
@@ -15,7 +15,7 @@ class KleisliTests extends CatsSuite {
   implicit def kleisliEq[F[_], A, B](implicit A: Arbitrary[A], FB: Eq[F[B]]): Eq[Kleisli[F, A, B]] =
     Eq.by[Kleisli[F, A, B], A => F[B]](_.run)
 
-  implicit val eitherTEq = EitherT.catsDataEqForEitherT[Kleisli[Option, Int, ?], Unit, Int]
+  implicit val eitherTEq = XorT.catsDataEqForXorT[Kleisli[Option, Int, ?], Unit, Int]
 
   implicit val iso = CartesianTests.Isomorphisms.invariant[Kleisli[Option, Int, ?]]
 

--- a/tests/src/test/scala/cats/tests/OptionTTests.scala
+++ b/tests/src/test/scala/cats/tests/OptionTTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.data.{EitherT, OptionT}
+import cats.data.{OptionT, Xor, XorT}
 import cats.kernel.laws.{GroupLaws, OrderLaws}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
@@ -68,32 +68,32 @@ class OptionTTests extends CatsSuite {
 
   {
     // F has a MonadError
-    type SEither[A] = Either[String, A]
+    type SXor[A] = Xor[String, A]
 
-    implicit val monadError = OptionT.catsDataMonadErrorForOptionT[SEither, String]
+    implicit val monadError = OptionT.catsDataMonadErrorForOptionT[SXor, String]
 
     import org.scalacheck.Arbitrary
-    implicit val arb1 = implicitly[Arbitrary[OptionT[SEither, Int]]]
-    implicit val arb2 = implicitly[Arbitrary[OptionT[SEither, Int => Int]]]
+    implicit val arb1 = implicitly[Arbitrary[OptionT[SXor, Int]]]
+    implicit val arb2 = implicitly[Arbitrary[OptionT[SXor, Int => Int]]]
 
-    implicit val eq0 = OptionT.catsDataEqForOptionT[SEither, Option[Int]]
-    implicit val eq1 = OptionT.catsDataEqForOptionT[SEither, Int]
-    implicit val eq2 = OptionT.catsDataEqForOptionT[SEither, Unit]
-    implicit val eq3 = OptionT.catsDataEqForOptionT[SEither, SEither[Unit]]
-    implicit val eq4 = OptionT.catsDataEqForOptionT[SEither, SEither[Int]]
-    implicit val eq5 = EitherT.catsDataEqForEitherT[OptionT[SEither, ?], String, Int]
-    implicit val eq6 = OptionT.catsDataEqForOptionT[SEither, (Int, Int, Int)]
+    implicit val eq0 = OptionT.catsDataEqForOptionT[SXor, Option[Int]]
+    implicit val eq1 = OptionT.catsDataEqForOptionT[SXor, Int]
+    implicit val eq2 = OptionT.catsDataEqForOptionT[SXor, Unit]
+    implicit val eq3 = OptionT.catsDataEqForOptionT[SXor, SXor[Unit]]
+    implicit val eq4 = OptionT.catsDataEqForOptionT[SXor, SXor[Int]]
+    implicit val eq5 = XorT.catsDataEqForXorT[OptionT[SXor, ?], String, Int]
+    implicit val eq6 = OptionT.catsDataEqForOptionT[SXor, (Int, Int, Int)]
 
-    implicit val iso = CartesianTests.Isomorphisms.invariant[OptionT[SEither, ?]]
+    implicit val iso = CartesianTests.Isomorphisms.invariant[OptionT[SXor, ?]]
 
-    checkAll("OptionT[Either[String, ?], Int]", MonadErrorTests[OptionT[SEither, ?], String].monadError[Int, Int, Int])
+    checkAll("OptionT[Either[String, ?], Int]", MonadErrorTests[OptionT[SXor, ?], String].monadError[Int, Int, Int])
     checkAll("MonadError[OptionT[Either[String, ?], ?]]", SerializableTests.serializable(monadError))
 
-    Monad[OptionT[SEither, ?]]
-    FlatMap[OptionT[SEither, ?]]
-    Applicative[OptionT[SEither, ?]]
-    Apply[OptionT[SEither, ?]]
-    Functor[OptionT[SEither, ?]]
+    Monad[OptionT[SXor, ?]]
+    FlatMap[OptionT[SXor, ?]]
+    Applicative[OptionT[SXor, ?]]
+    Apply[OptionT[SXor, ?]]
+    Functor[OptionT[SXor, ?]]
   }
 
   {
@@ -219,9 +219,9 @@ class OptionTTests extends CatsSuite {
     }
   }
 
-  test("OptionT[Id, A].toRight consistent with Either.fromOption") {
+  test("OptionT[Id, A].toRight consistent with Xor.fromOption") {
     forAll { (o: OptionT[Id, Int], s: String) =>
-      o.toRight(s).value should === (Either.fromOption(o.value, s))
+      o.toRight(s).value should === (Xor.fromOption(o.value, s))
     }
   }
 

--- a/tests/src/test/scala/cats/tests/ValidatedTests.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.data.{EitherT, NonEmptyList, Validated, ValidatedNel}
+import cats.data.{NonEmptyList, Validated, ValidatedNel, XorT}
 import cats.data.Validated.{Valid, Invalid}
 import cats.laws.discipline.{BitraverseTests, TraverseTests, ApplicativeErrorTests, SerializableTests, CartesianTests}
 import org.scalacheck.Arbitrary._
@@ -19,7 +19,7 @@ class ValidatedTests extends CatsSuite {
   checkAll("Validated[?, ?]", BitraverseTests[Validated].bitraverse[Option, Int, Int, Int, String, String, String])
   checkAll("Bitraverse[Validated]", SerializableTests.serializable(Bitraverse[Validated]))
 
-  implicit val eq0 = EitherT.catsDataEqForEitherT[Validated[String, ?], String, Int]
+  implicit val eq0 = XorT.catsDataEqForXorT[Validated[String, ?], String, Int]
 
   checkAll("Validated[String, Int]", ApplicativeErrorTests[Validated[String, ?], String].applicativeError[Int, Int, Int])
   checkAll("ApplicativeError[Validated, String]", SerializableTests.serializable(ApplicativeError[Validated[String, ?], String]))
@@ -140,9 +140,9 @@ class ValidatedTests extends CatsSuite {
     }
   }
 
-  test("andThen consistent with Either's flatMap"){
+  test("andThen consistent with Xor's flatMap"){
     forAll { (v: Validated[String, Int], f: Int => Validated[String, Int]) =>
-      v.andThen(f) should === (v.withEither(_.flatMap(f(_).toEither)))
+      v.andThen(f) should === (v.withXor(_.flatMap(f(_).toXor)))
     }
   }
 

--- a/tests/src/test/scala/cats/tests/WriterTTests.scala
+++ b/tests/src/test/scala/cats/tests/WriterTTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.data.{EitherT, Validated, Writer, WriterT}
+import cats.data.{Validated, Writer, WriterT, XorT}
 import cats.functor.{Bifunctor, Contravariant}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
@@ -348,8 +348,8 @@ class WriterTTests extends CatsSuite {
     implicit val iso = CartesianTests.Isomorphisms.invariant[WriterT[Validated[String, ?], ListWrapper[Int], ?]]
     implicit def eq1[A:Eq]: Eq[WriterT[Validated[String, ?], ListWrapper[Int], A]] =
       WriterT.catsDataEqForWriterT[Validated[String, ?], ListWrapper[Int], A]
-    implicit val eq2: Eq[EitherT[WriterT[Validated[String, ?], ListWrapper[Int], ?], String, Int]] =
-      EitherT.catsDataEqForEitherT[WriterT[Validated[String, ?], ListWrapper[Int], ?], String, Int]
+    implicit val eq2: Eq[XorT[WriterT[Validated[String, ?], ListWrapper[Int], ?], String, Int]] =
+      XorT.catsDataEqForXorT[WriterT[Validated[String, ?], ListWrapper[Int], ?], String, Int]
     implicit def arb0[A:Arbitrary]: Arbitrary[WriterT[Validated[String, ?], ListWrapper[Int], A]] =
       arbitrary.catsLawsArbitraryForWriterT[Validated[String, ?], ListWrapper[Int], A]
 
@@ -365,7 +365,7 @@ class WriterTTests extends CatsSuite {
     // F has a MonadError and L has a Monoid
     implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
     implicit val iso = CartesianTests.Isomorphisms.invariant[WriterT[Option, ListWrapper[Int], ?]]
-    implicit val eq0: Eq[EitherT[WriterT[Option, ListWrapper[Int], ?], Unit, Int]] = EitherT.catsDataEqForEitherT[WriterT[Option, ListWrapper[Int], ?], Unit, Int]
+    implicit val eq0: Eq[XorT[WriterT[Option, ListWrapper[Int], ?], Unit, Int]] = XorT.catsDataEqForXorT[WriterT[Option, ListWrapper[Int], ?], Unit, Int]
 
 
     Functor[WriterT[Option, ListWrapper[Int], ?]]

--- a/tests/src/test/scala/cats/tests/XorTTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTTests.scala
@@ -2,7 +2,7 @@ package cats
 package tests
 
 import cats.functor.Bifunctor
-import cats.data.{EitherT, Xor, XorT}
+import cats.data.{Xor, XorT}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.kernel.laws.{OrderLaws, GroupLaws}
@@ -46,8 +46,8 @@ class XorTTests extends CatsSuite {
   {
     //if a Monad is defined
     implicit val F = ListWrapper.monad
-    implicit val eq0 = XorT.catsDataEqForXorT[ListWrapper, String, Either[String, Int]]
-    implicit val eq1 = EitherT.catsDataEqForEitherT[XorT[ListWrapper, String, ?], String, Int](eq0)
+    implicit val eq0 = XorT.catsDataEqForXorT[ListWrapper, String, Xor[String, Int]]
+    implicit val eq1 = XorT.catsDataEqForXorT[XorT[ListWrapper, String, ?], String, Int](eq0)
 
     Functor[XorT[ListWrapper, String, ?]]
     Applicative[XorT[ListWrapper, String, ?]]

--- a/tests/src/test/scala/cats/tests/XorTests.scala
+++ b/tests/src/test/scala/cats/tests/XorTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.data.{EitherT, NonEmptyList, Xor}
+import cats.data.{NonEmptyList, Xor, XorT}
 import cats.data.Xor._
 import cats.laws.discipline.{SemigroupKTests}
 import cats.laws.discipline.arbitrary._
@@ -22,7 +22,7 @@ class XorTests extends CatsSuite {
 
   checkAll("Xor[String, NonEmptyList[Int]]", GroupLaws[Xor[String, NonEmptyList[Int]]].semigroup)
 
-  implicit val eq0 = EitherT.catsDataEqForEitherT[Xor[String, ?], String, Int]
+  implicit val eq0 = XorT.catsDataEqForXorT[Xor[String, ?], String, Int]
 
   checkAll("Xor[String, Int]", MonadErrorTests[Xor[String, ?], String].monadError[Int, Int, Int])
   checkAll("MonadError[Xor, String]", SerializableTests.serializable(MonadError[Xor[String, ?], String]))


### PR DESCRIPTION
All APIs that are present in 0.6.x continue to use `Xor`. New additions, notably FlatMapRec stuff, use `Either`.