### PR TITLE
Remove superfluous Comonad constraint from Free's run

### DIFF
--- a/bench/src/main/scala/cats/bench/TrampolineBench.scala
+++ b/bench/src/main/scala/cats/bench/TrampolineBench.scala
@@ -20,9 +20,13 @@ class TrampolineBench {
       y <- Eval.defer(evalFib(n - 2))
     } yield x + y
 
+  private def fun0natId =
+    new (Function0 ~> Id) {
+      def apply[A](fa: Function0[A]): A = fa.extract
+    }
 
   @Benchmark
-  def trampoline(): Int = trampolineFib(N).run
+  def trampoline(): Int = trampolineFib(N).run(fun0natId)
 
   def trampolineFib(n: Int): Trampoline[Int] =
     if (n < 2) Trampoline.done(n) else for {

--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -69,11 +69,13 @@ sealed abstract class Free[S[_], A] extends Product with Serializable {
   }
 
   /**
-   * Run to completion, using the given comonad to extract the
-   * resumption.
+   * Run to completion, using the given natural transformation to extract the
+   * resumption. We use a natural transformation from S to Id, because it
+   * is essentially a function `S[X] => X forall X`, and we want the `X`
+   * parameter to be existentially quantified here.
    */
-  final def run(implicit S: Comonad[S]): A =
-    go(S.extract)
+  final def run(f: S ~> Id)(implicit S: Functor[S]): A =
+    go(f.apply)
 
   /**
    * Run to completion, using a function that maps the resumption


### PR DESCRIPTION
At the moment, Free's run method requires a `Comonad` constraint, which I think captures the wrong abstraction.
What is actually needed, is a `forall X. S[X] => X` function (which Comonad's `extract` incidentally is), but this is much more general than a Comonad, and therefore the current constraint is too restrictive.

A possible way of existentially quantifying the `X` is by requiring a natural transformation (or `FunctionK`) `S ~> Id`, which of course expands to the required signature. What this means is that now there is an explicit argument that we require for `run`, instead of the implicit Comonad instance.

I'm not sure if this is the best way of solving this problem, so please let me know if there is a nicer way - but I definitely think that requiring `Comonad` is unnecessary in this context.
