### PR TITLE
fix doctest plugin / use same command for release and travis build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -396,7 +396,7 @@ addCommandAlias("validateKernelJS", "kernelLawsJS/test")
 
 addCommandAlias("validateFreeJS", "freeJS/test") //separated due to memory constraint on travis
 
-addCommandAlias("validate", ";clean;validateJS;validateFreeJS;validateJVM")
+addCommandAlias("validate", ";clean;validateJS;validateKernelJS;validateFreeJS;validateJVM")
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Base Build Settings - Should not need to edit below this line.
@@ -477,10 +477,7 @@ lazy val sharedReleaseProcess = Seq(
     checkSnapshotDependencies,
     inquireVersions,
     runClean,
-    releaseStepCommand("validateJS"),
-    releaseStepCommand("validateKernelJS"),
-    releaseStepCommand("validateFreeJS"),
-    ReleaseStep(action = Command.process("validateJVM", _), enableCrossBuild = true),
+    releaseStepCommand("validate"),
     setReleaseVersion,
     commitReleaseVersion,
     tagRelease,

--- a/build.sbt
+++ b/build.sbt
@@ -94,7 +94,8 @@ lazy val commonJsSettings = Seq(
   // Only used for scala.js for now
   botBuild := scala.sys.env.get("TRAVIS").isDefined,
   // batch mode decreases the amount of memory needed to compile scala.js code
-  scalaJSOptimizerOptions := scalaJSOptimizerOptions.value.withBatchMode(botBuild.value)
+  scalaJSOptimizerOptions := scalaJSOptimizerOptions.value.withBatchMode(botBuild.value),
+  doctestGenTests := Seq.empty
 )
 
 lazy val commonJvmSettings = Seq(
@@ -187,7 +188,7 @@ lazy val catsJS = project.in(file(".catsJS"))
   .aggregate(macrosJS, kernelJS, kernelLawsJS, coreJS, lawsJS, freeJS, testsJS, js)
   .dependsOn(macrosJS, kernelJS, kernelLawsJS, coreJS, lawsJS, freeJS, testsJS % "test-internal -> test", js)
   .enablePlugins(ScalaJSPlugin)
-  .disablePlugins(DoctestPlugin)
+
 
 
 lazy val macros = crossProject.crossType(CrossType.Pure)
@@ -198,7 +199,7 @@ lazy val macros = crossProject.crossType(CrossType.Pure)
   .settings(scalacOptions := scalacOptions.value.filter(_ != "-Xfatal-warnings"))
 
 lazy val macrosJVM = macros.jvm
-lazy val macrosJS = macros.js.disablePlugins(DoctestPlugin)
+lazy val macrosJS = macros.js
 
 lazy val kernel = crossProject.crossType(CrossType.Pure)
   .in(file("kernel"))
@@ -212,7 +213,7 @@ lazy val kernel = crossProject.crossType(CrossType.Pure)
   .jvmSettings((commonJvmSettings ++ (mimaPreviousArtifacts := Set("org.typelevel" %% "cats-kernel" % "0.7.0"))):_*)
 
 lazy val kernelJVM = kernel.jvm
-lazy val kernelJS = kernel.js.disablePlugins(DoctestPlugin)
+lazy val kernelJS = kernel.js
 
 lazy val kernelLaws = crossProject.crossType(CrossType.Pure)
   .in(file("kernel-laws"))
@@ -228,7 +229,7 @@ lazy val kernelLaws = crossProject.crossType(CrossType.Pure)
   .dependsOn(kernel)
 
 lazy val kernelLawsJVM = kernelLaws.jvm
-lazy val kernelLawsJS = kernelLaws.js.disablePlugins(DoctestPlugin)
+lazy val kernelLawsJS = kernelLaws.js
 
 lazy val core = crossProject.crossType(CrossType.Pure)
   .dependsOn(macros, kernel)
@@ -240,7 +241,7 @@ lazy val core = crossProject.crossType(CrossType.Pure)
   .jvmSettings(commonJvmSettings:_*)
 
 lazy val coreJVM = core.jvm
-lazy val coreJS = core.js.disablePlugins(DoctestPlugin)
+lazy val coreJS = core.js
 
 lazy val laws = crossProject.crossType(CrossType.Pure)
   .dependsOn(macros, kernel, core, kernelLaws)
@@ -252,7 +253,7 @@ lazy val laws = crossProject.crossType(CrossType.Pure)
   .jvmSettings(commonJvmSettings:_*)
 
 lazy val lawsJVM = laws.jvm
-lazy val lawsJS = laws.js.disablePlugins(DoctestPlugin)
+lazy val lawsJS = laws.js
 
 lazy val free = crossProject.crossType(CrossType.Pure)
   .dependsOn(macros, core, tests % "test-internal -> test")
@@ -262,7 +263,7 @@ lazy val free = crossProject.crossType(CrossType.Pure)
   .jvmSettings(commonJvmSettings:_*)
 
 lazy val freeJVM = free.jvm
-lazy val freeJS = free.js.disablePlugins(DoctestPlugin)
+lazy val freeJS = free.js
 
 lazy val tests = crossProject.crossType(CrossType.Pure)
   .dependsOn(macros, core, laws)
@@ -275,7 +276,7 @@ lazy val tests = crossProject.crossType(CrossType.Pure)
   .jvmSettings(commonJvmSettings:_*)
 
 lazy val testsJVM = tests.jvm
-lazy val testsJS = tests.js.disablePlugins(DoctestPlugin)
+lazy val testsJS = tests.js
 
 // bench is currently JVM-only
 lazy val bench = project.dependsOn(macrosJVM, coreJVM, freeJVM, lawsJVM)
@@ -294,7 +295,7 @@ lazy val js = project
   .settings(catsSettings:_*)
   .settings(commonJsSettings:_*)
   .enablePlugins(ScalaJSPlugin)
-  .disablePlugins(DoctestPlugin)
+
 
 // cats-jvm is JVM-only
 lazy val jvm = project

--- a/build.sbt
+++ b/build.sbt
@@ -390,9 +390,11 @@ addCommandAlias("buildJVM", "catsJVM/test")
 
 addCommandAlias("validateJVM", ";scalastyle;buildJVM;makeSite")
 
-addCommandAlias("validateJS", ";catsJS/compile;kernelLawsJS/test;testsJS/test;js/test;freeJS/test")
+addCommandAlias("validateJS", ";catsJS/compile;kernelLawsJS/test;testsJS/test;js/test")
 
-addCommandAlias("validate", ";clean;validateJS;validateJVM")
+addCommandAlias("validateFreeJS", "freeJS/test") //separated due to memory constraint on travis
+
+addCommandAlias("validate", ";clean;validateJS;validateFreeJS;validateJVM")
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Base Build Settings - Should not need to edit below this line.
@@ -474,6 +476,7 @@ lazy val sharedReleaseProcess = Seq(
     inquireVersions,
     runClean,
     releaseStepCommand("validateJS"),
+    releaseStepCommand("validateFreeJS"),
     ReleaseStep(action = Command.process("validateJVM", _), enableCrossBuild = true),
     setReleaseVersion,
     commitReleaseVersion,

--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,6 @@ import sbtunidoc.Plugin.UnidocKeys._
 import ReleaseTransformations._
 import ScoverageSbtPlugin._
 import scala.xml.transform.{RewriteRule, RuleTransformer}
-import com.github.tkawachi.doctest.DoctestPlugin
 
 lazy val botBuild = settingKey[Boolean]("Build by TravisCI instead of local dev environment")
 

--- a/build.sbt
+++ b/build.sbt
@@ -390,7 +390,9 @@ addCommandAlias("buildJVM", "catsJVM/test")
 
 addCommandAlias("validateJVM", ";scalastyle;buildJVM;makeSite")
 
-addCommandAlias("validateJS", ";catsJS/compile;kernelLawsJS/test;testsJS/test;js/test")
+addCommandAlias("validateJS", ";catsJS/compile;testsJS/test;js/test")
+
+addCommandAlias("validateKernelJS", "kernelLawsJS/test")
 
 addCommandAlias("validateFreeJS", "freeJS/test") //separated due to memory constraint on travis
 
@@ -476,6 +478,7 @@ lazy val sharedReleaseProcess = Seq(
     inquireVersions,
     runClean,
     releaseStepCommand("validateJS"),
+    releaseStepCommand("validateKernelJS"),
     releaseStepCommand("validateFreeJS"),
     ReleaseStep(action = Command.process("validateJVM", _), enableCrossBuild = true),
     setReleaseVersion,

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -27,9 +27,10 @@ fi
 
 sbt_cmd="sbt ++$TRAVIS_SCALA_VERSION"
 
-scala_js="$sbt_cmd validateJS"
-scala_jvm="$sbt_cmd coverage validateJVM coverageReport && codecov"
+js="$sbt_cmd validateJS"
+free_js="$sbt_cmd validateFreeJS"
+jvm="$sbt_cmd coverage validateJVM coverageReport && codecov"
   		  
-run_cmd="$scala_js && $scala_jvm $publish_cmd"
+run_cmd="$js && $free_js && $jvm $publish_cmd"
 
 eval $run_cmd

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -27,12 +27,9 @@ fi
 
 sbt_cmd="sbt ++$TRAVIS_SCALA_VERSION"
 
-coverage="$sbt_cmd coverage validateJVM coverageReport && codecov"
-
-
-scala_js="$sbt_cmd macrosJS/compile coreJS/compile lawsJS/compile && $sbt_cmd kernelLawsJS/test && $sbt_cmd testsJS/test && $sbt_cmd js/test"		
-scala_jvm="$sbt_cmd validateJVM"		
+scala_js="$sbt_cmd validateJS"
+scala_jvm="$sbt_cmd coverage validateJVM coverageReport && codecov"
   		  
-run_cmd="$coverage && $scala_js && $scala_jvm $publish_cmd"
+run_cmd="$scala_js && $scala_jvm $publish_cmd"
 
 eval $run_cmd

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -28,9 +28,10 @@ fi
 sbt_cmd="sbt ++$TRAVIS_SCALA_VERSION"
 
 js="$sbt_cmd validateJS"
+kernel_js="$sbt_cmd validateKernelJS"
 free_js="$sbt_cmd validateFreeJS"
 jvm="$sbt_cmd coverage validateJVM coverageReport && codecov"
   		  
-run_cmd="$js && $free_js && $jvm $publish_cmd"
+run_cmd="$js && $free_js && $kernel_js && $jvm && $sbt_cmd $publish_cmd"
 
 eval $run_cmd


### PR DESCRIPTION
1. disabled doctest plugin on all js projects which was enabled by this [commit])https://github.com/typelevel/cats/commit/67eacc7c3aa2f6ebebcb67eb6ee122103fdce4b1)
2. use the same commands for travis and release
3. added freeJS test to `validateJS`
4. try use aggregated project `test` as much as possible (will see if travis can handle)

