### PR TITLE
WIP: Iterable <=> Foldable interop

### DIFF
--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -5,6 +5,7 @@ import cats.instances.long._
 import cats.instances.int._
 import simulacrum.typeclass
 import scala.collection.immutable.Iterable
+import scala.collection.generic.CanBuildFrom
 
 /**
  * Data structures that can be folded to a summary value.
@@ -400,6 +401,12 @@ object Foldable {
     def foldRight[A, B](fa: F[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
       iterateRight(fa.iterator, lb)(f)
   }
+
+  /**
+   * Create a scala collection from the given Foldable
+   */
+  def toCollection[F[_], A, C](fa: F[A])(implicit F: Foldable[F], CBF: CanBuildFrom[Nothing, A, C]): C =
+    F.foldLeft(fa, CBF()) { (bldr, a) => bldr += a }.result
 }
 
 private[cats] class FoldableIterable[F[_], T](ft: F[T])(implicit F: Foldable[F]) extends Iterable[T] {


### PR DESCRIPTION
This is just a sketch (no tests yet, incomplete) to give interop between standard scala `Iterable[T]` and `Foldable[F]`.

Is see this as having two benefits:
1. education. Seeing that Foldable and Iterable are exactly equivalent in terms of computational power can help teach the value of this type class relative to an inheritance model.
2. this allows easier interop with any iterable class that may exist, or code that accepts iterable. In this case, we can sometimes avoid a copy to create an `Iterable` as needed.
