### PR TITLE
Update CHANGES.md, AUTHORS.md, and README.md for 0.7.2.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -18,6 +18,7 @@ possible:
  * Aldo Stracquadanio
  * Alejandro Gómez
  * Alessandro Lacava
+ * Alexandru Nedelcu
  * Alexander Semenov
  * Alexey Levan
  * Alissa Pajer
@@ -37,6 +38,7 @@ possible:
  * Brian McKenna
  * Cody Allen
  * Colt Frederickson
+ * Csongor Kiss
  * Dale Wijnand
  * Daniel Spiewak
  * Dave Gurnell
@@ -53,11 +55,13 @@ possible:
  * Eugene Yokota
  * Feynman Liang
  * Frank S. Thomas
+ * Giulio De Luise
  * Hamish Dickson
  * Ian McIntosh
  * ImLiar
  * Jean-Rémi Desjardins
  * Jisoo Park
+ * Jose Emilio Labra Gayo
  * Josh Marcus
  * Juan Pedro Moreno
  * Julien Richard-Foy

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,7 +4,7 @@
 
 Version 0.7.2 is a patch release that was released to fix a major bug
 ([#1346](https://github.com/typelevel/cats/issues/1346)) that appeared
-in 0.7.2. It also contains several other improvements.
+in 0.7.0. It also contains several other improvements.
 
 It should be safe to upgrade from 0.7.0 to 0.7.2 -- there are no major
 API changes between these releases.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,32 @@
+## Version 0.7.2
+
+> 2016 September 1
+
+Version 0.7.2 is a patch release that was released to fix a major bug
+([#1346](https://github.com/typelevel/cats/issues/1346)) that appeared
+in 0.7.2. It also contains several other improvements.
+
+It should be safe to upgrade from 0.7.0 to 0.7.2 -- there are no major
+API changes between these releases.
+
+### Changes
+
+Fixes:
+
+ * [#1347](https://github.com/typelevel/cats/pull/1347): fixes broken `Monoid[Map[K, V]].combineAll` implementation.
+ * [#1304](https://github.com/typelevel/cats/pull/1304): fix `CoflatMap` documentation.
+ * [#1322](https://github.com/typelevel/cats/pull/1322): fix SBT commands (`release`, `validate`, etc.).
+ * [#1311](https://github.com/typelevel/cats/pull/1311): rename some implicit instances for consistency.
+
+Additions:
+
+ * [#1319](https://github.com/typelevel/cats/pull/1347): add missing `BigDecimal` instances.
+ * [#1324](https://github.com/typelevel/cats/pull/1324): add missing function and `BitSet` instances.
+
+Note that 0.7.2 was preceeded by a botched 0.7.1. release. Please
+avoid using this version of Cats -- it has major incompatibilities
+with 0.7.0 and is not documented here.
+
 ## Version 0.7.0
 
 > 2016 August 21

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ To get started with SBT, simply add the following to your `build.sbt`
 file:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats" % "0.7.0"
+libraryDependencies += "org.typelevel" %% "cats" % "0.7.2"
 ```
 
 This will pull in all of Cats' modules. If you only require some


### PR DESCRIPTION
This adds four new authors, summarizes the PRs that were
pulled into the 0.7.x branch, and explains the release.
It also mentions that 0.7.1 was botched and should not
be used.