### PR TITLE
append and prepend on NonEmptyVectors

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -57,6 +57,26 @@ final class NonEmptyVector[A] private (val toVector: Vector[A]) extends AnyVal {
   def concatNev(other: NonEmptyVector[A]): NonEmptyVector[A] = new NonEmptyVector(toVector ++ other.toVector)
 
   /**
+   * Append an item to this, producing a new `NonEmptyVector`.
+   */
+  def append(a: A): NonEmptyVector[A] = new NonEmptyVector(toVector :+ a)
+
+  /**
+    * Alias for [[append]]
+    */
+  def :+(a: A): NonEmptyVector[A] = append(a)
+
+  /**
+   * Prepend an item to this, producing a new `NonEmptyVector`.
+   */
+  def prepend(a: A): NonEmptyVector[A] = new NonEmptyVector(a +: toVector)
+
+  /**
+    * Alias for [[prepend]]
+    */
+  def +:(a: A): NonEmptyVector[A] = prepend(a)
+
+  /**
    * Find the first element matching the predicate, if one exists
    */
   def find(f: A => Boolean): Option[A] = toVector.find(f)

--- a/tests/src/test/scala/cats/tests/NonEmptyVectorTests.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyVectorTests.scala
@@ -185,6 +185,28 @@ class NonEmptyVectorTests extends CatsSuite {
     }
   }
 
+  test(":+ is consistent with concat") {
+    forAll { (nonEmptyVector: NonEmptyVector[Int], i: Int) =>
+      nonEmptyVector :+ i should === (nonEmptyVector.concat(Vector(i)))
+    }
+  }
+  test("append is consistent with :+") {
+    forAll { (nonEmptyVector: NonEmptyVector[Int], i: Int) =>
+      nonEmptyVector append i should === (nonEmptyVector :+ i)
+    }
+  }
+
+  test("+: is consistent with concatNev") {
+    forAll { (nonEmptyVector: NonEmptyVector[Int], i: Int) =>
+      i +: nonEmptyVector should === (NonEmptyVector.of(i).concatNev(nonEmptyVector))
+    }
+  }
+  test("prepend is consistent with +:") {
+    forAll { (nonEmptyVector: NonEmptyVector[Int], i: Int) =>
+      nonEmptyVector prepend i should === (i +: nonEmptyVector)
+    }
+  }
+
   test("NonEmptyVector#of on varargs is consistent with NonEmptyVector#apply on Vector") {
     forAll { (head: Int, tail: Vector[Int]) =>
       NonEmptyVector.of(head, tail:_*) should === (NonEmptyVector(head, tail))


### PR DESCRIPTION
Append and prepend are everyday operations on Vectors and the need quickly arises when working with NonEmptyVectors. They maintain the NonEmpty invariant.