### PR TITLE
Update documentation to use correct markdown

### DIFF
--- a/docs/src/site/index.md
+++ b/docs/src/site/index.md
@@ -14,7 +14,7 @@ The name is a playful shortening of the word *category*.
   around Q3 2016).</p> </div>
 
 
-# <a name="getting-started" href="#getting-started"></a>Getting Started
+### <a name="getting-started" href="#getting-started"></a>Getting Started
 
 Cats is currently available for Scala 2.10 and 2.11.
 
@@ -78,7 +78,7 @@ we can without making unnecessary sacrifices of purity and
 usability. Where sacrifices have to be made, we will strive to make
 these obvious, and will keep them well documented.
 
-# <a name="project-structure" href="#project-structure"></a>Project Structure
+### <a name="project-structure" href="#project-structure"></a>Project Structure
 
 In an attempt to be more modular, Cats is broken up into a number of sub-projects:
 
@@ -89,7 +89,7 @@ In an attempt to be more modular, Cats is broken up into a number of sub-project
 * *tests* - tests that check type class instances with laws from *laws*
 * *docs* - The source for this website
 
-# <a name="copyright" href="#copyright"></a>Copyright and License
+### <a name="copyright" href="#copyright"></a>Copyright and License
 
 All code is available to you under the MIT license, available at
 http://opensource.org/licenses/mit-license.php and also in the


### PR DESCRIPTION
The markdown on this page is rendering incorrectly. Sections have changed to generate headings consistent with the rest of the page.

<img width="1167" alt="screen shot 2016-09-18 at 4 52 41 pm" src="https://cloud.githubusercontent.com/assets/766985/18616237/8a64d164-7dc0-11e6-8a67-c6cdebead21e.png">
