### PR TITLE
Adding reader method to MonadReader

### DIFF
--- a/core/src/main/scala/cats/MonadReader.scala
+++ b/core/src/main/scala/cats/MonadReader.scala
@@ -7,6 +7,9 @@ trait MonadReader[F[_], R] extends Monad[F] {
 
   /** Modify the environment */
   def local[A](f: R => R)(fa: F[A]): F[A]
+
+  /** Retrieves a function of the environment */
+  def reader[A](f: R => A): F[A] = map(ask)(f)
 }
 
 object MonadReader {

--- a/laws/src/main/scala/cats/laws/MonadReaderLaws.scala
+++ b/laws/src/main/scala/cats/laws/MonadReaderLaws.scala
@@ -16,6 +16,9 @@ trait MonadReaderLaws[F[_], R] extends MonadLaws[F] {
 
   def monadReaderLocalFlatMap[A, B](fra: F[A], f: A => F[B], g: R => R): IsEq[F[B]] =
     F.local(g)(F.flatMap(fra)(f)) <-> F.flatMap(F.local(g)(fra))(a => F.local(g)(f(a)))
+
+  def monadReaderReaderAsk[A](f: R => A): IsEq[F[A]] =
+    F.reader(f) <-> F.map(F.ask)(f)
 }
 
 object MonadReaderLaws {

--- a/laws/src/main/scala/cats/laws/discipline/MonadReaderTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadReaderTests.scala
@@ -36,7 +36,8 @@ trait MonadReaderTests[F[_], R] extends MonadTests[F] {
         "monadReader ask idempotent" -> laws.monadReaderAskIdempotent,
         "monadReader local ask" -> forAll(laws.monadReaderLocalAsk _),
         "monadReader local pure" -> forAll(laws.monadReaderLocalPure[A] _),
-        "monadReader local flatMap" -> forAll(laws.monadReaderLocalFlatMap[A, B] _)
+        "monadReader local flatMap" -> forAll(laws.monadReaderLocalFlatMap[A, B] _),
+        "monadReader reader ask" -> forAll(laws.monadReaderReaderAsk[A] _)
       )
     }
   }


### PR DESCRIPTION
Adding `reader` method to `MonadReader`, as present in [Haskell](https://hackage.haskell.org/package/mtl-2.2.1/docs/Control-Monad-Reader-Class.html)