### PR TITLE
Add more syntax

### DIFF
--- a/core/src/main/scala/cats/arrow/Compose.scala
+++ b/core/src/main/scala/cats/arrow/Compose.scala
@@ -8,10 +8,10 @@ import simulacrum.typeclass
  */
 @typeclass trait Compose[F[_, _]] { self =>
 
-  @simulacrum.op(">>>", alias = true)
+  @simulacrum.op(":<<", alias = true)
   def compose[A, B, C](f: F[B, C], g: F[A, B]): F[A, C]
 
-  @simulacrum.op("<<<", alias = true)
+  @simulacrum.op(">>:", alias = true)
   def andThen[A, B, C](f: F[A, B], g: F[B, C]): F[A, C] =
     compose(g, f)
 

--- a/core/src/main/scala/cats/arrow/Compose.scala
+++ b/core/src/main/scala/cats/arrow/Compose.scala
@@ -8,7 +8,7 @@ import simulacrum.typeclass
  */
 @typeclass trait Compose[F[_, _]] { self =>
 
-  @simulacrum.op(":<<", alias = true)
+  @simulacrum.op("<<<", alias = true)
   def compose[A, B, C](f: F[B, C], g: F[A, B]): F[A, C]
 
   @simulacrum.op(">>>", alias = true)

--- a/core/src/main/scala/cats/arrow/Compose.scala
+++ b/core/src/main/scala/cats/arrow/Compose.scala
@@ -11,7 +11,7 @@ import simulacrum.typeclass
   @simulacrum.op(":<<", alias = true)
   def compose[A, B, C](f: F[B, C], g: F[A, B]): F[A, C]
 
-  @simulacrum.op(">>:", alias = true)
+  @simulacrum.op(">>>", alias = true)
   def andThen[A, B, C](f: F[A, B], g: F[B, C]): F[A, C] =
     compose(g, f)
 

--- a/core/src/main/scala/cats/arrow/Compose.scala
+++ b/core/src/main/scala/cats/arrow/Compose.scala
@@ -7,8 +7,11 @@ import simulacrum.typeclass
  * Must obey the laws defined in cats.laws.ComposeLaws.
  */
 @typeclass trait Compose[F[_, _]] { self =>
+
+  @simulacrum.op(">>>", alias = true)
   def compose[A, B, C](f: F[B, C], g: F[A, B]): F[A, C]
 
+  @simulacrum.op("<<<", alias = true)
   def andThen[A, B, C](f: F[A, B], g: F[B, C]): F[A, C] =
     compose(g, f)
 

--- a/tests/src/test/scala/cats/tests/SyntaxTests.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxTests.scala
@@ -47,12 +47,13 @@ object SyntaxTests extends AllInstances with AllSyntax {
     val z: Boolean = x.isEmpty
   }
 
-  def testCompose[F[_,_] : Compose, A, B, C]: Unit = {
+  def testCompose[F[_,_] : Compose, A, B, C, D]: Unit = {
     val x = mock[F[A, B]]
     val y = mock[F[B, C]]
+    val z = mock[F[C, D]]
 
-    x >>> y
-    y <<< x
+    x >>: y >>: z
+    z :<< y :<< x
   }
 
   def testEq[A: Eq]: Unit = {

--- a/tests/src/test/scala/cats/tests/SyntaxTests.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxTests.scala
@@ -52,8 +52,9 @@ object SyntaxTests extends AllInstances with AllSyntax {
     val y = mock[F[B, C]]
     val z = mock[F[C, D]]
 
-    x >>: y >>: z
-    z :<< y :<< x
+    val a = x >>> y >>> z
+    val b = z :<< y :<< x
+
   }
 
   def testEq[A: Eq]: Unit = {

--- a/tests/src/test/scala/cats/tests/SyntaxTests.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxTests.scala
@@ -53,7 +53,7 @@ object SyntaxTests extends AllInstances with AllSyntax {
     val z = mock[F[C, D]]
 
     val a = x >>> y >>> z
-    val b = z :<< y :<< x
+    val b = z <<< y <<< x
 
   }
 

--- a/tests/src/test/scala/cats/tests/SyntaxTests.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxTests.scala
@@ -1,9 +1,10 @@
 package cats
 package tests
 
+import cats.arrow.Compose
 import cats.instances.AllInstances
 import cats.syntax.AllSyntax
-import cats.functor.{Invariant, Contravariant}
+import cats.functor.{Contravariant, Invariant}
 
 /**
  * Test that our syntax implicits are working.
@@ -44,6 +45,14 @@ object SyntaxTests extends AllInstances with AllSyntax {
     val x = mock[A]
     implicit val y = mock[Eq[A]]
     val z: Boolean = x.isEmpty
+  }
+
+  def testCompose[F[_,_] : Compose, A, B, C]: Unit = {
+    val x = mock[F[A, B]]
+    val y = mock[F[B, C]]
+
+    x >>> y
+    y <<< x
   }
 
   def testEq[A: Eq]: Unit = {


### PR DESCRIPTION
@non As we talked about at Lamba.world :-)

- [x] Compose syntax
- [x] `Monoid.combineAll` which I would like syntax for, is the same thing as `Foldable.fold`or `Foldable.combineAll` which already comes in from `Foldable.Ops` right?