### PR TITLE
More instances for prod

### DIFF
--- a/core/src/main/scala/cats/data/Prod.scala
+++ b/core/src/main/scala/cats/data/Prod.scala
@@ -23,12 +23,22 @@ private[data] sealed abstract class ProdInstances extends ProdInstances0 {
     def eqv(x: Prod[F, G, A], y: Prod[F, G, A]): Boolean =
       FF.eqv(x.first, y.first) && GG.eqv(x.second, y.second)
   }
+
+  implicit def catsDataShowForProd[F[_], G[_], A](implicit FF: Show[F[A]], GF: Show[G[A]]): Show[Prod[F, G, A]] = new ProdShow[F, G, A] {
+    def F: Show[F[A]] = FF
+    def G: Show[G[A]] = GF
+  }
 }
 
 private[data] sealed abstract class ProdInstances0 extends ProdInstances1 {
   implicit def catsDataMonoidKForProd[F[_], G[_]](implicit FF: MonoidK[F], GG: MonoidK[G]): MonoidK[λ[α => Prod[F, G, α]]] = new ProdMonoidK[F, G] {
     def F: MonoidK[F] = FF
     def G: MonoidK[G] = GG
+  }
+
+  implicit def catsDataOrderForProd[F[_], G[_], A](implicit FF: Order[F[A]], GF: Order[G[A]]): Order[Prod[F, G, A]] = new ProdOrder[F, G, A] {
+    def F: Order[F[A]] = FF
+    def G: Order[G[A]] = GF
   }
 }
 
@@ -85,21 +95,10 @@ private[data] sealed abstract class ProdInstances7 extends ProdInstances8 {
   }
 }
 
-private[data] sealed abstract class ProdInstances8 extends ProdInstances9 {
+private[data] sealed abstract class ProdInstances8 {
   implicit def catsDataMonadCombineForProd[F[_], G[_]](implicit FF: MonadCombine[F], GF: MonadCombine[G]): MonadCombine[λ[α => Prod[F, G, α]]] = new ProdMonadCombine[F, G] {
     def F: MonadCombine[F] = FF
     def G: MonadCombine[G] = GF
-  }
-}
-
-private[data] sealed abstract class ProdInstances9 {
-  implicit def catsDataOrderForProd[F[_], G[_], A](implicit FF: Order[F[A]], GF: Order[G[A]]): Order[Prod[F, G, A]] = new ProdOrder[F, G, A] {
-    def F: Order[F[A]] = FF
-    def G: Order[G[A]] = GF
-  }
-  implicit def catsDataShowForProd[F[_], G[_], A](implicit FF: Show[F[A]], GF: Show[G[A]]): Show[Prod[F, G, A]] = new ProdShow[F, G, A] {
-    def F: Show[F[A]] = FF
-    def G: Show[G[A]] = GF
   }
 }
 

--- a/core/src/main/scala/cats/data/Prod.scala
+++ b/core/src/main/scala/cats/data/Prod.scala
@@ -14,9 +14,9 @@ final case class Prod[F[_], G[_], A](first: F[A], second: G[A])
 object Prod extends ProdInstances
 
 private[data] sealed abstract class ProdInstances extends ProdInstances0 {
-  implicit def catsDataAlternativeForProd[F[_], G[_]](implicit FF: Alternative[F], GG: Alternative[G]): Alternative[λ[α => Prod[F, G, α]]] = new ProdAlternative[F, G] {
-    def F: Alternative[F] = FF
-    def G: Alternative[G] = GG
+  implicit def catsDataMonadCombineForProd[F[_], G[_]](implicit FF: MonadCombine[F], GF: MonadCombine[G]): MonadCombine[λ[α => Prod[F, G, α]]] = new ProdMonadCombine[F, G] {
+    def F: MonadCombine[F] = FF
+    def G: MonadCombine[G] = GF
   }
 
   implicit def catsDataOrderForProd[F[_], G[_], A](implicit FF: Order[F[A]], GF: Order[G[A]]): Order[Prod[F, G, A]] = new ProdOrder[F, G, A] {
@@ -57,16 +57,16 @@ private[data] sealed abstract class ProdInstances2 extends ProdInstances3 {
 }
 
 private[data] sealed abstract class ProdInstances3 extends ProdInstances4 {
-  implicit def catsDataApplyForProd[F[_], G[_]](implicit FF: Apply[F], GG: Apply[G]): Apply[λ[α => Prod[F, G, α]]] = new ProdApply[F, G] {
-    def F: Apply[F] = FF
-    def G: Apply[G] = GG
+  implicit def catsDataMonadForProd[F[_], G[_]](implicit FM: Monad[F], GM: Monad[G]): Monad[λ[α => Prod[F, G, α]]] = new ProdMonad[F, G] {
+    def F: Monad[F] = FM
+    def G: Monad[G] = GM
   }
 }
 
 private[data] sealed abstract class ProdInstances4 extends ProdInstances5 {
-  implicit def catsDataFunctorForProd[F[_], G[_]](implicit FF: Functor[F], GG: Functor[G]): Functor[λ[α => Prod[F, G, α]]] = new ProdFunctor[F, G] {
-    def F: Functor[F] = FF
-    def G: Functor[G] = GG
+  implicit def catsDataTraverseForProd[F[_], G[_]](implicit FF: Traverse[F], GF: Traverse[G]): Traverse[λ[α => Prod[F, G, α]]] = new ProdTraverse[F, G] {
+    def F: Traverse[F] = FF
+    def G: Traverse[G] = GF
   }
   implicit def catsDataContravariantForProd[F[_], G[_]](implicit FC: Contravariant[F], GC: Contravariant[G]): Contravariant[λ[α => Prod[F, G, α]]] = new ProdContravariant[F, G] {
     def F: Contravariant[F] = FC
@@ -75,30 +75,27 @@ private[data] sealed abstract class ProdInstances4 extends ProdInstances5 {
 }
 
 private[data] sealed abstract class ProdInstances5 extends ProdInstances6 {
-  implicit def catsDataMonadForProd[F[_], G[_]](implicit FM: Monad[F], GM: Monad[G]): Monad[λ[α => Prod[F, G, α]]] = new ProdMonad[F, G] {
-    def F: Monad[F] = FM
-    def G: Monad[G] = GM
+  implicit def catsDataApplyForProd[F[_], G[_]](implicit FF: Apply[F], GG: Apply[G]): Apply[λ[α => Prod[F, G, α]]] = new ProdApply[F, G] {
+    def F: Apply[F] = FF
+    def G: Apply[G] = GG
   }
 }
 
 private[data] sealed abstract class ProdInstances6 extends ProdInstances7 {
+  implicit def catsDataFunctorForProd[F[_], G[_]](implicit FF: Functor[F], GG: Functor[G]): Functor[λ[α => Prod[F, G, α]]] = new ProdFunctor[F, G] {
+    def F: Functor[F] = FF
+    def G: Functor[G] = GG
+  }
   implicit def catsDataFoldableForProd[F[_], G[_]](implicit FF: Foldable[F], GF: Foldable[G]): Foldable[λ[α => Prod[F, G, α]]] = new ProdFoldable[F, G] {
     def F: Foldable[F] = FF
     def G: Foldable[G] = GF
   }
 }
 
-private[data] sealed abstract class ProdInstances7 extends ProdInstances8 {
-  implicit def catsDataTraverseForProd[F[_], G[_]](implicit FF: Traverse[F], GF: Traverse[G]): Traverse[λ[α => Prod[F, G, α]]] = new ProdTraverse[F, G] {
-    def F: Traverse[F] = FF
-    def G: Traverse[G] = GF
-  }
-}
-
-private[data] sealed abstract class ProdInstances8 {
-  implicit def catsDataMonadCombineForProd[F[_], G[_]](implicit FF: MonadCombine[F], GF: MonadCombine[G]): MonadCombine[λ[α => Prod[F, G, α]]] = new ProdMonadCombine[F, G] {
-    def F: MonadCombine[F] = FF
-    def G: MonadCombine[G] = GF
+private[data] sealed abstract class ProdInstances7 {
+  implicit def catsDataAlternativeForProd[F[_], G[_]](implicit FF: Alternative[F], GG: Alternative[G]): Alternative[λ[α => Prod[F, G, α]]] = new ProdAlternative[F, G] {
+    def F: Alternative[F] = FF
+    def G: Alternative[G] = GG
   }
 }
 

--- a/core/src/main/scala/cats/data/Prod.scala
+++ b/core/src/main/scala/cats/data/Prod.scala
@@ -19,9 +19,9 @@ private[data] sealed abstract class ProdInstances extends ProdInstances0 {
     def G: Alternative[G] = GG
   }
 
-  implicit def catsDataEqForProd[F[_], G[_], A](implicit FF: Eq[F[A]], GG: Eq[G[A]]): Eq[Prod[F, G, A]] = new Eq[Prod[F, G, A]] {
-    def eqv(x: Prod[F, G, A], y: Prod[F, G, A]): Boolean =
-      FF.eqv(x.first, y.first) && GG.eqv(x.second, y.second)
+  implicit def catsDataOrderForProd[F[_], G[_], A](implicit FF: Order[F[A]], GF: Order[G[A]]): Order[Prod[F, G, A]] = new ProdOrder[F, G, A] {
+    def F: Order[F[A]] = FF
+    def G: Order[G[A]] = GF
   }
 
   implicit def catsDataShowForProd[F[_], G[_], A](implicit FF: Show[F[A]], GF: Show[G[A]]): Show[Prod[F, G, A]] = new ProdShow[F, G, A] {
@@ -36,9 +36,9 @@ private[data] sealed abstract class ProdInstances0 extends ProdInstances1 {
     def G: MonoidK[G] = GG
   }
 
-  implicit def catsDataOrderForProd[F[_], G[_], A](implicit FF: Order[F[A]], GF: Order[G[A]]): Order[Prod[F, G, A]] = new ProdOrder[F, G, A] {
-    def F: Order[F[A]] = FF
-    def G: Order[G[A]] = GF
+  implicit def catsDataEqForProd[F[_], G[_], A](implicit FF: Eq[F[A]], GG: Eq[G[A]]): Eq[Prod[F, G, A]] = new Eq[Prod[F, G, A]] {
+    def eqv(x: Prod[F, G, A], y: Prod[F, G, A]): Boolean =
+      FF.eqv(x.first, y.first) && GG.eqv(x.second, y.second)
   }
 }
 

--- a/core/src/main/scala/cats/data/Prod.scala
+++ b/core/src/main/scala/cats/data/Prod.scala
@@ -85,10 +85,21 @@ private[data] sealed abstract class ProdInstances7 extends ProdInstances8 {
   }
 }
 
-private[data] sealed abstract class ProdInstances8 {
+private[data] sealed abstract class ProdInstances8 extends ProdInstances9 {
   implicit def catsDataMonadCombineForProd[F[_], G[_]](implicit FF: MonadCombine[F], GF: MonadCombine[G]): MonadCombine[λ[α => Prod[F, G, α]]] = new ProdMonadCombine[F, G] {
     def F: MonadCombine[F] = FF
     def G: MonadCombine[G] = GF
+  }
+}
+
+private[data] sealed abstract class ProdInstances9 {
+  implicit def catsDataOrderForProd[F[_], G[_], A](implicit FF: Order[F[A]], GF: Order[G[A]]): Order[Prod[F, G, A]] = new ProdOrder[F, G, A] {
+    def F: Order[F[A]] = FF
+    def G: Order[G[A]] = GF
+  }
+  implicit def catsDataShowForProd[F[_], G[_], A](implicit FF: Show[F[A]], GF: Show[G[A]]): Show[Prod[F, G, A]] = new ProdShow[F, G, A] {
+    def F: Show[F[A]] = FF
+    def G: Show[G[A]] = GF
   }
 }
 
@@ -175,4 +186,19 @@ sealed trait ProdMonadCombine[F[_], G[_]] extends MonadCombine[λ[α => Prod[F, 
   with ProdMonad[F, G] with ProdAlternative[F, G] {
   def F: MonadCombine[F]
   def G: MonadCombine[G]
+}
+
+sealed trait ProdShow[F[_], G[_], A] extends Show[Prod[F, G, A]] {
+  def F: Show[F[A]]
+  def G: Show[G[A]]
+
+  def show(prod: Prod[F, G, A]): String = s"Prod(${F.show(prod.first)}, ${G.show(prod.second)})"
+}
+
+sealed trait ProdOrder[F[_], G[_], A] extends Order[Prod[F, G, A]] {
+  def F: Order[F[A]]
+  def G: Order[G[A]]
+
+  def compare(x: Prod[F, G, A], y: Prod[F, G, A]): Int =
+    Array(F.compare(x.first, y.first), G.compare(x.second, y.second)).find(_ != 0).getOrElse(0)
 }

--- a/core/src/main/scala/cats/data/Prod.scala
+++ b/core/src/main/scala/cats/data/Prod.scala
@@ -18,55 +18,13 @@ private[data] sealed abstract class ProdInstances extends ProdInstances0 {
     def F: MonadCombine[F] = FF
     def G: MonadCombine[G] = GF
   }
-
   implicit def catsDataOrderForProd[F[_], G[_], A](implicit FF: Order[F[A]], GF: Order[G[A]]): Order[Prod[F, G, A]] = new ProdOrder[F, G, A] {
     def F: Order[F[A]] = FF
     def G: Order[G[A]] = GF
   }
-
   implicit def catsDataShowForProd[F[_], G[_], A](implicit FF: Show[F[A]], GF: Show[G[A]]): Show[Prod[F, G, A]] = new ProdShow[F, G, A] {
     def F: Show[F[A]] = FF
     def G: Show[G[A]] = GF
-  }
-}
-
-private[data] sealed abstract class ProdInstances0 extends ProdInstances1 {
-  implicit def catsDataMonoidKForProd[F[_], G[_]](implicit FF: MonoidK[F], GG: MonoidK[G]): MonoidK[λ[α => Prod[F, G, α]]] = new ProdMonoidK[F, G] {
-    def F: MonoidK[F] = FF
-    def G: MonoidK[G] = GG
-  }
-
-  implicit def catsDataEqForProd[F[_], G[_], A](implicit FF: Eq[F[A]], GG: Eq[G[A]]): Eq[Prod[F, G, A]] = new Eq[Prod[F, G, A]] {
-    def eqv(x: Prod[F, G, A], y: Prod[F, G, A]): Boolean =
-      FF.eqv(x.first, y.first) && GG.eqv(x.second, y.second)
-  }
-}
-
-private[data] sealed abstract class ProdInstances1 extends ProdInstances2 {
-  implicit def catsDataSemigroupKForProd[F[_], G[_]](implicit FF: SemigroupK[F], GG: SemigroupK[G]): SemigroupK[λ[α => Prod[F, G, α]]] = new ProdSemigroupK[F, G] {
-    def F: SemigroupK[F] = FF
-    def G: SemigroupK[G] = GG
-  }
-}
-
-private[data] sealed abstract class ProdInstances2 extends ProdInstances3 {
-  implicit def catsDataApplicativeForProd[F[_], G[_]](implicit FF: Applicative[F], GG: Applicative[G]): Applicative[λ[α => Prod[F, G, α]]] = new ProdApplicative[F, G] {
-    def F: Applicative[F] = FF
-    def G: Applicative[G] = GG
-  }
-}
-
-private[data] sealed abstract class ProdInstances3 extends ProdInstances4 {
-  implicit def catsDataMonadForProd[F[_], G[_]](implicit FM: Monad[F], GM: Monad[G]): Monad[λ[α => Prod[F, G, α]]] = new ProdMonad[F, G] {
-    def F: Monad[F] = FM
-    def G: Monad[G] = GM
-  }
-}
-
-private[data] sealed abstract class ProdInstances4 extends ProdInstances5 {
-  implicit def catsDataTraverseForProd[F[_], G[_]](implicit FF: Traverse[F], GF: Traverse[G]): Traverse[λ[α => Prod[F, G, α]]] = new ProdTraverse[F, G] {
-    def F: Traverse[F] = FF
-    def G: Traverse[G] = GF
   }
   implicit def catsDataContravariantForProd[F[_], G[_]](implicit FC: Contravariant[F], GC: Contravariant[G]): Contravariant[λ[α => Prod[F, G, α]]] = new ProdContravariant[F, G] {
     def F: Contravariant[F] = FC
@@ -74,28 +32,55 @@ private[data] sealed abstract class ProdInstances4 extends ProdInstances5 {
   }
 }
 
-private[data] sealed abstract class ProdInstances5 extends ProdInstances6 {
+private[data] sealed abstract class ProdInstances0 extends ProdInstances1 {
+  implicit def catsDataTraverseForProd[F[_], G[_]](implicit FF: Traverse[F], GF: Traverse[G]): Traverse[λ[α => Prod[F, G, α]]] = new ProdTraverse[F, G] {
+    def F: Traverse[F] = FF
+    def G: Traverse[G] = GF
+  }
+  implicit def catsDataAlternativeForProd[F[_], G[_]](implicit FF: Alternative[F], GG: Alternative[G]): Alternative[λ[α => Prod[F, G, α]]] = new ProdAlternative[F, G] {
+    def F: Alternative[F] = FF
+    def G: Alternative[G] = GG
+  }
+  implicit def catsDataMonadForProd[F[_], G[_]](implicit FM: Monad[F], GM: Monad[G]): Monad[λ[α => Prod[F, G, α]]] = new ProdMonad[F, G] {
+    def F: Monad[F] = FM
+    def G: Monad[G] = GM
+  }
+  implicit def catsDataEqForProd[F[_], G[_], A](implicit FF: Eq[F[A]], GG: Eq[G[A]]): Eq[Prod[F, G, A]] = new Eq[Prod[F, G, A]] {
+    def eqv(x: Prod[F, G, A], y: Prod[F, G, A]): Boolean =
+      FF.eqv(x.first, y.first) && GG.eqv(x.second, y.second)
+  }
+}
+
+private[data] sealed abstract class ProdInstances1 extends ProdInstances2 {
+  implicit def catsDataFoldableForProd[F[_], G[_]](implicit FF: Foldable[F], GF: Foldable[G]): Foldable[λ[α => Prod[F, G, α]]] = new ProdFoldable[F, G] {
+    def F: Foldable[F] = FF
+    def G: Foldable[G] = GF
+  }
+  implicit def catsDataMonoidKForProd[F[_], G[_]](implicit FF: MonoidK[F], GG: MonoidK[G]): MonoidK[λ[α => Prod[F, G, α]]] = new ProdMonoidK[F, G] {
+    def F: MonoidK[F] = FF
+    def G: MonoidK[G] = GG
+  }
+  implicit def catsDataApplicativeForProd[F[_], G[_]](implicit FF: Applicative[F], GG: Applicative[G]): Applicative[λ[α => Prod[F, G, α]]] = new ProdApplicative[F, G] {
+    def F: Applicative[F] = FF
+    def G: Applicative[G] = GG
+  }
+}
+
+private[data] sealed abstract class ProdInstances2 extends ProdInstances3 {
+  implicit def catsDataSemigroupKForProd[F[_], G[_]](implicit FF: SemigroupK[F], GG: SemigroupK[G]): SemigroupK[λ[α => Prod[F, G, α]]] = new ProdSemigroupK[F, G] {
+    def F: SemigroupK[F] = FF
+    def G: SemigroupK[G] = GG
+  }
   implicit def catsDataApplyForProd[F[_], G[_]](implicit FF: Apply[F], GG: Apply[G]): Apply[λ[α => Prod[F, G, α]]] = new ProdApply[F, G] {
     def F: Apply[F] = FF
     def G: Apply[G] = GG
   }
 }
 
-private[data] sealed abstract class ProdInstances6 extends ProdInstances7 {
+private[data] sealed abstract class ProdInstances3 {
   implicit def catsDataFunctorForProd[F[_], G[_]](implicit FF: Functor[F], GG: Functor[G]): Functor[λ[α => Prod[F, G, α]]] = new ProdFunctor[F, G] {
     def F: Functor[F] = FF
     def G: Functor[G] = GG
-  }
-  implicit def catsDataFoldableForProd[F[_], G[_]](implicit FF: Foldable[F], GF: Foldable[G]): Foldable[λ[α => Prod[F, G, α]]] = new ProdFoldable[F, G] {
-    def F: Foldable[F] = FF
-    def G: Foldable[G] = GF
-  }
-}
-
-private[data] sealed abstract class ProdInstances7 {
-  implicit def catsDataAlternativeForProd[F[_], G[_]](implicit FF: Alternative[F], GG: Alternative[G]): Alternative[λ[α => Prod[F, G, α]]] = new ProdAlternative[F, G] {
-    def F: Alternative[F] = FF
-    def G: Alternative[G] = GG
   }
 }
 

--- a/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
@@ -130,6 +130,9 @@ object arbitrary extends ArbitraryInstances0 {
   implicit def catsLawsCogenForCoproduct[F[_], G[_], A](implicit F: Cogen[F[A]], G: Cogen[G[A]]): Cogen[Coproduct[F, G, A]] =
     Cogen((seed, x) => x.run.fold(F.perturb(seed, _), G.perturb(seed, _)))
 
+  implicit def catLawsCogenForProd[F[_], G[_], A](implicit F: Cogen[F[A]], G: Cogen[G[A]]): Cogen[Prod[F, G, A]] =
+    Cogen((seed, t) => F.perturb(G.perturb(seed, t.second), t.first))
+
   implicit def catsLawsArbitraryForShow[A: Arbitrary]: Arbitrary[Show[A]] =
     Arbitrary(Show.fromToString[A])
 

--- a/tests/src/test/scala/cats/tests/ProdTests.scala
+++ b/tests/src/test/scala/cats/tests/ProdTests.scala
@@ -45,6 +45,7 @@ class ProdTests extends CatsSuite {
 
   {
     implicit val monad = ListWrapper.monad
+    implicit val iso = CartesianTests.Isomorphisms.invariant[Prod[ListWrapper, ListWrapper, ?]]
     checkAll("Prod[ListWrapper, ListWrapper, ?]", MonadTests[Prod[ListWrapper, ListWrapper, ?]].monad[Int, Int, Int])
     checkAll("Monad[Prod[ListWrapper, ListWrapper, ?]]", SerializableTests.serializable(Monad[Prod[ListWrapper, ListWrapper, ?]]))
   }

--- a/tests/src/test/scala/cats/tests/ProdTests.scala
+++ b/tests/src/test/scala/cats/tests/ProdTests.scala
@@ -49,4 +49,18 @@ class ProdTests extends CatsSuite {
     checkAll("Prod[ListWrapper, ListWrapper, ?]", MonadTests[Prod[ListWrapper, ListWrapper, ?]].monad[Int, Int, Int])
     checkAll("Monad[Prod[ListWrapper, ListWrapper, ?]]", SerializableTests.serializable(Monad[Prod[ListWrapper, ListWrapper, ?]]))
   }
+
+  {
+    implicit val foldable = ListWrapper.foldable
+    checkAll("Prod[ListWrapper, ListWrapper, ?]", FoldableTests[Prod[ListWrapper, ListWrapper, ?]].foldable[Int, Int])
+    checkAll("Foldable[Prod[ListWrapper, ListWrapper, ?]]", SerializableTests.serializable(Foldable[Prod[ListWrapper, ListWrapper, ?]]))
+  }
+
+  {
+    implicit val traverse = ListWrapper.traverse
+
+    checkAll("Prod[ListWrapper, ListWrapper, ?]", TraverseTests[Prod[ListWrapper, ListWrapper, ?]].traverse[Int, Int, Int, Int, Option, Option])
+    checkAll("Traverse[Prod[ListWrapper, ListWrapper, ?]]", SerializableTests.serializable(Traverse[Prod[ListWrapper, ListWrapper, ?]]))
+  }
+
 }

--- a/tests/src/test/scala/cats/tests/ProdTests.scala
+++ b/tests/src/test/scala/cats/tests/ProdTests.scala
@@ -18,6 +18,8 @@ class ProdTests extends CatsSuite {
   checkAll("Prod[Show, Order, Int]", ContravariantTests[λ[α => Prod[Show, Order, α]]].contravariant[Int, Int, Int])
   checkAll("Contravariant[Prod[Show, Order, Int]]", SerializableTests.serializable(Contravariant[λ[α => Prod[Show, Order, α]]]))
 
+  checkAll("Show[Prod[Option, Option, Int]]", SerializableTests.serializable(Show[Prod[Option, Option, Int]]))
+
   {
     implicit val monoidK = ListWrapper.monoidK
     checkAll("Prod[ListWrapper, ListWrapper, ?]", MonoidKTests[Prod[ListWrapper, ListWrapper, ?]].monoidK[Int])
@@ -67,6 +69,25 @@ class ProdTests extends CatsSuite {
     implicit val iso = CartesianTests.Isomorphisms.invariant[Prod[ListWrapper, ListWrapper, ?]]
     checkAll("Prod[ListWrapper, ListWrapper, ?]", MonadCombineTests[Prod[ListWrapper, ListWrapper, ?]].monadCombine[Int, Int, Int])
     checkAll("MonadCombine[Prod[ListWrapper, ListWrapper, ?]]", SerializableTests.serializable(MonadCombine[Prod[ListWrapper, ListWrapper, ?]]))
+  }
+
+  test("order") {
+    forAll { t: Prod[Id, Id, Int] =>
+      val u: Prod[Id, Id, Int] = Prod(t.second, t.first)
+      val Prod(t1, t2) = t
+      val Prod(u1, u2) = u
+
+      Order[Prod[Id, Id, Int]].compare(t, u) should === (Order[(Int, Int)].compare((t1, t2), (u1, u2)))
+    }
+  }
+
+  test("show") {
+    forAll { (l1: Option[Int], l2: Option[Int]) =>
+      val showOptionInt = implicitly[Show[Option[Int]]]
+      val prod = Prod(l1, l2)
+
+      Show[Prod[Option, Option, Int]].show(prod) should === (s"Prod(${showOptionInt.show(l1)}, ${showOptionInt.show(l2)})")
+    }
   }
 
 }

--- a/tests/src/test/scala/cats/tests/ProdTests.scala
+++ b/tests/src/test/scala/cats/tests/ProdTests.scala
@@ -58,9 +58,15 @@ class ProdTests extends CatsSuite {
 
   {
     implicit val traverse = ListWrapper.traverse
-
     checkAll("Prod[ListWrapper, ListWrapper, ?]", TraverseTests[Prod[ListWrapper, ListWrapper, ?]].traverse[Int, Int, Int, Int, Option, Option])
     checkAll("Traverse[Prod[ListWrapper, ListWrapper, ?]]", SerializableTests.serializable(Traverse[Prod[ListWrapper, ListWrapper, ?]]))
+  }
+
+  {
+    implicit val monadCombine = ListWrapper.monadCombine
+    implicit val iso = CartesianTests.Isomorphisms.invariant[Prod[ListWrapper, ListWrapper, ?]]
+    checkAll("Prod[ListWrapper, ListWrapper, ?]", MonadCombineTests[Prod[ListWrapper, ListWrapper, ?]].monadCombine[Int, Int, Int])
+    checkAll("MonadCombine[Prod[ListWrapper, ListWrapper, ?]]", SerializableTests.serializable(MonadCombine[Prod[ListWrapper, ListWrapper, ?]]))
   }
 
 }

--- a/tests/src/test/scala/cats/tests/ProdTests.scala
+++ b/tests/src/test/scala/cats/tests/ProdTests.scala
@@ -6,6 +6,7 @@ import cats.functor.Contravariant
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
+import cats.kernel.laws.OrderLaws
 
 class ProdTests extends CatsSuite {
   implicit val iso = CartesianTests.Isomorphisms.invariant[Prod[Option, List, ?]]
@@ -71,14 +72,14 @@ class ProdTests extends CatsSuite {
     checkAll("MonadCombine[Prod[ListWrapper, ListWrapper, ?]]", SerializableTests.serializable(MonadCombine[Prod[ListWrapper, ListWrapper, ?]]))
   }
 
-  test("order") {
-    forAll { t: Prod[Id, Id, Int] =>
-      val u: Prod[Id, Id, Int] = Prod(t.second, t.first)
-      val Prod(t1, t2) = t
-      val Prod(u1, u2) = u
+  {
+    implicit val E = ListWrapper.eqv[Int]
+    implicit val O = ListWrapper.order[Int]
+    implicit val P = ListWrapper.partialOrder[Int]
 
-      Order[Prod[Id, Id, Int]].compare(t, u) should === (Order[(Int, Int)].compare((t1, t2), (u1, u2)))
-    }
+    checkAll("Prod[ListWrapper, ListWrapper, Int]", OrderLaws[Prod[ListWrapper, ListWrapper, Int]].eqv)
+    checkAll("Prod[ListWrapper, ListWrapper, Int]", OrderLaws[Prod[ListWrapper, ListWrapper, Int]].order)
+    checkAll("Prod[ListWrapper, ListWrapper, Int]", OrderLaws[Prod[ListWrapper, ListWrapper, Int]].partialOrder)
   }
 
   test("show") {

--- a/tests/src/test/scala/cats/tests/ProdTests.scala
+++ b/tests/src/test/scala/cats/tests/ProdTests.scala
@@ -84,10 +84,9 @@ class ProdTests extends CatsSuite {
 
   test("show") {
     forAll { (l1: Option[Int], l2: Option[Int]) =>
-      val showOptionInt = implicitly[Show[Option[Int]]]
       val prod = Prod(l1, l2)
 
-      Show[Prod[Option, Option, Int]].show(prod) should === (s"Prod(${showOptionInt.show(l1)}, ${showOptionInt.show(l2)})")
+      Show[Prod[Option, Option, Int]].show(prod) should === (s"Prod(${Show[Option[Int]].show(l1)}, ${Show[Option[Int]].show(l2)})")
     }
   }
 

--- a/tests/src/test/scala/cats/tests/ProdTests.scala
+++ b/tests/src/test/scala/cats/tests/ProdTests.scala
@@ -42,4 +42,10 @@ class ProdTests extends CatsSuite {
     checkAll("Prod[ListWrapper, ListWrapper, ?]", FunctorTests[Prod[ListWrapper, ListWrapper, ?]].functor[Int, Int, Int])
     checkAll("Functor[Prod[ListWrapper, ListWrapper, ?]]", SerializableTests.serializable(Functor[Prod[ListWrapper, ListWrapper, ?]]))
   }
+
+  {
+    implicit val monad = ListWrapper.monad
+    checkAll("Prod[ListWrapper, ListWrapper, ?]", MonadTests[Prod[ListWrapper, ListWrapper, ?]].monad[Int, Int, Int])
+    checkAll("Monad[Prod[ListWrapper, ListWrapper, ?]]", SerializableTests.serializable(Monad[Prod[ListWrapper, ListWrapper, ?]]))
+  }
 }


### PR DESCRIPTION
Creating more instances for `Prod`:

- [x] `Monad`
- [x] `Foldable`
- [x] `Traverse`
- [x] `Order`
- [x] `MonadCombine`
- [x] `Show`

fixes https://github.com/typelevel/cats/issues/1375