### PR TITLE
fix homepage docs

### DIFF
--- a/docs/src/site/index.md
+++ b/docs/src/site/index.md
@@ -16,6 +16,7 @@ The name is a playful shortening of the word *category*.
 
 ### <a name="getting-started" href="#getting-started"></a>Getting Started
 
+
 Cats is currently available for Scala 2.10 and 2.11.
 
 To get started with SBT, simply add the following to your build.sbt file:
@@ -34,7 +35,9 @@ functionality, you can pick-and-choose from amongst these modules
 
 Release notes for Cats are available in [CHANGES.md](https://github.com/typelevel/cats/blob/master/CHANGES.md).
 
+
 # <a name="motivations" href="#motivations"></a>Motivations
+
 
 ### Approachability
 

--- a/docs/src/site/index.md
+++ b/docs/src/site/index.md
@@ -81,7 +81,9 @@ we can without making unnecessary sacrifices of purity and
 usability. Where sacrifices have to be made, we will strive to make
 these obvious, and will keep them well documented.
 
+
 ### <a name="project-structure" href="#project-structure"></a>Project Structure
+
 
 In an attempt to be more modular, Cats is broken up into a number of sub-projects:
 
@@ -92,7 +94,9 @@ In an attempt to be more modular, Cats is broken up into a number of sub-project
 * *tests* - tests that check type class instances with laws from *laws*
 * *docs* - The source for this website
 
+
 ### <a name="copyright" href="#copyright"></a>Copyright and License
+
 
 All code is available to you under the MIT license, available at
 http://opensource.org/licenses/mit-license.php and also in the


### PR DESCRIPTION
Previously, _Getting Started_ and _Motivations_ headers didn't look
correctly because of the spacing.

# Before:
![screen shot 2016-10-11 at 09 53 00](https://cloud.githubusercontent.com/assets/694179/19262668/957c4278-8f98-11e6-80f0-f2926e233c32.png)

# After:
![screen shot 2016-10-11 at 09 53 16](https://cloud.githubusercontent.com/assets/694179/19262671/9bac4a76-8f98-11e6-9336-ca9ca2ebf56c.png)
