### PR TITLE
0.8.0 time!

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -26,18 +26,22 @@ possible:
  * Amir Mohammad Saied
  * Andrea Fiore
  * Andrew Jones
+ * Andy Scott
  * Angelo Genovese
  * Antoine Comte
  * Arya Irani
  * Ash Pook
  * Aλ
+ * Ben Hutchison
  * Benjamin Thuillier
  * Binh Nguyen
  * Bobby Rauchenberg
  * Brendan McAdams
  * Brian McKenna
+ * Chris Birchall
  * Cody Allen
  * Colt Frederickson
+ * Connie Chen
  * Csongor Kiss
  * Dale Wijnand
  * Daniel Spiewak
@@ -48,6 +52,7 @@ possible:
  * David Gregory
  * Denis Mikhaylov
  * Derek Wickern
+ * Earl St Sauver
  * Edmund Noble
  * Eric Torreborre
  * Erik LaBianca
@@ -57,11 +62,15 @@ possible:
  * Feynman Liang
  * Frank S. Thomas
  * Giulio De Luise
+ * Guillaume Massé
  * Hamish Dickson
  * Ian McIntosh
  * ImLiar
+ * Israel Pérez González
+ * Jan-Hendrik Zab
  * Jean-Rémi Desjardins
  * Jisoo Park
+ * Jon Hanson
  * Jose Emilio Labra Gayo
  * Josh Marcus
  * Juan Pedro Moreno
@@ -75,6 +84,7 @@ possible:
  * Luke Wyman
  * Madder
  * Marc Siegel
+ * Mark de Jong
  * Markus Hauck
  * mathhun
  * Matt Martin
@@ -91,16 +101,20 @@ possible:
  * Pascal Voitot
  * Paul Phillips
  * Pavkin Vladimir
+ * Pepe García
  * Pere Villega
  * Peter Neyens
  * Philip Wills
+ * Rafa Paradela
  * Raúl Raja Martínez
  * Richard Miller
  * Rintcius Blok
  * Rob Norris
  * Romain Ruetschi
  * Ross A. Baker
+ * Rüdiger Klaehn
  * Ryan Case
+ * Sam Ritchie
  * Sarunas Valaskevicius
  * Shunsuke Otani
  * Simeon H. K. Fitch
@@ -110,6 +124,7 @@ possible:
  * Stew O'Connor
  * Sumedh Mungee
  * Taylor Brown
+ * Tom Switzer
  * Tomas Mikula
  * Travis Brown
  * Wedens

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -56,7 +56,7 @@ Miscellaneous improvements (syntax, documentation, tests):
  * [#1386](https://github.com/typelevel/cats/pull/1386): `FunctionK` tests and examples now use kind-projector 0.9's polymorphic lambdas
  * [#1410](https://github.com/typelevel/cats/pull/1410): Replace `Coproduct#run` with `Coproduct#fold`
  * [#1331](https://github.com/typelevel/cats/pull/1331): Less expensive `tailRecM`-`flatMap` consistency checking
- * [#1330](https://github.com/typelevel/cats/pull/1330): More consistent parameter-less method definitions and usage, other syntactic improvments
+ * [#1330](https://github.com/typelevel/cats/pull/1330): More consistent parameter-less method definitions and usage, other syntactic improvements
  * [#1340](https://github.com/typelevel/cats/pull/1340): New [Scaladex](https://index.scala-lang.org) badge
  * [#1416](https://github.com/typelevel/cats/pull/1416): New diagram of type classes
  * [#1352](https://github.com/typelevel/cats/pull/1352): API docs for `FunctionK`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 ## Version 0.8.0
 
-> 2016 October 18
+> 2016 October 25
 
 Version 0.8.0 is the eighth Cats release, and the first release with support for Scala 2.12 (specifically the 2.12.0-RC2 release candidate).
 
@@ -8,10 +8,11 @@ Apart from the introduction of Scala 2.12 support, the biggest change in this re
 of `Xor` and `XorT`. See the [FAQ](http://typelevel.org/cats/faq.html#either) for information about
 the motivations for this change and recommendations for migration.
 
-Removals:
+Removals and deprecations:
 
- * [#1310](https://github.com/typelevel/cats/pull/1310): `Xor` and `XorT`
+ * [#1310](https://github.com/typelevel/cats/pull/1310): `Xor` and `XorT` are gone
  * [#1370](https://github.com/typelevel/cats/pull/1370): `RecursiveTailRecM` and `Free#foldMapUnsafe` are gone and stack safety is checked in the laws for `Monad`
+ * [#1411](https://github.com/typelevel/cats/pull/1411): `FreeT#interpret` is deprecated in favor of the (equivalent) `compile`
 
 Additions:
 
@@ -29,6 +30,7 @@ Additions:
  * [#1399](https://github.com/typelevel/cats/pull/1399): `Order.fromComparable`
  * [#1394](https://github.com/typelevel/cats/pull/1394): `Traverse#flatSequence`
  * [#1417](https://github.com/typelevel/cats/pull/1417): `MonadTests#stackUnsafeMonad` laws for instances where `tailRecM` is known to be unsafe
+ * [#1411](https://github.com/typelevel/cats/pull/1411): `compile` and `foldMap` for the `Free` and `FreeT` companion objects
 
 New instances:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,60 @@
+## Version 0.8.0
+
+> 2016 October 18
+
+Version 0.8.0 is the eighth Cats release.
+
+Removals:
+
+ * [#1310](https://github.com/typelevel/cats/pull/1310): `Xor` and `XorT`
+ * [#1370](https://github.com/typelevel/cats/pull/1370): `RecursiveTailRecM` and `Free#foldMapUnsafe` are gone and stack safety is checked in the laws for `Monad`
+
+Additions:
+
+ * [#1356](https://github.com/typelevel/cats/pull/1356): `append` and `prepend` (and operator aliases) for `NonEmptyVector`
+ * [#1327](https://github.com/typelevel/cats/pull/1327): `EitherT.fromOption`
+ * [#1388](https://github.com/typelevel/cats/pull/1388): `StateT.set` and `StateT.setF`
+ * [#1392](https://github.com/typelevel/cats/pull/1392): `StateT.get`
+ * [#1325](https://github.com/typelevel/cats/pull/1325): `WriterT.lift`
+ * [#1391](https://github.com/typelevel/cats/pull/1391): `MonadReader#reader`
+ * [#1352](https://github.com/typelevel/cats/pull/1352): Macro-powered `FunctionK.lift`
+ * [#1398](https://github.com/typelevel/cats/pull/1398): `<<<` and `>>>` aliases for `Compose`'s `compose` and `andThen`
+
+New instances:
+
+ * [#1319](https://github.com/typelevel/cats/pull/1319): `Order` and `Group` for `BigDecimal`
+ * [#1354](https://github.com/typelevel/cats/pull/1354): `Semigroup` for `Ior`
+ * [#1395](https://github.com/typelevel/cats/pull/1395): `Order` for `Symbol`
+ * [#1324](https://github.com/typelevel/cats/pull/1324): `PartialOrder` and other instances for `BitSet`
+ * [#1324](https://github.com/typelevel/cats/pull/1324): `Eq` and `PartialOrder` for `Either`
+ * [#1324](https://github.com/typelevel/cats/pull/1324): `PartialOrder`, `Monoid`, and other instances for `Function0`
+ * [#1324](https://github.com/typelevel/cats/pull/1324): `Monoid` and other instances for `Function1`
+
+Renaming and rearrangements:
+
+ * [#1385](https://github.com/typelevel/cats/pull/1385): The `cats.js.std` package is now `cats.js.instances`
+ * [#1324](https://github.com/typelevel/cats/pull/1324): Many instances moved from cats-core to cats-kernel
+
+Miscellaneous improvements (syntax, documentation, tests):
+
+ * [#1347](https://github.com/typelevel/cats/pull/1347): Consistency laws for `combineAll` and `combineAllOption`
+ * [#1324](https://github.com/typelevel/cats/pull/1324): Performance improvements for `Either` instances
+ * [#1386](https://github.com/typelevel/cats/pull/1386): `FunctionK` tests and examples now use kind-projector 0.9's polymorphic lambdas
+ * [#1410](https://github.com/typelevel/cats/pull/1410): Replace `Coproduct#run` with `Coproduct#fold`
+ * [#1331](https://github.com/typelevel/cats/pull/1331): Less expensive `tailRecM`-`flatMap` consistency checking
+ * [#1330](https://github.com/typelevel/cats/pull/1330): More consistent parameter-less method definitions and usage, other syntactic improvments
+ * [#1340](https://github.com/typelevel/cats/pull/1340): New [Scaladex](https://index.scala-lang.org) badge
+ * [#1352](https://github.com/typelevel/cats/pull/1352): API docs for `FunctionK`
+ * [#1259](https://github.com/typelevel/cats/pull/1259): 0.6-to-0.7 migration guide
+ * [#1304](https://github.com/typelevel/cats/pull/1304), [#1317](https://github.com/typelevel/cats/pull/1317), [#1323](https://github.com/typelevel/cats/pull/1323), [#1350](https://github.com/typelevel/cats/pull/1350), [#1366](https://github.com/typelevel/cats/pull/1366), [#1376](https://github.com/typelevel/cats/pull/1376), [#1380](https://github.com/typelevel/cats/pull/1380), [#1390](https://github.com/typelevel/cats/pull/1390), [#1407](https://github.com/typelevel/cats/pull/1407): Other miscellaneous documentation improvements
+
+Build:
+
+ * [#1345](https://github.com/typelevel/cats/pull/1345): Update ScalaCheck (to 1.13.2) and Discipline (to 0.6)
+ * [#1353](https://github.com/typelevel/cats/pull/1353): Generated sources are included in source jars
+ * [#1322](https://github.com/typelevel/cats/pull/1322): Scala.js test clean-up
+ * [#1389](https://github.com/typelevel/cats/pull/1389): More memory for Travis CI
+
 ## Version 0.7.2
 
 > 2016 September 1

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,10 @@
 
 Version 0.8.0 is the eighth Cats release, and the first release with support for Scala 2.12 (specifically the 2.12.0-RC2 release candidate).
 
+Apart from the introduction of Scala 2.12 support, the biggest change in this release is the removal
+of `Xor` and `XorT`. See the [FAQ](http://typelevel.org/cats/faq.html#either) for information about
+the motivations for this change and recommendations for migration.
+
 Removals:
 
  * [#1310](https://github.com/typelevel/cats/pull/1310): `Xor` and `XorT`

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 > 2016 October 18
 
-Version 0.8.0 is the eighth Cats release.
+Version 0.8.0 is the eighth Cats release, and the first release with support for Scala 2.12 (specifically the 2.12.0-RC2 release candidate).
 
 Removals:
 
@@ -11,6 +11,8 @@ Removals:
 
 Additions:
 
+ * [#1382](https://github.com/typelevel/cats/pull/1382), [#1415](https://github.com/typelevel/cats/pull/1415): Support for Scala 2.12.0-RC2
+ * [#1414](https://github.com/typelevel/cats/pull/1414): `Foldable#iteratorFoldM` and lazy `foldM` implementations for many standard library instances
  * [#1356](https://github.com/typelevel/cats/pull/1356): `append` and `prepend` (and operator aliases) for `NonEmptyVector`
  * [#1327](https://github.com/typelevel/cats/pull/1327): `EitherT.fromOption`
  * [#1388](https://github.com/typelevel/cats/pull/1388): `StateT.set` and `StateT.setF`
@@ -19,6 +21,10 @@ Additions:
  * [#1391](https://github.com/typelevel/cats/pull/1391): `MonadReader#reader`
  * [#1352](https://github.com/typelevel/cats/pull/1352): Macro-powered `FunctionK.lift`
  * [#1398](https://github.com/typelevel/cats/pull/1398): `<<<` and `>>>` aliases for `Compose`'s `compose` and `andThen`
+ * [#1408](https://github.com/typelevel/cats/pull/1408): `toNestedValidated` and `toNestedValidatedNel` for `EitherT`
+ * [#1399](https://github.com/typelevel/cats/pull/1399): `Order.fromComparable`
+ * [#1394](https://github.com/typelevel/cats/pull/1394): `Traverse#flatSequence`
+ * [#1417](https://github.com/typelevel/cats/pull/1417): `MonadTests#stackUnsafeMonad` laws for instances where `tailRecM` is known to be unsafe
 
 New instances:
 
@@ -29,11 +35,13 @@ New instances:
  * [#1324](https://github.com/typelevel/cats/pull/1324): `Eq` and `PartialOrder` for `Either`
  * [#1324](https://github.com/typelevel/cats/pull/1324): `PartialOrder`, `Monoid`, and other instances for `Function0`
  * [#1324](https://github.com/typelevel/cats/pull/1324): `Monoid` and other instances for `Function1`
+ * [#1399](https://github.com/typelevel/cats/pull/1399): Instances for `java.util.UUID`
 
 Renaming and rearrangements:
 
  * [#1385](https://github.com/typelevel/cats/pull/1385): The `cats.js.std` package is now `cats.js.instances`
  * [#1324](https://github.com/typelevel/cats/pull/1324): Many instances moved from cats-core to cats-kernel
+ * [#1394](https://github.com/typelevel/cats/pull/1394): `Traverse#traverseM` is now `flatTraverse`
 
 Miscellaneous improvements (syntax, documentation, tests):
 
@@ -45,8 +53,9 @@ Miscellaneous improvements (syntax, documentation, tests):
  * [#1330](https://github.com/typelevel/cats/pull/1330): More consistent parameter-less method definitions and usage, other syntactic improvments
  * [#1340](https://github.com/typelevel/cats/pull/1340): New [Scaladex](https://index.scala-lang.org) badge
  * [#1352](https://github.com/typelevel/cats/pull/1352): API docs for `FunctionK`
+ * [#1369](https://github.com/typelevel/cats/pull/1369), [#1418](https://github.com/typelevel/cats/pull/1418): New project site based on [sbt-microsites](https://github.com/47deg/sbt-microsites)
  * [#1259](https://github.com/typelevel/cats/pull/1259): 0.6-to-0.7 migration guide
- * [#1304](https://github.com/typelevel/cats/pull/1304), [#1317](https://github.com/typelevel/cats/pull/1317), [#1323](https://github.com/typelevel/cats/pull/1323), [#1350](https://github.com/typelevel/cats/pull/1350), [#1366](https://github.com/typelevel/cats/pull/1366), [#1376](https://github.com/typelevel/cats/pull/1376), [#1380](https://github.com/typelevel/cats/pull/1380), [#1390](https://github.com/typelevel/cats/pull/1390), [#1407](https://github.com/typelevel/cats/pull/1407): Other miscellaneous documentation improvements
+ * [#1304](https://github.com/typelevel/cats/pull/1304), [#1317](https://github.com/typelevel/cats/pull/1317), [#1323](https://github.com/typelevel/cats/pull/1323), [#1350](https://github.com/typelevel/cats/pull/1350), [#1366](https://github.com/typelevel/cats/pull/1366), [#1376](https://github.com/typelevel/cats/pull/1376), [#1380](https://github.com/typelevel/cats/pull/1380), [#1390](https://github.com/typelevel/cats/pull/1390), [#1403](https://github.com/typelevel/cats/pull/1403), [#1407](https://github.com/typelevel/cats/pull/1407), [#1421](https://github.com/typelevel/cats/pull/1421): Other miscellaneous documentation improvements
 
 Build:
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -35,6 +35,8 @@ New instances:
  * [#1324](https://github.com/typelevel/cats/pull/1324): `Eq` and `PartialOrder` for `Either`
  * [#1324](https://github.com/typelevel/cats/pull/1324): `PartialOrder`, `Monoid`, and other instances for `Function0`
  * [#1324](https://github.com/typelevel/cats/pull/1324): `Monoid` and other instances for `Function1`
+ * [#1402](https://github.com/typelevel/cats/pull/1402): `Monad`, `MonadCombine`, `Traverse`, `Order`, etc. for `Prod`
+ * [#1413](https://github.com/typelevel/cats/pull/1413): `MonadError` for `StateT`
  * [#1399](https://github.com/typelevel/cats/pull/1399): Instances for `java.util.UUID`
 
 Renaming and rearrangements:
@@ -52,6 +54,7 @@ Miscellaneous improvements (syntax, documentation, tests):
  * [#1331](https://github.com/typelevel/cats/pull/1331): Less expensive `tailRecM`-`flatMap` consistency checking
  * [#1330](https://github.com/typelevel/cats/pull/1330): More consistent parameter-less method definitions and usage, other syntactic improvments
  * [#1340](https://github.com/typelevel/cats/pull/1340): New [Scaladex](https://index.scala-lang.org) badge
+ * [#1416](https://github.com/typelevel/cats/pull/1416): New diagram of type classes
  * [#1352](https://github.com/typelevel/cats/pull/1352): API docs for `FunctionK`
  * [#1369](https://github.com/typelevel/cats/pull/1369), [#1418](https://github.com/typelevel/cats/pull/1418): New project site based on [sbt-microsites](https://github.com/47deg/sbt-microsites)
  * [#1259](https://github.com/typelevel/cats/pull/1259): 0.6-to-0.7 migration guide
@@ -62,6 +65,7 @@ Build:
  * [#1345](https://github.com/typelevel/cats/pull/1345): Update ScalaCheck (to 1.13.2) and Discipline (to 0.6)
  * [#1353](https://github.com/typelevel/cats/pull/1353): Generated sources are included in source jars
  * [#1322](https://github.com/typelevel/cats/pull/1322): Scala.js test clean-up
+ * [#1426](https://github.com/typelevel/cats/pull/1426): Human-friendly names in metadata for published artifacts
  * [#1389](https://github.com/typelevel/cats/pull/1389): More memory for Travis CI
 
 ## Version 0.7.2


### PR DESCRIPTION
I'd like to get an 0.8.0 release out sooner rather than later (see discussion on [Gitter](https://gitter.im/typelevel/cats?at=58068e502189c68f42fb6df9)), so I thought I'd get the ball rolling with a first draft of the release notes.

I'll also start a checklist for things that need to happen before the release. I'm only including PRs that other people have expressed an interest in seeing in this release (e.g. #1382) or that look ready-to-go and non-controversial, but we can add others if there's other stuff people want in 0.8.

- [x] Make a decision on #1334 (rename `Bifunctor` to `Functor2`, etc.)
- [x] Merge #1417 (`stackUnsafeMonad` laws, has two :+1:s)
- [x] Merge #1416 (type class hierarchy diagram, two :+1:s)
- [x] Merge #1399 (instances for `UUID`, has two :+1:s)
- [x] Merge #1394 (`flatTraverse` and `flatSequence`, has two :+1:s)
- [x] Merge #1415 (Scala 2.12.0-RC2 support, three :+1:s)
- [x] Review and merge #1408 (`toNestedValidated` for `EitherT`, one :+1:)
- [x] Review and merge #1402 (more `Prod` instances, two 👍 s)
- [x] Review and merge #1411 (`Free.foldMap` and `compile`)
- [x] Add `Xor`-to-`Either` migration guide
- [x] Review and merge #1428 (minor clarification in FAQ about `Xor` and `Either`)
- [x] Review FAQ entry about required stack safety of `tailRecM` (#1427)
- [x] Finalize release notes

I'll take care of finalizing the release notes, and could take a stab at the migration guide and `tailRecM` notes, but someone else might be able to get to those two tasks before me.

