### PR TITLE
Lazy foldM for "Iterables"

### DIFF
--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -379,11 +379,11 @@ object Foldable {
     loop()
   }
 
-  def iterableFoldM[M[_], A, B](fa: Iterable[A], z: B)(f: (B, A) => M[B])(implicit M: Monad[M]): M[B] = {
-    val go: ((B, Iterable[A])) => M[Either[(B, Iterable[A]), B]] = { case (b, fa) =>
-      if (fa.isEmpty) M.pure(Right(b))
-      else M.map(f(b, fa.head))(b1 => Left((b1, fa.tail)))
+  def iteratorFoldM[M[_], A, B](it: Iterator[A], z: B)(f: (B, A) => M[B])(implicit M: Monad[M]): M[B] = {
+    val go: ((B, Iterator[A])) => M[Either[(B, Iterator[A]), B]] = { case (b, it) =>
+      if (it.hasNext) M.map(f(b, it.next))(b1 => Left((b1, it)))
+      else M.pure(Right(b))
     }
-    M.tailRecM((z, fa))(go)
+    M.tailRecM((z, it))(go)
   }
 }

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -1,5 +1,6 @@
 package cats
 
+import cats.data.Xor
 import scala.collection.mutable
 import cats.instances.long._
 import simulacrum.typeclass
@@ -172,10 +173,26 @@ import simulacrum.typeclass
     foldLeft(fa, B.empty)((b, a) => B.combine(b, f(a)))
 
   /**
-   * Left associative monadic folding on `F`.
+   * Left associative monadic fold on `F`.
+   *
+   * The default implementation of this is based on `foldLeft`, and thus will
+   * always fold across the entire structure. When `G` has a `MonadRec` instance,
+   * the [[foldMRec]] variation may be preferred, as it may be able to
+   * short-circuit the fold.
    */
   def foldM[G[_], A, B](fa: F[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
     foldLeft(fa, G.pure(z))((gb, a) => G.flatMap(gb)(f(_, a)))
+
+  /**
+   * Left associative monadic fold on `F`.
+   *
+   * This is similar to [[foldM]] (and the default implementation is
+   * identical), but certain structures are able to implement this in such a
+   * way that folds can be short-circuited (not traverse the entirety of the
+   * structure), depending on the `G` result produced at a given step.
+   */
+  def foldMRec[G[_], A, B](fa: F[A], z: B)(f: (B, A) => G[B])(implicit G: MonadRec[G]): G[B] =
+    foldM(fa, z)(f)
 
   /**
    * Traverse `F[A]` using `Applicative[G]`.
@@ -371,5 +388,13 @@ object Foldable {
     def loop(): Eval[B] =
       Eval.defer(if (it.hasNext) f(it.next, loop()) else lb)
     loop()
+  }
+
+  def iterableFoldMRec[M[_], A, B](fa: Iterable[A], z: B)(f: (B, A) => M[B])(implicit M: MonadRec[M]): M[B] = {
+    val go: ((B, Iterable[A])) => M[(B, Iterable[A]) Xor B] = { case (b, fa) =>
+      if (fa.isEmpty) M.pure(Xor.right(b))
+      else M.map(f(b, fa.head))(b1 => Xor.left((b1, fa.tail)))
+    }
+    M.tailRecM((z, fa))(go)
   }
 }

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -80,8 +80,8 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
 
       override def filter[A](fa: List[A])(f: A => Boolean): List[A] = fa.filter(f)
 
-      override def foldMRec[G[_], A, B](fa: List[A], z: B)(f: (B, A) => G[B])(implicit G: MonadRec[G]): G[B] =
-        Foldable.iterableFoldMRec(fa, z)(f)
+      override def foldM[G[_], A, B](fa: List[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
+        Foldable.iterableFoldM(fa, z)(f)
     }
 
   implicit def catsStdShowForList[A:Show]: Show[List[A]] =

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -81,7 +81,7 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
       override def filter[A](fa: List[A])(f: A => Boolean): List[A] = fa.filter(f)
 
       override def foldM[G[_], A, B](fa: List[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
-        Foldable.iterableFoldM(fa, z)(f)
+        Foldable.iteratorFoldM(fa.toIterator, z)(f)
     }
 
   implicit def catsStdShowForList[A:Show]: Show[List[A]] =

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -79,6 +79,9 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
       override def isEmpty[A](fa: List[A]): Boolean = fa.isEmpty
 
       override def filter[A](fa: List[A])(f: A => Boolean): List[A] = fa.filter(f)
+
+      override def foldMRec[G[_], A, B](fa: List[A], z: B)(f: (B, A) => G[B])(implicit G: MonadRec[G]): G[B] =
+        Foldable.iterableFoldMRec(fa, z)(f)
     }
 
   implicit def catsStdShowForList[A:Show]: Show[List[A]] =

--- a/core/src/main/scala/cats/instances/map.scala
+++ b/core/src/main/scala/cats/instances/map.scala
@@ -80,7 +80,7 @@ trait MapInstances extends cats.kernel.instances.MapInstances {
       override def isEmpty[A](fa: Map[K, A]): Boolean = fa.isEmpty
 
       override def foldM[G[_], A, B](fa: Map[K, A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
-        Foldable.iterableFoldM(fa.values, z)(f)
+        Foldable.iteratorFoldM(fa.valuesIterator, z)(f)
     }
   // scalastyle:on method.length
 }

--- a/core/src/main/scala/cats/instances/map.scala
+++ b/core/src/main/scala/cats/instances/map.scala
@@ -79,8 +79,8 @@ trait MapInstances extends cats.kernel.instances.MapInstances {
 
       override def isEmpty[A](fa: Map[K, A]): Boolean = fa.isEmpty
 
-      override def foldMRec[G[_], A, B](fa: Map[K, A], z: B)(f: (B, A) => G[B])(implicit G: MonadRec[G]): G[B] =
-        Foldable.iterableFoldMRec(fa.values, z)(f)
+      override def foldM[G[_], A, B](fa: Map[K, A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
+        Foldable.iterableFoldM(fa.values, z)(f)
     }
   // scalastyle:on method.length
 }

--- a/core/src/main/scala/cats/instances/map.scala
+++ b/core/src/main/scala/cats/instances/map.scala
@@ -78,6 +78,9 @@ trait MapInstances extends cats.kernel.instances.MapInstances {
       override def size[A](fa: Map[K, A]): Long = fa.size.toLong
 
       override def isEmpty[A](fa: Map[K, A]): Boolean = fa.isEmpty
+
+      override def foldMRec[G[_], A, B](fa: Map[K, A], z: B)(f: (B, A) => G[B])(implicit G: MonadRec[G]): G[B] =
+        Foldable.iterableFoldMRec(fa.values, z)(f)
     }
   // scalastyle:on method.length
 }

--- a/core/src/main/scala/cats/instances/set.scala
+++ b/core/src/main/scala/cats/instances/set.scala
@@ -29,9 +29,7 @@ trait SetInstances extends cats.kernel.instances.SetInstances {
       override def isEmpty[A](fa: Set[A]): Boolean = fa.isEmpty
 
       override def foldM[G[_], A, B](fa: Set[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
-        // Repeatedly calling .tail on a large set is really slow, so we
-        // convert to a stream first.
-        Foldable.iterableFoldM(fa.toStream, z)(f)
+        Foldable.iteratorFoldM(fa.toIterator, z)(f)
     }
 
   implicit def catsStdShowForSet[A:Show]: Show[Set[A]] = new Show[Set[A]] {

--- a/core/src/main/scala/cats/instances/set.scala
+++ b/core/src/main/scala/cats/instances/set.scala
@@ -27,6 +27,11 @@ trait SetInstances extends cats.kernel.instances.SetInstances {
         fa.forall(p)
 
       override def isEmpty[A](fa: Set[A]): Boolean = fa.isEmpty
+
+      override def foldMRec[G[_], A, B](fa: Set[A], z: B)(f: (B, A) => G[B])(implicit G: MonadRec[G]): G[B] =
+        // Repeatedly calling .tail on a large set is really slow, so we
+        // convert to a stream first.
+        Foldable.iterableFoldMRec(fa.toStream, z)(f)
     }
 
   implicit def catsStdShowForSet[A:Show]: Show[Set[A]] = new Show[Set[A]] {

--- a/core/src/main/scala/cats/instances/set.scala
+++ b/core/src/main/scala/cats/instances/set.scala
@@ -28,10 +28,10 @@ trait SetInstances extends cats.kernel.instances.SetInstances {
 
       override def isEmpty[A](fa: Set[A]): Boolean = fa.isEmpty
 
-      override def foldMRec[G[_], A, B](fa: Set[A], z: B)(f: (B, A) => G[B])(implicit G: MonadRec[G]): G[B] =
+      override def foldM[G[_], A, B](fa: Set[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
         // Repeatedly calling .tail on a large set is really slow, so we
         // convert to a stream first.
-        Foldable.iterableFoldMRec(fa.toStream, z)(f)
+        Foldable.iterableFoldM(fa.toStream, z)(f)
     }
 
   implicit def catsStdShowForSet[A:Show]: Show[Set[A]] = new Show[Set[A]] {

--- a/core/src/main/scala/cats/instances/stream.scala
+++ b/core/src/main/scala/cats/instances/stream.scala
@@ -106,6 +106,9 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
       override def filter[A](fa: Stream[A])(f: A => Boolean): Stream[A] = fa.filter(f)
 
       override def collect[A, B](fa: Stream[A])(f: PartialFunction[A, B]): Stream[B] = fa.collect(f)
+
+      override def foldMRec[G[_], A, B](fa: Stream[A], z: B)(f: (B, A) => G[B])(implicit G: MonadRec[G]): G[B] =
+        Foldable.iterableFoldMRec(fa, z)(f)
     }
 
   implicit def catsStdShowForStream[A: Show]: Show[Stream[A]] =

--- a/core/src/main/scala/cats/instances/stream.scala
+++ b/core/src/main/scala/cats/instances/stream.scala
@@ -108,7 +108,7 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
       override def collect[A, B](fa: Stream[A])(f: PartialFunction[A, B]): Stream[B] = fa.collect(f)
 
       override def foldM[G[_], A, B](fa: Stream[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
-        Foldable.iterableFoldM(fa, z)(f)
+        Foldable.iteratorFoldM(fa.toIterator, z)(f)
     }
 
   implicit def catsStdShowForStream[A: Show]: Show[Stream[A]] =

--- a/core/src/main/scala/cats/instances/stream.scala
+++ b/core/src/main/scala/cats/instances/stream.scala
@@ -107,8 +107,8 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
 
       override def collect[A, B](fa: Stream[A])(f: PartialFunction[A, B]): Stream[B] = fa.collect(f)
 
-      override def foldMRec[G[_], A, B](fa: Stream[A], z: B)(f: (B, A) => G[B])(implicit G: MonadRec[G]): G[B] =
-        Foldable.iterableFoldMRec(fa, z)(f)
+      override def foldM[G[_], A, B](fa: Stream[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
+        Foldable.iterableFoldM(fa, z)(f)
     }
 
   implicit def catsStdShowForStream[A: Show]: Show[Stream[A]] =

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -88,7 +88,7 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
       override def collect[A, B](fa: Vector[A])(f: PartialFunction[A, B]): Vector[B] = fa.collect(f)
 
       override def foldM[G[_], A, B](fa: Vector[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
-        Foldable.iterableFoldM(fa, z)(f)
+        Foldable.iteratorFoldM(fa.toIterator, z)(f)
     }
 
   implicit def catsStdShowForVector[A:Show]: Show[Vector[A]] =

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -87,8 +87,8 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
 
       override def collect[A, B](fa: Vector[A])(f: PartialFunction[A, B]): Vector[B] = fa.collect(f)
 
-      override def foldMRec[G[_], A, B](fa: Vector[A], z: B)(f: (B, A) => G[B])(implicit G: MonadRec[G]): G[B] =
-        Foldable.iterableFoldMRec(fa, z)(f)
+      override def foldM[G[_], A, B](fa: Vector[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
+        Foldable.iterableFoldM(fa, z)(f)
     }
 
   implicit def catsStdShowForVector[A:Show]: Show[Vector[A]] =

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -86,6 +86,9 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
       override def filter[A](fa: Vector[A])(f: A => Boolean): Vector[A] = fa.filter(f)
 
       override def collect[A, B](fa: Vector[A])(f: PartialFunction[A, B]): Vector[B] = fa.collect(f)
+
+      override def foldMRec[G[_], A, B](fa: Vector[A], z: B)(f: (B, A) => G[B])(implicit G: MonadRec[G]): G[B] =
+        Foldable.iterableFoldMRec(fa, z)(f)
     }
 
   implicit def catsStdShowForVector[A:Show]: Show[Vector[A]] =

--- a/tests/src/test/scala/cats/tests/FoldableTests.scala
+++ b/tests/src/test/scala/cats/tests/FoldableTests.scala
@@ -115,8 +115,7 @@ class FoldableTestsAdditional extends CatsSuite {
     val expected = n.toLong*(n.toLong+1)/2
     val foldMResult = F.foldM(fromRange(1 to n), 0L)(nonzero)
     assert(foldMResult.get == expected)
-    val foldMRecResult = F.foldMRec(fromRange(1 to n), 0L)(nonzero)
-    assert(foldMRecResult.get == expected)
+    ()
   }
 
   test("Foldable[List].foldM stack safety") {
@@ -164,8 +163,8 @@ class FoldableTestsAdditional extends CatsSuite {
     val large = Stream((1 to 10000): _*)
     assert(contains(large, 10000).value)
 
-    // test laziness of foldMRec
-    dangerous.foldMRec(0)((acc, a) => if (a < 2) Some(acc + a) else None) should === (None)
+    // test laziness of foldM
+    dangerous.foldM(0)((acc, a) => if (a < 2) Some(acc + a) else None) should === (None)
   }
 }
 

--- a/tests/src/test/scala/cats/tests/FoldableTests.scala
+++ b/tests/src/test/scala/cats/tests/FoldableTests.scala
@@ -107,14 +107,36 @@ class FoldableTestsAdditional extends CatsSuite {
     larger.value should === (large.map(_ + 1))
   }
 
-  test("Foldable[List].foldM stack safety") {
-    def nonzero(acc: Long, x: Long): Option[Long] =
+  def checkFoldMStackSafety[F[_]](fromRange: Range => F[Int])(implicit F: Foldable[F]): Unit = {
+    def nonzero(acc: Long, x: Int): Option[Long] =
       if (x == 0) None else Some(acc + x)
 
-    val n = 100000L
-    val expected = n*(n+1)/2
-    val actual = Foldable[List].foldM((1L to n).toList, 0L)(nonzero)
-    assert(actual.get == expected)
+    val n = 100000
+    val expected = n.toLong*(n.toLong+1)/2
+    val foldMResult = F.foldM(fromRange(1 to n), 0L)(nonzero)
+    assert(foldMResult.get == expected)
+    val foldMRecResult = F.foldMRec(fromRange(1 to n), 0L)(nonzero)
+    assert(foldMRecResult.get == expected)
+  }
+
+  test("Foldable[List].foldM stack safety") {
+    checkFoldMStackSafety[List](_.toList)
+  }
+
+  test("Foldable[Stream].foldM stack safety") {
+    checkFoldMStackSafety[Stream](_.toStream)
+  }
+
+  test("Foldable[Vector].foldM stack safety") {
+    checkFoldMStackSafety[Vector](_.toVector)
+  }
+
+  test("Foldable[Set].foldM stack safety") {
+    checkFoldMStackSafety[Set](_.toSet)
+  }
+
+  test("Foldable[Map[String, ?]].foldM stack safety") {
+    checkFoldMStackSafety[Map[String, ?]](_.map(x => x.toString -> x).toMap)
   }
 
   test("Foldable[Stream]") {
@@ -141,6 +163,9 @@ class FoldableTestsAdditional extends CatsSuite {
     // test trampolining
     val large = Stream((1 to 10000): _*)
     assert(contains(large, 10000).value)
+
+    // test laziness of foldMRec
+    dangerous.foldMRec(0)((acc, a) => if (a < 2) Some(acc + a) else None) should === (None)
   }
 }
 


### PR DESCRIPTION
If I am understanding correctly, now that `FlatMap` has `tailRecM` we can revisit #1030.

I adapted an [old commit](https://github.com/ceedubs/cats/commit/4d08b603f86db440a5d0db5291fac1294f8f3524) by @ceedubs for a PR to add `MonadRec` by @TomasMikula.