### PR TITLE
Rename interpret and replace ~>

### DIFF
--- a/free/src/test/scala/cats/free/FreeTTests.scala
+++ b/free/src/test/scala/cats/free/FreeTTests.scala
@@ -101,20 +101,20 @@ class FreeTTests extends CatsSuite {
     val d: FreeT[JustFunctor, JustFunctor, Int] = transLiftInstance.liftT[JustFunctor, Int](JustFunctor(1))
   }
 
-  test("interpret to universal id equivalent to original instance") {
+  test("compile to universal id equivalent to original instance") {
     forAll { a: FreeTOption[Int] =>
-      val b = a.interpret(FunctionK.id)
+      val b = a.compile(FunctionK.id)
       Eq[FreeTOption[Int]].eqv(a, b) should ===(true)
-      val fk = FreeT.interpret[Option, Option, Option](FunctionK.id)
+      val fk = FreeT.compile[Option, Option, Option](FunctionK.id)
       a should === (fk(a))
     }
   }
 
-  test("interpret stack-safety") {
+  test("compile stack-safety") {
     val a = (0 until 50000).foldLeft(Applicative[FreeTOption].pure(()))(
       (fu, i) => fu.flatMap(u => Applicative[FreeTOption].pure(u))
     )
-    val b = a.interpret(FunctionK.id) // used to overflow
+    val b = a.compile(FunctionK.id) // used to overflow
   }
 
   test("foldMap consistent with runM") {


### PR DESCRIPTION
Not that I'm impatient or anything, but here are the changes suggested by @non in @johnynek's #1411, which is currently the last thing we've said we want for the 0.8.0 release.

I went with `FunctionK` instead of `~>` because there are a lot of `FunctionK`s in cats-free and no `~>`s outside of FreeT.scala.