### PR TITLE
Revamp type classes doc

### DIFF
--- a/docs/src/main/tut/typeclasses.md
+++ b/docs/src/main/tut/typeclasses.md
@@ -5,10 +5,3 @@ section: "typeclasses"
 position: 1
 ---
 {% include_relative typeclasses/typeclasses.md %}
-
-{% for x in site.pages %}
-{% if x.section == 'typeclasses' %}
-- [{{x.title}}]({{site.baseurl}}{{x.url}})
-{% endif %}
-{% endfor %}
-

--- a/docs/src/main/tut/typeclasses/typeclasses.md
+++ b/docs/src/main/tut/typeclasses/typeclasses.md
@@ -1,8 +1,8 @@
 # Type classes
-Polymorphism is the idea that a single entity (function, object, interface) can change behavior depending on various
-implementations of an (potentially different) entity. In object-oriented languages the most common type of polymorphism
-is *subtype* polymorphism, where an abstract class or interface takes on many forms through inheritance.  Contrast this
-with *ad hoc* polymorphism, where a function varies with its inputs depending on the type.
+Type classes are a powerful tool used in functional programming to enable ad-hoc polymorphism, more commonly
+known as overloading. Where many object-oriented languages leverage subtyping for polymorphic code, functional
+programming tends towards a combination of parametric polymorphism (think type parameters, like Java generics)
+and ad-hoc polymorphism.
 
 ## Example: collapsing a list
 The following code snippets show code that sums a list of integers, concatenates a list of strings, and unions a list


### PR DESCRIPTION
Also removed type class list at bottom of type classes page since it's now in the sidebar

I think the previous version didn't really motivate type classes or discuss how type classes compare to the "usual" subclassing. I think this new one does a better job, but of course am open to comments/criticisms :-)
