### PR TITLE
Remove `defaultTailRecM` from monad doc

### DIFF
--- a/docs/src/main/tut/typeclasses/monad.md
+++ b/docs/src/main/tut/typeclasses/monad.md
@@ -136,8 +136,14 @@ implicit def optionTMonad[F[_]](implicit F : Monad[F]) = {
           case Some(a) => f(a).value
         }
       }
+
     def tailRecM[A, B](a: A)(f: A => OptionT[F, Either[A, B]]): OptionT[F, B] =
-      defaultTailRecM(a)(f)
+      OptionT {
+        F.tailRecM(a)(a0 => F.map(f(a0).value) {
+          case None => Either.right[A, Option[B]](None)
+          case Some(b0) => b0.map(Some(_))
+        })
+      }
   }
 }
 ```


### PR DESCRIPTION
Replaced `defaultTailRecM` with a handwritten example.