### PR TITLE
Fix Arbitrary instances in Free tests for ScalaCheck 1.13.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -94,7 +94,7 @@ lazy val includeGeneratedSrc: Setting[_] = {
 
 lazy val catsSettings = buildSettings ++ commonSettings ++ publishSettings ++ scoverageSettings ++ javadocSettings
 
-lazy val scalaCheckVersion = "1.13.2"
+lazy val scalaCheckVersion = "1.13.3"
 lazy val scalaTestVersion = "3.0.0"
 lazy val disciplineVersion = "0.7.1"
 

--- a/free/src/test/scala/cats/free/FreeTTests.scala
+++ b/free/src/test/scala/cats/free/FreeTTests.scala
@@ -164,7 +164,7 @@ object FreeTTests extends FreeTTestsInstances {
       F.arbitrary.map(FreeT.liftF[F, G, A])
     )
 
-    val nextDepth = Gen.chooseNum(1, maxDepth - 1)
+    val nextDepth = Gen.chooseNum(1, math.max(1, maxDepth - 1))
 
     def withFlatMapped = for {
       fDepth <- nextDepth

--- a/free/src/test/scala/cats/free/FreeTests.scala
+++ b/free/src/test/scala/cats/free/FreeTests.scala
@@ -127,7 +127,7 @@ sealed trait FreeTestsInstances {
       A.arbitrary.map(Free.pure[F, A]),
       F.arbitrary.map(Free.liftF[F, A]))
 
-    val nextDepth = Gen.chooseNum(1, maxDepth - 1)
+    val nextDepth = Gen.chooseNum(1, math.max(1, maxDepth - 1))
 
     def withFlatMapped = for {
       fDepth <- nextDepth


### PR DESCRIPTION
A couple of weeks ago [I noticed](https://gitter.im/typelevel/cats?at=58080b6d48292577613d18e9) that updating to ScalaCheck 1.13.3 was causing weird ScalaTest errors. I "fixed" this by not updating to ScalaCheck 1.13.3.

Staying on 1.13.2 is no longer an option now that we're updating to 2.12.0, and I've confirmed that the same thing happens with 1.13.4 and 2.12.0. 

The problem isn't actually ScalaTest calling `getSimpleName`—that's just making the error message uselessly obscure. Instead the problem seems to be some new bounds checking for `Gen.Choose` that was introduced in ScalaCheck 1.13.3. This PR fixes the issue by ensuring we don't call `Gen.chooseNum` with `min = 1` and `max = 0`.

This seems sensible but someone whose familiar with the logic of these `Arbitrary` instances should confirm that it doesn't mess things up.

Note that we can't update to 1.13.4 yet, since that's not published for 2.12.0-RC2. This PR will make that possible once Catalysts is ready, though.