### PR TITLE
Add Validated.fromBoolean

### DIFF
--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -220,7 +220,7 @@ sealed abstract class Validated[+E, +A] extends Product with Serializable {
     fold(_ => this, a => if (f(a)) this else Validated.invalid(onFailure))
 }
 
-object Validated extends ValidatedInstances with ValidatedFunctions{
+object Validated extends ValidatedInstances with ValidatedFunctions {
   final case class Valid[+A](a: A) extends Validated[Nothing, A]
   final case class Invalid[+E](e: E) extends Validated[E, Nothing]
 }
@@ -391,4 +391,17 @@ trait ValidatedFunctions {
    * the invalid of the `Validated` when the specified `Option` is `None`.
    */
   def fromOption[A, B](o: Option[B], ifNone: => A): Validated[A, B] = o.fold(invalid[A, B](ifNone))(valid)
+
+  /**
+   * Converts `false` to an Invalid with the given value or a Valid with Unit if `true`.
+   * This is useful to convert boolean checks, for example
+   * {{{
+   * scala> Validated.fromBoolean(1 > 42, "Not the answer")
+   * res0: Validated[String, Unit] = Invalid(Not the answer)
+   * scala> Validated.fromBoolean(42 > 1, "Not the answer")
+   * res1: Validated[String, Unit] = Valid(())
+   * }}}
+   */
+  def fromBoolean[A](cond: Boolean, ifFalse: => A): Validated[A, Unit] =
+    if (cond) valid(()) else invalid(ifFalse)
 }


### PR DESCRIPTION
This adds a new method `fromBoolean` to the `Validated` object.

The intention is that this allows an easy conversion of boolean conditions into a `Valid` or `Invalid`.

Essentially it is a shorthand for writing an `if` that returns a `Validated.valid(())` on success and otherwise some error.

Example use case:

```scala
case class Person(first: String, last: String)
def validatePerson(p: Person): ValidatedNel[String,Unit] = {
  Validated.fromBoolean(p.first.nonEmpty, "first name must not be empty").toValidatedNel |+|
    Validated.fromBoolean(p.last.nonEmpty, "last name msut not be empty").toValidatedNel
}
```