### PR TITLE
Reduce stack depth in StateT

### DIFF
--- a/core/src/main/scala/cats/data/StateT.scala
+++ b/core/src/main/scala/cats/data/StateT.scala
@@ -30,7 +30,7 @@ final class StateT[F[_], S, A](val runF: F[S => F[(S, A)]]) extends Serializable
   def map[B](f: A => B)(implicit F: Monad[F]): StateT[F, S, B] =
     transform { case (s, a) => (s, f(a)) }
 
-  def product[B](sb: StateT[F, S, B])(implicit F: Monad[F]): StateT[F, S, (A, B)] =
+  def product[B](sb: StateT[F, S, B])(implicit F: FlatMap[F]): StateT[F, S, (A, B)] =
     StateT.applyF(F.map2(runF, sb.runF) { (ssa, ssb) =>
       ssa.andThen { fsa =>
         F.flatMap(fsa) { case (s, a) =>


### PR DESCRIPTION
I hit some stack overflows using traverse with StateT. I don't think this will always solve the issue, but I tried to minimize stack depth in a number of cases.