### PR TITLE
Rename SemigroupK instance for Either for consistency

### DIFF
--- a/core/src/main/scala/cats/instances/either.scala
+++ b/core/src/main/scala/cats/instances/either.scala
@@ -92,7 +92,7 @@ trait EitherInstances extends cats.kernel.instances.EitherInstances {
     }
   // scalastyle:on method.length
 
-  implicit def catsDataSemigroupKForEither[L]: SemigroupK[Either[L, ?]] =
+  implicit def catsStdSemigroupKForEither[L]: SemigroupK[Either[L, ?]] =
     new SemigroupK[Either[L, ?]] {
       def combineK[A](x: Either[L, A], y: Either[L, A]): Either[L, A] = x match {
         case Left(_) => y


### PR DESCRIPTION
I'm not sure I entirely understand the instance naming conventions but this one was clearly inconsistent.