### PR TITLE
Phantom of the functors

### DIFF
--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -1,7 +1,7 @@
 package cats
 package data
 
-import cats.functor.Contravariant
+import cats.functor.Phantom
 
 /**
  * [[Const]] is a phantom type, it does not contain a value of its second type parameter `B`
@@ -51,8 +51,8 @@ private[data] sealed abstract class ConstInstances extends ConstInstances0 {
     def show(f: Const[A, B]): String = f.show
   }
 
-  implicit def catsDataContravariantForConst[C]: Contravariant[Const[C, ?]] = new Contravariant[Const[C, ?]] {
-    override def contramap[A, B](fa: Const[C, A])(f: (B) => A): Const[C, B] =
+  implicit def catsDataPhantomForConst[C]: Phantom[Const[C, ?]] = new Phantom[Const[C, ?]] {
+    override def pmap[A, B](fa: Const[C, A]): Const[C, B] =
       fa.retag[B]
   }
 

--- a/core/src/main/scala/cats/functor/Phantom.scala
+++ b/core/src/main/scala/cats/functor/Phantom.scala
@@ -1,0 +1,21 @@
+package cats
+package functor
+
+import simulacrum.typeclass
+
+/**
+  * Phantom-variant Functor.
+  * Values of type A must not appear in F[A].
+  * Natural result of a functor being both covariant and contravariant.
+  */
+@typeclass trait Phantom[F[_]] extends Contravariant[F] {
+  def functor: Functor[F] = new Functor[F] {
+    override def map[A, B](fa: F[A])(f: (A) => B): F[B] = pmap(fa)
+  }
+
+  def pmap[A, B](fa: F[A]): F[B]
+
+  override def imap[A, B](fa: F[A])(f: A => B)(g: B => A): F[B] = pmap[A, B](fa)
+
+  override def contramap[A, B](fa: F[A])(f: B => A): F[B] = pmap[A, B](fa)
+}

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -29,6 +29,7 @@ package object syntax {
   object option extends OptionSyntax
   object order extends OrderSyntax
   object partialOrder extends PartialOrderSyntax
+  object phantom extends PhantomSyntax
   object profunctor extends ProfunctorSyntax
   object reducible extends ReducibleSyntax
   object semigroup extends SemigroupSyntax

--- a/core/src/main/scala/cats/syntax/phantom.scala
+++ b/core/src/main/scala/cats/syntax/phantom.scala
@@ -1,0 +1,6 @@
+package cats
+package syntax
+
+import cats.functor.Phantom
+
+trait PhantomSyntax extends Phantom.ToPhantomOps

--- a/docs/src/main/tut/datatypes/const.md
+++ b/docs/src/main/tut/datatypes/const.md
@@ -25,7 +25,7 @@ final case class Const[A, B](getConst: A)
 
 The `Const` data type takes two type parameters, but only ever stores a value of the first type parameter.
 Because the second type parameter is not used in the data type, the type parameter is referred to as a
-"phantom type".
+"phantom type". This is also the reason `Const` is a `Phantom` functor in its second type parameter.
 
 ## Why do we care?
 It would seem `Const` gives us no benefit over a data type that would simply not have the second type parameter.

--- a/docs/src/main/tut/typeclasses/phantom.md
+++ b/docs/src/main/tut/typeclasses/phantom.md
@@ -1,0 +1,32 @@
+---
+layout: docs
+title:  "Phantom"
+section: "typeclasses"
+source: "core/src/main/scala/cats/functor/Phantom.scala"
+scaladoc: "#cats.functor.Phantom"
+---
+# Phantom
+
+The `Phantom` type class is for functors that define a `pmap`
+function with the following type:
+
+```scala
+def pmap[A, B](fa: F[A]): F[B]
+```
+
+It looks like regular (also called `Covariant`) [`Functor`](functor.html)'s `map` or [`Contravariant`](contravariant.html)'s `contramap`,
+but with no `f` transformation provided. Essentially, to implement this `F[A]` must not contain any values of type `A`; 
+it must be "phantom" in that type parameter. Equivalently, imagine a type `F[A]` which is a covariant `Functor` and also a `Contravariant` functor:
+
+```scala
+def map[A, B](fa: F[A])(f: A => B): F[B]
+def contramap[A, B](fa: F[A])(g: B => A): F[B]
+def pmap[A, B](fa: F[A]): F[B] =
+    contramap[Unit, B](map[A, Unit](fa)(_ => ()))(_ => ())
+```
+
+Generally speaking, if a type `F[A]` is both a covariant and a contravariant `Functor`, it cannot contain values of type `A`.
+Thus, you can implement `pmap` interms of both `contramap` and `pmap`, and a value of type `F[A]` is also 
+a value of type `F[B]` for any types `A` and `B`.
+
+The canonical example of a `Phantom` instance is [`Const`](const.html).

--- a/docs/src/main/tut/typeclasses/typeclasses.md
+++ b/docs/src/main/tut/typeclasses/typeclasses.md
@@ -240,6 +240,7 @@ type class instances easy.
     MonadCombine [group=g1]
     Invariant [group=g4]
     Contravariant [group=g4]
+    Phantom [group=g4]
     CoflatMap [group=g5]
     Comonad [group=g5]
     Bimonad [group=g5]
@@ -249,6 +250,8 @@ type class instances easy.
     Functor -> CoflatMap
     subgraph cluster_s3{
       Invariant -> Contravariant
+      Functor -> Phantom 
+      Contravariant -> Phantom 
       graph[style=dotted,label="functor"]
     }
     Invariant -> Functor

--- a/laws/src/main/scala/cats/laws/PhantomLaws.scala
+++ b/laws/src/main/scala/cats/laws/PhantomLaws.scala
@@ -1,0 +1,21 @@
+package cats
+package laws
+
+import cats.functor.Phantom
+import cats.syntax.phantom._
+
+/**
+ * Laws that must be obeyed by any `cats.functor.Phantom`.
+ */
+trait PhantomLaws[F[_]] extends ContravariantLaws[F] {
+  implicit override def F: Phantom[F]
+
+  def phantomIdentity[A, B](fa: F[A]): IsEq[F[A]] =
+    fa.pmap[B].pmap[A] <-> fa
+
+}
+
+object PhantomLaws {
+  def apply[F[_]](implicit ev: Phantom[F]): PhantomLaws[F] =
+    new PhantomLaws[F] { def F: Phantom[F] = ev }
+}

--- a/laws/src/main/scala/cats/laws/discipline/PhantomTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/PhantomTests.scala
@@ -1,0 +1,32 @@
+package cats
+package laws
+package discipline
+
+import cats.functor.Phantom
+import org.scalacheck.{Arbitrary, Cogen}
+import org.scalacheck.Prop._
+
+trait PhantomTests[F[_]] extends ContravariantTests[F] {
+  def laws: PhantomLaws[F]
+
+  def phantom[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
+    ArbFA: Arbitrary[F[A]],
+    CogenA: Cogen[A],
+    CogenB: Cogen[B],
+    CogenC: Cogen[C],
+    EqFA: Eq[F[A]],
+    EqFC: Eq[F[C]]
+  ): RuleSet = {
+    new DefaultRuleSet(
+      name = "phantom",
+      parent = Some(contravariant[A, B, C]),
+      "phantom identity" -> forAll(laws.phantomIdentity[A, C] _)
+    )
+  }
+}
+
+object PhantomTests {
+  def apply[F[_]: Phantom]: PhantomTests[F] =
+    new PhantomTests[F] { def laws: PhantomLaws[F] = PhantomLaws[F] }
+}
+

--- a/tests/src/test/scala/cats/tests/ConstTests.scala
+++ b/tests/src/test/scala/cats/tests/ConstTests.scala
@@ -4,7 +4,7 @@ package tests
 import cats.kernel.laws.{GroupLaws, OrderLaws}
 
 import cats.data.{Const, NonEmptyList}
-import cats.functor.Contravariant
+import cats.functor.Phantom
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 
@@ -24,7 +24,7 @@ class ConstTests extends CatsSuite {
   // Get Apply[Const[C : Semigroup, ?]], not Applicative[Const[C : Monoid, ?]]
   {
     implicit def nonEmptyListSemigroup[A]: Semigroup[NonEmptyList[A]] = SemigroupK[NonEmptyList].algebra
-    implicit val iso = CartesianTests.Isomorphisms.invariant[Const[NonEmptyList[String], ?]](Const.catsDataContravariantForConst)
+    implicit val iso = CartesianTests.Isomorphisms.invariant[Const[NonEmptyList[String], ?]](Const.catsDataPhantomForConst)
     checkAll("Apply[Const[NonEmptyList[String], Int]]", ApplyTests[Const[NonEmptyList[String], ?]].apply[Int, Int, Int])
     checkAll("Apply[Const[NonEmptyList[String], ?]]", SerializableTests.serializable(Apply[Const[NonEmptyList[String], ?]]))
   }
@@ -42,8 +42,8 @@ class ConstTests extends CatsSuite {
   checkAll("PartialOrder[Const[Set[Int], String]]", OrderLaws[Const[Set[Int], String]].partialOrder)
   checkAll("Order[Const[Int, String]]", OrderLaws[Const[Int, String]].order)
 
-  checkAll("Const[String, Int]", ContravariantTests[Const[String, ?]].contravariant[Int, Int, Int])
-  checkAll("Contravariant[Const[String, ?]]", SerializableTests.serializable(Contravariant[Const[String, ?]]))
+  checkAll("Const[String, Int]", PhantomTests[Const[String, ?]].phantom[Int, Int, Int])
+  checkAll("Phantom[Const[String, ?]]", SerializableTests.serializable(Phantom[Const[String, ?]]))
 
   checkAll("Const[?, ?]", BifoldableTests[Const].bifoldable[Int, Int, Int])
   checkAll("Bifoldable[Const]", SerializableTests.serializable(Bifoldable[Const]))

--- a/tests/src/test/scala/cats/tests/ContravariantTests.scala
+++ b/tests/src/test/scala/cats/tests/ContravariantTests.scala
@@ -7,7 +7,7 @@ import org.scalactic.CanEqual
 class ContravariantTest extends CatsSuite {
 
   test("narrow equals contramap(identity)") {
-    implicit val constInst = Const.catsDataContravariantForConst[Int]
+    implicit val constInst = Const.catsDataPhantomForConst[Int]
     implicit val canEqual: CanEqual[cats.data.Const[Int,Some[Int]],cats.data.Const[Int,Some[Int]]] =
       StrictCatsEquality.lowPriorityConversionCheckedConstraint
     forAll { (i: Int) =>


### PR DESCRIPTION
Phantom-variant functors! As @adelbertc has noted with his "functor diamond", phantom functors are what happen when a functor equivalently either:
1. Is both covariant and contravariant, or
2. Contains no values of the type param (e.g. `F[A]` has no `A` values)
This pattern comes up very frequently in user code dealing with phantom types.

The canonical example of a Phantom-variant functor is `Const[A, ?]`. Phantom-variant functors, though they are both covariant and contravariant, cannot express this fact exactly through our typeclass encoding because a) diamond inheritance is forbidden in simulacrum typeclasses and b) typeclass laws can only have one parent. That's why Phantom only extends `Contravariant` and provides a derivable covariant Functor, and only the `Contravariant` tests are run on Phantom functors.

This brought up a couple of issues in cats, notably:
1. The limits of our typeclass encoding, and
2. The only test for `Contravariant.narrow` tests that it is equivalent to `contramap(identity)`, but the `Contravariant` functor used is a phantom functor (`Const`). This means that actually the only test being performed is that `Contravariant.narrow` is equivalent to `contramap(f) forall f: A => B`. Not a giant issue, but effectively means we do not have real coverage for `Contravariant.narrow`.

This PR is not binary-compatible because it changes the name of the `Const` `Contravariant` instance, because it's now a `Phantom` instance. If that is an issue please let me know and I can add it separately in another `Instances` trait.