### PR TITLE
Add TraverseM for stack-safe traverse on collections

### DIFF
--- a/core/src/main/scala/cats/Composed.scala
+++ b/core/src/main/scala/cats/Composed.scala
@@ -69,6 +69,9 @@ private[cats] trait ComposedTraverse[F[_], G[_]] extends Traverse[λ[α => F[G[�
 
   override def traverse[H[_]: Applicative, A, B](fga: F[G[A]])(f: A => H[B]): H[F[G[B]]] =
     F.traverse(fga)(ga => G.traverse(ga)(f))
+
+  override def traverseM[H[_]: Monad, A, B](fga: F[G[A]])(f: A => H[B]): H[F[G[B]]] =
+    F.traverseM(fga)(ga => G.traverseM(ga)(f))
 }
 
 private[cats] trait ComposedTraverseFilter[F[_], G[_]] extends TraverseFilter[λ[α => F[G[α]]]] with ComposedTraverse[F, G] {

--- a/core/src/main/scala/cats/Traverse.scala
+++ b/core/src/main/scala/cats/Traverse.scala
@@ -33,6 +33,16 @@ import simulacrum.typeclass
   def traverse[G[_]: Applicative, A, B](fa: F[A])(f: A => G[B]): G[F[B]]
 
   /**
+   * This is exactly like traverse, except that it requires a Monad[G].
+   * It does this so that can use tailRecM to avoid stack overflows.
+   *
+   * combinators and potentially large data-structures should ideally
+   * override this.
+   */
+  def traverseM[G[_]: Monad, A, B](fa: F[A])(f: A => G[B]): G[F[B]] =
+    traverse[G, A, B](fa)(f)
+
+  /**
    * Behaves just like traverse, but uses [[Unapply]] to find the
    * Applicative instance for G.
    *

--- a/core/src/main/scala/cats/data/Coproduct.scala
+++ b/core/src/main/scala/cats/data/Coproduct.scala
@@ -48,6 +48,12 @@ final case class Coproduct[F[_], G[_], A](run: Either[F[A], G[A]]) {
       , x => A.map(G.traverse(x)(g))(rightc(_))
     )
 
+  def traverseM[X[_], B](g: A => X[B])(implicit F: Traverse[F], G: Traverse[G], A: Monad[X]): X[Coproduct[F, G, B]] =
+    run.fold(
+      x => A.map(F.traverseM(x)(g))(leftc(_))
+      , x => A.map(G.traverseM(x)(g))(rightc(_))
+    )
+
   def isLeft: Boolean =
     run.isLeft
 
@@ -203,6 +209,9 @@ private[data] trait CoproductTraverse[F[_], G[_]] extends CoproductFoldable[F, G
 
   override def traverse[X[_] : Applicative, A, B](fa: Coproduct[F, G, A])(f: A => X[B]): X[Coproduct[F, G, B]] =
     fa traverse f
+
+  override def traverseM[X[_] : Monad, A, B](fa: Coproduct[F, G, A])(f: A => X[B]): X[Coproduct[F, G, B]] =
+    fa traverseM f
 }
 
 private[data] trait CoproductCoflatMap[F[_], G[_]] extends CoflatMap[Coproduct[F, G, ?]] {

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -104,6 +104,9 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
   def traverse[G[_], D](f: B => G[D])(implicit traverseF: Traverse[F], applicativeG: Applicative[G]): G[EitherT[F, A, D]] =
     applicativeG.map(traverseF.traverse(value)(axb => Traverse[Either[A, ?]].traverse(axb)(f)))(EitherT.apply)
 
+  def traverseM[G[_], D](f: B => G[D])(implicit traverseF: Traverse[F], monadG: Monad[G]): G[EitherT[F, A, D]] =
+    monadG.map(traverseF.traverseM(value)(axb => Traverse[Either[A, ?]].traverseM(axb)(f)))(EitherT.apply)
+
   def foldLeft[C](c: C)(f: (C, B) => C)(implicit F: Foldable[F]): C =
     F.foldLeft(value, c)((c, axb) => axb.foldLeft(c)(f))
 
@@ -466,6 +469,9 @@ private[data] sealed trait EitherTTraverse[F[_], L] extends Traverse[EitherT[F, 
 
   override def traverse[G[_]: Applicative, A, B](fa: EitherT[F, L, A])(f: A => G[B]): G[EitherT[F, L, B]] =
     fa traverse f
+
+  override def traverseM[G[_]: Monad, A, B](fa: EitherT[F, L, A])(f: A => G[B]): G[EitherT[F, L, B]] =
+    fa traverseM f
 }
 
 private[data] sealed trait EitherTBifoldable[F[_]] extends Bifoldable[EitherT[F, ?, ?]] {

--- a/core/src/main/scala/cats/data/IdT.scala
+++ b/core/src/main/scala/cats/data/IdT.scala
@@ -24,6 +24,9 @@ final case class IdT[F[_], A](value: F[A]) {
   def traverse[G[_], B](f: A => G[B])(implicit F: Traverse[F], G: Applicative[G]): G[IdT[F, B]] =
     G.map(F.traverse(value)(f))(IdT(_))
 
+  def traverseM[G[_], B](f: A => G[B])(implicit F: Traverse[F], G: Monad[G]): G[IdT[F, B]] =
+    G.map(F.traverseM(value)(f))(IdT(_))
+
   def ap[B](f: IdT[F, A => B])(implicit F: Apply[F]): IdT[F, B] =
     IdT(F.ap(f.value)(value))
 
@@ -70,6 +73,9 @@ private[data] sealed trait IdTTraverse[F[_]] extends Traverse[IdT[F, ?]] with Id
 
   def traverse[G[_]: Applicative, A, B](fa: IdT[F, A])(f: A => G[B]): G[IdT[F, B]] =
     fa.traverse(f)
+
+  override def traverseM[G[_]: Monad, A, B](fa: IdT[F, A])(f: A => G[B]): G[IdT[F, B]] =
+    fa.traverseM(f)
 }
 
 private[data] sealed abstract class IdTInstances1 {

--- a/core/src/main/scala/cats/data/Nested.scala
+++ b/core/src/main/scala/cats/data/Nested.scala
@@ -221,6 +221,9 @@ private[data] trait NestedTraverse[F[_], G[_]] extends Traverse[Nested[F, G, ?]]
 
   override def traverse[H[_]: Applicative, A, B](fga: Nested[F, G, A])(f: A => H[B]): H[Nested[F, G, B]] =
     Applicative[H].map(FG.traverse(fga.value)(f))(Nested(_))
+
+  override def traverseM[H[_]: Monad, A, B](fga: Nested[F, G, A])(f: A => H[B]): H[Nested[F, G, B]] =
+    Applicative[H].map(FG.traverseM(fga.value)(f))(Nested(_))
 }
 
 private[data] trait NestedReducible[F[_], G[_]] extends Reducible[Nested[F, G, ?]] with NestedFoldable[F, G] {

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -88,6 +88,9 @@ final case class NonEmptyList[A](head: A, tail: List[A]) {
   def traverse[G[_], B](f: A => G[B])(implicit G: Applicative[G]): G[NonEmptyList[B]] =
     G.map2Eval(f(head), Always(Traverse[List].traverse(tail)(f)))(NonEmptyList(_, _)).value
 
+  def traverseM[G[_], B](f: A => G[B])(implicit G: Monad[G]): G[NonEmptyList[B]] =
+    G.map2Eval(f(head), Always(Traverse[List].traverseM(tail)(f)))(NonEmptyList(_, _)).value
+
   def coflatMap[B](f: NonEmptyList[A] => B): NonEmptyList[B] = {
     val buf = ListBuffer.empty[B]
     @tailrec def consume(as: List[A]): List[B] =
@@ -189,6 +192,9 @@ private[data] sealed trait NonEmptyListInstances extends NonEmptyListInstances0 
 
       def traverse[G[_], A, B](fa: NonEmptyList[A])(f: A => G[B])(implicit G: Applicative[G]): G[NonEmptyList[B]] =
         fa traverse f
+
+      override def traverseM[G[_], A, B](fa: NonEmptyList[A])(f: A => G[B])(implicit G: Monad[G]): G[NonEmptyList[B]] =
+        fa traverseM f
 
       override def foldLeft[A, B](fa: NonEmptyList[A], b: B)(f: (B, A) => B): B =
         fa.foldLeft(b)(f)

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -209,6 +209,8 @@ private[data] sealed trait NonEmptyVectorInstances {
       def traverse[G[_], A, B](fa: NonEmptyVector[A])(f: (A) => G[B])(implicit G: Applicative[G]): G[NonEmptyVector[B]] =
         G.map2Eval(f(fa.head), Always(Traverse[Vector].traverse(fa.tail)(f)))(NonEmptyVector(_, _)).value
 
+      override def traverseM[G[_], A, B](fa: NonEmptyVector[A])(f: (A) => G[B])(implicit G: Monad[G]): G[NonEmptyVector[B]] =
+        G.map2Eval(f(fa.head), Always(Traverse[Vector].traverseM(fa.tail)(f)))(NonEmptyVector(_, _)).value
 
       override def foldLeft[A, B](fa: NonEmptyVector[A], b: B)(f: (B, A) => B): B =
         fa.foldLeft(b)(f)

--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -207,6 +207,9 @@ private[data] trait OneAndLowPriority2 extends OneAndLowPriority1 {
       def traverse[G[_], A, B](fa: OneAnd[F, A])(f: (A) => G[B])(implicit G: Applicative[G]): G[OneAnd[F, B]] = {
         G.map2Eval(f(fa.head), Always(F.traverse(fa.tail)(f)))(OneAnd(_, _)).value
       }
+      override def traverseM[G[_], A, B](fa: OneAnd[F, A])(f: (A) => G[B])(implicit G: Monad[G]): G[OneAnd[F, B]] = {
+        G.map2Eval(f(fa.head), Always(F.traverseM(fa.tail)(f)))(OneAnd(_, _)).value
+      }
 
       def foldLeft[A, B](fa: OneAnd[F, A], b: B)(f: (B, A) => B): B = {
         fa.foldLeft(b)(f)

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -109,6 +109,9 @@ final case class OptionT[F[_], A](value: F[Option[A]]) {
   def traverse[G[_], B](f: A => G[B])(implicit F: Traverse[F], G: Applicative[G]): G[OptionT[F, B]] =
     G.map(F.compose(optionInstance).traverse(value)(f))(OptionT.apply)
 
+  def traverseM[G[_], B](f: A => G[B])(implicit F: Traverse[F], G: Monad[G]): G[OptionT[F, B]] =
+    G.map(F.compose(optionInstance).traverseM(value)(f))(OptionT.apply)
+
   def foldLeft[B](b: B)(f: (B, A) => B)(implicit F: Foldable[F]): B =
     F.compose(optionInstance).foldLeft(value, b)(f)
 
@@ -284,6 +287,9 @@ private[data] sealed trait OptionTTraverseFilter[F[_]] extends TraverseFilter[Op
 
   override def traverse[G[_]: Applicative, A, B](fa: OptionT[F, A])(f: A => G[B]): G[OptionT[F, B]] =
     fa traverse f
+
+  override def traverseM[G[_]: Monad, A, B](fa: OptionT[F, A])(f: A => G[B]): G[OptionT[F, B]] =
+    fa traverseM f
 }
 
 private[data] trait OptionTSemigroup[F[_], A] extends Semigroup[OptionT[F, A]] {

--- a/core/src/main/scala/cats/data/Prod.scala
+++ b/core/src/main/scala/cats/data/Prod.scala
@@ -161,6 +161,9 @@ sealed trait ProdTraverse[F[_], G[_]] extends Traverse[λ[α => Prod[F, G, α]]]
 
   override def traverse[H[_]: Applicative, A, B](fa: Prod[F, G, A])(f: A => H[B]): H[Prod[F, G, B]] =
     (F.traverse(fa.first)(f) |@| G.traverse(fa.second)(f)).map(Prod(_, _))
+
+  override def traverseM[H[_]: Monad, A, B](fa: Prod[F, G, A])(f: A => H[B]): H[Prod[F, G, B]] =
+    (F.traverseM(fa.first)(f) |@| G.traverseM(fa.second)(f)).map(Prod(_, _))
 }
 
 sealed trait ProdMonadCombine[F[_], G[_]] extends MonadCombine[λ[α => Prod[F, G, α]]]

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -70,6 +70,11 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
           G.map2Eval(f(a), lglb)(_ :: _)
         }.value
 
+      override def traverseM[G[_], A, B](fa: List[A])(f: A => G[B])(implicit G: Monad[G]): G[List[B]] =
+        G.map(foldM[G, A, List[B]](fa, List.empty[B]) { (listB, a) =>
+          G.map(f(a))(_ :: listB)
+        })(_.reverse)
+
       override def exists[A](fa: List[A])(p: A => Boolean): Boolean =
         fa.exists(p)
 

--- a/core/src/main/scala/cats/instances/option.scala
+++ b/core/src/main/scala/cats/instances/option.scala
@@ -67,6 +67,8 @@ trait OptionInstances extends cats.kernel.instances.OptionInstances {
           case None => Applicative[G].pure(None)
           case Some(a) => Applicative[G].map(f(a))(Some(_))
         }
+      override def traverseM[G[_]: Monad, A, B](fa: Option[A])(f: A => G[B]): G[Option[B]] =
+        traverse[G, A, B](fa)(f)
 
       override def filter[A](fa: Option[A])(p: A => Boolean): Option[A] =
         fa.filter(p)

--- a/core/src/main/scala/cats/instances/stream.scala
+++ b/core/src/main/scala/cats/instances/stream.scala
@@ -54,6 +54,18 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
         }.value
       }
 
+      override def traverseM[G[_], A, B](fa: Stream[A])(f: A => G[B])(implicit G: Monad[G]): G[Stream[B]] = {
+        // This forces the stream as it goes, which seems unavoidable since
+        // by the time we apply f we have materialize b
+        def step(pair: (Stream[A], List[B])): G[Either[(Stream[A], List[B]), Stream[B]]] =
+          pair match {
+            case (a #:: tail, bs) => G.map(f(a)) { b => Left((tail, b :: bs)) }
+            case (_, bs) => G.pure(Right(bs.reverse.toStream))
+          }
+
+        G.tailRecM((fa, List.empty[B]))(step)
+      }
+
       def tailRecM[A, B](a: A)(fn: A => Stream[Either[A, B]]): Stream[B] = {
         val it: Iterator[B] = new Iterator[B] {
           var stack: Stream[Either[A, B]] = fn(a)

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -78,6 +78,9 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
         G.map2Eval(f(a), lgvb)(_ +: _)
       }.value
 
+      override def traverseM[G[_], A, B](fa: Vector[A])(f: A => G[B])(implicit G: Monad[G]): G[Vector[B]] =
+        foldM[G, A, Vector[B]](fa, Vector.empty[B]) { (vec, a) => G.map(f(a))(vec :+ _) }
+
       override def exists[A](fa: Vector[A])(p: A => Boolean): Boolean =
         fa.exists(p)
 

--- a/laws/src/main/scala/cats/laws/TraverseLaws.scala
+++ b/laws/src/main/scala/cats/laws/TraverseLaws.scala
@@ -13,6 +13,9 @@ trait TraverseLaws[F[_]] extends FunctorLaws[F] with FoldableLaws[F] {
     fa.traverse[Id, B](f) <-> F.map(fa)(f)
   }
 
+  def traverseMConsistency[A, B, M[_]: Monad](fa: F[A], f: A => M[B]): IsEq[M[F[B]]] =
+    fa.traverse[M, B](f) <-> fa.traverseM[M, B](f)
+
   def traverseSequentialComposition[A, B, C, M[_], N[_]](
     fa: F[A],
     f: A => M[B],

--- a/laws/src/main/scala/cats/laws/discipline/TraverseTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/TraverseTests.scala
@@ -3,6 +3,7 @@ package laws
 package discipline
 
 import org.scalacheck.{Arbitrary, Cogen, Prop}
+import cats.instances.list._
 import Prop._
 
 
@@ -35,7 +36,7 @@ trait TraverseTests[F[_]] extends FunctorTests[F] with FoldableTests[F] {
       def parents: Seq[RuleSet] = Seq(functor[A, B, C], foldable[A, M])
       def props: Seq[(String, Prop)] = Seq(
         "traverse identity" -> forAll(laws.traverseIdentity[A, C] _),
-        "traverseM consistency" -> forAll(laws.traverseMConsistency[A, C, Id] _),
+        "traverseM consistency" -> forAll(laws.traverseMConsistency[A, C, List] _),
         "traverse sequential composition" -> forAll(laws.traverseSequentialComposition[A, B, C, X, Y] _),
         "traverse parallel composition" -> forAll(laws.traverseParallelComposition[A, B, X, Y] _),
         "traverse derive foldMap" -> forAll(laws.foldMapDerived[A, M] _)

--- a/laws/src/main/scala/cats/laws/discipline/TraverseTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/TraverseTests.scala
@@ -35,6 +35,7 @@ trait TraverseTests[F[_]] extends FunctorTests[F] with FoldableTests[F] {
       def parents: Seq[RuleSet] = Seq(functor[A, B, C], foldable[A, M])
       def props: Seq[(String, Prop)] = Seq(
         "traverse identity" -> forAll(laws.traverseIdentity[A, C] _),
+        "traverseM consistency" -> forAll(laws.traverseMConsistency[A, C, Id] _),
         "traverse sequential composition" -> forAll(laws.traverseSequentialComposition[A, B, C, X, Y] _),
         "traverse parallel composition" -> forAll(laws.traverseParallelComposition[A, B, X, Y] _),
         "traverse derive foldMap" -> forAll(laws.foldMapDerived[A, M] _)


### PR DESCRIPTION
This is related to #1473 

The idea here is to make an optional method, `traverseM` that large structures can override which requires a Monad solely to have access to `tailRecM`.

This can make a traversal of for instance `StateT` across a large list actually work, which is nice.

An open question is should we just do this instead:
```scala
val a: Applicative[F] = ...

a match {
  case m: Monad[_] =>
    val mf = m.asInstanceOf[Monad[F]] // should be a safe cast, I think
    // use tailRecM in list, stream, map, vector, nonemptylist, nonemptyvector
  case other =>
    // use the map2 approach
}
```

The above will make more code just work because users don't modify their code at all, but it does have the cast, which I *think* is always safe. I don't think you can be a subclass of `Applicative[F]` and `Monad[G]` if `G != F`. I wish the scala compiler knew this, if true. Can anyone think of a counter example?