### PR TITLE
Proof of concept of ComposedMonad

### DIFF
--- a/core/src/main/scala/cats/Monad.scala
+++ b/core/src/main/scala/cats/Monad.scala
@@ -11,7 +11,14 @@ import simulacrum.typeclass
  *
  * Must obey the laws defined in cats.laws.MonadLaws.
  */
-@typeclass trait Monad[F[_]] extends FlatMap[F] with Applicative[F] {
+@typeclass trait Monad[F[_]] extends FlatMap[F] with Applicative[F] { self =>
   override def map[A, B](fa: F[A])(f: A => B): F[B] =
     flatMap(fa)(a => pure(f(a)))
+
+  def composeTraverseMonad[G[_]](implicit tg: Traverse[G], mg: Monad[G]): Monad[λ[α => F[G[α]]]] =
+    new ComposedTraverseMonad[F, G] {
+      def F = self
+      def G = mg
+      def TG = tg
+    }
 }

--- a/tests/src/test/scala/cats/tests/EvalTests.scala
+++ b/tests/src/test/scala/cats/tests/EvalTests.scala
@@ -102,6 +102,13 @@ class EvalTests extends CatsSuite {
   checkAll("Eval[Int]", GroupLaws[Eval[Int]].group)
 
   {
+    implicit val M = Monad[Eval].composeTraverseMonad[Option]
+    type EvalOption[T] = Eval[Option[T]]
+    implicit val iso = CartesianTests.Isomorphisms.invariant[EvalOption]
+    checkAll("Eval[Option[Int]]", MonadTests[EvalOption].monad[Int, Int, Int])
+    checkAll("Monad[EvalOption]", SerializableTests.serializable(M))
+  }
+  {
     implicit val A = ListWrapper.monoid[Int]
     checkAll("Eval[ListWrapper[Int]]", GroupLaws[Eval[ListWrapper[Int]]].monoid)
   }


### PR DESCRIPTION
This allows us to make a monad for `F[G[_]]`, so if you have `Future[Option[_]]` or `Eval[List[_]]`.

The constraint is that the inner type has to be traversable.

So far, I did not yet find a way to compose our old friend tailRecM, but I think this is interesting.