### PR TITLE
Hide traits in data package

### DIFF
--- a/core/src/main/scala/cats/data/Coproduct.scala
+++ b/core/src/main/scala/cats/data/Coproduct.scala
@@ -150,7 +150,7 @@ private[data] sealed abstract class CoproductInstances0 extends CoproductInstanc
     }
 }
 
-sealed abstract class CoproductInstances extends CoproductInstances0 {
+private[data] sealed abstract class CoproductInstances extends CoproductInstances0 {
 
   implicit def catsDataComonadForCoproduct[F[_], G[_]](implicit F0: Comonad[F], G0: Comonad[G]): Comonad[Coproduct[F, G, ?]] =
     new CoproductComonad[F, G] {

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -234,7 +234,7 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
 
 object EitherT extends EitherTInstances with EitherTFunctions
 
-trait EitherTFunctions {
+private[data] trait EitherTFunctions {
   final def left[F[_], A, B](fa: F[A])(implicit F: Functor[F]): EitherT[F, A, B] = EitherT(F.map(fa)(Either.left))
 
   final def right[F[_], A, B](fb: F[B])(implicit F: Functor[F]): EitherT[F, A, B] = EitherT(F.map(fb)(Either.right))

--- a/core/src/main/scala/cats/data/Func.scala
+++ b/core/src/main/scala/cats/data/Func.scala
@@ -59,19 +59,19 @@ private[data] abstract class FuncInstances1 {
     }
 }
 
-sealed trait FuncFunctor[F[_], C] extends Functor[λ[α => Func[F, C, α]]] {
+private[data] sealed trait FuncFunctor[F[_], C] extends Functor[λ[α => Func[F, C, α]]] {
   def F: Functor[F]
   override def map[A, B](fa: Func[F, C, A])(f: A => B): Func[F, C, B] =
     fa.map(f)(F)
 }
 
-sealed trait FuncContravariant[F[_], C] extends Contravariant[λ[α => Func[F, α, C]]] {
+private[data] sealed trait FuncContravariant[F[_], C] extends Contravariant[λ[α => Func[F, α, C]]] {
   def F: Contravariant[F]
   def contramap[A, B](fa: Func[F, A, C])(f: B => A): Func[F, B, C] =
     Func.func(a => fa.run(f(a)))
 }
 
-sealed trait FuncApply[F[_], C] extends Apply[λ[α => Func[F, C, α]]] with FuncFunctor[F, C] {
+private[data] sealed trait FuncApply[F[_], C] extends Apply[λ[α => Func[F, C, α]]] with FuncFunctor[F, C] {
   def F: Apply[F]
   def ap[A, B](f: Func[F, C, A => B])(fa: Func[F, C, A]): Func[F, C, B] =
     Func.func(c => F.ap(f.run(c))(fa.run(c)))
@@ -79,7 +79,7 @@ sealed trait FuncApply[F[_], C] extends Apply[λ[α => Func[F, C, α]]] with Fun
     Func.func(c => F.product(fa.run(c), fb.run(c)))
 }
 
-sealed trait FuncApplicative[F[_], C] extends Applicative[λ[α => Func[F, C, α]]] with FuncApply[F, C] {
+private[data] sealed trait FuncApplicative[F[_], C] extends Applicative[λ[α => Func[F, C, α]]] with FuncApply[F, C] {
   def F: Applicative[F]
   def pure[A](a: A): Func[F, C, A] =
     Func.func(c => F.pure(a))

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -185,7 +185,7 @@ private[data] sealed abstract class IorInstances0 {
   }
 }
 
-sealed trait IorFunctions {
+private[data] sealed trait IorFunctions {
   def left[A, B](a: A): A Ior B = Ior.Left(a)
   def right[A, B](b: B): A Ior B = Ior.Right(b)
   def both[A, B](a: A, b: B): A Ior B = Ior.Both(a, b)

--- a/core/src/main/scala/cats/data/Prod.scala
+++ b/core/src/main/scala/cats/data/Prod.scala
@@ -84,19 +84,19 @@ private[data] sealed abstract class ProdInstances3 {
   }
 }
 
-sealed trait ProdFunctor[F[_], G[_]] extends Functor[λ[α => Prod[F, G, α]]] {
+private[data] sealed trait ProdFunctor[F[_], G[_]] extends Functor[λ[α => Prod[F, G, α]]] {
   def F: Functor[F]
   def G: Functor[G]
   override def map[A, B](fa: Prod[F, G, A])(f: A => B): Prod[F, G, B] = Prod(F.map(fa.first)(f), G.map(fa.second)(f))
 }
 
-sealed trait ProdContravariant[F[_], G[_]] extends Contravariant[λ[α => Prod[F, G, α]]] {
+private[data] sealed trait ProdContravariant[F[_], G[_]] extends Contravariant[λ[α => Prod[F, G, α]]] {
   def F: Contravariant[F]
   def G: Contravariant[G]
   def contramap[A, B](fa: Prod[F, G, A])(f: B => A): Prod[F, G, B] = Prod(F.contramap(fa.first)(f), G.contramap(fa.second)(f))
 }
 
-sealed trait ProdApply[F[_], G[_]] extends Apply[λ[α => Prod[F, G, α]]] with ProdFunctor[F, G] {
+private[data] sealed trait ProdApply[F[_], G[_]] extends Apply[λ[α => Prod[F, G, α]]] with ProdFunctor[F, G] {
   def F: Apply[F]
   def G: Apply[G]
   override def ap[A, B](f: Prod[F, G, A => B])(fa: Prod[F, G, A]): Prod[F, G, B] =
@@ -105,33 +105,33 @@ sealed trait ProdApply[F[_], G[_]] extends Apply[λ[α => Prod[F, G, α]]] with 
     Prod(F.product(fa.first, fb.first), G.product(fa.second, fb.second))
 }
 
-sealed trait ProdApplicative[F[_], G[_]] extends Applicative[λ[α => Prod[F, G, α]]] with ProdApply[F, G] {
+private[data] sealed trait ProdApplicative[F[_], G[_]] extends Applicative[λ[α => Prod[F, G, α]]] with ProdApply[F, G] {
   def F: Applicative[F]
   def G: Applicative[G]
   def pure[A](a: A): Prod[F, G, A] = Prod(F.pure(a), G.pure(a))
 }
 
-sealed trait ProdSemigroupK[F[_], G[_]] extends SemigroupK[λ[α => Prod[F, G, α]]] {
+private[data] sealed trait ProdSemigroupK[F[_], G[_]] extends SemigroupK[λ[α => Prod[F, G, α]]] {
   def F: SemigroupK[F]
   def G: SemigroupK[G]
   override def combineK[A](x: Prod[F, G, A], y: Prod[F, G, A]): Prod[F, G, A] =
     Prod(F.combineK(x.first, y.first), G.combineK(x.second, y.second))
 }
 
-sealed trait ProdMonoidK[F[_], G[_]] extends MonoidK[λ[α => Prod[F, G, α]]] with ProdSemigroupK[F, G] {
+private[data] sealed trait ProdMonoidK[F[_], G[_]] extends MonoidK[λ[α => Prod[F, G, α]]] with ProdSemigroupK[F, G] {
   def F: MonoidK[F]
   def G: MonoidK[G]
   override def empty[A]: Prod[F, G, A] =
     Prod(F.empty[A], G.empty[A])
 }
 
-sealed trait ProdAlternative[F[_], G[_]] extends Alternative[λ[α => Prod[F, G, α]]]
+private[data] sealed trait ProdAlternative[F[_], G[_]] extends Alternative[λ[α => Prod[F, G, α]]]
   with ProdApplicative[F, G] with ProdMonoidK[F, G] {
   def F: Alternative[F]
   def G: Alternative[G]
 }
 
-sealed trait ProdMonad[F[_], G[_]] extends Monad[λ[α => Prod[F, G, α]]] with ProdApplicative[F, G] {
+private[data] sealed trait ProdMonad[F[_], G[_]] extends Monad[λ[α => Prod[F, G, α]]] with ProdApplicative[F, G] {
   def F: Monad[F]
   def G: Monad[G]
   override def pure[A](a: A): Prod[F, G, A] =
@@ -144,7 +144,7 @@ sealed trait ProdMonad[F[_], G[_]] extends Monad[λ[α => Prod[F, G, α]]] with 
     Prod(F.tailRecM(a)(f(_).first), G.tailRecM(a)(f(_).second))
 }
 
-sealed trait ProdFoldable[F[_], G[_]] extends Foldable[λ[α => Prod[F, G, α]]] {
+private[data] sealed trait ProdFoldable[F[_], G[_]] extends Foldable[λ[α => Prod[F, G, α]]] {
   def F: Foldable[F]
   def G: Foldable[G]
 
@@ -155,7 +155,7 @@ sealed trait ProdFoldable[F[_], G[_]] extends Foldable[λ[α => Prod[F, G, α]]]
     F.foldRight(fa.first, G.foldRight(fa.second, lb)(f))(f)
 }
 
-sealed trait ProdTraverse[F[_], G[_]] extends Traverse[λ[α => Prod[F, G, α]]] with ProdFoldable[F, G] {
+private[data] sealed trait ProdTraverse[F[_], G[_]] extends Traverse[λ[α => Prod[F, G, α]]] with ProdFoldable[F, G] {
   def F: Traverse[F]
   def G: Traverse[G]
 
@@ -163,20 +163,20 @@ sealed trait ProdTraverse[F[_], G[_]] extends Traverse[λ[α => Prod[F, G, α]]]
     (F.traverse(fa.first)(f) |@| G.traverse(fa.second)(f)).map(Prod(_, _))
 }
 
-sealed trait ProdMonadCombine[F[_], G[_]] extends MonadCombine[λ[α => Prod[F, G, α]]]
+private[data] sealed trait ProdMonadCombine[F[_], G[_]] extends MonadCombine[λ[α => Prod[F, G, α]]]
   with ProdMonad[F, G] with ProdAlternative[F, G] {
   def F: MonadCombine[F]
   def G: MonadCombine[G]
 }
 
-sealed trait ProdShow[F[_], G[_], A] extends Show[Prod[F, G, A]] {
+private[data] sealed trait ProdShow[F[_], G[_], A] extends Show[Prod[F, G, A]] {
   def F: Show[F[A]]
   def G: Show[G[A]]
 
   def show(prod: Prod[F, G, A]): String = s"Prod(${F.show(prod.first)}, ${G.show(prod.second)})"
 }
 
-sealed trait ProdOrder[F[_], G[_], A] extends Order[Prod[F, G, A]] {
+private[data] sealed trait ProdOrder[F[_], G[_], A] extends Order[Prod[F, G, A]] {
   def F: Order[F[A]]
   def G: Order[G[A]]
 

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -347,7 +347,7 @@ private[data] sealed abstract class ValidatedInstances2 {
     }
 }
 
-trait ValidatedFunctions {
+private[data] trait ValidatedFunctions {
   def invalid[A, B](a: A): Validated[A, B] = Validated.Invalid(a)
 
   def invalidNel[A, B](a: A): ValidatedNel[A, B] = Validated.Invalid(NonEmptyList(a, Nil))

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -385,7 +385,7 @@ private[data] sealed trait WriterTCoflatMap[F[_], L] extends CoflatMap[WriterT[F
 }
 
 
-trait WriterTFunctions {
+private[data] trait WriterTFunctions {
   def putT[F[_], L, V](vf: F[V])(l: L)(implicit functorF: Functor[F]): WriterT[F, L, V] =
     WriterT(functorF.map(vf)(v => (l, v)))
 


### PR DESCRIPTION
Hide
- traits for type class instances: `Coproduct`, `Func` and `Prod`.
- traits for functions: `EitherT`, `Ior`, `Validated` and `WriterT`.

See #1160.