### PR TITLE
enable mima binary compatibility check for cats-kernel

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -211,6 +211,8 @@ lazy val macros = crossProject.crossType(CrossType.Pure)
 lazy val macrosJVM = macros.jvm
 lazy val macrosJS = macros.js
 
+val binaryCompatibleVersion = "0.8.0"
+
 lazy val kernel = crossProject.crossType(CrossType.Pure)
   .in(file("kernel"))
   .settings(moduleName := "cats-kernel", name := "Cats kernel")
@@ -221,7 +223,13 @@ lazy val kernel = crossProject.crossType(CrossType.Pure)
   .settings(sourceGenerators in Compile += (sourceManaged in Compile).map(KernelBoiler.gen).taskValue)
   .settings(includeGeneratedSrc)
   .jsSettings(commonJsSettings:_*)
-  .jvmSettings((commonJvmSettings ++ (mimaPreviousArtifacts := Set("org.typelevel" %% "cats-kernel" % "0.7.0"))):_*)
+  .jvmSettings((commonJvmSettings ++
+    (mimaPreviousArtifacts := {
+      if (scalaVersion.value startsWith "2.12")
+        Set()
+      else
+        Set("org.typelevel" %% "cats-kernel" % binaryCompatibleVersion)
+    })):_*)
 
 lazy val kernelJVM = kernel.jvm
 lazy val kernelJS = kernel.js
@@ -409,7 +417,7 @@ lazy val publishSettings = Seq(
 // These aliases serialise the build for the benefit of Travis-CI.
 addCommandAlias("buildJVM", "catsJVM/test")
 
-addCommandAlias("validateJVM", ";scalastyle;buildJVM;makeMicrosite")
+addCommandAlias("validateJVM", ";scalastyle;buildJVM;mimaReportBinaryIssues;makeMicrosite")
 
 addCommandAlias("validateJS", ";catsJS/compile;testsJS/test;js/test")
 
@@ -569,4 +577,3 @@ lazy val update2_12 = Seq(
     }
   }
 )
-

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 addSbtPlugin("com.eed3si9n"         % "sbt-unidoc"            % "0.3.3")
 addSbtPlugin("com.github.gseitz"    % "sbt-release"           % "1.0.3")
 addSbtPlugin("com.jsuereth"         % "sbt-pgp"               % "1.0.0")
-addSbtPlugin("com.typesafe"         % "sbt-mima-plugin"       % "0.1.11")
+addSbtPlugin("com.typesafe"         % "sbt-mima-plugin"       % "0.1.12")
 addSbtPlugin("com.typesafe.sbt"     % "sbt-ghpages"           % "0.5.3")
 addSbtPlugin("pl.project13.scala"   % "sbt-jmh"               % "0.2.16")
 addSbtPlugin("org.scalastyle"      %% "scalastyle-sbt-plugin" % "0.8.0")

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -31,7 +31,7 @@ js="$sbt_cmd validateJS"
 kernel_js="$sbt_cmd validateKernelJS"
 free_js="$sbt_cmd validateFreeJS"
 jvm="$sbt_cmd coverage validateJVM coverageReport && codecov"
-  		  
+
 run_cmd="$js && $free_js && $kernel_js && $jvm && $sbt_cmd $publish_cmd"
 
 eval $run_cmd


### PR DESCRIPTION
This wasn't running. I added the command to `validateJVM`.

Once we publish a 2.12 version we'll want to remove my switch that excludes mima for the 2.12 build - anything that changes should get caught in the meantime.

I'll also make a strong push for enabling this plugin for more of our modules, and being okay with minor version bumps if we do want to move fast. Life's tough downstream when you can't trust the version number.