### PR TITLE
Show instance for scala.Symbol

### DIFF
--- a/core/src/main/scala/cats/instances/all.scala
+++ b/core/src/main/scala/cats/instances/all.scala
@@ -18,3 +18,4 @@ trait AllInstances
   with    TryInstances
   with    TupleInstances
   with    UUIDInstances
+  with    SymbolInstances

--- a/core/src/main/scala/cats/instances/symbol.scala
+++ b/core/src/main/scala/cats/instances/symbol.scala
@@ -1,0 +1,9 @@
+package cats
+package instances
+
+package object symbol extends SymbolInstances
+
+trait SymbolInstances extends cats.kernel.instances.SymbolInstances {
+  implicit val catsStdShowForSymbol: Show[Symbol] =
+    Show.fromToString[Symbol]
+}


### PR DESCRIPTION
This also makes sure, that cats.instances.AllInstances contains the Symbol instances.

BTW, there are other instances, which are not in AllInstances (and as a result, are not in scope after doing `import cats.implicits._`), e.g., Eq[BitSet]. Is this intentional?