### PR TITLE
Add MFunctor type class for mapping monad morphisms over monad transformers

### DIFF
--- a/core/src/main/scala/cats/MFunctor.scala
+++ b/core/src/main/scala/cats/MFunctor.scala
@@ -1,0 +1,16 @@
+package cats
+
+/**
+ * A type class which abstracts over the ability to lift a natural transformation
+ * (monad morphism) `M ~> N` into a MonadTransformer. In other words, a functor
+ * in the category of monads.
+ */
+
+trait MFunctor[MT[_[_]]] {
+
+  /**
+   * Analogous to fmap
+   */
+  def hoist[M[_], N[_]](m: M ~> N): MT[M] => MT[N]
+
+}

--- a/core/src/main/scala/cats/MFunctor.scala
+++ b/core/src/main/scala/cats/MFunctor.scala
@@ -1,16 +1,33 @@
 package cats
 
+import simulacrum.typeclass
+
 /**
- * A type class which abstracts over the ability to lift a natural transformation
- * (monad morphism) `M ~> N` into a MonadTransformer. In other words, a functor
- * in the category of monads.
+ * Functor in the category of functors.
+ *
+ * If the ordinary `Functor` lifts a function `A => B` to `F[A] => F[B]`, then
+ * this lifts a natural transformation `M ~> N` to `F[M] => F[N]`, where
+ * `~>` represents the type `M[A] => N[A]`, for all `A`.
+ *
+ * All monad transformers are an instance of this, with the underlying monad
+ * being the subject of the lifted transformation.
+ *
  */
 
-trait MFunctor[MT[_[_]]] {
+@typeclass trait MFunctor[F[_[_]]] {
+
+ /**
+  * Sometimes we know more about the underlying `F`, so the transformation
+  * can be constrained to reflect this knowledge.
+  *
+  * In case of monad transformers, for instance, we always know that `F`
+  * is a monad.
+  */
+  type C[M[_]]
 
   /**
-   * Analogous to fmap
+   * Analogous to `lift` of `Functor`
    */
-  def hoist[M[_], N[_]](m: M ~> N): MT[M] => MT[N]
+  def hoist[M[_]: C, N[_]: C](m: M ~> N): F[M] => F[N]
 
 }

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -333,7 +333,9 @@ private[data] abstract class EitherTInstances extends EitherTInstances1 {
 
   implicit def catsDataMFunctorForEitherT[E, A]: MFunctor[EitherT[?[_], E, A]] =
     new MFunctor[EitherT[?[_], E, A]] {
-      def hoist[M[_], N[_]](m: M ~> N): EitherT[M, E, A] => EitherT[N, E, A] =
+      type C[M[_]] = Monad[M]
+
+      def hoist[M[_]: Monad, N[_]: Monad](m: M ~> N): EitherT[M, E, A] => EitherT[N, E, A] =
         e => EitherT(m(e.value))
     }
 

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -331,6 +331,12 @@ private[data] abstract class EitherTInstances extends EitherTInstances1 {
         EitherT.liftT(ma)
     }
 
+  implicit def catsDataMFunctorForEitherT[E, A]: MFunctor[EitherT[?[_], E, A]] =
+    new MFunctor[EitherT[?[_], E, A]] {
+      def hoist[M[_], N[_]](m: M ~> N): EitherT[M, E, A] => EitherT[N, E, A] =
+        e => EitherT(m(e.value))
+    }
+
   implicit def catsMonoidForEitherT[F[_], L, A](implicit F: Monoid[F[Either[L, A]]]): Monoid[EitherT[F, L, A]] =
     new EitherTMonoid[F, L, A] { implicit val F0 = F }
 

--- a/core/src/main/scala/cats/data/IdT.scala
+++ b/core/src/main/scala/cats/data/IdT.scala
@@ -96,7 +96,9 @@ private[data] sealed abstract class IdTInstances0 extends IdTInstances1 {
 
   implicit def catsDataMFunctorForIdT[F[_], A]: MFunctor[IdT[?[_], A]] =
     new MFunctor[IdT[?[_], A]] {
-      def hoist[M[_], N[_]](m: M ~> N): IdT[M, A] => IdT[N, A] =
+      type C[M[_]] = Monad[M]
+
+      def hoist[M[_]: Monad, N[_]: Monad](m: M ~> N): IdT[M, A] => IdT[N, A] =
         i => IdT(m(i.value))
     }
 }

--- a/core/src/main/scala/cats/data/IdT.scala
+++ b/core/src/main/scala/cats/data/IdT.scala
@@ -93,6 +93,12 @@ private[data] sealed abstract class IdTInstances0 extends IdTInstances1 {
 
   implicit def catsDataOrderForIdT[F[_], A](implicit F: Order[F[A]]): Order[IdT[F, A]] =
     F.on(_.value)
+
+  implicit def catsDataMFunctorForIdT[F[_], A]: MFunctor[IdT[?[_], A]] =
+    new MFunctor[IdT[?[_], A]] {
+      def hoist[M[_], N[_]](m: M ~> N): IdT[M, A] => IdT[N, A] =
+        i => IdT(m(i.value))
+    }
 }
 
 private[data] sealed abstract class IdTInstances extends IdTInstances0 {

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -97,6 +97,12 @@ private[data] sealed abstract class KleisliInstances extends KleisliInstances0 {
   implicit val catsDataArrowForKleisliId: Arrow[Kleisli[Id, ?, ?]] =
     catsDataArrowForKleisli[Id]
 
+  implicit def catsDataMFunctorForKleisli[A, B]: MFunctor[Kleisli[?[_], A, B]] =
+    new MFunctor[Kleisli[?[_], A, B]] {
+      def hoist[M[_], N[_]](m: M ~> N): Kleisli[M, A, B] => Kleisli[N, A, B] =
+        k => k.transform(m)
+    }
+
   implicit def catsDataChoiceForKleisli[F[_]](implicit ev: Monad[F]): Choice[Kleisli[F, ?, ?]] =
     new Choice[Kleisli[F, ?, ?]] {
       def id[A]: Kleisli[F, A, A] = Kleisli(ev.pure)

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -99,7 +99,9 @@ private[data] sealed abstract class KleisliInstances extends KleisliInstances0 {
 
   implicit def catsDataMFunctorForKleisli[A, B]: MFunctor[Kleisli[?[_], A, B]] =
     new MFunctor[Kleisli[?[_], A, B]] {
-      def hoist[M[_], N[_]](m: M ~> N): Kleisli[M, A, B] => Kleisli[N, A, B] =
+      type C[M[_]] = Monad[M]
+
+      def hoist[M[_]: Monad, N[_]: Monad](m: M ~> N): Kleisli[M, A, B] => Kleisli[N, A, B] =
         k => k.transform(m)
     }
 

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -215,6 +215,12 @@ private[data] sealed trait OptionTInstances1 extends OptionTInstances2 {
       def liftT[M[_]: Functor, A](ma: M[A]): OptionT[M, A] = OptionT.liftF(ma)
     }
 
+  implicit def catsDataMFunctorForOptionT[A]: MFunctor[OptionT[?[_], A]] =
+    new MFunctor[OptionT[?[_], A]] {
+      def hoist[M[_], N[_]](m: M ~> N): OptionT[M, A] => OptionT[N, A] =
+        o => OptionT(m(o.value))
+    }
+
   implicit def catsDataMonoidKForOptionT[F[_]](implicit F0: Monad[F]): MonoidK[OptionT[F, ?]] =
     new OptionTMonoidK[F] { implicit val F = F0 }
 

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -217,7 +217,9 @@ private[data] sealed trait OptionTInstances1 extends OptionTInstances2 {
 
   implicit def catsDataMFunctorForOptionT[A]: MFunctor[OptionT[?[_], A]] =
     new MFunctor[OptionT[?[_], A]] {
-      def hoist[M[_], N[_]](m: M ~> N): OptionT[M, A] => OptionT[N, A] =
+      type C[M[_]] = Monad[M]
+
+      def hoist[M[_]: Monad, N[_]: Monad](m: M ~> N): OptionT[M, A] => OptionT[N, A] =
         o => OptionT(m(o.value))
     }
 

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -87,6 +87,12 @@ private[data] sealed abstract class WriterTInstances extends WriterTInstances0 {
         WriterT(Functor[M].map(ma)((W.empty, _)))
     }
 
+  implicit def catsDataMFunctorForWriterT[W, A](implicit W: Monoid[W]): MFunctor[WriterT[?[_], W, A]] =
+    new MFunctor[WriterT[?[_], W, A]] {
+      def hoist[M[_], N[_]](m: M ~> N): WriterT[M, W, A] => WriterT[N, W, A] =
+        w => WriterT(m(w.run))
+    }
+
   implicit def catsDataShowForWriterT[F[_], L, V](implicit F: Show[F[(L, V)]]): Show[WriterT[F, L, V]] = new Show[WriterT[F, L, V]] {
     override def show(f: WriterT[F, L, V]): String = f.show
   }

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -89,7 +89,9 @@ private[data] sealed abstract class WriterTInstances extends WriterTInstances0 {
 
   implicit def catsDataMFunctorForWriterT[W, A](implicit W: Monoid[W]): MFunctor[WriterT[?[_], W, A]] =
     new MFunctor[WriterT[?[_], W, A]] {
-      def hoist[M[_], N[_]](m: M ~> N): WriterT[M, W, A] => WriterT[N, W, A] =
+      type C[M[_]] = Monad[M]
+
+      def hoist[M[_]: Monad, N[_]: Monad](m: M ~> N): WriterT[M, W, A] => WriterT[N, W, A] =
         w => WriterT(m(w.run))
     }
 

--- a/free/src/main/scala/cats/free/FreeT.scala
+++ b/free/src/main/scala/cats/free/FreeT.scala
@@ -218,6 +218,12 @@ private[free] sealed trait FreeTInstances1 extends FreeTInstances2 {
       override def liftT[M[_]: Functor, A](ma: M[A]): FreeT[S, M, A] =
         FreeT.liftT(ma)
     }
+
+  implicit def catsDataMFunctorForFreeT[S[_], A]: MFunctor[FreeT[S, ?[_], A]] =
+    new MFunctor[FreeT[S, ?[_], A]] {
+      def hoist[M[_], N[_]](m: M ~> N): FreeT[S, M, A] => FreeT[S, N, A] =
+        f => f.hoist(m)
+    }
 }
 
 private[free] sealed trait FreeTInstances0 extends FreeTInstances1 {


### PR DESCRIPTION
WIP:

This generalises the notion of changing the underlying monad of a monad transformer using a natural transformation.

I opened the PR to have some feedback/discussion on the following points:

- Currently the natural transformation is not constrained to be a monad morphism, but I feel like it should be (or a constraint parameter?)
- No syntax yet, I'm not sure what's the best way to do this
- No laws yet - these are the same as the functor laws
- No examples