### PR TITLE
Docs Data Type list fix

### DIFF
--- a/docs/src/main/tut/datatypes.md
+++ b/docs/src/main/tut/datatypes.md
@@ -7,7 +7,7 @@ position: 2
 # Data Types
 
 {% for x in site.pages %}
-  {% if x.section == 'data' %}
+  {% if x.section == 'data' and x.title != page.title %}
 - [{{x.title}}]({{site.baseurl}}{{x.url}})
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
At present, the documentation page for data types has a list of all the available data types: in this bullet list, the "Data Types" page itself is listed (see attached image).

<img width="727" alt="datatype-bug" src="https://cloud.githubusercontent.com/assets/810447/21147782/0dde6c00-c14e-11e6-85f2-4db1b3381f90.png">


 This PR fixes the generation of the data type bullet list, so that "Data Type" is no longer listed as a valid data type.