### PR TITLE
make stack-safety-test for tailRecM in MonadTests only fail when checking the test

### DIFF
--- a/laws/src/main/scala/cats/laws/discipline/MonadTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MonadTests.scala
@@ -34,7 +34,7 @@ trait MonadTests[F[_]] extends ApplicativeTests[F] with FlatMapTests[F] {
         "monad left identity" -> forAll(laws.monadLeftIdentity[A, B] _),
         "monad right identity" -> forAll(laws.monadRightIdentity[A] _),
         "map flatMap coherence" -> forAll(laws.mapFlatMapCoherence[A, B] _)
-      ) ++ (if (Platform.isJvm) Seq[(String, Prop)]("tailRecM stack safety" -> laws.tailRecMStackSafety) else Seq.empty)
+      ) ++ (if (Platform.isJvm) Seq[(String, Prop)]("tailRecM stack safety" -> Prop.lzy(laws.tailRecMStackSafety)) else Seq.empty)
     }
   }
 


### PR DESCRIPTION

Previously, already calling `MonadTests[Signal].monad[Int, Int, Int].all` would cause a StackOverflowError, now this is only caused when executing the test and can be captured e.g. by using `check`.

In our case, this solved a ScalaTest test suite from aborting and thus not executing any tests to just a failing test.