### PR TITLE
Implement NonEmptyList#FilterNot

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -34,12 +34,35 @@ final case class NonEmptyList[A](head: A, tail: List[A]) {
   def ::(a: A): NonEmptyList[A] = NonEmptyList(a, head :: tail)
 
   /**
-   * remove elements not matching the predicate
+   * Remove elements not matching the predicate
+   *
+   * {{{
+   * scala> import cats.data.NonEmptyList
+   * scala> val nel = NonEmptyList.of(1, 2, 3, 4, 5)
+   * scala> nel.filter(_ < 3)
+   * res0: scala.collection.immutable.List[Int] = List(1, 2)
+   * }}}
    */
   def filter(p: A => Boolean): List[A] = {
     val ftail = tail.filter(p)
     if (p(head)) head :: ftail
     else ftail
+  }
+
+  /**
+    * Remove elements matching the predicate
+    *
+    * {{{
+    * scala> import cats.data.NonEmptyList
+    * scala> val nel = NonEmptyList.of(1, 2, 3, 4, 5)
+    * scala> nel.filterNot(_ < 3)
+    * res0: scala.collection.immutable.List[Int] = List(3, 4, 5)
+    * }}}
+    */
+  def filterNot(p: A => Boolean): List[A] = {
+    val ftail = tail.filterNot(p)
+    if (p(head)) ftail
+    else head :: ftail
   }
 
   /**

--- a/tests/src/test/scala/cats/tests/NonEmptyListTests.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyListTests.scala
@@ -81,6 +81,13 @@ class NonEmptyListTests extends CatsSuite {
     }
   }
 
+  test("NonEmptyList#filterNot is consistent with List#filterNot") {
+    forAll { (nel: NonEmptyList[Int], p: Int => Boolean) =>
+      val list = nel.toList
+      nel.filterNot(p) should === (list.filterNot(p))
+    }
+  }
+
   test("NonEmptyList#find is consistent with List#find") {
     forAll { (nel: NonEmptyList[Int], p: Int => Boolean) =>
       val list = nel.toList


### PR DESCRIPTION
`NonEmptyList` is implementing the `filter` method, but not the `filterNot`, which is available at `scala.collection.immutable.List`. This method is useful in order to avoid negating a filter condition.