### PR TITLE
Implement NonEmptyVector#filterNot

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -37,9 +37,28 @@ final class NonEmptyVector[A] private (val toVector: Vector[A]) extends AnyVal {
   def tail: Vector[A] = toVector.tail
 
   /**
-   * remove elements not matching the predicate
-   */
+    * Remove elements not matching the predicate
+    *
+    * {{{
+    * scala> import cats.data.NonEmptyVector
+    * scala> val nev = NonEmptyVector.of(1, 2, 3, 4, 5)
+    * scala> nev.filter(_ < 3)
+    * res0: scala.collection.immutable.Vector[Int] = Vector(1, 2)
+    * }}}
+    */
   def filter(f: A => Boolean): Vector[A] = toVector.filter(f)
+
+  /**
+    * Remove elements matching the predicate
+    *
+    * {{{
+    * scala> import cats.data.NonEmptyVector
+    * scala> val nev = NonEmptyVector.of(1, 2, 3, 4, 5)
+    * scala> nev.filterNot(_ < 3)
+    * res0: scala.collection.immutable.Vector[Int] = Vector(3, 4, 5)
+    * }}}
+    */
+  def filterNot(f: A => Boolean): Vector[A] = toVector.filterNot(f)
 
   /**
    * Alias for [[concat]]

--- a/tests/src/test/scala/cats/tests/NonEmptyVectorTests.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyVectorTests.scala
@@ -93,6 +93,13 @@ class NonEmptyVectorTests extends CatsSuite {
     }
   }
 
+  test("NonEmptyVector#filterNot is consistent with Vector#filterNot") {
+    forAll { (nonEmptyVector: NonEmptyVector[Int], p: Int => Boolean) =>
+      val vector = nonEmptyVector.toVector
+      nonEmptyVector.filterNot(p) should === (vector.filterNot(p))
+    }
+  }
+
   test("NonEmptyVector#find is consistent with Vector#find") {
     forAll { (nonEmptyVector: NonEmptyVector[Int], p: Int => Boolean) =>
       val vector = nonEmptyVector.toVector


### PR DESCRIPTION
As a follow up for the PR #1512, `NonEmptyVector` is also implementing the filter method, but not the `filterNot`, which is available at `scala.collection.immutable.Vector`. This method is useful in order to avoid negating a filter condition.