### PR TITLE
Implement NonEmptyVector#size

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -166,7 +166,29 @@ final class NonEmptyVector[A] private (val toVector: Vector[A]) extends AnyVal {
   def show(implicit A: Show[A]): String =
     s"NonEmpty${Show[Vector[A]].show(toVector)}"
 
+  /**
+    * Counts the number of elements in the collection.
+    *
+    * {{{
+    * scala> import cats.data.NonEmptyVector
+    * scala> val nev = NonEmptyVector.of(1, 2, 3, 4, 5)
+    * scala> nev.length
+    * res0: Int = 5
+    * }}}
+    */
   def length: Int = toVector.length
+
+  /**
+    * Counts the number of elements in the collection.
+    *
+    * {{{
+    * scala> import cats.data.NonEmptyVector
+    * scala> val nev = NonEmptyVector.of(1, 2, 3, 4, 5)
+    * scala> nev.size
+    * res0: Int = 5
+    * }}}
+    */
+  def size: Int = toVector.size
 
   override def toString: String = s"NonEmpty${toVector.toString}"
 

--- a/tests/src/test/scala/cats/tests/NonEmptyVectorTests.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyVectorTests.scala
@@ -53,14 +53,6 @@ class NonEmptyVectorTests extends CatsSuite {
   checkAll("NonEmptyVector[Int]", MonadTests[NonEmptyVector].monad[Int, Int, Int])
   checkAll("Monad[NonEmptyVector]", SerializableTests.serializable(Monad[NonEmptyVector]))
 
-
-  test("size is consistent with toList.size") {
-    forAll { (nonEmptyVector: NonEmptyVector[Int]) =>
-      nonEmptyVector.size should === (nonEmptyVector.toList.size.toLong)
-    }
-  }
-
-
   test("Show is not empty and is formatted as expected") {
     forAll { (nonEmptyVector: NonEmptyVector[Int]) =>
       nonEmptyVector.show.nonEmpty should === (true)
@@ -286,6 +278,18 @@ class NonEmptyVectorTests extends CatsSuite {
           head should === (nonEmptyVector.head)
           tail should === (nonEmptyVector.tail)
       }
+    }
+  }
+
+  test("NonEmptyVector#length consistent with Vector#length") {
+    forAll { (nonEmptyVector: NonEmptyVector[Int]) =>
+      nonEmptyVector.length should === (nonEmptyVector.toVector.length)
+    }
+  }
+
+  test("NonEmptyVector#size consistent with Vector#size") {
+    forAll { (nonEmptyVector: NonEmptyVector[Int]) =>
+      nonEmptyVector.size should === (nonEmptyVector.toVector.size)
     }
   }
 


### PR DESCRIPTION
Scala `Vector` instance haves both `length` and `size` methods implemented and working in the same way, this commit adds this missing method to Cats `NonEmptyVector`, so the class becomes more consistent with its Scala counterpart.