### PR TITLE
Implement NonEmptyList#Collect

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -67,6 +67,30 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) {
   }
 
   /**
+    * Builds a new `List` by applying a partial function to
+    * all the elements from this `NonEmptyList` on which the function is defined
+    *
+    * {{{
+    * scala> import cats.data.NonEmptyList
+    * scala> val nel = NonEmptyList.of(1, 2, 3, 4, 5)
+    * scala> nel.collect { case v if v < 3 => v }
+    * res0: scala.collection.immutable.List[Int] = List(1, 2)
+    * scala> nel.collect {
+    *      |  case v if v % 2 == 0 => "even"
+    *      |  case _ => "odd"
+    *      | }
+    * res1: scala.collection.immutable.List[String] = List(odd, even, odd, even, odd)
+    * }}}
+    */
+  def collect[B](pf: PartialFunction[A, B]) : List[B] = {
+    if (pf.isDefinedAt(head)) {
+      pf.apply(head) :: tail.collect(pf)
+    } else {
+      tail.collect(pf)
+    }
+  }
+
+  /**
    * Append another NonEmptyList
    */
   def concat[AA >: A](other: NonEmptyList[AA]): NonEmptyList[AA] =

--- a/tests/src/test/scala/cats/tests/NonEmptyListTests.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyListTests.scala
@@ -88,6 +88,13 @@ class NonEmptyListTests extends CatsSuite {
     }
   }
 
+  test("NonEmptyList#collect is consistent with List#collect") {
+    forAll { (nel: NonEmptyList[Int], pf: PartialFunction[Int, String]) =>
+      val list = nel.toList
+      nel.collect(pf) should === (list.collect(pf))
+    }
+  }
+
   test("NonEmptyList#find is consistent with List#find") {
     forAll { (nel: NonEmptyList[Int], p: Int => Boolean) =>
       val list = nel.toList


### PR DESCRIPTION
- "collect" method is really useful when wanting to do a transformation in some of the elements from a collection, applying a partial function. This PR implements this method both for `NonEmptyVector` and `NonEmptyList`.