### PR TITLE
Foldable/Reducible intercalate update

### DIFF
--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -402,9 +402,20 @@ import simulacrum.typeclass
    * }}}
    */
   def intercalate[A](fa: F[A], a: A)(implicit A: Monoid[A]): A =
-    reduceLeftOption(fa){ (acc, aa) =>
-      A.combine(acc, A.combine(a, aa))
-    }.getOrElse(A.empty)
+    A.combineAll(intersperseList(toList(fa), a))
+
+  protected def intersperseList[A](xs: List[A], x: A): List[A] = {
+    val bld = List.newBuilder[A]
+    val it = xs.iterator
+    if (it.hasNext) {
+      bld += it.next
+      while(it.hasNext) {
+        bld += x
+        bld += it.next
+      }
+    }
+    bld.result
+  }
 
   def compose[G[_]: Foldable]: Foldable[λ[α => F[G[α]]]] =
     new ComposedFoldable[F, G] {

--- a/core/src/main/scala/cats/Reducible.scala
+++ b/core/src/main/scala/cats/Reducible.scala
@@ -171,10 +171,11 @@ import simulacrum.typeclass
    * }}}
    */
   def intercalate1[A](fa: F[A], a: A)(implicit A: Semigroup[A]): A =
-    reduceLeft(fa)((acc, aa) => A.combine(acc, A.combine(a, aa)))
-
-  override def intercalate[A](fa: F[A], a: A)(implicit A: Monoid[A]): A =
-    intercalate1(fa, a)
+    toNonEmptyList(fa) match {
+      case NonEmptyList(hd, Nil) => hd
+      case NonEmptyList(hd, tl) =>
+        Reducible[NonEmptyList].reduce(NonEmptyList(hd, a :: intersperseList(tl, a)))
+    }
 }
 
 /**

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -109,6 +109,12 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) {
   def reduceLeft[AA >: A](f: (AA, AA) => AA): AA =
     tail.foldLeft[AA](head)(f)
 
+  /**
+   * Reduce using the `Semigroup` of `AA`.
+   */
+  def reduce[AA >: A](implicit S: Semigroup[AA]): AA =
+    S.combineAllOption(toList).get
+
   def traverse[G[_], B](f: A => G[B])(implicit G: Applicative[G]): G[NonEmptyList[B]] =
     G.map2Eval(f(head), Always(Traverse[List].traverse(tail)(f)))(NonEmptyList(_, _)).value
 
@@ -238,6 +244,9 @@ private[data] sealed trait NonEmptyListInstances extends NonEmptyListInstances0 
 
       override def reduceLeft[A](fa: NonEmptyList[A])(f: (A, A) => A): A =
         fa.reduceLeft(f)
+
+      override def reduce[A](fa: NonEmptyList[A])(implicit A: Semigroup[A]): A =
+        fa.reduce
 
       override def map[A, B](fa: NonEmptyList[A])(f: A => B): NonEmptyList[B] =
         fa map f

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -250,6 +250,11 @@ private[data] sealed trait NonEmptyVectorInstances {
         go(f(a))
         NonEmptyVector.fromVectorUnsafe(buf.result())
       }
+
+      override def toList[A](fa: NonEmptyVector[A]): List[A] = fa.toVector.toList
+
+      override def toNonEmptyList[A](fa: NonEmptyVector[A]): NonEmptyList[A] =
+        NonEmptyList(fa.head, fa.tail.toList)
     }
 
   implicit def catsDataEqForNonEmptyVector[A](implicit A: Eq[A]): Eq[NonEmptyVector[A]] =

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -83,6 +83,8 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
       override def foldM[G[_], A, B](fa: List[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
         Foldable.iteratorFoldM(fa.toIterator, z)(f)
 
+      override def fold[A](fa: List[A])(implicit A: Monoid[A]): A = A.combineAll(fa)
+
       override def toList[A](fa: List[A]): List[A] = fa
     }
 

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -82,6 +82,8 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
 
       override def foldM[G[_], A, B](fa: List[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
         Foldable.iteratorFoldM(fa.toIterator, z)(f)
+
+      override def toList[A](fa: List[A]): List[A] = fa
     }
 
   implicit def catsStdShowForList[A:Show]: Show[List[A]] =

--- a/core/src/main/scala/cats/instances/map.scala
+++ b/core/src/main/scala/cats/instances/map.scala
@@ -81,6 +81,11 @@ trait MapInstances extends cats.kernel.instances.MapInstances {
 
       override def foldM[G[_], A, B](fa: Map[K, A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
         Foldable.iteratorFoldM(fa.valuesIterator, z)(f)
+
+      override def fold[A](fa: Map[K, A])(implicit A: Monoid[A]): A =
+        A.combineAll(fa.values)
+
+      override def toList[A](fa: Map[K, A]): List[A] = fa.values.toList
     }
   // scalastyle:on method.length
 }

--- a/core/src/main/scala/cats/instances/set.scala
+++ b/core/src/main/scala/cats/instances/set.scala
@@ -31,6 +31,8 @@ trait SetInstances extends cats.kernel.instances.SetInstances {
       override def foldM[G[_], A, B](fa: Set[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
         Foldable.iteratorFoldM(fa.toIterator, z)(f)
 
+      override def fold[A](fa: Set[A])(implicit A: Monoid[A]): A = A.combineAll(fa)
+
       override def toList[A](fa: Set[A]): List[A] = fa.toList
     }
 

--- a/core/src/main/scala/cats/instances/set.scala
+++ b/core/src/main/scala/cats/instances/set.scala
@@ -30,6 +30,8 @@ trait SetInstances extends cats.kernel.instances.SetInstances {
 
       override def foldM[G[_], A, B](fa: Set[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
         Foldable.iteratorFoldM(fa.toIterator, z)(f)
+
+      override def toList[A](fa: Set[A]): List[A] = fa.toList
     }
 
   implicit def catsStdShowForSet[A:Show]: Show[Set[A]] = new Show[Set[A]] {

--- a/core/src/main/scala/cats/instances/stream.scala
+++ b/core/src/main/scala/cats/instances/stream.scala
@@ -109,6 +109,8 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
 
       override def foldM[G[_], A, B](fa: Stream[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
         Foldable.iteratorFoldM(fa.toIterator, z)(f)
+
+      override def toList[A](fa: Stream[A]): List[A] = fa.toList
     }
 
   implicit def catsStdShowForStream[A: Show]: Show[Stream[A]] =

--- a/core/src/main/scala/cats/instances/stream.scala
+++ b/core/src/main/scala/cats/instances/stream.scala
@@ -110,6 +110,8 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
       override def foldM[G[_], A, B](fa: Stream[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
         Foldable.iteratorFoldM(fa.toIterator, z)(f)
 
+      override def fold[A](fa: Stream[A])(implicit A: Monoid[A]): A = A.combineAll(fa)
+
       override def toList[A](fa: Stream[A]): List[A] = fa.toList
     }
 

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -89,6 +89,8 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
 
       override def foldM[G[_], A, B](fa: Vector[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
         Foldable.iteratorFoldM(fa.toIterator, z)(f)
+
+      override def toList[A](fa: Vector[A]): List[A] = fa.toList
     }
 
   implicit def catsStdShowForVector[A:Show]: Show[Vector[A]] =

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -90,6 +90,8 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
       override def foldM[G[_], A, B](fa: Vector[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
         Foldable.iteratorFoldM(fa.toIterator, z)(f)
 
+      override def fold[A](fa: Vector[A])(implicit A: Monoid[A]): A = A.combineAll(fa)
+
       override def toList[A](fa: Vector[A]): List[A] = fa.toList
     }
 


### PR DESCRIPTION
Follow up on #1520, after @johnynek 's comment.

This should reduce the complexity for `intercalate` from `O(N^2)` to `O(N)`.
I also overrode `toList` in some `Foldable` instances.