### PR TITLE
Remove link to apply.html from menu

### DIFF
--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -48,8 +48,6 @@ options:
      - title: Functor
        url: typeclasses/functor.html
        menu_section: monads
-     - title: Apply
-       url: typeclasses/apply.html
        menu_section: monads
      - title: Applicative
        url: typeclasses/applicative.html


### PR DESCRIPTION
After PR #1513 there's no such page. 
http://typelevel.org/cats/typeclasses/apply.html returns 404.