### PR TITLE
inject for free programs

### DIFF
--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -145,8 +145,8 @@ sealed abstract class Free[S[_], A] extends Product with Serializable {
    * Lift into `G` (typically a `Coproduct`) given `Inject`. Analogous
    * to `Free.inject` but lifts programs rather than constructors.
    */
-  final def inject[G[_]](implicit ev: Inject[F, G]): Free[G, A] =
-    compile(λ[F ~> G](ev.inj(_)))
+  final def inject[G[_]](implicit ev: Inject[S, G]): Free[G, A] =
+    compile(λ[S ~> G](ev.inj(_)))
 
   override def toString: String =
     "Free(...)"

--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -141,6 +141,13 @@ sealed abstract class Free[S[_], A] extends Product with Serializable {
       }
     }(Free.catsFreeMonadForFree)
 
+  /**
+   * Lift into `G` (typically a `Coproduct`) given `Inject`. Analogous
+   * to `Free.inject` but lifts programs rather than constructors.
+   */
+  final def inject[G[_]](implicit ev: Inject[F, G]): Free[G, A] =
+    compile(λ[F ~> G](ev.inj(_)))
+
   override def toString: String =
     "Free(...)"
 }

--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -144,6 +144,17 @@ sealed abstract class Free[S[_], A] extends Product with Serializable {
   /**
    * Lift into `G` (typically a `Coproduct`) given `Inject`. Analogous
    * to `Free.inject` but lifts programs rather than constructors.
+   *
+   *{{{
+   *scala> type Lo[A] = cats.data.Coproduct[List, Option, A]
+   *defined type alias Lo
+   *
+   *scala> val fo = Free.liftF(Option("foo"))
+   *fo: cats.free.Free[Option,String] = Free(...)
+   *
+   *scala> fo.inject[Lo]
+   *res4: cats.free.Free[Lo,String] = Free(...)
+   *}}}
    */
   final def inject[G[_]](implicit ev: Inject[S, G]): Free[G, A] =
     compile(λ[S ~> G](ev.inj(_)))


### PR DESCRIPTION
This adds an `inject` operation for `Free` that lifts programs rather than constructors. This allows you to use existing `Free` programs (like doobie `ConnectionIO`) in coproducts without having to write implicit modules of lifted constructors.

I'll add a test if people think this is useful.