### PR TITLE
Add piecemeal import for MonadError

### DIFF
--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -24,6 +24,7 @@ package object syntax {
   object invariant extends InvariantSyntax
   object list extends ListSyntax
   object monadCombine extends MonadCombineSyntax
+  object monadError extends MonadErrorSyntax
   object monadFilter extends MonadFilterSyntax
   object monoid extends MonoidSyntax
   object option extends OptionSyntax


### PR DESCRIPTION
@jackcviers and @Wogan pointed out on our gitter channel that there is no piecemeal syntax import for `MonadError`.