### PR TITLE
Switch from CrossVersion.full to CrossVersion.patch for TLS compatibi…

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,7 @@ lazy val commonSettings = Seq(
   libraryDependencies ++= Seq(
     "com.github.mpilquist" %%% "simulacrum" % "0.10.0",
     "org.typelevel" %%% "machinist" % "0.6.1",
-    compilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full),
+    compilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.patch),
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.3")
   ),
   fork in test := true,
@@ -453,7 +453,7 @@ lazy val scalaMacroDependencies: Seq[Setting[_]] = Seq(
       // in Scala 2.10, quasiquotes are provided by macro paradise
       case Some((2, 10)) =>
         Seq(
-          compilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.full),
+          compilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.patch),
               "org.scalamacros" %% "quasiquotes" % "2.1.0" cross CrossVersion.binary
         )
     }

--- a/build.sbt
+++ b/build.sbt
@@ -445,7 +445,7 @@ lazy val crossVersionSharedSources: Seq[Setting[_]] =
   }
 
 lazy val scalaMacroDependencies: Seq[Setting[_]] = Seq(
-  libraryDependencies += "org.scala-lang" %%% "scala-reflect" % scalaVersion.value % "provided",
+  libraryDependencies += scalaOrganization.value %%% "scala-reflect" % scalaVersion.value % "provided",
   libraryDependencies ++= {
     CrossVersion.partialVersion(scalaVersion.value) match {
       // if scala 2.11+ is used, quasiquotes are merged into scala-reflect


### PR DESCRIPTION
…lity.

To use Typelevel Scala versions which are not exactly aligned with the corresponding Lightbend Scala version (ie. because they include and additional `-bin-patch-nnn` suffix in their version) we need to modify project builds which use `CrossVersion.full` (which includes the suffix) to use `CrossVersion.patch` (which doesn't) where appropriate (eg. for macro-paradise and other compiler plugins).

See https://github.com/typelevel/scala/issues/135