### PR TITLE
fix ref to non-existent dir in contributing

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -171,8 +171,8 @@ Write about checking laws
 ### source for the documentation
 The documentation for this website is stored alongside the source, in the [docs subproject](https://github.com/typelevel/cats/tree/master/docs).
 
-* The source for the static pages is in `docs/src/site`
 * The source for the tut compiled pages is in `docs/src/main/tut`
+* The menu structure for these pages is in `docs/src/main/resources/microsite/data/menu.yml`
 
 ### Generating the Site
 


### PR DESCRIPTION
it seems as if there are no static pages any more in the website.

I added a path to the menu file instead, as it might help to give people a lead on how the menus are
constructed.