### PR TITLE
docs: freemonad docs, make pureCompiler example more error prone

### DIFF
--- a/docs/src/main/tut/datatypes/freemonad.md
+++ b/docs/src/main/tut/datatypes/freemonad.md
@@ -276,7 +276,8 @@ state in an immutable map, avoiding mutation altogether.
 import cats.data.State
 
 type KVStoreState[A] = State[Map[String, Any], A]
-val pureCompiler: KVStoreA ~> KVStoreState = new (KVStoreA ~> KVStoreState) {
+
+def pureCompiler: KVStoreA ~> KVStoreState = new (KVStoreA ~> KVStoreState) {
   def apply[A](fa: KVStoreA[A]): KVStoreState[A] =
     fa match {
       case Put(key, value) => State.modify(_.updated(key, value))


### PR DESCRIPTION
If somebody tries examples from the documentation without an assumption about the structure, there is a possibility to end up with something like this:

```scala
package example

import cats.data.State
import cats.free.Free
import cats.free.Free.liftF
import cats.{Id, ~>}

import scala.collection.mutable

object HelloFreeMonad extends App {

  sealed trait KVStoreA[A]
  case class Put[T](key: String, value: T) extends KVStoreA[Unit]
  case class Get[T](key: String) extends KVStoreA[Option[T]]
  case class Delete(key: String) extends KVStoreA[Unit]

  type KVStore[A] = Free[KVStoreA, A]

  // Put returns nothing (i.e. Unit).
  def put[T](key: String, value: T): KVStore[Unit] =
    liftF[KVStoreA, Unit](Put[T](key, value))

  // Get returns a T value.
  def get[T](key: String): KVStore[Option[T]] =
    liftF[KVStoreA, Option[T]](Get[T](key))

  // Delete returns nothing (i.e. Unit).
  def delete(key: String): KVStore[Unit] =
    liftF(Delete(key))

  // Update composes get and set, and returns nothing.
  def update[T](key: String, f: T => T): KVStore[Unit] =
    for {
      vMaybe <- get[T](key)
      _ <- vMaybe.map(v => put[T](key, f(v))).getOrElse(Free.pure(()))
    } yield ()

  type KVStoreState[A] = State[Map[String, Any], A]

  // the program will crash if a key is not found,
  // or if a type is incorrectly specified.
  def impureCompiler: KVStoreA ~> Id  =
    new (KVStoreA ~> Id) {

      // a very simple (and imprecise) key-value store
      val kvs = mutable.Map.empty[String, Any]

      def apply[A](fa: KVStoreA[A]): Id[A] =
        fa match {
          case Put(key, value) =>
            println(s"put($key, $value)")
            kvs(key) = value
            ()
          case Get(key) =>
            println(s"get($key)")
            kvs.get(key).map(_.asInstanceOf[A])
          case Delete(key) =>
            println(s"delete($key)")
            kvs.remove(key)
            ()
        }
    }

  val pureCompilerFailing: KVStoreA ~> KVStoreState = new (KVStoreA ~> KVStoreState) {
    def apply[A](fa: KVStoreA[A]): KVStoreState[A] = {
      fa match {
        case Put(key, value) => State.modify(_.updated(key, value))
        case Get(key) => State.inspect(_.get(key).map(_.asInstanceOf[A]))
        case Delete(key) => State.modify(_ - key)
      }
    }
  }

  def pureCompilerNotFailing: KVStoreA ~> KVStoreState = new (KVStoreA ~> KVStoreState) {
    def apply[A](fa: KVStoreA[A]): KVStoreState[A] = {
      fa match {
        case Put(key, value) => State.modify(_.updated(key, value))
        case Get(key) => State.inspect(_.get(key).map(_.asInstanceOf[A]))
        case Delete(key) => State.modify(_ - key)
      }
    }
  }

  override def main(args: Array[String]): Unit = {
    val program: Free[KVStoreA, Option[Int]] = for {
      _ <- put("wild-cats", 2)
      _ <- update[Int]("wild-cats", (_ + 12))
      _ <- put("tame-cats", 5)
      n <- get[Int]("wild-cats")
      _ <- delete("tame-cats")
    } yield n

    val result1 = program.foldMap(impureCompiler)
    val result2 = program.foldMap(pureCompilerNotFailing).run(Map.empty).value
    val result3 = program.foldMap(pureCompilerFailing).run(Map.empty).value

    println(result1)
    println(result2)
    println(result3)
  }
}
```

In this case `pureCompiler` that is defined with `def` would work fine inside `main` and outside of it. Although, the definition of a compiler with `val` works _only_ inside `main`. 

Stacktrace:

```scala
Exception in thread "main" java.lang.NullPointerException
	at cats.free.Free.$anonfun$foldMap$1(Free.scala:126)
	at cats.free.Free$$Lambda$6/1190524793.apply(Unknown Source)
	at cats.data.StateTMonad.$anonfun$tailRecM$2(StateT.scala:236)
	at cats.data.StateTMonad$$Lambda$29/667026744.apply(Unknown Source)
	at cats.EvalInstances$$anon$1.tailRecM(Eval.scala:307)
	at cats.EvalInstances$$anon$1.tailRecM(Eval.scala:301)
	at cats.data.StateTMonad.$anonfun$tailRecM$1(StateT.scala:235)
	at cats.data.StateTMonad$$Lambda$26/1529306539.apply(Unknown Source)
	at cats.data.StateT.$anonfun$run$1(StateT.scala:38)
	at cats.data.StateT$$Lambda$27/182738614.apply(Unknown Source)
	at cats.Eval$$anon$5$$anon$6.$anonfun$start$1(Eval.scala:84)
	at cats.Eval$$anon$5$$anon$6$$Lambda$37/1447689627.apply(Unknown Source)
	at cats.Eval$Compute.loop$1(Eval.scala:279)
	at cats.Eval$Compute.value(Eval.scala:293)
	at example.Hello$.main(Hello.scala:95)
	at example.Hello.main(Hello.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at com.intellij.rt.execution.application.AppMain.main(AppMain.java:147)
```

Unfortunately for the beginners it is quite confusing. Perhaps, there is a reasonable explanation why does it happen, but I couldn't figure that out quickly. If somebody could explain in a few words why does it happen I would be very happy.

I suggest to change it to `def` because it works in all possible cases.

Thank you!