### PR TITLE
Add basic exception-handling to Eval.

### DIFF
--- a/tests/src/test/scala/cats/tests/EvalTests.scala
+++ b/tests/src/test/scala/cats/tests/EvalTests.scala
@@ -89,16 +89,9 @@ class EvalTests extends CatsSuite {
       else if (i % 100 == 0) loop(i - 1, e.map(n => n).handleErrorWith(_ => Now(-999)))
       else loop(i - 1, e.map(n => n))
 
-    // we expect to use 1k stack frames of error handling
+    // we expect to use ~1k stack frames of error handling, which
+    // should be safe.
     loop(100000, Now(6)).value should === (6)
-
-    // we expect to use at least 100k stack frames and fail
-    try {
-      loop(10000000, Now(7)).value
-      fail("we expected a StackOverflowError but didn't get one")
-    } catch { case t: StackOverflowError =>
-      succeed
-    }
   }
 
   test("Eval.raise(t).handleErrorWith(f) = f(t)") {

--- a/tests/src/test/scala/cats/tests/EvalTests.scala
+++ b/tests/src/test/scala/cats/tests/EvalTests.scala
@@ -86,7 +86,7 @@ class EvalTests extends CatsSuite {
     checkAll("Eval[Int]", MonadTests[Eval].monad[Int, Int, Int])
   }
   checkAll("Bimonad[Eval]", SerializableTests.serializable(Bimonad[Eval]))
-  checkAll("Monad[Eval]", SerializableTests.serializable(Monad[Eval]))
+  checkAll("MonadError[Eval, Throwable]", SerializableTests.serializable(MonadError[Eval, Throwable]))
 
   checkAll("Eval[Int]", ReducibleTests[Eval].reducible[Option, Int, Int])
   checkAll("Reducible[Eval]", SerializableTests.serializable(Reducible[Eval]))

--- a/tests/src/test/scala/cats/tests/EvalTests.scala
+++ b/tests/src/test/scala/cats/tests/EvalTests.scala
@@ -92,9 +92,9 @@ class EvalTests extends CatsSuite {
     // we expect to use 1k stack frames of error handling
     loop(100000, Now(6)).value should === (6)
 
-    // we expect to use 10k stack frames of error handling and fail
+    // we expect to use at least 100k stack frames and fail
     try {
-      loop(1000000, Now(7)).value
+      loop(10000000, Now(7)).value
       fail("we expected a StackOverflowError but didn't get one")
     } catch { case t: StackOverflowError =>
       succeed

--- a/tests/src/test/scala/cats/tests/EvalTests.scala
+++ b/tests/src/test/scala/cats/tests/EvalTests.scala
@@ -83,6 +83,52 @@ class EvalTests extends CatsSuite {
     }
   }
 
+  test("handleErrorWith is semi-stacksafe") {
+    def loop(i: Int, e: Eval[Int]): Eval[Int] =
+      if (i <= 0) e
+      else if (i % 100 == 0) loop(i - 1, e.map(n => n).handleErrorWith(_ => Now(-999)))
+      else loop(i - 1, e.map(n => n))
+
+    // we expect to use 1k stack frames of error handling
+    loop(100000, Now(6)).value should === (6)
+
+    // we expect to use 10k stack frames of error handling and fail
+    try {
+      loop(1000000, Now(7)).value
+      fail("we expected a StackOverflowError but didn't get one")
+    } catch { case t: StackOverflowError =>
+      succeed
+    }
+  }
+
+  test("Eval.raise(t).handleErrorWith(f) = f(t)") {
+    forAll { (t: Throwable, f: Throwable => Eval[Int]) =>
+      Eval.raise(t).handleErrorWith(f) should === (f(t))
+    }
+  }
+
+  test(".recoverWith and .handleErrorWith are equivalent") {
+    forAll { (e0: Eval[Int], f: Throwable => Eval[Int], p: PartialFunction[Throwable, Eval[Int]]) =>
+
+      // should be an error at least 1/3 of the time.
+      val e = e0.map { n => if (n % 3 == 0) n / 0 else n / 2 }
+
+      // test with a total recovery function
+      val x1 = Try(e.handleErrorWith(f))
+      val y1 = Try(e.recoverWith { case e => f(e) })
+      x1 should === (y1)
+
+      // test with a partial recovery function
+      val x2 = Try(e.recoverWith(p).value)
+      val y2 = Try(e.handleErrorWith(t => if (p.isDefinedAt(t)) p(t) else Eval.raise(t)).value)
+      x2 should === (y2)
+
+      // ensure that this works if we throw directly
+      val z2 = Try(e.handleErrorWith(t => if (p.isDefinedAt(t)) p(t) else throw t).value)
+      x2 should === (z2)
+    }
+  }
+
   {
     implicit val iso = CartesianTests.Isomorphisms.invariant[Eval]
     checkAll("Eval[Int]", BimonadTests[Eval].bimonad[Int, Int, Int])


### PR DESCRIPTION
These methods provide the basis for a `MonadError[Eval, Throwable]`
instance, without adding any overhead for people who don't wish to use
these (admittedly limited) capabilities.

Since `Eval` defers evaluation, we can take advantage of this to defer
additional recovery logic to the eventual evaluation. Critically, it doesn't
add any kind of *error node* to the `Eval` AST, or any extra overhead to
the default evaluation paths.

This came up when I was trying to catch up on https://github.com/typelevel/cats/pull/1552.
I realized there was no real reason why we couldn't have a
`MonadError[Eval, Throwable]` instance.

Review by @johnynek, @alexandru, et al.