### PR TITLE
Fix mistake in documentation of Group.remove

### DIFF
--- a/kernel/src/main/scala/cats/kernel/Group.scala
+++ b/kernel/src/main/scala/cats/kernel/Group.scala
@@ -17,7 +17,7 @@ trait Group[@sp(Int, Long, Float, Double) A] extends Any with Monoid[A] {
   /**
    * Remove the element `b` from `a`.
    *
-   * Equivalent to `combine(a, inverse(a))`
+   * Equivalent to `combine(a, inverse(b))`
    */
   def remove(a: A, b: A): A = combine(a, inverse(b))
 


### PR DESCRIPTION
Documentation initially said `remove` was equivalent to `combine(a, inverse(a))`. Changed to be equivalent to `combine(a, inverse(b))` instead.