### PR TITLE
Add Edmund Noble to maintainers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ The current maintainers (people who can merge pull requests) are:
  * [fthomas](https://github.com/fthomas) Frank Thomas
  * [julien-truffaut](https://github.com/julien-truffaut) Julien Truffaut
  * [kailuowang](https://github.com/kailuowang) Kailuo Wang
+ * [edmundnoble](https://github.com/edmundnoble) Edmund Noble
 
 We are currently following a practice of requiring at least two
 sign-offs to merge PRs (and for large or contentious issues we may


### PR DESCRIPTION
I've already polled the current maintainers and they were unanimous in wanting to add Edmund to the list. I also spoke to Edmund and he agreed, so this PR is just a formality at this point.