### PR TITLE
Add Applicative.unit

### DIFF
--- a/core/src/main/scala/cats/Applicative.scala
+++ b/core/src/main/scala/cats/Applicative.scala
@@ -22,6 +22,14 @@ import simulacrum.typeclass
    */
   def pure[A](x: A): F[A]
 
+  /**
+   * Returns an `F[Unit]` instance, equivalent with `pure(())`.
+   *
+   * A useful shorthand, also allowing implementations to optimize the
+   * returned reference (e.g. it can be a `val`).
+   */
+  def unit: F[Unit] = pure(())
+
   override def map[A, B](fa: F[A])(f: A => B): F[B] =
     ap(pure(f))(fa)
 

--- a/core/src/main/scala/cats/Applicative.scala
+++ b/core/src/main/scala/cats/Applicative.scala
@@ -23,7 +23,7 @@ import simulacrum.typeclass
   def pure[A](x: A): F[A]
 
   /**
-   * Returns an `F[Unit]` instance, equivalent with `pure(())`.
+   * Returns an `F[Unit]` value, equivalent with `pure(())`.
    *
    * A useful shorthand, also allowing implementations to optimize the
    * returned reference (e.g. it can be a `val`).

--- a/laws/src/main/scala/cats/laws/ApplicativeLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplicativeLaws.scala
@@ -35,6 +35,9 @@ trait ApplicativeLaws[F[_]] extends ApplyLaws[F] {
   def apProductConsistent[A, B](fa: F[A], f: F[A => B]): IsEq[F[B]] =
     F.ap(f)(fa) <-> F.map(F.product(f, fa)) { case (f, a) => f(a) }
 
+  def applicativeUnit[A](a: A): IsEq[F[A]] =
+    F.unit.map(_ => a) <-> F.pure(a)
+
   // The following are the lax monoidal functor identity laws - the associativity law is covered by
   // Cartesian's associativity law.
 

--- a/laws/src/main/scala/cats/laws/discipline/ApplicativeTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ApplicativeTests.scala
@@ -31,6 +31,7 @@ trait ApplicativeTests[F[_]] extends ApplyTests[F] {
       "applicative homomorphism" -> forAll(laws.applicativeHomomorphism[A, B] _),
       "applicative interchange" -> forAll(laws.applicativeInterchange[A, B] _),
       "applicative map" -> forAll(laws.applicativeMap[A, B] _),
+      "applicative unit" -> forAll(laws.applicativeUnit[A] _),
       "ap consistent with product + map" -> forAll(laws.apProductConsistent[A, B] _),
       "monoidal left identity" -> forAll((fa: F[A]) => iso.leftIdentity(laws.monoidalLeftIdentity(fa))),
       "monoidal right identity" -> forAll((fa: F[A]) => iso.rightIdentity(laws.monoidalRightIdentity(fa))))


### PR DESCRIPTION
Adding a short-hand to `Applicative` for `F.pure(())`.

```scala
@typeclass trait Applicative[F[_]] extends Apply[F] { self =>
  /**
   * Returns an `F[Unit]` value, equivalent with `pure(())`.
   *
   * A useful shorthand, also allowing implementations to optimize the
   * returned reference (e.g. it can be a `val`).
   */
  def unit: F[Unit] = pure(())
```

Reasons:

1. I find myself doing `F.pure(()).map(_ => a)` a lot (due to `pure` not taking a by-name param and having no way to do that otherwise, but that's another discussion)
2. `F[Unit]` is often used to indicate callbacks that are going to trigger side-effects, like for resource clean-ups - for example in `Task.doOnFinish` and we often need to create empty `F[Unit]` instances that don't do anything; `F.pure(())` is more noisy versus `F.unit`
3. `Applicative` implementations can optimize this to always return the same reference, instead of rebuilding `pure(())` over and over again

Prior art:

```scala
scala.concurrent.Future.unit
```