### PR TITLE
Add NonEmptyList#fromFoldable

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -313,6 +313,9 @@ object NonEmptyList extends NonEmptyListInstances {
       case h :: t => NonEmptyList(h, t)
     }
 
+  def fromFoldable[F[_], A](fa: F[A])(implicit F: Foldable[F]): Option[NonEmptyList[A]] =
+    fromList(F.toList(fa))
+
   def fromReducible[F[_], A](fa: F[A])(implicit F: Reducible[F]): NonEmptyList[A] =
     F.toNonEmptyList(fa)
 }

--- a/tests/src/test/scala/cats/tests/NonEmptyListTests.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyListTests.scala
@@ -256,6 +256,12 @@ class NonEmptyListTests extends CatsSuite {
       nel.groupBy(f).mapValues(_.toList) should === (nel.toList.groupBy(f))
     }
   }
+
+  test("NonEmptyList#fromFoldabale is consistent with NonEmptyList#fromList") {
+    forAll { (xs: List[Int]) =>
+      NonEmptyList.fromList(xs) should === (NonEmptyList.fromFoldable(xs))
+    }
+  }
 }
 
 class ReducibleNonEmptyListCheck extends ReducibleCheck[NonEmptyList]("NonEmptyList") {


### PR DESCRIPTION
Adds a new method `NonEmptyList#fromFoldable`.  This generalizes `NonEmptyList.fromList` such that you can also create a `NonEmptyList` from anything that has a `Foldable` instance, e.g., `Vector`, `Set`, ... 