### PR TITLE
Rename Inject to InjectK

### DIFF
--- a/core/src/main/scala/cats/InjectK.scala
+++ b/core/src/main/scala/cats/InjectK.scala
@@ -4,11 +4,12 @@ import cats.arrow.FunctionK
 import cats.data.EitherK
 
 /**
- * Inject type class as described in "Data types a la carte" (Swierstra 2008).
+ * The injection type class as described in "Data types a la carte"
+ * (Swierstra 2008).
  *
  * @see [[http://www.staff.science.uu.nl/~swier004/publications/2008-jfp.pdf]]
  */
-sealed abstract class Inject[F[_], G[_]] {
+sealed abstract class InjectK[F[_], G[_]] {
   def inj: FunctionK[F, G]
 
   def prj: FunctionK[G, λ[α => Option[F[α]]]]
@@ -18,29 +19,29 @@ sealed abstract class Inject[F[_], G[_]] {
   def unapply[A](ga: G[A]): Option[F[A]] = prj(ga)
 }
 
-private[cats] sealed abstract class InjectInstances {
-  implicit def catsReflexiveInjectInstance[F[_]]: Inject[F, F] =
-    new Inject[F, F] {
+private[cats] sealed abstract class InjectKInstances {
+  implicit def catsReflexiveInjectKInstance[F[_]]: InjectK[F, F] =
+    new InjectK[F, F] {
       val inj = λ[FunctionK[F, F]](identity(_))
 
       val prj = λ[FunctionK[F, λ[α => Option[F[α]]]]](Some(_))
     }
 
-  implicit def catsLeftInjectInstance[F[_], G[_]]: Inject[F, EitherK[F, G, ?]] =
-    new Inject[F, EitherK[F, G, ?]] {
+  implicit def catsLeftInjectKInstance[F[_], G[_]]: InjectK[F, EitherK[F, G, ?]] =
+    new InjectK[F, EitherK[F, G, ?]] {
       val inj = λ[FunctionK[F, EitherK[F, G, ?]]](EitherK.leftc(_))
 
       val prj = λ[FunctionK[EitherK[F, G, ?], λ[α => Option[F[α]]]]](_.run.left.toOption)
     }
 
-  implicit def catsRightInjectInstance[F[_], G[_], H[_]](implicit I: Inject[F, G]): Inject[F, EitherK[H, G, ?]] =
-    new Inject[F, EitherK[H, G, ?]] {
+  implicit def catsRightInjectKInstance[F[_], G[_], H[_]](implicit I: InjectK[F, G]): InjectK[F, EitherK[H, G, ?]] =
+    new InjectK[F, EitherK[H, G, ?]] {
       val inj = λ[FunctionK[G, EitherK[H, G, ?]]](EitherK.rightc(_)) compose I.inj
 
       val prj = λ[FunctionK[EitherK[H, G, ?], λ[α => Option[F[α]]]]](_.run.right.toOption.flatMap(I.prj(_)))
     }
 }
 
-object Inject extends InjectInstances {
-  def apply[F[_], G[_]](implicit I: Inject[F, G]): Inject[F, G] = I
+object InjectK extends InjectKInstances {
+  def apply[F[_], G[_]](implicit I: InjectK[F, G]): InjectK[F, G] = I
 }

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -10,11 +10,11 @@ package object cats {
   type ⊥ = Nothing
   type ⊤ = Any
 
-  /** [[cats.Inject]][F, G] */
-  type :<:[F[_], G[_]] = Inject[F, G]
+  /** [[cats.InjectK]][F, G] */
+  type :<:[F[_], G[_]] = InjectK[F, G]
 
-  /** [[cats.Inject]][F, G] */
-  type :≺:[F[_], G[_]] = Inject[F, G]
+  /** [[cats.InjectK]][F, G] */
+  type :≺:[F[_], G[_]] = InjectK[F, G]
 
 /**
  * Identity, encoded as `type Id[A] = A`, a convenient alias to make

--- a/docs/src/main/tut/typeclasses/symbols.md
+++ b/docs/src/main/tut/typeclasses/symbols.md
@@ -1,6 +1,6 @@
 #Symbols
 
-Below is a list of symbols used in cats.  
+Below is a list of symbols used in cats.
 
 The `~>`, `⊥` and `⊤` symbols can be imported with `import cats._`.
 
@@ -25,7 +25,7 @@ A scaladoc generated list is also available on the [Scaladoc symbols page](http:
 | `x |+| y`  | Semigroup combine      | [`Semigroup[A]`]({{ site.sources }}/kernel/src/main/scala/cats/kernel/Semigroup.scala)      | `combine(x: A, y: A): A`               |
 | `x <+> y`  | SemigroupK combine     | [`SemigroupK[F[_]]`]({{ site.sources }}/core/src/main/scala/cats/SemigroupK.scala)          | `combineK(x: F[A], y: F[A]): F[A]`     |
 | `F ~> G`   | natural transformation | [`FunctionK[F[_], G[_]]`]({{ site.sources }}/core/src/main/scala/cats/arrow/FunctionK.scala)| `FunctionK` alias                      |
-| `F :<: G`  | inject                 | [`Inject[F[_], G[_]]`]({{ site.sources }}/free/src/main/scala/cats/free/package.scala)      | `Inject` alias                         |
-| `F :≺: G`  | inject                 | [`Inject[F[_], G[_]]`]({{ site.sources }}/free/src/main/scala/cats/free/package.scala)      | `Inject` alias                         |
+| `F :<: G`  | inject                 | [`InjectK[F[_], G[_]]`]({{ site.sources }}/free/src/main/scala/cats/free/package.scala)     | `InjectK` alias                         |
+| `F :≺: G`  | inject                 | [`InjectK[F[_], G[_]]`]({{ site.sources }}/free/src/main/scala/cats/free/package.scala)     | `InjectK` alias                         |
 | `⊥`        | bottom                 | [N/A]({{ site.sources }}/core/src/main/scala/cats/package.scala)                            | `Nothing`                              |
 | `⊤`        | top                    | [N/A]({{ site.sources }}/core/src/main/scala/cats/package.scala)                            | `Any`                                  |

--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -140,7 +140,7 @@ sealed abstract class Free[S[_], A] extends Product with Serializable {
     }(Free.catsFreeMonadForFree)
 
   /**
-   * Lift into `G` (typically a `EitherK`) given `Inject`. Analogous
+   * Lift into `G` (typically a `EitherK`) given `InjectK`. Analogous
    * to `Free.inject` but lifts programs rather than constructors.
    *
    *{{{
@@ -154,7 +154,7 @@ sealed abstract class Free[S[_], A] extends Product with Serializable {
    *res4: cats.free.Free[Lo,String] = Free(...)
    *}}}
    */
-  final def inject[G[_]](implicit ev: Inject[S, G]): Free[G, A] =
+  final def inject[G[_]](implicit ev: InjectK[S, G]): Free[G, A] =
     compile(λ[S ~> G](ev.inj(_)))
 
   override def toString: String =
@@ -209,28 +209,28 @@ object Free {
     λ[FunctionK[Free[F, ?], M]](f => f.foldMap(fk))
 
   /**
-   * This method is used to defer the application of an Inject[F, G]
+   * This method is used to defer the application of an InjectK[F, G]
    * instance. The actual work happens in
-   * `FreeInjectPartiallyApplied#apply`.
+   * `FreeInjectKPartiallyApplied#apply`.
    *
    * This method exists to allow the `F` and `G` parameters to be
    * bound independently of the `A` parameter below.
    */
-  def inject[F[_], G[_]]: FreeInjectPartiallyApplied[F, G] =
-    new FreeInjectPartiallyApplied
+  def inject[F[_], G[_]]: FreeInjectKPartiallyApplied[F, G] =
+    new FreeInjectKPartiallyApplied
 
   /**
    * Pre-application of an injection to a `F[A]` value.
    */
-  final class FreeInjectPartiallyApplied[F[_], G[_]] private[free] {
-    def apply[A](fa: F[A])(implicit I: Inject[F, G]): Free[G, A] =
+  final class FreeInjectKPartiallyApplied[F[_], G[_]] private[free] {
+    def apply[A](fa: F[A])(implicit I: InjectK[F, G]): Free[G, A] =
       Free.liftF(I.inj(fa))
   }
 
-  def injectRoll[F[_], G[_], A](ga: G[Free[F, A]])(implicit I: Inject[G, F]): Free[F, A] =
+  def injectRoll[F[_], G[_], A](ga: G[Free[F, A]])(implicit I: InjectK[G, F]): Free[F, A] =
     Free.roll(I.inj(ga))
 
-  def match_[F[_], G[_], A](fa: Free[F, A])(implicit F: Functor[F], I: Inject[G, F]): Option[G[Free[F, A]]] =
+  def match_[F[_], G[_], A](fa: Free[F, A])(implicit F: Functor[F], I: InjectK[G, F]): Option[G[Free[F, A]]] =
     fa.resume.fold(I.prj(_), _ => None)
 
   /**

--- a/tests/src/test/scala/cats/tests/InjectKTests.scala
+++ b/tests/src/test/scala/cats/tests/InjectKTests.scala
@@ -4,7 +4,7 @@ import cats.data.EitherK
 import cats.tests.CatsSuite
 import org.scalacheck._
 
-class InjectTests extends CatsSuite {
+class InjectKTests extends CatsSuite {
 
   sealed trait Test1Algebra[A]
 
@@ -52,8 +52,8 @@ class InjectTests extends CatsSuite {
       } yield x + y
 
     forAll { (x: Int, y: Int) =>
-      val expr1: T[Int] = Inject[Test1Algebra, T].inj(Test1(x, _ + 1))
-      val expr2: T[Int] = Inject[Test2Algebra, T].inj(Test2(y, _ * 2))
+      val expr1: T[Int] = InjectK[Test1Algebra, T].inj(Test1(x, _ + 1))
+      val expr2: T[Int] = InjectK[Test2Algebra, T].inj(Test2(y, _ * 2))
       val res = distr[T, Int](expr1, expr2)
       res should ===(Some(x + y))
     }
@@ -71,8 +71,8 @@ class InjectTests extends CatsSuite {
       } yield x + y
 
     forAll { (x: Int, y: Int) =>
-      val expr1: T[Int] = Inject[Test1Algebra, T].apply(Test1(x, _ + 1))
-      val expr2: T[Int] = Inject[Test2Algebra, T].apply(Test2(y, _ * 2))
+      val expr1: T[Int] = InjectK[Test1Algebra, T].apply(Test1(x, _ + 1))
+      val expr2: T[Int] = InjectK[Test2Algebra, T].apply(Test2(y, _ * 2))
       val res = distr[T, Int](expr1, expr2)
       res should ===(Some(x + y))
     }
@@ -80,20 +80,20 @@ class InjectTests extends CatsSuite {
 
   test("apply in left") {
     forAll { (y: Test1Algebra[Int]) =>
-      Inject[Test1Algebra, T].inj(y) == EitherK(Left(y)) should ===(true)
+      InjectK[Test1Algebra, T].inj(y) == EitherK(Left(y)) should ===(true)
     }
   }
 
   test("apply in right") {
     forAll { (y: Test2Algebra[Int]) =>
-      Inject[Test2Algebra, T].inj(y) == EitherK(Right(y)) should ===(true)
+      InjectK[Test2Algebra, T].inj(y) == EitherK(Right(y)) should ===(true)
     }
   }
 
   test("null identity") {
     val listIntNull = null.asInstanceOf[List[Int]]
-    Inject.catsReflexiveInjectInstance[List].inj[Int](listIntNull) should ===(listIntNull)
-    Inject.catsReflexiveInjectInstance[List].prj[Int](listIntNull) should ===(Some(listIntNull))
+    InjectK.catsReflexiveInjectKInstance[List].inj[Int](listIntNull) should ===(listIntNull)
+    InjectK.catsReflexiveInjectKInstance[List].prj[Int](listIntNull) should ===(Some(listIntNull))
   }
 
 }


### PR DESCRIPTION
Rename `Inject` to `InjectK` to be consistent with names/renames for `EitherK`, `FunctionK`, `Tuple2K`, and friends. See #1589.

This is a breaking API and breaking binary change.

Additionally, this opens the door to  "re-introduce" `Inject` for `Either`:

```scala
sealed abstract class Inject[A, B] {
  def inj: A => B
  def prj: B => Option[A]
  def apply(a: A): B = inj(a)
  def unapply(b: B): Option[A] = prj(b)
}

private[cats] sealed abstract class InjectInstances {
  implicit def catsReflexiveInjectInstance[A]: Inject[A, A] =
    new Inject[A, A] {
      val inj = identity
      val prj = Some(_)
    }

  implicit def catsLeftInjectInstance[A, B]: Inject[A, Either[A, B]] =
    new Inject[A, Either[A, B]] {
      val inj = Left(_)
      val prj = _.left.toOption
    }

  implicit def catsRightInjectInstance[A, B, C](implicit I: Inject[A, B]): Inject[A, Either[C, B]] =
    new Inject[A, Either[C, B]] {
      val inj = a => Right(I.inj(a))
      val prj = _.right.toOption.flatMap(I.prj)
    }

}

object Inject extends InjectInstances {
  def apply[A, B](implicit I: Inject[A, B]): Inject[A, B] = I
}
```

Inject for Either would be useful when combining error algebras across domains with `Free`.