### PR TITLE
Use Cogen for Kleisli and Func Arbitrary instances

### DIFF
--- a/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
@@ -76,11 +76,11 @@ object arbitrary extends ArbitraryInstances0 {
       B.perturb(seed, _),
       (a, b) => A.perturb(B.perturb(seed, b), a)))
 
-  implicit def catsLawsArbitraryForKleisli[F[_], A, B](implicit F: Arbitrary[F[B]]): Arbitrary[Kleisli[F, A, B]] =
-    Arbitrary(F.arbitrary.map(fb => Kleisli[F, A, B](_ => fb)))
+  implicit def catsLawsArbitraryForKleisli[F[_], A, B](implicit AA: Arbitrary[A], CA: Cogen[A], F: Arbitrary[F[B]]): Arbitrary[Kleisli[F, A, B]] =
+    Arbitrary(Arbitrary.arbitrary[A => F[B]].map(Kleisli(_)))
 
-  implicit def catsLawsArbitraryForCokleisli[F[_], A, B](implicit B: Arbitrary[B]): Arbitrary[Cokleisli[F, A, B]] =
-    Arbitrary(B.arbitrary.map(b => Cokleisli[F, A, B](_ => b)))
+  implicit def catsLawsArbitraryForCokleisli[F[_], A, B](implicit AFA: Arbitrary[F[A]], CFA: Cogen[F[A]], B: Arbitrary[B]): Arbitrary[Cokleisli[F, A, B]] =
+    Arbitrary(Arbitrary.arbitrary[F[A] => B].map(Cokleisli(_)))
 
   implicit def catsLawsArbitraryForOptionT[F[_], A](implicit F: Arbitrary[F[Option[A]]]): Arbitrary[OptionT[F, A]] =
     Arbitrary(F.arbitrary.map(OptionT.apply))
@@ -106,11 +106,11 @@ object arbitrary extends ArbitraryInstances0 {
   implicit def catsLawsArbitraryForTuple2K[F[_], G[_], A](implicit F: Arbitrary[F[A]], G: Arbitrary[G[A]]): Arbitrary[Tuple2K[F, G, A]] =
     Arbitrary(F.arbitrary.flatMap(fa => G.arbitrary.map(ga => Tuple2K[F, G, A](fa, ga))))
 
-  implicit def catsLawsArbitraryForFunc[F[_], A, B](implicit F: Arbitrary[F[B]]): Arbitrary[Func[F, A, B]] =
-    Arbitrary(F.arbitrary.map(fb => Func.func[F, A, B](_ => fb)))
+  implicit def catsLawsArbitraryForFunc[F[_], A, B](implicit AA: Arbitrary[A], CA: Cogen[A], F: Arbitrary[F[B]]): Arbitrary[Func[F, A, B]] =
+    Arbitrary(Arbitrary.arbitrary[A => F[B]].map(Func.func))
 
-  implicit def catsLawsArbitraryForAppFunc[F[_], A, B](implicit F: Arbitrary[F[B]], FF: Applicative[F]): Arbitrary[AppFunc[F, A, B]] =
-    Arbitrary(F.arbitrary.map(fb => Func.appFunc[F, A, B](_ => fb)))
+  implicit def catsLawsArbitraryForAppFunc[F[_], A, B](implicit AA: Arbitrary[A], CA: Cogen[A], F: Arbitrary[F[B]], FF: Applicative[F]): Arbitrary[AppFunc[F, A, B]] =
+    Arbitrary(Arbitrary.arbitrary[A => F[B]].map(Func.appFunc(_)))
 
   implicit def catsLawsArbitraryForWriter[L:Arbitrary, V:Arbitrary]: Arbitrary[Writer[L, V]] =
     catsLawsArbitraryForWriterT[Id, L, V]


### PR DESCRIPTION
I think that this resolves #1605. It may have merge conflicts with #1584
and I think that one should probably be merged first.

I noticed a slight discrepancy between how I've implemented this (taking
implicit `Cogen` and `Arbitrary` instances) vs how the current `StateT`
arbitrary instance works (it takes an implicit `Arbitrary[S => F[(S, A)]]]`). I'm not really sure whether one approach is better than the other. We should probably align on one of the two, though.