### PR TITLE
Fix doc for InvariantMonoidal

### DIFF
--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -72,6 +72,9 @@ options:
      - title: Invariant
        url: typeclasses/invariant.html
        menu_section: variance
+     - title: InvariantMonoidal
+       url: typeclasses/invariantmonoidal.html
+       menu_section: variance
 
   - title: Foldable
     url: typeclasses/foldable.html

--- a/docs/src/main/tut/typeclasses/invariantmonoidal.md
+++ b/docs/src/main/tut/typeclasses/invariantmonoidal.md
@@ -1,4 +1,4 @@
-  ---
+---
 layout: docs
 title:  "InvariantMonoidal"
 section: "typeclasses"


### PR DESCRIPTION
InvariantMonoidal was not generated because of a typo and not present on the left-side menu, this PR solves both issues.

Related to #1609.