### PR TITLE
Allow non-constant arbitrary functions for (Co)Kleisli, State, Func

### DIFF
--- a/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
@@ -77,8 +77,8 @@ object arbitrary extends ArbitraryInstances0 {
       (a, b) => A.perturb(B.perturb(seed, b), a)))
 
 
-  implicit def catsLawsArbitraryForCokleisli[F[_], A, B](implicit B: Arbitrary[B]): Arbitrary[Cokleisli[F, A, B]] =
-    Arbitrary(B.arbitrary.map(b => Cokleisli[F, A, B](_ => b)))
+  implicit def catsLawsArbitraryForCokleisli[F[_], A, B](implicit FAB: Arbitrary[F[A] => B]): Arbitrary[Cokleisli[F, A, B]] =
+    Arbitrary(FAB.arbitrary.map(Cokleisli(_)))
 
   implicit def catsLawsArbitraryForOptionT[F[_], A](implicit F: Arbitrary[F[Option[A]]]): Arbitrary[OptionT[F, A]] =
     Arbitrary(F.arbitrary.map(OptionT.apply))
@@ -104,11 +104,11 @@ object arbitrary extends ArbitraryInstances0 {
   implicit def catsLawsArbitraryForTuple2K[F[_], G[_], A](implicit F: Arbitrary[F[A]], G: Arbitrary[G[A]]): Arbitrary[Tuple2K[F, G, A]] =
     Arbitrary(F.arbitrary.flatMap(fa => G.arbitrary.map(ga => Tuple2K[F, G, A](fa, ga))))
 
-  implicit def catsLawsArbitraryForFunc[F[_], A, B](implicit F: Arbitrary[F[B]]): Arbitrary[Func[F, A, B]] =
-    Arbitrary(F.arbitrary.map(fb => Func.func[F, A, B](_ => fb)))
+  implicit def catsLawsArbitraryForFunc[F[_], A, B](implicit AFB: Arbitrary[A => F[B]]): Arbitrary[Func[F, A, B]] =
+    Arbitrary(AFB.arbitrary.map(Func.func(_)))
 
-  implicit def catsLawsArbitraryForAppFunc[F[_], A, B](implicit F: Arbitrary[F[B]], FF: Applicative[F]): Arbitrary[AppFunc[F, A, B]] =
-    Arbitrary(F.arbitrary.map(fb => Func.appFunc[F, A, B](_ => fb)))
+  implicit def catsLawsArbitraryForAppFunc[F[_], A, B](implicit AFB: Arbitrary[A => F[B]], FF: Applicative[F]): Arbitrary[AppFunc[F, A, B]] =
+    Arbitrary(AFB.arbitrary.map(Func.appFunc(_)))
 
   implicit def catsLawsArbitraryForWriter[L:Arbitrary, V:Arbitrary]: Arbitrary[Writer[L, V]] =
     catsLawsArbitraryForWriterT[Id, L, V]
@@ -156,10 +156,10 @@ object arbitrary extends ArbitraryInstances0 {
   implicit def catsLawsArbitraryForNested[F[_], G[_], A](implicit FG: Arbitrary[F[G[A]]]): Arbitrary[Nested[F, G, A]] =
     Arbitrary(FG.arbitrary.map(Nested(_)))
 
-  implicit def catsLawArbitraryForState[S: Arbitrary: Cogen, A: Arbitrary]: Arbitrary[State[S, A]] =
+  implicit def catsLawArbitraryForState[S, A](implicit SSA: Arbitrary[S => Eval[(S, A)]]): Arbitrary[State[S, A]] =
     catsLawArbitraryForStateT[Eval, S, A]
 
-  implicit def catsLawArbitraryForReader[A: Arbitrary, B: Arbitrary]: Arbitrary[Reader[A, B]] =
+  implicit def catsLawArbitraryForReader[A, B](implicit AB: Arbitrary[A => B]): Arbitrary[Reader[A, B]] =
     catsLawsArbitraryForKleisli[Id, A, B]
 }
 
@@ -174,7 +174,7 @@ private[discipline] sealed trait ArbitraryInstances0 {
   implicit def catsLawsCogenForWriterT[F[_], L, V](implicit F: Cogen[F[(L, V)]]): Cogen[WriterT[F, L, V]] =
     F.contramap(_.run)
 
-  implicit def catsLawsArbitraryForKleisli[F[_], A, B](implicit F: Arbitrary[F[B]]): Arbitrary[Kleisli[F, A, B]] =
-    Arbitrary(F.arbitrary.map(fb => Kleisli[F, A, B](_ => fb)))
+  implicit def catsLawsArbitraryForKleisli[F[_], A, B](implicit AFB: Arbitrary[A => F[B]]): Arbitrary[Kleisli[F, A, B]] =
+    Arbitrary(AFB.arbitrary.map(Kleisli(_)))
 
 }


### PR DESCRIPTION
Resolves #1605.

This is a replacement for #1606.

Now that `Arbitrary` instances for functions have been improved with the introduction of `Cogen` in scalacheck, we can pick up better arbitrary functions than the constant ones we were using.