### PR TITLE
[WIP] adding `FunctorK`

### DIFF
--- a/core/src/main/scala/cats/FunctorK.scala
+++ b/core/src/main/scala/cats/FunctorK.scala
@@ -1,0 +1,10 @@
+package cats
+
+import arrow.FunctionK
+
+import simulacrum.typeclass
+
+
+@typeclass trait FunctorK[F[_[_]]] {
+  def mapK[G[_], H[_]](fg: F[G])(f: FunctionK[G, H]): F[H]
+}

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -82,6 +82,10 @@ private[data] sealed trait KleisliFunctions {
 
 private[data] sealed abstract class KleisliInstances extends KleisliInstances0 {
 
+  implicit def catsDataFunctorKForKleisli[A, B]: FunctorK[Kleisli[?[_], A, B]] = new FunctorK[Kleisli[?[_], A, B]]{
+    def mapK[G[_], H[_]](fg: Kleisli[G, A, B])(f: G ~> H): Kleisli[H, A, B] = fg.transform(f)
+  }
+
   implicit def catsDataMonoidForKleisli[F[_], A, B](implicit FB0: Monoid[F[B]]): Monoid[Kleisli[F, A, B]] =
     new KleisliMonoid[F, A, B] { def FB: Monoid[F[B]] = FB0 }
 

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -66,6 +66,10 @@ object WriterT extends WriterTInstances with WriterTFunctions {
 }
 
 private[data] sealed abstract class WriterTInstances extends WriterTInstances0 {
+  implicit def catsDataFunctorKForWriterT[L, V]: FunctorK[WriterT[?[_], L, V]] = new FunctorK[WriterT[?[_], L, V]]{
+    def mapK[G[_], H[_]](fg: WriterT[G, L, V])(f: G ~> H): WriterT[H, L, V] = WriterT(f(fg.run))
+  }
+
 
   implicit def catsDataMonadForWriterTId[L:Monoid]: Monad[WriterT[Id, L, ?]] =
     catsDataMonadWriterForWriterT[Id, L]

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -19,6 +19,7 @@ trait AllSyntax
     with FlatMapSyntax
     with FoldableSyntax
     with FunctorSyntax
+    with FunctorKSyntax
     with FunctorFilterSyntax
     with GroupSyntax
     with InvariantSyntax

--- a/core/src/main/scala/cats/syntax/functorK.scala
+++ b/core/src/main/scala/cats/syntax/functorK.scala
@@ -1,0 +1,4 @@
+package cats
+package syntax
+
+trait FunctorKSyntax extends FunctorK.ToFunctorKOps

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -19,6 +19,7 @@ package object syntax {
   object flatMap extends FlatMapSyntax
   object foldable extends FoldableSyntax
   object functor extends FunctorSyntax
+  object functorK extends FunctorKSyntax
   object functorFilter extends FunctorFilterSyntax
   object group extends GroupSyntax
   object invariant extends InvariantSyntax

--- a/laws/src/main/scala/cats/laws/FunctorKLaws.scala
+++ b/laws/src/main/scala/cats/laws/FunctorKLaws.scala
@@ -1,0 +1,21 @@
+package cats
+package laws
+
+import arrow.FunctionK
+import syntax.all._
+
+trait FunctorKLaws[F[_[_]]] {
+  implicit def F: FunctorK[F]
+
+  def covariantIdentity[G[_]](fg: F[G]): IsEq[F[G]] =
+    fg.mapK(FunctionK.id[G]) <-> fg
+
+  def covariantComposition[G[_], H[_], I[_]](fg: F[G], f: FunctionK[G, H], g: FunctionK[H, I]): IsEq[F[I]] =
+    fg.mapK(f).mapK(g) <-> fg.mapK(f andThen g)
+
+}
+
+object FunctorKLaws {
+  def apply[F[_[_]]](implicit ev: FunctorK[F]): FunctorKLaws[F] =
+    new FunctorKLaws[F] { def F: FunctorK[F] = ev }
+}

--- a/laws/src/main/scala/cats/laws/discipline/FunctorKTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FunctorKTests.scala
@@ -1,0 +1,34 @@
+package cats
+package laws
+package discipline
+
+import cats.arrow.FunctionK
+import org.scalacheck.{Arbitrary, Prop}
+import Prop._
+import org.typelevel.discipline.Laws
+
+trait FunctorKTests[F[_[_]]] extends Laws {
+  def laws: FunctorKLaws[F]
+
+  def functorK[G[_], H[_], I[_], A: Arbitrary](implicit
+                                                        ArbFA: Arbitrary[F[G]],
+                                                        ArbitraryG: Arbitrary[G[A]],
+                                                        ArbitraryH: Arbitrary[H[A]],
+                                                        ArbitraryI: Arbitrary[I[A]],
+                                                        ArbitraryFK: Arbitrary[FunctionK[G, H]],
+                                                        ArbitraryFK2: Arbitrary[FunctionK[H, I]],
+                                                        EqFA: Eq[F[G]],
+                                                        EqFC: Eq[F[I]]
+                                                       ): RuleSet = {
+    new DefaultRuleSet(
+      name =  "functorK",
+      parent = None,
+      "covariant identity" -> forAll(laws.covariantIdentity[G] _),
+      "covariant composition" -> forAll(laws.covariantComposition[G, H, I] _))
+  }
+}
+
+object FunctorKTests {
+  def apply[F[_[_]]: FunctorK]: FunctorKTests[F] =
+    new FunctorKTests[F] { def laws: FunctorKLaws[F] = FunctorKLaws[F] }
+}

--- a/laws/src/main/scala/cats/laws/discipline/FunctorKTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FunctorKTests.scala
@@ -11,17 +11,17 @@ trait FunctorKTests[F[_[_]]] extends Laws {
   def laws: FunctorKLaws[F]
 
   def functorK[G[_], H[_], I[_], A: Arbitrary](implicit
-                                                        ArbFA: Arbitrary[F[G]],
-                                                        ArbitraryG: Arbitrary[G[A]],
-                                                        ArbitraryH: Arbitrary[H[A]],
-                                                        ArbitraryI: Arbitrary[I[A]],
-                                                        ArbitraryFK: Arbitrary[FunctionK[G, H]],
-                                                        ArbitraryFK2: Arbitrary[FunctionK[H, I]],
-                                                        EqFA: Eq[F[G]],
-                                                        EqFC: Eq[F[I]]
-                                                       ): RuleSet = {
+    ArbFA: Arbitrary[F[G]],
+    ArbitraryG: Arbitrary[G[A]],
+    ArbitraryH: Arbitrary[H[A]],
+    ArbitraryI: Arbitrary[I[A]],
+    ArbitraryFK: Arbitrary[FunctionK[G, H]],
+    ArbitraryFK2: Arbitrary[FunctionK[H, I]],
+    EqFA: Eq[F[G]],
+    EqFC: Eq[F[I]]
+  ): RuleSet = {
     new DefaultRuleSet(
-      name =  "functorK",
+      name = "functorK",
       parent = None,
       "covariant identity" -> forAll(laws.covariantIdentity[G] _),
       "covariant composition" -> forAll(laws.covariantComposition[G, H, I] _))

--- a/tests/src/test/scala/cats/tests/KleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/KleisliTests.scala
@@ -7,7 +7,7 @@ import cats.functor.{Contravariant, Strong}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
-import org.scalacheck.Arbitrary
+import org.scalacheck.{Arbitrary, Gen}
 import cats.kernel.laws.GroupLaws
 import cats.laws.discipline.{SemigroupKTests, MonoidKTests}
 
@@ -115,6 +115,15 @@ class KleisliTests extends CatsSuite {
     implicit val catsDataSemigroupKForKleisli = Kleisli.catsDataSemigroupKForKleisli[Option]
     checkAll("Kleisli[Option, Int, Int]", SemigroupKTests[λ[α => Kleisli[Option, α, α]]].semigroupK[Int])
     checkAll("SemigroupK[λ[α => Kleisli[Option, α, α]]]", SerializableTests.serializable(catsDataSemigroupKForKleisli))
+  }
+
+  {
+
+    implicit val catsDataArbitraryOptionList: Arbitrary[FunctionK[Option, List]] = Arbitrary(Gen.const(λ[FunctionK[Option, List]](_.toList)))
+    implicit val catsDataArbitraryListVector: Arbitrary[FunctionK[List, Vector]] = Arbitrary(Gen.const(λ[FunctionK[List, Vector]](_.toVector)))
+
+    checkAll("Kleisli[Option, Int, Int]", FunctorKTests[Kleisli[?[_], Int, Int]].functorK[Option, List, Vector, Int])
+    checkAll("FunctorK[Kleisli[?[_], Int, Int]", SerializableTests.serializable(FunctorK[Kleisli[?[_], Int, Int]]))
   }
 
   checkAll("Reader[Int, Int]", FunctorTests[Reader[Int, ?]].functor[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/WriterTTests.scala
+++ b/tests/src/test/scala/cats/tests/WriterTTests.scala
@@ -7,6 +7,8 @@ import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
 
+import org.scalacheck.{Arbitrary, Gen}
+
 import cats.kernel.laws.OrderLaws
 
 class WriterTTests extends CatsSuite {
@@ -384,5 +386,15 @@ class WriterTTests extends CatsSuite {
 
     checkAll("WriterT[Option, ListWrapper[Int], ?]", MonadErrorTests[WriterT[Option, ListWrapper[Int], ?], Unit].monadError[Int, Int, Int])
     checkAll("MonadError[WriterT[Option, ListWrapper[Int], ?], Unit]", SerializableTests.serializable(MonadError[WriterT[Option, ListWrapper[Int], ?], Unit]))
+  }
+
+
+  {
+
+    implicit val catsDataArbitraryOptionList: Arbitrary[Option ~> List] = Arbitrary(Gen.const(λ[Option ~> List](_.toList)))
+    implicit val catsDataArbitraryListVector: Arbitrary[List ~> Vector] = Arbitrary(Gen.const(λ[List ~> Vector](_.toVector)))
+
+    checkAll("WriterT[Option, Int, Int]", FunctorKTests[WriterT[?[_], Int, Int]].functorK[Option, List, Vector, Int])
+    checkAll("FunctorK[WriterT[?[_], Int, Int]", SerializableTests.serializable(FunctorK[WriterT[?[_], Int, Int]]))
   }
 }


### PR DESCRIPTION
Submitted to solicit feedbacks.  
The incentive for adding this is so that later we can transform final tagless encoded algebra with `FunctionK`s if we can have `FunctorK` instances automatically derived by kittens. 
E.g.

```Scala 
trait Algebra[F[_]] extends Product with Serializable {
   def parseInt: String => F[Int] 
   def parseFloat: String => F[Float] 
}
case class OptionInterpeter (
   val passInt: String => Option[Int] = Try((_:String).toInt).toOption
   val passFloat: String => Option[Float] = Try((_:String).toFloat).toOption
) extends Algebra[Option] {
```
Assume that Kittens can auto derive a `FunctorK` instance for `Algebra[F[_]]`, then we can do
```Scala
val transformed: Algebra[List] = OptionInterpeter().mapK(λ[Option ~> List](_.toList))
```