### PR TITLE
WIP: Attempt to reduce build time on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ install:
   - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
   - pip install --user codecov
   - gem install jekyll -v 2.5
+  - mkdir ~/.sbt/0.13/plugins/ && echo 'addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC1")' >> ~/.sbt/0.13/plugins/build.sbt
 
 notifications:
   webhooks:
@@ -51,6 +52,10 @@ cache:
   - $HOME/.sbt/launchers
   - $HOME/.ivy2/cache
   - $HOME/.nvm
+  - $HOME/.cache/pip
+  - $HOME/.gem
+  - $HOME/.rvm
+  - vendor/bundle
 
 before_cache:
   - du -h -d 1 $HOME/.ivy2/cache


### PR DESCRIPTION
- [x] cache `pip` artifacts (codecov and deps)
- [x] cache `gem` artifacts (jekyll and deps)
- [x] enable [coursier](https://github.com/coursier/coursier) for faster dependencies resolution (only on CI)