### PR TITLE
Rename Eval.raise to Eval.raiseError

### DIFF
--- a/tests/src/test/scala/cats/tests/EvalTests.scala
+++ b/tests/src/test/scala/cats/tests/EvalTests.scala
@@ -94,9 +94,9 @@ class EvalTests extends CatsSuite {
     loop(100000, Now(6)).value should === (6)
   }
 
-  test("Eval.raise(t).handleErrorWith(f) = f(t)") {
-    forAll { (t: Throwable, f: Throwable => Eval[Int]) =>
-      Eval.raise(t).handleErrorWith(f) should === (f(t))
+  test("Eval.raiseError(e).handleErrorWith(f) = f(e)") {
+    forAll { (e: Throwable, f: Throwable => Eval[Int]) =>
+      Eval.raiseError(e).handleErrorWith(f) should === (f(e))
     }
   }
 
@@ -113,7 +113,7 @@ class EvalTests extends CatsSuite {
 
       // test with a partial recovery function
       val x2 = Try(e.recoverWith(p).value)
-      val y2 = Try(e.handleErrorWith(t => if (p.isDefinedAt(t)) p(t) else Eval.raise(t)).value)
+      val y2 = Try(e.handleErrorWith(e => if (p.isDefinedAt(e)) p(e) else Eval.raiseError(e)).value)
       x2 should === (y2)
 
       // ensure that this works if we throw directly


### PR DESCRIPTION
This PR renames `Eval.raise` to `Eval.raiseError`.

This is a pet peeve of mine, but the naming of failing data constructors isn't consistent across the board, so we've got:

- `Eval.raise`
- `ApplicativeError.raiseError`
- `cats.effect.IO.fail`
- `Future.failure`
- `scalaz.concurrent.Task.fail`
- `scalaz.MonadError.raiseError`
- `fs2.Task.fail`
- `monix.eval.Task.raiseError`

If we have `raiseError` in `ApplicativeError`, then I see no reason to not use it across the board. 
And if that's not OK for some reason related to `Throwable`, then the next option should be `fail`, not `raise`.

Either way, we should standardise on something.

EDIT: trying to do the same in `cats-effect` - https://github.com/typelevel/cats-effect/pull/33