### PR TITLE
show(f:T) to show(t:T)

### DIFF
--- a/core/src/main/scala/cats/Show.scala
+++ b/core/src/main/scala/cats/Show.scala
@@ -11,7 +11,7 @@ import cats.functor.Contravariant
  * explicitly provided one.
  */
 @typeclass trait Show[T] {
-  def show(f: T): String
+  def show(t: T): String
 }
 
 object Show {


### PR DESCRIPTION
f could be misleading. usually f parameter is used for functions