### PR TITLE
Make simulacrum a compile time only dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ lazy val commonSettings = Seq(
     Resolver.sonatypeRepo("snapshots")
   ),
   libraryDependencies ++= Seq(
-    "com.github.mpilquist" %%% "simulacrum" % "0.10.0",
+    "com.github.mpilquist" %%% "simulacrum" % "0.10.0" % "compile-time",
     "org.typelevel" %%% "machinist" % "0.6.1",
     compilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.patch),
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.3")
@@ -45,7 +45,9 @@ lazy val commonSettings = Seq(
   parallelExecution in Test := false,
   scalacOptions in (Compile, doc) := (scalacOptions in (Compile, doc)).value.filter(_ != "-Xfatal-warnings"),
   // workaround for https://github.com/scalastyle/scalastyle-sbt-plugin/issues/47
-  scalastyleSources in Compile ++= (unmanagedSourceDirectories in Compile).value
+  scalastyleSources in Compile ++= (unmanagedSourceDirectories in Compile).value,
+  ivyConfigurations += config("compile-time").hide,
+  unmanagedClasspath in Compile ++= update.value.select(configurationFilter("compile-time"))
 ) ++ warnUnusedImport ++ update2_12
 
 lazy val tagName = Def.setting{


### PR DESCRIPTION
@yilinwei mentioned on the gitter channel that we could change the simulacrum dependency to be compile time only.