### PR TITLE
Make InjectK use FunctionK.id for reflexive injection

### DIFF
--- a/core/src/main/scala/cats/InjectK.scala
+++ b/core/src/main/scala/cats/InjectK.scala
@@ -22,7 +22,7 @@ sealed abstract class InjectK[F[_], G[_]] {
 private[cats] sealed abstract class InjectKInstances {
   implicit def catsReflexiveInjectKInstance[F[_]]: InjectK[F, F] =
     new InjectK[F, F] {
-      val inj = λ[FunctionK[F, F]](identity(_))
+      val inj = FunctionK.id[F]
 
       val prj = λ[FunctionK[F, λ[α => Option[F[α]]]]](Some(_))
     }


### PR DESCRIPTION
Tiny tweak.

A similar update/cleanup can be done if an applicative for type constructors is introduced and a "`liftK`" helper is added to `FunctionK`