### PR TITLE
Unseal InjectK to allow for extension by other libraries

### DIFF
--- a/core/src/main/scala/cats/InjectK.scala
+++ b/core/src/main/scala/cats/InjectK.scala
@@ -9,14 +9,14 @@ import cats.data.EitherK
  *
  * @see [[http://www.staff.science.uu.nl/~swier004/publications/2008-jfp.pdf]]
  */
-sealed abstract class InjectK[F[_], G[_]] {
+abstract class InjectK[F[_], G[_]] {
   def inj: FunctionK[F, G]
 
   def prj: FunctionK[G, λ[α => Option[F[α]]]]
 
-  def apply[A](fa: F[A]): G[A] = inj(fa)
+  final def apply[A](fa: F[A]): G[A] = inj(fa)
 
-  def unapply[A](ga: G[A]): Option[F[A]] = prj(ga)
+  final def unapply[A](ga: G[A]): Option[F[A]] = prj(ga)
 }
 
 private[cats] sealed abstract class InjectKInstances {


### PR DESCRIPTION
It would be extremely useful to open up the injection helpers in Free to support any target coproduct type. This is the simplest solution to address this "issue".

Related gitter conversation: https://gitter.im/typelevel/cats?at=590627c9d32c6f2f0956189d

For discussion:
- Should this be converted to a trait?
- Should `apply`/`unapply` be removed?
- Should a test be added to ensure injection into type constructors other than `EitherK` can occur?
