### PR TITLE
Make catsKernelOrderingForOrder a proper implicit conversion

### DIFF
--- a/kernel/src/main/scala/cats/kernel/Order.scala
+++ b/kernel/src/main/scala/cats/kernel/Order.scala
@@ -164,7 +164,7 @@ object Order extends OrderFunctions[Order] {
    * Implicitly convert a `Order[A]` to a `scala.math.Ordering[A]`
    * instance.
    */
-  implicit def catsKernelOrderingForOrder[A](implicit ev: Order[A]): Ordering[A] =
+  implicit def catsKernelOrderingForOrder[A](ev: Order[A]): Ordering[A] =
     ev.toOrdering
 
   /**


### PR DESCRIPTION
The existing implicit conversion from Order to Ordering does not function as an implicit conversion, because the argument is marked implicit. I.e., as @paulp stated:
```scala
scala> import cats.Order.catsKernelOrderingForOrder
import cats.Order.catsKernelOrderingForOrder

scala> implicitly[cats.Order[Int] => scala.math.Ordering[Int]]
<console>:13: error: No implicit view available from cats.Order[Int] => scala.math.Ordering[Int].
       implicitly[cats.Order[Int] => scala.math.Ordering[Int]]
```