### PR TITLE
Adds Freestyle to `Related Projects` list

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ There are many projects that integrate with Cats:
  * [Dogs](https://github.com/stew/dogs): pure functional collections and data structures.
  * [Fetch](https://github.com/47deg/fetch): efficient data access to heterogeneous data sources.
  * [Frameless](https://github.com/adelbertc/frameless): Expressive types for Spark.
+ * [Freestyle](https://github.com/47deg/freestyle): pure functional framework for Free and Tagless Final apps & libs.
  * [FS2](https://github.com/functional-streams-for-scala): compositional, streaming I/O library
  * [Kittens](https://github.com/milessabin/kittens): automatically derived type class instances.
  * [Monix](https://github.com/monixio/monix): high-performance library for composing asynchronous and event-based programs.


### PR DESCRIPTION
Feeestyle is a framework and collection of libraries for building purely functional applications and libraries. Freestyle integrates closely with cats and uses several of the cat's typeclasses and datatypes both internally and in the user facing APIs.

We'd love to be included in the list of Related Projects.

More info about Freestyle can be found at http://frees.io/

Thank you for you consideration :)