### PR TITLE
Make Show inherit from a contravariant base trait

### DIFF
--- a/core/src/main/scala/cats/Show.scala
+++ b/core/src/main/scala/cats/Show.scala
@@ -10,11 +10,16 @@ import cats.functor.Contravariant
  * made a toString method, a Show instance will only exist if someone
  * explicitly provided one.
  */
-@typeclass trait Show[T] {
+@typeclass trait Show[T] extends Show.ContravariantShow[T] {
+  // duplicated so simulacrum knows it requires an instance of this trait
   def show(t: T): String
 }
 
 object Show {
+  trait ContravariantShow[-T] {
+    def show(t: T): String
+  }
+
   /** creates an instance of [[Show]] using the provided function */
   def show[A](f: A => String): Show[A] = new Show[A] {
     def show(a: A): String = f(a)
@@ -27,7 +32,7 @@ object Show {
 
   final case class Shown(override val toString: String) extends AnyVal
   object Shown {
-    implicit def mat[A](x: A)(implicit z: Show[A]): Shown = Shown(z show x)
+    implicit def mat[A](x: A)(implicit z: ContravariantShow[A]): Shown = Shown(z show x)
   }
 
   final case class ShowInterpolator(_sc: StringContext) extends AnyVal {

--- a/tests/src/test/scala/cats/tests/ShowTests.scala
+++ b/tests/src/test/scala/cats/tests/ShowTests.scala
@@ -10,23 +10,28 @@ class ShowTests extends CatsSuite {
   checkAll("Contravariant[Show]", ContravariantTests[Show].contravariant[Int, Int, Int])
   checkAll("Contravariant[Show]", SerializableTests.serializable(Contravariant[Show]))
 
+  sealed trait TimeOfDay
+  case object Morning extends TimeOfDay
+  object TimeOfDay {
+    implicit val showTimeOfDay: Show[TimeOfDay] = Show.show { case Morning => "morning" }
+  }
+
   test("show string interpolator") {
     case class Cat(name: String)
     object Cat {
       implicit val showCat: Show[Cat] = Show.show(_.name)
     }
-
-    sealed trait TimeOfDay
-    case object Morning extends TimeOfDay
-    object TimeOfDay {
-      implicit val showTimeOfDay: Show[TimeOfDay] = Show.show { case Morning => "morning" }
-    }
-
     val tod: TimeOfDay = Morning
     val cat = Cat("Whiskers")
 
     assertResult("Good morning, Whiskers!")(show"Good $tod, $cat!")
 
     assertResult("Good morning, Whiskers!")(show"Good $tod, ${List(cat).head}!")
+  }
+
+  test("show string interpolator and contravariance") {
+    val tod: Morning.type = Morning
+
+    assertResult("Good morning")(show"Good $tod")
   }
 }


### PR DESCRIPTION
Contravariance in type class parameters is well-documented to be an issue for the compiler. Specifically, the compiler has a useless version of "specificity" which forces the least specific instance to be used, if there are overlapping instances and the user does not use an explicit inheritance-based prioritization.

However, the benefit is still there: firstly there is no need for a `Show[BitSet]`, because the existing `Show[Set[Int]]` is narrowed implicitly. In the same vein, `Some(1).show` works even if your instance only exists for `Option[Int]` and not `Some[Int]`. These benefits become more apparent when you construct values from inside a `show` interpolator, and need to use type ascriptions with the existing version of `Show`.

For examples of how users can make overlapping `Show` work, see https://github.com/paulp/psp-std/blob/master/std/src/main/scala/std/Show.scala.

This PR breaks the API in the following ways:
a) Not only was the BitSet show instance no longer necessary, but it actually began to conflict with the Set[Int] instance.
b) Implicit specificity no longer functions properly. Specifically, users cannot have a `Show[Supertype]` and `Show[Subtype]` and expect that `implicitly[Show[Subtype]]` will materialize the latter.

To be clear this is a trade-off. I am not sure how, practically, user usage of Show benefits and is hurt by this change.