### PR TITLE
Fix typo in FreeApplicative doc.

### DIFF
--- a/docs/src/main/tut/datatypes/freeapplicative.md
+++ b/docs/src/main/tut/datatypes/freeapplicative.md
@@ -111,7 +111,7 @@ val parCompiler =
     }
   }
 
-val parValidation = prog.foldMap[ParValidator](parCompiler)
+val parValidator = prog.foldMap[ParValidator](parCompiler)
 ```
 
 ### Logging


### PR DESCRIPTION
It seems like we use `validator` as a variable name for a similar value in the previous chapter.
And beside of that, this value is made from `ParValidator` type.