### PR TITLE
Override fromTry and fromEither for Try and Either

### DIFF
--- a/core/src/main/scala/cats/instances/either.scala
+++ b/core/src/main/scala/cats/instances/either.scala
@@ -40,6 +40,7 @@ trait EitherInstances extends cats.kernel.instances.EitherInstances {
           case Left(e) => f(e)
           case r @ Right(_) => r
         }
+
       def raiseError[B](e: A): Either[A, B] = Left(e)
 
       override def map[B, C](fa: Either[A, B])(f: B => C): Either[A, C] =
@@ -89,6 +90,9 @@ trait EitherInstances extends cats.kernel.instances.EitherInstances {
 
       override def recoverWith[B](fab: Either[A, B])(pf: PartialFunction[A, Either[A, B]]): Either[A, B] =
         fab recoverWith pf
+
+      override def fromEither[B](fab: Either[A, B]): Either[A, B] =
+        fab
 
       override def ensure[B](fab: Either[A, B])(error: => A)(predicate: B => Boolean): Either[A, B] =
         fab.ensure(error)(predicate)

--- a/core/src/main/scala/cats/instances/try.scala
+++ b/core/src/main/scala/cats/instances/try.scala
@@ -75,6 +75,8 @@ trait TryInstances extends TryInstances1 {
 
       override def recoverWith[A](ta: Try[A])(pf: PartialFunction[Throwable, Try[A]]): Try[A] = ta.recoverWith(pf)
 
+      override def fromTry[A](t: Try[A])(implicit ev: Throwable <:< Throwable): Try[A] = t
+
       override def map[A, B](ta: Try[A])(f: A => B): Try[B] = ta.map(f)
 
       override def reduceLeftToOption[A, B](fa: Try[A])(f: A => B)(g: (B, A) => B): Option[B] =

--- a/laws/src/main/scala/cats/laws/ApplicativeErrorLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplicativeErrorLaws.scala
@@ -36,6 +36,9 @@ trait ApplicativeErrorLaws[F[_], E] extends ApplicativeLaws[F] {
 
   def attemptConsistentWithAttemptT[A](fa: F[A]): IsEq[EitherT[F, E, A]] =
     EitherT(F.attempt(fa)) <-> F.attemptT(fa)
+
+  def attemptFromEitherConsistentWithPure[A](eab: Either[E, A]): IsEq[F[Either[E, A]]] =
+    F.attempt(F.fromEither(eab)) <-> F.pure(eab)
 }
 
 object ApplicativeErrorLaws {

--- a/laws/src/main/scala/cats/laws/discipline/ApplicativeErrorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ApplicativeErrorTests.scala
@@ -46,7 +46,8 @@ trait ApplicativeErrorTests[F[_], E] extends ApplicativeTests[F] {
         "applicativeError handleErrorWith consistent with recoverWith" -> forAll(laws.handleErrorWithConsistentWithRecoverWith[A] _),
         "applicativeError handleError consistent with recover" -> forAll(laws.handleErrorConsistentWithRecover[A] _),
         "applicativeError recover consistent with recoverWith" -> forAll(laws.recoverConsistentWithRecoverWith[A] _),
-        "applicativeError attempt consistent with attemptT" -> forAll(laws.attemptConsistentWithAttemptT[A] _)
+        "applicativeError attempt consistent with attemptT" -> forAll(laws.attemptConsistentWithAttemptT[A] _),
+        "applicativeError attempt fromEither consistent with pure" -> forAll(laws.attemptFromEitherConsistentWithPure[A] _)
       )
     }
   }


### PR DESCRIPTION
- Overrides `ApplicativeError#fromTry` for `Try`
- Overrides `ApplicativeError#fromEither` for `Either`
- Add an additional law for `ApplicativeError` ensuring consistency between `attempt` + `fromEither` and `pure`.

The last two are sort of a follow up after #1651. 