### PR TITLE
Remove implicit params from ops classes (WIP)

### DIFF
--- a/core/src/main/scala/cats/syntax/applicativeError.scala
+++ b/core/src/main/scala/cats/syntax/applicativeError.scala
@@ -7,8 +7,8 @@ trait ApplicativeErrorSyntax {
   implicit final def catsSyntaxApplicativeErrorId[E](e: E): ApplicativeErrorIdOps[E] =
     new ApplicativeErrorIdOps(e)
 
-  implicit final def catsSyntaxApplicativeError[F[_], E, A](fa: F[A])(implicit F: ApplicativeError[F, E]): ApplicativeErrorOps[F, E, A] =
-    new ApplicativeErrorOps[F, E, A](fa)
+  implicit final def catsSyntaxApplicativeError[F[_], A](fa: F[A]): ApplicativeErrorOps[F, A] =
+    new ApplicativeErrorOps[F, A](fa)
 }
 
 final class ApplicativeErrorIdOps[E](val e: E) extends AnyVal {
@@ -16,22 +16,22 @@ final class ApplicativeErrorIdOps[E](val e: E) extends AnyVal {
     F.raiseError(e)
 }
 
-final class ApplicativeErrorOps[F[_], E, A](val fa: F[A]) extends AnyVal {
-  def handleError(f: E => A)(implicit F: ApplicativeError[F, E]): F[A] =
+final class ApplicativeErrorOps[F[_], A](val fa: F[A]) extends AnyVal {
+  def handleError[E](f: E => A)(implicit F: ApplicativeError[F, E]): F[A] =
     F.handleError(fa)(f)
 
-  def handleErrorWith(f: E => F[A])(implicit F: ApplicativeError[F, E]): F[A] =
+  def handleErrorWith[E](f: E => F[A])(implicit F: ApplicativeError[F, E]): F[A] =
     F.handleErrorWith(fa)(f)
 
-  def attempt(implicit F: ApplicativeError[F, E]): F[Either[E, A]] =
+  def attempt[E](implicit F: ApplicativeError[F, E]): F[Either[E, A]] =
     F.attempt(fa)
 
-  def attemptT(implicit F: ApplicativeError[F, E]): EitherT[F, E, A] =
+  def attemptT[E](implicit F: ApplicativeError[F, E]): EitherT[F, E, A] =
     F.attemptT(fa)
 
-  def recover(pf: PartialFunction[E, A])(implicit F: ApplicativeError[F, E]): F[A] =
+  def recover[E](pf: PartialFunction[E, A])(implicit F: ApplicativeError[F, E]): F[A] =
     F.recover(fa)(pf)
 
-  def recoverWith(pf: PartialFunction[E, F[A]])(implicit F: ApplicativeError[F, E]): F[A] =
+  def recoverWith[E](pf: PartialFunction[E, F[A]])(implicit F: ApplicativeError[F, E]): F[A] =
     F.recoverWith(fa)(pf)
 }

--- a/core/src/main/scala/cats/syntax/bitraverse.scala
+++ b/core/src/main/scala/cats/syntax/bitraverse.scala
@@ -2,12 +2,12 @@ package cats
 package syntax
 
 trait BitraverseSyntax extends BitraverseSyntax1 {
-  implicit final def catsSyntaxBitraverse[F[_, _]: Bitraverse, A, B](fab: F[A, B]): BitraverseOps[F, A, B] =
+  implicit final def catsSyntaxBitraverse[F[_, _], A, B](fab: F[A, B]): BitraverseOps[F, A, B] =
     new BitraverseOps[F, A, B](fab)
 }
 
 private[syntax] trait BitraverseSyntax1 {
-  implicit final def catsSyntaxNestedBitraverse[F[_, _]: Bitraverse, G[_], A, B](fgagb: F[G[A], G[B]]): NestedBitraverseOps[F, G, A, B] =
+  implicit final def catsSyntaxNestedBitraverse[F[_, _], G[_], A, B](fgagb: F[G[A], G[B]]): NestedBitraverseOps[F, G, A, B] =
     new NestedBitraverseOps[F, G, A, B](fgagb)
 }
 

--- a/core/src/main/scala/cats/syntax/flatMap.scala
+++ b/core/src/main/scala/cats/syntax/flatMap.scala
@@ -3,10 +3,10 @@ package syntax
 
 trait FlatMapSyntax extends FlatMap.ToFlatMapOps {
 
-  implicit final def catsSyntaxFlatten[F[_]: FlatMap, A](ffa: F[F[A]]): FlattenOps[F, A] =
+  implicit final def catsSyntaxFlatten[F[_], A](ffa: F[F[A]]): FlattenOps[F, A] =
     new FlattenOps[F, A](ffa)
 
-  implicit final def catsSyntaxIfM[F[_]: FlatMap](fa: F[Boolean]): IfMOps[F] =
+  implicit final def catsSyntaxIfM[F[_]](fa: F[Boolean]): IfMOps[F] =
     new IfMOps[F](fa)
 }
 

--- a/core/src/main/scala/cats/syntax/foldable.scala
+++ b/core/src/main/scala/cats/syntax/foldable.scala
@@ -2,7 +2,7 @@ package cats
 package syntax
 
 trait FoldableSyntax extends Foldable.ToFoldableOps {
-  implicit final def catsSyntaxNestedFoldable[F[_]: Foldable, G[_], A](fga: F[G[A]]): NestedFoldableOps[F, G, A] =
+  implicit final def catsSyntaxNestedFoldable[F[_], G[_], A](fga: F[G[A]]): NestedFoldableOps[F, G, A] =
     new NestedFoldableOps[F, G, A](fga)
 }
 

--- a/core/src/main/scala/cats/syntax/monadCombine.scala
+++ b/core/src/main/scala/cats/syntax/monadCombine.scala
@@ -3,10 +3,10 @@ package syntax
 
 trait MonadCombineSyntax {
   // TODO: use simulacrum instances eventually
-  implicit final def catsSyntaxMonadCombine[F[_]: MonadCombine, G[_], A](fga: F[G[A]]): MonadCombineOps[F, G, A] =
+  implicit final def catsSyntaxMonadCombine[F[_], G[_], A](fga: F[G[A]]): MonadCombineOps[F, G, A] =
     new MonadCombineOps[F, G, A](fga)
 
-  implicit final def catsSyntaxMonadCombineSeparate[F[_]: MonadCombine, G[_, _], A, B](fgab: F[G[A, B]]): SeparateOps[F, G, A, B] =
+  implicit final def catsSyntaxMonadCombineSeparate[F[_], G[_, _], A, B](fgab: F[G[A, B]]): SeparateOps[F, G, A, B] =
     new SeparateOps[F, G, A, B](fgab)
 }
 

--- a/core/src/main/scala/cats/syntax/monadError.scala
+++ b/core/src/main/scala/cats/syntax/monadError.scala
@@ -2,7 +2,7 @@ package cats
 package syntax
 
 trait MonadErrorSyntax {
-  implicit final def catsSyntaxMonadError[F[_], E, A](fa: F[A])(implicit F: MonadError[F, E]): MonadErrorOps[F, E, A] =
+  implicit final def catsSyntaxMonadError[F[_], E, A](fa: F[A]): MonadErrorOps[F, E, A] =
     new MonadErrorOps(fa)
 }
 

--- a/core/src/main/scala/cats/syntax/monoid.scala
+++ b/core/src/main/scala/cats/syntax/monoid.scala
@@ -3,7 +3,7 @@ package syntax
 
 trait MonoidSyntax extends SemigroupSyntax {
   // TODO: use simulacrum instances eventually
-  implicit final def catsSyntaxMonoid[A: Monoid](a: A): MonoidOps[A] =
+  implicit final def catsSyntaxMonoid[A](a: A): MonoidOps[A] =
     new MonoidOps[A](a)
 }
 

--- a/core/src/main/scala/cats/syntax/reducible.scala
+++ b/core/src/main/scala/cats/syntax/reducible.scala
@@ -2,7 +2,7 @@ package cats
 package syntax
 
 trait ReducibleSyntax extends Reducible.ToReducibleOps {
-  implicit final def catsSyntaxNestedReducible[F[_]: Reducible, G[_], A](fga: F[G[A]]): NestedReducibleOps[F, G, A] =
+  implicit final def catsSyntaxNestedReducible[F[_], G[_], A](fga: F[G[A]]): NestedReducibleOps[F, G, A] =
     new NestedReducibleOps[F, G, A](fga)
 }
 


### PR DESCRIPTION
I missed this during the consistent ops classes PR. *Some* implicit conversions to ops classes take type class instances implicitly still, despite the fact that they don't and can't use them, adding to compile time.

There is a cost I hadn't predicted, however. Type inference does not function as well. `ApplicativeErrorTests` in particular fails to compile, because the `handle` lambdas do not have annotated parameter types so knowing `F[_]` and `A` is not enough for the compiler to know `E`.

Keeping the implicit parameter on the conversion means that with missing instances users get `handle is not a method of F[A]` instead of `cannot find implicit ApplicativeError[F, E]`. This also has the effect that type class ops could conflict less often, but AFAIK we do not have type class ops with duplicate names and never will.

Removing the implicit parameter from the conversion has the effect of users being able to use several `ApplicativeError` (or analogous) instances with syntax, provided that the type parameters on the syntax methods allow the user to disambiguate the instances.

Actually *using* the implicit parameters being passed in the body of the ops class means that ops classes are unable to extend `AnyVal`, because they close over the parameter.

 From my perspective we have three options to fix this:
a) Remove all implicit parameters from non-macro ops class conversions. **This PR implements this**. Makes type inference worse in exchange for the most consistent and readable missing-instance error messages and more flexible instance selection. Also doesn't worsen the inconsistency between macro and non-macro ops classes.
b) For *multi-parameter* type classes, keep the unused implicit parameter to fix type inference, and fix the type parameter of the ops class using it. The (IMO) least consistent and hardest to explain option, has the best type inference and in most cases best missing-instance error messages (except for multi-parameter type classes, where they revert to `is not a method`).
c) For *all* type classes, actually *use* the implicit parameter. The least efficient option, with the worst missing-instance error messages, but it's the most consistent.

Option b) would mean we have *three* flavors of ops class conversions: some that take implicit params and use them, but have ops classes implemented with zero-cost macros; some that are multi-parameter and take implicit params just to fix type parameters and don't use them; and some that take no implicit params at all. This is why I think it's the least consistent and hardest to explain.

I'm looking for feedback, but leaning toward a) and fixing `ApplicativeErrorTests`.