### PR TITLE
Fixing `Eq[Function1]` in testsJS; break JS build to separate matrix build. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,19 @@ git:
 scala:
   - 2.10.6
   - 2.11.11
+  - 2.12.2
 
 jdk:
   - oraclejdk7
+  - oraclejdk8
 
 matrix:
-  include:
+  exclude:
   - scala: 2.12.2
+    jdk: oraclejdk7
+  - scala: 2.10.6
+    jdk: oraclejdk8
+  - scala: 2.11.11
     jdk: oraclejdk8
 
 before_install:
@@ -38,11 +44,15 @@ notifications:
     on_success: change
     on_failure: always
     on_start: false
+
 env:
+  matrix:
+    - JS_BUILD=true
+    - JS_BUILD=false
   global:
-  - secure: Kf44XQFpq2QGe3rn98Dsf5Uz3WXzPDralS54co7sqT5oQGs1mYLYZRYz+I75ZSo5ffZ86H7M+AI9YFofqGwAjBixBbqf1tGkUh3oZp2fN3QfqzazGV3HzC+o41zALG5FL+UBaURev9ChQ5fYeTtFB7YAzejHz4y5E97awk934Rg=
-  - secure: QbNAu0jCaKrwjJi7KZtYEBA/pYbTJ91Y1x/eLAJpsamswVOvwnThA/TLYuux+oiZQCiDUpBzP3oxksIrEEUAhl0lMtqRFY3MrcUr+si9NIjX8hmoFwkvZ5o1b7pmLF6Vz3rQeP/EWMLcljLzEwsrRXeK0Ei2E4vFpsg8yz1YXJg=
-  - TRAVIS_NODE_VERSION="4"
+    - secure: Kf44XQFpq2QGe3rn98Dsf5Uz3WXzPDralS54co7sqT5oQGs1mYLYZRYz+I75ZSo5ffZ86H7M+AI9YFofqGwAjBixBbqf1tGkUh3oZp2fN3QfqzazGV3HzC+o41zALG5FL+UBaURev9ChQ5fYeTtFB7YAzejHz4y5E97awk934Rg=
+    - secure: QbNAu0jCaKrwjJi7KZtYEBA/pYbTJ91Y1x/eLAJpsamswVOvwnThA/TLYuux+oiZQCiDUpBzP3oxksIrEEUAhl0lMtqRFY3MrcUr+si9NIjX8hmoFwkvZ5o1b7pmLF6Vz3rQeP/EWMLcljLzEwsrRXeK0Ei2E4vFpsg8yz1YXJg=
+    - TRAVIS_NODE_VERSION="4"
 
 cache:
   directories:

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -226,7 +226,7 @@ private trait KleisliSemigroup[F[_], A, B] extends Semigroup[Kleisli[F, A, B]] {
 private trait KleisliMonoid[F[_], A, B] extends Monoid[Kleisli[F, A, B]] with KleisliSemigroup[F, A, B] {
   implicit def FB: Monoid[F[B]]
 
-  override def empty: Kleisli[F, A, B] = Kleisli[F, A, B](a => FB.empty)
+  override def empty: Kleisli[F, A, B] = Kleisli[F, A, B](_ => FB.empty)
 }
 
 private trait KleisliMonadError[F[_], A, E] extends MonadError[Kleisli[F, A, ?], E] with KleisliApplicativeError[F, A, E] with KleisliMonadReader[F, A] {

--- a/laws/src/main/scala/cats/laws/discipline/Eq.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Eq.scala
@@ -13,7 +13,7 @@ object eq {
    * and comparing the application of the two functions.
    */
   implicit def catsLawsEqForFn1[A, B](implicit A: Arbitrary[A], B: Eq[B]): Eq[A => B] = new Eq[A => B] {
-    val sampleCnt: Int = if (Platform.isJvm) 50 else 5
+    val sampleCnt: Int = if (Platform.isJvm) 50 else 10
 
     def eqv(f: A => B, g: A => B): Boolean = {
       val samples = List.fill(sampleCnt)(A.arbitrary.sample).collect{

--- a/laws/src/test/scala/cats/laws/discipline/EqTests.scala
+++ b/laws/src/test/scala/cats/laws/discipline/EqTests.scala
@@ -1,5 +1,0 @@
-package cats.laws.discipline
-
-class EqTests {
-
-}

--- a/laws/src/test/scala/cats/laws/discipline/EqTests.scala
+++ b/laws/src/test/scala/cats/laws/discipline/EqTests.scala
@@ -1,0 +1,5 @@
+package cats.laws.discipline
+
+class EqTests {
+
+}

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -20,18 +20,24 @@ export publish_cmd="publishLocal"
 if [[ $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "master" && $(cat version.sbt) =~ "-SNAPSHOT" ]]; then
   export publish_cmd="publish gitSnapshots publish"
   # temporarily disable to stabilize travis
-  #if [[ $TRAVIS_SCALA_VERSION = "2.11.8" ]]; then
-  #  export publish_cmd="$publish_cmd ghpagesPushSite"
+  #if [[ $TRAVIS_SCALA_VERSION = "2.11.11" ]]; then
+  #  export publish_cmd="publishMicrosite"
   #fi
 fi
 
 sbt_cmd="sbt ++$TRAVIS_SCALA_VERSION"
 
-js="$sbt_cmd validateJS"
+core_js="$sbt_cmd validateJS"
 kernel_js="$sbt_cmd validateKernelJS"
 free_js="$sbt_cmd validateFreeJS"
+
+js="$core_js && $free_js && $kernel_js"
 jvm="$sbt_cmd coverage validateJVM coverageReport && codecov"
 
-run_cmd="$js && $free_js && $kernel_js && $jvm && $sbt_cmd $publish_cmd"
+if [[ $JS_BUILD == "true" ]]; then
+run_cmd="$js"
+else
+run_cmd="$jvm && $sbt_cmd $publish_cmd"
+fi
 
 eval $run_cmd

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -20,7 +20,7 @@ export publish_cmd="publishLocal"
 if [[ $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "master" && $(cat version.sbt) =~ "-SNAPSHOT" ]]; then
   export publish_cmd="publish gitSnapshots publish"
   # temporarily disable to stabilize travis
-  #if [[ $TRAVIS_SCALA_VERSION = "2.11.11" ]]; then
+  #if [[ $TRAVIS_SCALA_VERSION =~ ^2\.11\. ]]; then
   #  export publish_cmd="publishMicrosite"
   #fi
 fi


### PR DESCRIPTION
This PR breaks out the scalajs builds to separate travis matrix build to cut down build time which was exceeding the 50 minute hard limit set by traivs. 
see [#1666](https://github.com/typelevel/cats/pull/1666#issuecomment-301656528) for further discussion. 