### PR TITLE
Add Daniel Spiewak to maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ The current maintainers (people who can merge pull requests) are:
  * [non](https://github.com/non) Erik Osheim
  * [mpilquist](https://github.com/mpilquist) Michael Pilquist
  * [milessabin](https://github.com/milessabin) Miles Sabin
+ * [djspiewak](https://github.com/djspiewak) Daniel Spiewak
  * [fthomas](https://github.com/fthomas) Frank Thomas
  * [julien-truffaut](https://github.com/julien-truffaut) Julien Truffaut
  * [kailuowang](https://github.com/kailuowang) Kailuo Wang


### PR DESCRIPTION
The current maintainers are polled, all feedbacks are positive. Daniel himself also agreed to help out. So this PR will make it formal.