### PR TITLE
Use 2 workers in JVM build

### DIFF
--- a/tests/src/test/scala/cats/tests/CatsSuite.scala
+++ b/tests/src/test/scala/cats/tests/CatsSuite.scala
@@ -19,7 +19,7 @@ trait TestSettings extends Configuration with Matchers {
       maxDiscardedFactor = if (Platform.isJvm) PosZDouble(5.0) else PosZDouble(50.0),
       minSize = PosZInt(0),
       sizeRange = if (Platform.isJvm) PosZInt(10) else PosZInt(5),
-      workers = PosInt(1))
+      workers = if (Platform.isJvm) PosInt(2) else PosInt(1))
 
   lazy val slowCheckConfiguration: PropertyCheckConfiguration =
     if (Platform.isJvm) checkConfiguration


### PR DESCRIPTION
As far as I can tell, our CI build has 2 cores available on Travis. So I
suspect that 2 workers might be a sweet spot for our JVM testing. As I
understand it, the JS runtime is single-threaded, so we probably won't
benefit from additional workers on it (as our tests should be
CPU-bound).

I could be totally wrong about these assumptions, but I'm interested in
how the build times for this PR compare.