### PR TITLE
Build JVM before JS on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,8 +47,8 @@ notifications:
 
 env:
   matrix:
-    - JS_BUILD=true
     - JS_BUILD=false
+    - JS_BUILD=true
   global:
     - secure: Kf44XQFpq2QGe3rn98Dsf5Uz3WXzPDralS54co7sqT5oQGs1mYLYZRYz+I75ZSo5ffZ86H7M+AI9YFofqGwAjBixBbqf1tGkUh3oZp2fN3QfqzazGV3HzC+o41zALG5FL+UBaURev9ChQ5fYeTtFB7YAzejHz4y5E97awk934Rg=
     - secure: QbNAu0jCaKrwjJi7KZtYEBA/pYbTJ91Y1x/eLAJpsamswVOvwnThA/TLYuux+oiZQCiDUpBzP3oxksIrEEUAhl0lMtqRFY3MrcUr+si9NIjX8hmoFwkvZ5o1b7pmLF6Vz3rQeP/EWMLcljLzEwsrRXeK0Ei2E4vFpsg8yz1YXJg=


### PR DESCRIPTION
If there are **no other builds** (for other PRs, branches, ...), switching the JVM/JS order to JS/JVM can be 10-15 minutes quicker.

There are now 6 Travis jobs for every build (3 Scala versions and JVM / JS) and only 5 are executing at the same time. By switching the order, the three longer JVM jobs are started first and when the 2.11 JS job finishes, the 2.12 JS job can start (which doesn't take as long as the 2.12 JVM job which is now started last).  

I ran Travis [twice](http://imgur.com/a/dPLRz) resulting in total build times of 31 and 39 minutes while the last master builds took around 50 minutes.

This is just a minor improvement of the Travis matrix build change by @kailuowang in #1671.