### PR TITLE
Clean up EitherT doctests

### DIFF
--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -172,10 +172,10 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
    * {{{
    * scala> import cats.implicits._
    * scala> type Error = String
-   * scala> val v1: Validated[NonEmptyList[Error], Int] = Validated.Invalid(NonEmptyList.of("error 1"))
-   * scala> val v2: Validated[NonEmptyList[Error], Int] = Validated.Invalid(NonEmptyList.of("error 2"))
-   * scala> val eithert: EitherT[Option, Error, Int] = EitherT(Some(Either.left("error 3")))
-   * scala> eithert.withValidated { v3 => (v1 |@| v2 |@| v3.leftMap(NonEmptyList.of(_))).map{ case (i, j, k) => i + j + k } }
+   * scala> val v1: Validated[NonEmptyList[Error], Int] = Validated.invalidNel("error 1")
+   * scala> val v2: Validated[NonEmptyList[Error], Int] = Validated.invalidNel("error 2")
+   * scala> val eithert: EitherT[Option, Error, Int] = EitherT.leftT[Option, Int]("error 3")
+   * scala> eithert.withValidated { v3 => (v1 |@| v2 |@| v3.toValidatedNel).map { case (i, j, k) => i + j + k } }
    * res0: EitherT[Option, NonEmptyList[Error], Int] = EitherT(Some(Left(NonEmptyList(error 1, error 2, error 3))))
    * }}}
    */
@@ -192,16 +192,15 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
    * inconsistent with the behavior of the `ap` from `Monad` of `EitherT`.
    *
    * {{{
-   * scala> import cats.data.{Nested, EitherT}
+   * scala> import cats.data.EitherT
    * scala> import cats.implicits._
    * scala> val ff: EitherT[List, String, Int => String] =
    *      |   EitherT(List(Either.right(_.toString), Either.left("error")))
    * scala> val fa: EitherT[List, String, Int] =
    *      |   EitherT(List(Either.right(1), Either.right(2)))
-   * scala> type ListErrorOr[A] = Nested[List, Either[String, ?], A]
    * scala> ff.ap(fa)
    * res0: EitherT[List,String,String] = EitherT(List(Right(1), Right(2), Left(error)))
-   * scala> EitherT((ff.toNested: ListErrorOr[Int => String]).ap(fa.toNested: ListErrorOr[Int]).value)
+   * scala> EitherT((ff.toNested).ap(fa.toNested).value)
    * res1: EitherT[List,String,String] = EitherT(List(Right(1), Right(2), Left(error), Left(error)))
    * }}}
    *
@@ -209,25 +208,28 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
   def toNested: Nested[F, Either[A, ?], B] = Nested[F, Either[A, ?], B](value)
 
   /**
-    * Transform this `EitherT[F, A, B]` into a `[[Nested]][F, Validated[A, ?], B]` or `[[Nested]][F, ValidatedNel[A, B]`.
+    * Transform this `EitherT[F, A, B]` into a `[[Nested]][F, Validated[A, ?], B]`.
+    *
     * Example:
     * {{{
-    * scala> import cats.data.{Validated, EitherT, Nested}
+    * scala> import cats.data.{EitherT, Validated}
     * scala> import cats.implicits._
     * scala> val f: Int => String = i => (i*2).toString
     * scala> val r1: EitherT[Option, String, Int => String] = EitherT.right(Some(f))
-    *     | r1: cats.data.EitherT[Option,String,Int => String] = EitherT(Some(Right(<function1>)))
+    * r1: cats.data.EitherT[Option,String,Int => String] = EitherT(Some(Right(<function1>)))
     * scala> val r2: EitherT[Option, String, Int] = EitherT.right(Some(10))
-    *     | r2: cats.data.EitherT[Option,String,Int] = EitherT(Some(Right(10)))
-    * scala> type ValidatedOr[A] = Validated[String, A]
-    * scala> type OptionErrorOr[A] = Nested[Option, ValidatedOr, A]
-    * scala> (r1.toNestedValidated: OptionErrorOr[Int => String]).ap(r2.toNestedValidated: OptionErrorOr[Int])
-    * res0: OptionErrorOr[String] = Nested(Some(Valid(20)))
+    * r2: cats.data.EitherT[Option,String,Int] = EitherT(Some(Right(10)))
+    * scala> type ErrorOr[A] = Validated[String, A]
+    * scala> (r1.toNestedValidated).ap(r2.toNestedValidated)
+    * res0: cats.data.Nested[Option,ErrorOr,String] = Nested(Some(Valid(20)))
     * }}}
     */
   def toNestedValidated(implicit F: Functor[F]): Nested[F, Validated[A, ?], B] =
     Nested[F, Validated[A, ?], B](F.map(value)(_.toValidated))
 
+  /**
+   * Transform this `EitherT[F, A, B]` into a `[[Nested]][F, ValidatedNel[A, ?], B]`.
+   */
   def toNestedValidatedNel(implicit F: Functor[F]): Nested[F, ValidatedNel[A, ?], B] =
     Nested[F, ValidatedNel[A, ?], B](F.map(value)(_.toValidatedNel))
 }
@@ -237,7 +239,7 @@ object EitherT extends EitherTInstances {
   /**
    * Uses the [[http://typelevel.org/cats/guidelines.html#partially-applied-type-params Partially Applied Type Params technique]] for ergonomics.
    */
-  private[data] final class LeftPartiallyApplied[B](val dummy: Boolean = true ) extends AnyVal {
+  private[data] final class LeftPartiallyApplied[B](val dummy: Boolean = true) extends AnyVal {
     def apply[F[_], A](fa: F[A])(implicit F: Functor[F]): EitherT[F, A, B] = EitherT(F.map(fa)(Either.left))
   }
 
@@ -255,7 +257,7 @@ object EitherT extends EitherTInstances {
   /**
    * Uses the [[http://typelevel.org/cats/guidelines.html#partially-applied-type-params Partially Applied Type Params technique]] for ergonomics.
    */
-  private[data] final class LeftTPartiallyApplied[F[_], B](val dummy: Boolean = true ) extends AnyVal {
+  private[data] final class LeftTPartiallyApplied[F[_], B](val dummy: Boolean = true) extends AnyVal {
     def apply[A](a: A)(implicit F: Applicative[F]): EitherT[F, A, B] = EitherT(F.pure(Either.left(a)))
   }
 
@@ -273,7 +275,7 @@ object EitherT extends EitherTInstances {
   /**
    * Uses the [[http://typelevel.org/cats/guidelines.html#partially-applied-type-params Partially Applied Type Params technique]] for ergonomics.
    */
-  private[data] final class RightPartiallyApplied[A](val dummy: Boolean = true ) extends AnyVal {
+  private[data] final class RightPartiallyApplied[A](val dummy: Boolean = true) extends AnyVal {
     def apply[F[_], B](fb: F[B])(implicit F: Functor[F]): EitherT[F, A, B] = EitherT(F.map(fb)(Either.right))
   }
 
@@ -291,7 +293,7 @@ object EitherT extends EitherTInstances {
   /**
    * Uses the [[http://typelevel.org/cats/guidelines.html#partially-applied-type-params Partially Applied Type Params technique]] for ergonomics.
    */
-  private[data] final class PurePartiallyApplied[F[_], A](val dummy: Boolean = true ) extends AnyVal {
+  private[data] final class PurePartiallyApplied[F[_], A](val dummy: Boolean = true) extends AnyVal {
     def apply[B](b: B)(implicit F: Applicative[F]): EitherT[F, A, B] = right(F.pure(b))
   }
 
@@ -351,7 +353,7 @@ object EitherT extends EitherTInstances {
   /**
    * Uses the [[http://typelevel.org/cats/guidelines.html#partially-applied-type-params Partially Applied Type Params technique]] for ergonomics.
    */
-  private[data] final class FromEitherPartiallyApplied[F[_]](val dummy: Boolean = true ) extends AnyVal {
+  private[data] final class FromEitherPartiallyApplied[F[_]](val dummy: Boolean = true) extends AnyVal {
     def apply[E, A](either: Either[E, A])(implicit F: Applicative[F]): EitherT[F, E, A] =
       EitherT(F.pure(either))
   }
@@ -372,7 +374,7 @@ object EitherT extends EitherTInstances {
   /**
    * Uses the [[http://typelevel.org/cats/guidelines.html#partially-applied-type-params Partially Applied Type Params technique]] for ergonomics.
    */
-  private[data] final class FromOptionPartiallyApplied[F[_]](val dummy: Boolean = true ) extends AnyVal {
+  private[data] final class FromOptionPartiallyApplied[F[_]](val dummy: Boolean = true) extends AnyVal {
     def apply[E, A](opt: Option[A], ifNone: => E)(implicit F: Applicative[F]): EitherT[F, E, A] =
       EitherT(F.pure(Either.fromOption(opt, ifNone)))
   }
@@ -410,7 +412,7 @@ object EitherT extends EitherTInstances {
   /**
    * Uses the [[http://typelevel.org/cats/guidelines.html#partially-applied-type-params Partially Applied Type Params technique]] for ergonomics.
    */
-  private[data] final class CondPartiallyApplied[F[_]](val dummy: Boolean = true ) extends AnyVal {
+  private[data] final class CondPartiallyApplied[F[_]](val dummy: Boolean = true) extends AnyVal {
     def apply[E, A](test: Boolean, right: => A, left: => E)(implicit F: Applicative[F]): EitherT[F, E, A] =
       EitherT(F.pure(Either.cond(test, right, left)))
   }


### PR DESCRIPTION
With the partial unification fix in place, we can clean up some `EitherT` doctests a bit.