### PR TITLE
Make syntax.show extend ShowSyntax instead of Show.ToShowOps

### DIFF
--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -36,7 +36,7 @@ package object syntax {
   object reducible extends ReducibleSyntax
   object semigroup extends SemigroupSyntax
   object semigroupk extends SemigroupKSyntax
-  object show extends Show.ToShowOps
+  object show extends ShowSyntax
   object split extends SplitSyntax
   object strong extends StrongSyntax
   object monadTrans extends MonadTransSyntax

--- a/tests/src/test/scala/cats/tests/ShowTests.scala
+++ b/tests/src/test/scala/cats/tests/ShowTests.scala
@@ -11,8 +11,6 @@ class ShowTests extends CatsSuite {
   checkAll("Contravariant[Show]", SerializableTests.serializable(Contravariant[Show]))
 
   test("show string interpolator") {
-    import cats.syntax.show._
-
     case class Cat(name: String)
     object Cat {
       implicit val showCat: Show[Cat] = Show.show(_.name)


### PR DESCRIPTION
Nobody can use the `show` interpolator otherwise with a-la-carte imports 😝

Edit: Thanks @alexknvl for pointing this out.