### PR TITLE
Prepare for the 1.0.0-MF release

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -33,6 +33,7 @@ possible:
  * Arya Irani
  * Ash Pook
  * Aλ
+ * Ben Fradet
  * Ben Hutchison
  * Benjamin Thuillier
  * Binh Nguyen
@@ -53,7 +54,9 @@ possible:
  * David Allsopp
  * David Gregory
  * Denis Mikhaylov
+ * Denis
  * Derek Wickern
+ * Diego Esteban Alonso Blas
  * Earl St Sauver
  * Edmund Noble
  * Eric Torreborre
@@ -62,28 +65,38 @@ possible:
  * Eugene Burmako
  * Eugene Yokota
  * Fabian Schmitthenner
+ * Fabio Labella
  * Feynman Liang
  * Frank S. Thomas
  * Giulio De Luise
+ * Greg Pfeil
  * Guillaume Massé
  * Hamish Dickson
  * Ian McIntosh
  * ImLiar
  * Israel Pérez González
+ * Itamar Ravid
  * Jan-Hendrik Zab
  * Jean-Rémi Desjardins
+ * Jens
  * Jisoo Park
+ * João Ferreira
+ * John Sullivan
  * Jon Hanson
  * Jose Emilio Labra Gayo
+ * Joseph Abrahamson
  * Josh Marcus
  * Juan Pedro Moreno
  * Julien Richard-Foy
  * Julien Truffaut
  * Kailuo Wang
  * Kenji Yoshida
+ * Leandro Bolivar
+ * Lars Hupel
  * Long Cao
  * Luis Angel Vicente Sanchez
  * Luis Sanchez
+ * LukaJCB
  * Luke Wyman
  * Madder
  * Marc Siegel
@@ -98,19 +111,23 @@ possible:
  * Michael Pilquist
  * Mike Curry
  * Miles Sabin
+ * n4to4
  * Olivier Blanvillain
  * Olli Helenius
  * Owen Parry
  * P. Oscar Boykin
+ * Paolo G. Giarrusso
  * Pascal Voitot
  * Paul Phillips
  * Pavkin Vladimir
  * Pepe García
  * Pere Villega
  * Peter Neyens
+ * Peter Perhac
  * Philip Wills
  * Rafa Paradela
  * Raúl Raja Martínez
+ * RawToast
  * Richard Miller
  * Rintcius Blok
  * Rob Norris
@@ -120,6 +137,7 @@ possible:
  * Ryan Case
  * Sam Ritchie
  * Sarunas Valaskevicius
+ * Shohei Kamimori
  * Shunsuke Otani
  * Simeon H. K. Fitch
  * Sinisa Louc
@@ -127,14 +145,16 @@ possible:
  * Stephen Judkins
  * Stew O'Connor
  * Sumedh Mungee
+ * Takayuki Sakai
  * Taylor Brown
  * Tom Switzer
  * Tomas Mikula
  * Travis Brown
+ * Vladimir Samoylov
  * Wedens
  * Xavier Fernández Salas
  * Yosef Fertel
- * yilinwei
+ * Yilin Wei
  * Zach Abbott
  * zainab-ali
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,6 +65,7 @@ as many breaking changes as possible in this release before we lock down the API
  * [#1598](https://github.com/typelevel/cats/pull/1598): Implement a `ReaderWriterStateT` data type . by @iravid
  * [#1706](https://github.com/typelevel/cats/pull/1706): Clean up `ReaderWriterStateT`. by @peterneyens
  * [#1594](https://github.com/typelevel/cats/pull/1594): Add `NonEmptyList#fromFoldable`. by @markus1189
+ * [#1611](https://github.com/typelevel/cats/pull/1611): Added `NonEmptyTraverse`. by @LukaJCB
  * [#1592](https://github.com/typelevel/cats/pull/1592): added instances of `BitSet` to `allInstances`. by @kailuowang
  * [#1586](https://github.com/typelevel/cats/pull/1586): Add `Applicative.unit`. by @alexandru
  * [#1584](https://github.com/typelevel/cats/pull/1584): Move arbitrary instance of `StateT` to laws. by @kailuowang

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,171 @@
-## Version 0.9.0
+## Version 1.0.0-MF
 
+> 2017 June 3
+
+`MF` stands for milestone final. This is the last non-RC release before 1.0.0.
+ The main purpose/focus of this release is to offer a relatively stable API to
+ work with prior to 1.0.0. It can be deemed as a proposal for the final API
+ we are going to maintain binary compatibiliy after 1.0. 
+ We will give community some time to validate it before we release 1.0.0-RC1.
+ 
+### To migrate from 0.9.0
+
+Apology for the number of breaking changes in this release. We are trying to include
+as many breaking changes in this release before we lock down the API. 
+  
+ * `cats` no longer publish the all inclusive bundle package `"org.typelevel" % "cats"`, use `cats-core`, `cats-free`, or `cats-law` 
+   accordingly instead. If you need `cats.free`, use `"org.typelevel" % "cats-free"`, if you need `cats-laws` use 
+   `"org.typelevel" % "cats-laws"`, if neither, use `"org.typelevel" % "cats-core"`.
+ * `cats.free.Inject` is moved from `cats-free` to `cats-core` and renamed to `cats.InjectK`;
+   `cats.data.Prod` is renamed to `cats.data.Tuple2K`; `cats.data.Coproduct` is renamed to
+   `cats.data.EitherK`
+ * All `Unapply` enabled methods, e.g. `sequenceU`, `traverseU`, etc. are removed. `Unapply`
+   enabled syntax ops are also removed. Please use the partial unification SI-2712 fix
+   instead. The easiest way might be this [sbt-plugin](https://github.com/fiadliel/sbt-partial-unification).
+ *  `FunctorFilter`, `MonadCombine`, `MonadFilter`, `MonadReader`, `MonadState`, `MonadTrans`, `MonadWriter` and `TraverseFilter` are no longer in `cats`, the functionalities they provided are inhereted by the new [cats-mtl](https://github.com/edmundnoble/cats-mtl) project. Please check [here](https://github.com/edmundnoble/cats-mtl#migration-guide) for migration guide. 
+ * `CartesianBuilder` (i.e. `|@|`) syntax is deprecated, use the apply syntanx on tuples instead. E.g. `(x |@| y |@| z).map(...)` should be replaced by `(x, y, z).mapN(...)`
+ * The creation methods (`left`, `right`, `apply`, `pure`, etc.) in `EitherT` is improved to take less
+   type arguments.
+ * Several `cats-core` type class instances for `cats.kernel` were moved from their compainion objects to separate traits
+   and thus require imports from `cats.instances.xxx._` (or the recommended `import cats.implicits._`) now. See #1659 for more details. 
+ * `Free.suspend` is renamed to `Free.defer` for consistency. 
+ * `traverse1_`, `intercalate1` and `sequence1_` in `Reducible` were renamed to `nonEmptyTraverse_`, `nonEmptyIntercalate` and `nonEmptySequence_` respectively. 
+ * `foldLeftM` is removed from `Free`, use `foldM` on `Foldable` instead, see #1117 for detail. 
+ * `iteratorFoldM` was removed from `Foldable` due to #1716
+ * Apply syntax on tuple (e.g. `(x, y, z).map3(...)`)  was moved from `cats.syntax.tuple._` to `cats.syntax.apply._` and renamed to `mapN`, `contramapN` and `imapN` respectively.
+ * `Split` is removed, the method `split` is moved to `Arrow`. Note that only under `CommutativeArrow` does it guarantee the non-interference between the effects. see #1567
+
+ 
+### Breaking Changes:
+
+ * [#1614](https://github.com/typelevel/cats/pull/1614): added `leftT` and improved existing lift API for `EitherT`. by @kailuowang
+ * [#1596](https://github.com/typelevel/cats/pull/1596): Rename `Inject` to `InjectK`. by @andyscott
+ * [#1589](https://github.com/typelevel/cats/pull/1589): Rename `Prod`, `Coproduct` to `Tuple2K` and `EitherK`. by @kailuowang
+ * [#1583](https://github.com/typelevel/cats/pull/1583): Enable SI-2712 fix in cats / Remove unapply machinery. by @kailuowang
+ * [#1679](https://github.com/typelevel/cats/pull/1679): remove `Unapply` class. by @kailuowang
+ * [#1557](https://github.com/typelevel/cats/pull/1557): Improvements to `Inject`. @sellout
+ * [#1659](https://github.com/typelevel/cats/pull/1659): move instances into separate trait. by @yilinwei
+ * [#1709](https://github.com/typelevel/cats/pull/1709): Rename `suspend` to `defer`. by @peterneyens
+ * [#1611](https://github.com/typelevel/cats/pull/1611): Renamed `traverse1_`, `intercalate1` and `sequence1_` in `Reducible`. by @LukaJCB
+ * [#1117](https://github.com/typelevel/cats/pull/1117): `foldLeftM` without `Free`. by @TomasMikula 
+ * [#1487](https://github.com/typelevel/cats/pull/1487): `Apply` syntax for tuples. by @DavidGregory084
+ * [#1745](https://github.com/typelevel/cats/pull/1745): Deprecate `CartesianBuilder`. by @kailuowang
+ * [#1758](https://github.com/typelevel/cats/pull/1758): stop publishing cats all bundle , start to publish cats-testkit. by @kailuowang
+ * [#1766](https://github.com/typelevel/cats/pull/1766): Replace `Split` with `CommutativeArrow`, introduces `CommutativeMonad`. by @diesalbla
+ * [#1751](https://github.com/typelevel/cats/pull/1751): Removed `FunctorFilter`, `MonadCombine`, `MonadFilter`, `MonadReader`, `MonadState`, `MonadTrans`, `MonadWriter`, `TraverseFilter`. by @edmundnoble
+ 
+### New Features (API, instances, data types, etc):
+
+ * [#1707](https://github.com/typelevel/cats/pull/1707): Add NEL/NEV one. by @peterneyens 
+ * [#1680](https://github.com/typelevel/cats/pull/1680): ~~`MonadTrans` instance for RWST and make `MonadTrans` serializable.~~ by @wedens
+ * [#1658](https://github.com/typelevel/cats/pull/1658): Add `Validated.validNel`. by @edmundnoble
+ * [#1651](https://github.com/typelevel/cats/pull/1651): Add state method to `MonadState`. by @oskoi
+ * [#1628](https://github.com/typelevel/cats/pull/1628): add init and size methods to `NonEmptyList`. by @jtjeferreira
+ * [#1612](https://github.com/typelevel/cats/pull/1612): Add ensureWith to `Validated` and `Either` (#1550). by @LukaJCB
+ * [#1598](https://github.com/typelevel/cats/pull/1598): Implement a `ReaderWriterStateT` data type . by @iravid
+ * [#1706](https://github.com/typelevel/cats/pull/1706): Clean up `ReaderWriterStateT`. by @peterneyens
+ * [#1594](https://github.com/typelevel/cats/pull/1594): Add `NonEmptyList#fromFoldable`. by @markus1189
+ * [#1592](https://github.com/typelevel/cats/pull/1592): added instances of `BitSet` to `allInstances`. by @kailuowang
+ * [#1586](https://github.com/typelevel/cats/pull/1586): Add `Applicative.unit`. by @alexandru
+ * [#1584](https://github.com/typelevel/cats/pull/1584): Move arbitrary instance of `StateT` to laws. by @kailuowang
+ * [#1580](https://github.com/typelevel/cats/pull/1580): add `groupBy` to `NonEmptyList` and `groupByNel` to `List` syntax @julien-truffaut
+ * [#1578](https://github.com/typelevel/cats/pull/1578): add `last`, `sortBy` and `sorted` to `NonEmptyList`. by @julien-truffaut
+ * [#1571](https://github.com/typelevel/cats/pull/1571): added `whileM`, `untilM`, `iterateWhile`, etc to `Monad` . by @tpolecat & @kailuowang
+ * [#1548](https://github.com/typelevel/cats/pull/1548): `MonadError` instance for `Ior`. by @leandrob13
+ * [#1543](https://github.com/typelevel/cats/pull/1543): `MonadError` instance for `Kleisli`. by @durban
+ * [#1540](https://github.com/typelevel/cats/pull/1540): `Ior` syntax. by @leandrob13
+ * [#1537](https://github.com/typelevel/cats/pull/1537): Add `FlatMap.forEffect`. by @cranst0n
+ * [#1531](https://github.com/typelevel/cats/pull/1531): Add piecemeal import for `MonadError`. by @peterneyens
+ * [#1526](https://github.com/typelevel/cats/pull/1526): `Inject` for free programs. by @tpolecat
+ * [#1464](https://github.com/typelevel/cats/pull/1464): Adding `get` for `Foldable`. by @yilinwei
+ * [#1602](https://github.com/typelevel/cats/pull/1602): Stack-safe `Coyoneda`. by @edmundnoble
+ * [#1725](https://github.com/typelevel/cats/pull/1725): Add `InjectK` laws. by @andyscott
+ * [#1728](https://github.com/typelevel/cats/pull/1728): Adds an `As` class which represents subtyping relationships (`Liskov`). by @stew
+ * [#1178](https://github.com/typelevel/cats/pull/1178): Add `Is` constructor for Leibniz equality. by @tel
+ * [#1611](https://github.com/typelevel/cats/pull/1611): Add `NonEmptyTraverse` typeclass. by @LukaJCB
+ * [#1736](https://github.com/typelevel/cats/pull/1736): Added `StackSafeMonad` mixin. by @djspiewak
+ * [#1600](https://github.com/typelevel/cats/pull/1600): `Inject` for `Either`. by @andyscott
+ * [#1746](https://github.com/typelevel/cats/pull/1746): Add `EitherNel` type alias for `Either[NonEmptyList[E], A]`. by @andyscott
+ * [#1670](https://github.com/typelevel/cats/pull/1670): Add `Order`-> `Ordering` implicit conversion to implicits, instances. by @edmundnoble
+ * [#1649](https://github.com/typelevel/cats/pull/1649): Make `Show` inherit from a contravariant base trait for `show` string interpolator to be covariant. by @edmundnoble
+  * [#1761](https://github.com/typelevel/cats/pull/1761): Add index related helpers to `Traverse`. by @andyscott 
+  * [#1769](https://github.com/typelevel/cats/pull/1769): Add `Kleisli` `tap`, `tapWith`. by @tpolecat
+  * [#1739](https://github.com/typelevel/cats/pull/1739): Add `onError` and `adaptError` to `ApplicativeError`/`MonadError`. by @SystemFw
+  * [#1644](https://github.com/typelevel/cats/pull/1644): Add `MonadError` instance for `EitherT` that recovers from `F[_]` errors. by @leandrob13 
+  * [#1748](https://github.com/typelevel/cats/pull/1748): Stack-safe `FreeAppplicative`. by @edmundnoble
+  * [#1516](https://github.com/typelevel/cats/pull/1516): Implement `NonEmptyList#Collect` . by @xavier-fernandez
+ 
+  
+### Code improvements:
+
+ * [#1660](https://github.com/typelevel/cats/pull/1660): Override `fromTry` and `fromEither` for `Try` and `Either`. by @peterneyens
+ * [#1642](https://github.com/typelevel/cats/pull/1642): Unseal `InjectK` to allow for extension by other libraries. by @andyscott
+ * [#1641](https://github.com/typelevel/cats/pull/1641): Make `InjectK` use `FunctionK.id` for reflexive injection. by @andyscott
+ * [#1618](https://github.com/typelevel/cats/pull/1618): Override some methods in `Kleisli` instances. by @peterneyens
+ * [#1532](https://github.com/typelevel/cats/pull/1532): Override `Foldable` methods. by @peterneyens
+ * [#1456](https://github.com/typelevel/cats/pull/1456): Consistency for ops classes. by @edmundnoble
+ * [#1631](https://github.com/typelevel/cats/pull/1631): make all `PartialApplied` class value class to achieve zero cost. by @kailuowang
+ * [#1696](https://github.com/typelevel/cats/pull/1696): Make `syntax.show` extend `ShowSyntax` instead of `Show.ToShowOps`. by @edmundnoble
+ 
+### Bug fixes: 
+
+* [#1735](https://github.com/typelevel/cats/pull/1735): `StateT` no longer violates laws. by @djspiewak
+* [#1740](https://github.com/typelevel/cats/pull/1740):  removed `iteratorFoldM`. by @kailuowang
+
+### Other miscellaneous improvements (documentation, tests, build):
+
+ * [#1699](https://github.com/typelevel/cats/pull/1699): Link to sbt-partial-unification plugin . by @Blaisorblade   
+ * [#1698](https://github.com/typelevel/cats/pull/1698): Update gitter chat room name to cats-dev. . by @kailuowang 
+ * [#1695](https://github.com/typelevel/cats/pull/1695): update ETA for 1.0.0 . by @kailuowang   
+ * [#1604](https://github.com/typelevel/cats/pull/1604): Add tut doc for `FunctionK` . by @ceedubs
+ * [#1691](https://github.com/typelevel/cats/pull/1691): Build JVM before JS on travis. by @peterneyens
+ * [#1677](https://github.com/typelevel/cats/pull/1677): Update readme with the new dev channel.. by @kailuowang
+ * [#1673](https://github.com/typelevel/cats/pull/1673): Use 2 workers in JVM build. by @ceedubs
+ * [#1671](https://github.com/typelevel/cats/pull/1671): Fixing `Eq[Function1]` in testsJS; break JS build to separate matrix build.. by @kailuowang
+ * [#1666](https://github.com/typelevel/cats/pull/1666): Use `Cogen` for arbitrary instances. by @ceedubs
+ * [#1654](https://github.com/typelevel/cats/pull/1654): Update Circe URL. by @n4to4
+ * [#1653](https://github.com/typelevel/cats/pull/1653): Fix typo in `FreeApplicative` doc.. by @takayuky
+ * [#1647](https://github.com/typelevel/cats/pull/1647): Adds Freestyle to `Related Projects` list. by @raulraja
+ * [#1638](https://github.com/typelevel/cats/pull/1638): Make simulacrum a compile time only dependency. by @peterneyens
+ * [#1637](https://github.com/typelevel/cats/pull/1637): show(f:T) to show(t:T). by @PeterPerhac
+ * [#1636](https://github.com/typelevel/cats/pull/1636): added some category theory into `FunctionK` document. by @kailuowang
+ * [#1632](https://github.com/typelevel/cats/pull/1632): upgraded to scala 2.12.2 and 2.11.11 and scalaJs. by @kailuowang
+ * [#1629](https://github.com/typelevel/cats/pull/1629): add unit test for variance on methods in `EitherT`. by @jtjeferreira
+ * [#1622](https://github.com/typelevel/cats/pull/1622): Update `Discipline` and `ScalaTest`. by @peterneyens
+ * [#1615](https://github.com/typelevel/cats/pull/1615): Fix doc for `InvariantMonoidal`. by @BenFradet
+ * [#1609](https://github.com/typelevel/cats/pull/1609): Include `Id` docs in the menu. by @ceedubs
+ * [#1591](https://github.com/typelevel/cats/pull/1591): Improve test coverage. by @peterneyens
+ * [#1590](https://github.com/typelevel/cats/pull/1590): Check monad laws for `Cokleisli`. by @peterneyens
+ * [#1588](https://github.com/typelevel/cats/pull/1588): Docs/Tutorial -- Simplify `Kleisli` example. by @RawToast
+ * [#1581](https://github.com/typelevel/cats/pull/1581): restore the alphabetical order of maintainers list.. by @kailuowang
+ * [#1575](https://github.com/typelevel/cats/pull/1575): minor improvements to `tailRecM` doc. by @kailuowang
+ * [#1570](https://github.com/typelevel/cats/pull/1570): fixed a paragraph order. by @kailuowang
+ * [#1566](https://github.com/typelevel/cats/pull/1566): Fix mistake in documentation of `Group.remove`. by @LukaJCB
+ * [#1563](https://github.com/typelevel/cats/pull/1563): Remove references of the NEL `OneAnd` alias. by @peterneyens
+ * [#1561](https://github.com/typelevel/cats/pull/1561): Fix incorrect numbering in `FreeMonads` doc. by @cb372
+ * [#1555](https://github.com/typelevel/cats/pull/1555): by fix scala.js badge version @xuwei-k
+ * [#1551](https://github.com/typelevel/cats/pull/1551): added `MonadError` and `ApplicativeError` to hierarchy diagram. by @kailuowang
+ * [#1547](https://github.com/typelevel/cats/pull/1547): fix ref to non-existent dir in contributing. by @sullivan-
+ * [#1546](https://github.com/typelevel/cats/pull/1546): add to `Monad` `ifM` example. by @sullivan-
+ * [#1545](https://github.com/typelevel/cats/pull/1545): fix scaladoc for `Eval` methods `Unit`, `True`, `False`, `Zero`, `One`. by @sullivan-
+ * [#1541](https://github.com/typelevel/cats/pull/1541): Switch from CrossVersion.full to CrossVersion.patch for TLS compatibi…. by @milessabin
+ * [#1530](https://github.com/typelevel/cats/pull/1530): add a favicon for sbt-microsite. by @larsrh
+ * [#1529](https://github.com/typelevel/cats/pull/1529): Fix typo in `Applicative` doc.. by @cranst0n
+ * [#1525](https://github.com/typelevel/cats/pull/1525): Remove link to apply.html from menu. by @Leammas
+ * [#1693](https://github.com/typelevel/cats/pull/1693): Clean up EitherT doctests. by @peterneyens
+ * [#1697](https://github.com/typelevel/cats/pull/1697): Added two links to the learner page. by @kailuowang
+ * [#1726](https://github.com/typelevel/cats/pull/1726): Add underscore.io Advanced Scala with Cats. by @DieBauer
+ * [#1718](https://github.com/typelevel/cats/pull/1718): Fixed some things in the build. by @djspiewak
+ * [#1734](https://github.com/typelevel/cats/pull/1734): update sbt. by @jyane
+ * [#1737](https://github.com/typelevel/cats/pull/1737): Rewrote documentation on the IO monad to reference cats-effect. by @djspiewak
+ * [#1744](https://github.com/typelevel/cats/pull/1744): Make links link to the `.html` files instead of `.md`. by @LukaJCB
+ * [#1759](https://github.com/typelevel/cats/pull/1759): Faster tests by reducing the size of lists. @peterneyens
+ * [#1760](https://github.com/typelevel/cats/pull/1760): Decrease stack-safety test size. by @edmundnoble
+ * [#1752](https://github.com/typelevel/cats/pull/1752): More coverage. by @edmundnoble
+ * [#1472](https://github.com/typelevel/cats/pull/1472): Using regular syntax in the FreeApplicative tutorial. by @denisftw
+ * [#1565](https://github.com/typelevel/cats/pull/1565): added instance table to docs, enhanced typeclass diagram. by @kailuowang
+ * [#1573](https://github.com/typelevel/cats/pull/1573): Add symbols to FAQ. by @zainab-ali 
+ 
 > 2017 January 15
 
 The biggest user-facing change in this release is to the behavior of the `flatMap` (and related methods) provided by `EitherOps` for the standard library's `Either` for Scala 2.10 and 2.11. These methods now match the behavior of the `flatMap` on `Either` in Scala 2.12 in that they don't require the left-hand side types to match.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,10 +10,10 @@
  
 ### To migrate from 0.9.0
 
-Apology for the number of breaking changes in this release. We are trying to include
-as many breaking changes in this release before we lock down the API. 
+We apologize for the number of breaking changes in this release. We are trying to include
+as many breaking changes as possible in this release before we lock down the API. 
   
- * `cats` no longer publish the all inclusive bundle package `"org.typelevel" % "cats"`, use `cats-core`, `cats-free`, or `cats-law` 
+ * `cats` no longer publish the all-inclusive bundle package `"org.typelevel" % "cats"`, use `cats-core`, `cats-free`, or `cats-law` 
    accordingly instead. If you need `cats.free`, use `"org.typelevel" % "cats-free"`, if you need `cats-laws` use 
    `"org.typelevel" % "cats-laws"`, if neither, use `"org.typelevel" % "cats-core"`.
  * `cats.free.Inject` is moved from `cats-free` to `cats-core` and renamed to `cats.InjectK`;
@@ -23,17 +23,17 @@ as many breaking changes in this release before we lock down the API.
    enabled syntax ops are also removed. Please use the partial unification SI-2712 fix
    instead. The easiest way might be this [sbt-plugin](https://github.com/fiadliel/sbt-partial-unification).
  *  `FunctorFilter`, `MonadCombine`, `MonadFilter`, `MonadReader`, `MonadState`, `MonadTrans`, `MonadWriter` and `TraverseFilter` are no longer in `cats`, the functionalities they provided are inhereted by the new [cats-mtl](https://github.com/edmundnoble/cats-mtl) project. Please check [here](https://github.com/edmundnoble/cats-mtl#migration-guide) for migration guide. 
- * `CartesianBuilder` (i.e. `|@|`) syntax is deprecated, use the apply syntanx on tuples instead. E.g. `(x |@| y |@| z).map(...)` should be replaced by `(x, y, z).mapN(...)`
- * The creation methods (`left`, `right`, `apply`, `pure`, etc.) in `EitherT` is improved to take less
+ * `CartesianBuilder` (i.e. `|@|`) syntax is deprecated, use the apply syntax on tuples instead. E.g. `(x |@| y |@| z).map(...)` should be replaced by `(x, y, z).mapN(...)`
+ * The creation methods (`left`, `right`, `apply`, `pure`, etc.) in `EitherT` were improved to take less
    type arguments.
- * Several `cats-core` type class instances for `cats.kernel` were moved from their compainion objects to separate traits
+ * Several `cats-core` type class instances for `cats.kernel` were moved from their companion objects to separate traits
    and thus require imports from `cats.instances.xxx._` (or the recommended `import cats.implicits._`) now. See #1659 for more details. 
  * `Free.suspend` is renamed to `Free.defer` for consistency. 
  * `traverse1_`, `intercalate1` and `sequence1_` in `Reducible` were renamed to `nonEmptyTraverse_`, `nonEmptyIntercalate` and `nonEmptySequence_` respectively. 
  * `foldLeftM` is removed from `Free`, use `foldM` on `Foldable` instead, see #1117 for detail. 
  * `iteratorFoldM` was removed from `Foldable` due to #1716
  * Apply syntax on tuple (e.g. `(x, y, z).map3(...)`)  was moved from `cats.syntax.tuple._` to `cats.syntax.apply._` and renamed to `mapN`, `contramapN` and `imapN` respectively.
- * `Split` is removed, the method `split` is moved to `Arrow`. Note that only under `CommutativeArrow` does it guarantee the non-interference between the effects. see #1567
+ * `Split` is removed, and the method `split` is moved to `Arrow`. Note that only under `CommutativeArrow` does it guarantee the non-interference between the effects. see #1567
 
  
 ### Breaking Changes:
@@ -121,7 +121,7 @@ as many breaking changes in this release before we lock down the API.
  * [#1691](https://github.com/typelevel/cats/pull/1691): Build JVM before JS on travis. by @peterneyens
  * [#1677](https://github.com/typelevel/cats/pull/1677): Update readme with the new dev channel.. by @kailuowang
  * [#1673](https://github.com/typelevel/cats/pull/1673): Use 2 workers in JVM build. by @ceedubs
- * [#1671](https://github.com/typelevel/cats/pull/1671): Fixing `Eq[Function1]` in testsJS; break JS build to separate matrix build.. by @kailuowang
+ * [#1671](https://github.com/typelevel/cats/pull/1671): Fixing `Eq[Function1]` in testsJS; break JS build to separate matrix build. by @kailuowang
  * [#1666](https://github.com/typelevel/cats/pull/1666): Use `Cogen` for arbitrary instances. by @ceedubs
  * [#1654](https://github.com/typelevel/cats/pull/1654): Update Circe URL. by @n4to4
  * [#1653](https://github.com/typelevel/cats/pull/1653): Fix typo in `FreeApplicative` doc.. by @takayuky
@@ -137,13 +137,13 @@ as many breaking changes in this release before we lock down the API.
  * [#1591](https://github.com/typelevel/cats/pull/1591): Improve test coverage. by @peterneyens
  * [#1590](https://github.com/typelevel/cats/pull/1590): Check monad laws for `Cokleisli`. by @peterneyens
  * [#1588](https://github.com/typelevel/cats/pull/1588): Docs/Tutorial -- Simplify `Kleisli` example. by @RawToast
- * [#1581](https://github.com/typelevel/cats/pull/1581): restore the alphabetical order of maintainers list.. by @kailuowang
+ * [#1581](https://github.com/typelevel/cats/pull/1581): restore the alphabetical order of maintainers list. by @kailuowang
  * [#1575](https://github.com/typelevel/cats/pull/1575): minor improvements to `tailRecM` doc. by @kailuowang
  * [#1570](https://github.com/typelevel/cats/pull/1570): fixed a paragraph order. by @kailuowang
  * [#1566](https://github.com/typelevel/cats/pull/1566): Fix mistake in documentation of `Group.remove`. by @LukaJCB
  * [#1563](https://github.com/typelevel/cats/pull/1563): Remove references of the NEL `OneAnd` alias. by @peterneyens
  * [#1561](https://github.com/typelevel/cats/pull/1561): Fix incorrect numbering in `FreeMonads` doc. by @cb372
- * [#1555](https://github.com/typelevel/cats/pull/1555): by fix scala.js badge version @xuwei-k
+ * [#1555](https://github.com/typelevel/cats/pull/1555): fix scala.js badge version. by @xuwei-k
  * [#1551](https://github.com/typelevel/cats/pull/1551): added `MonadError` and `ApplicativeError` to hierarchy diagram. by @kailuowang
  * [#1547](https://github.com/typelevel/cats/pull/1547): fix ref to non-existent dir in contributing. by @sullivan-
  * [#1546](https://github.com/typelevel/cats/pull/1546): add to `Monad` `ifM` example. by @sullivan-

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,7 +13,7 @@
 We apologize for the number of breaking changes in this release. We are trying to include
 as many breaking changes as possible in this release before we lock down the API. 
   
- * `cats` no longer publish the all-inclusive bundle package `"org.typelevel" % "cats"`, use `cats-core`, `cats-free`, or `cats-law` 
+ * `cats` no longer publishes the all-inclusive bundle package `"org.typelevel" % "cats"`, use `cats-core`, `cats-free`, or `cats-law` 
    accordingly instead. If you need `cats.free`, use `"org.typelevel" % "cats-free"`, if you need `cats-laws` use 
    `"org.typelevel" % "cats-laws"`, if neither, use `"org.typelevel" % "cats-core"`.
  * `cats.free.Inject` is moved from `cats-free` to `cats-core` and renamed to `cats.InjectK`;
@@ -24,6 +24,7 @@ as many breaking changes as possible in this release before we lock down the API
    instead. The easiest way might be this [sbt-plugin](https://github.com/fiadliel/sbt-partial-unification).
  *  `FunctorFilter`, `MonadCombine`, `MonadFilter`, `MonadReader`, `MonadState`, `MonadTrans`, `MonadWriter` and `TraverseFilter` are no longer in `cats`, the functionalities they provided are inhereted by the new [cats-mtl](https://github.com/edmundnoble/cats-mtl) project. Please check [here](https://github.com/edmundnoble/cats-mtl#migration-guide) for migration guide. 
  * `CartesianBuilder` (i.e. `|@|`) syntax is deprecated, use the apply syntax on tuples instead. E.g. `(x |@| y |@| z).map(...)` should be replaced by `(x, y, z).mapN(...)`
+ * Apply syntax on tuple (e.g. `(x, y, z).map3(...)`)  was moved from `cats.syntax.tuple._` to `cats.syntax.apply._` and renamed to `mapN`, `contramapN` and `imapN` respectively.
  * The creation methods (`left`, `right`, `apply`, `pure`, etc.) in `EitherT` were improved to take less
    type arguments.
  * Several `cats-core` type class instances for `cats.kernel` were moved from their companion objects to separate traits
@@ -32,7 +33,6 @@ as many breaking changes as possible in this release before we lock down the API
  * `traverse1_`, `intercalate1` and `sequence1_` in `Reducible` were renamed to `nonEmptyTraverse_`, `nonEmptyIntercalate` and `nonEmptySequence_` respectively. 
  * `foldLeftM` is removed from `Free`, use `foldM` on `Foldable` instead, see #1117 for detail. 
  * `iteratorFoldM` was removed from `Foldable` due to #1716
- * Apply syntax on tuple (e.g. `(x, y, z).map3(...)`)  was moved from `cats.syntax.tuple._` to `cats.syntax.apply._` and renamed to `mapN`, `contramapN` and `imapN` respectively.
  * `Split` is removed, and the method `split` is moved to `Arrow`. Note that only under `CommutativeArrow` does it guarantee the non-interference between the effects. see #1567
 
  
@@ -59,7 +59,7 @@ as many breaking changes as possible in this release before we lock down the API
  * [#1707](https://github.com/typelevel/cats/pull/1707): Add NEL/NEV one. by @peterneyens 
  * [#1680](https://github.com/typelevel/cats/pull/1680): ~~`MonadTrans` instance for RWST and make `MonadTrans` serializable.~~ by @wedens
  * [#1658](https://github.com/typelevel/cats/pull/1658): Add `Validated.validNel`. by @edmundnoble
- * [#1651](https://github.com/typelevel/cats/pull/1651): Add state method to `MonadState`. by @oskoi
+ * [#1651](https://github.com/typelevel/cats/pull/1651): ~~Add state method to `MonadState`.~~ by @oskoi
  * [#1628](https://github.com/typelevel/cats/pull/1628): add init and size methods to `NonEmptyList`. by @jtjeferreira
  * [#1612](https://github.com/typelevel/cats/pull/1612): Add ensureWith to `Validated` and `Either` (#1550). by @LukaJCB
  * [#1598](https://github.com/typelevel/cats/pull/1598): Implement a `ReaderWriterStateT` data type . by @iravid

--- a/README.md
+++ b/README.md
@@ -30,19 +30,20 @@ To get started with SBT, simply add the following to your `build.sbt`
 file:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats" % "0.9.0"
+libraryDependencies += "org.typelevel" %% "cats-core" % "1.0.0-MF"
 ```
 
-This will pull in all of Cats' modules. If you only require some
+This will pull in the cats-core module. If you require some other
 functionality, you can pick-and-choose from amongst these modules
-(used in place of `"cats"`):
+(used in place of `"cats-core"`):
 
  * `cats-macros`: Macros used by Cats syntax (*required*).
  * `cats-kernel`: Small set of basic type classes (*required*).
  * `cats-core`: Most core type classes and functionality (*required*).
  * `cats-laws`: Laws for testing type class instances.
  * `cats-free`: Free structures such as the free monad, and supporting type classes.
-
+ * `cats-testkit`: lib for writing tests for typeclass instances using laws. 
+ 
 Release notes for Cats are available in [CHANGES.md](CHANGES.md).
 
 *Cats is still under active development. While we don't anticipate any
@@ -133,19 +134,35 @@ sign-offs to merge PRs (and for large or contentious issues we may
 wait for more). For typos or other small fixes to documentation we
 relax this to a single sign-off.
 
-### Related Projects
+### The cats ecosystem
+Many projects integrate with cats. By sharing the same set of 
+type classes, instances and data types, projects can speak the same "cats
+language", and integrate with each other with ease. 
 
-There are many projects that integrate with Cats:
+#### Generic libraries to support pure functional programming
+
+ * [cats-effect](https://github.com/typelevel/cats-effect): `IO`, `Sync`, `Async` and `Effect` type classes for the cats ecosystem
+ * [cats-mtl](https://github.com/edmundnoble/cats-mtl): transformer typeclasses for cats' Monads, Applicatives and Functors.
+ * [Mouse](https://github.com/benhutchison/mouse): a small companion to cats that provides convenient syntax (aka extension methods)
+ * [alleycats](https://github.com/non/alleycats): Cats instances and classes which are outlaws, miscreants, and ne'er-do-wells.
+ * [Dogs](https://github.com/stew/dogs): pure functional collections and data structures.
+ * [Kittens](https://github.com/milessabin/kittens): automatic type class derivation for Cats and generic utility functions
+ * [eff](https://github.com/atnos-org/eff): functional effects and effect handlers (alternative to monad transformers).
+ * [Freestyle](https://github.com/47deg/freestyle): pure functional framework for Free and Tagless Final apps & libs.
+ * [mainecoon](https://github.com/kailuowang/mainecoon): Transform and compose tagless final encoded algebras
+ * [iota](https://github.com/frees-io/iota): Fast [co]product types with a clean syntax
+  
+#### Libraries with more specific uses
 
  * [Circe](https://github.com/circe/circe): pure functional JSON library.
- * [Dogs](https://github.com/stew/dogs): pure functional collections and data structures.
  * [Fetch](https://github.com/47deg/fetch): efficient data access to heterogeneous data sources.
  * [Frameless](https://github.com/adelbertc/frameless): Expressive types for Spark.
- * [Freestyle](https://github.com/47deg/freestyle): pure functional framework for Free and Tagless Final apps & libs.
  * [FS2](https://github.com/functional-streams-for-scala): compositional, streaming I/O library
- * [Kittens](https://github.com/milessabin/kittens): automatically derived type class instances.
+ * [doobie](https://github.com/tpolecat/doobie): a pure functional JDBC layer for Scala
  * [Monix](https://github.com/monixio/monix): high-performance library for composing asynchronous and event-based programs.
- * [eff](https://github.com/atnos-org/eff): functional effects and effect handlers (alternative to monad transformers).
+ * [http4s](https://github.com/http4s/http4s): A minimal, idiomatic Scala interface for HTTP
+ * [hammock](https://github.com/pepegar/hammock): Purely functional HTTP client
+ * [atto](https://github.com/tpolecat/atto): friendly little text parsers
 
 ### Copyright and License
 

--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ functionality, you can pick-and-choose from amongst these modules
  * `cats-free`: Free structures such as the free monad, and supporting type classes.
  * `cats-testkit`: lib for writing tests for typeclass instances using laws. 
  
+ There are several other cats modules that are in separate repos so that they can 
+ maintain independent release cycles. 
+ 
+ * [cats-effect](https://github.com/typelevel/cats-effect): `IO`, `Sync`, `Async` and `Effect` type classes for the cats ecosystem
+ * [cats-mtl](https://github.com/edmundnoble/cats-mtl): transformer typeclasses for cats' Monads, Applicatives and Functors.
+ * [alleycats](https://github.com/non/alleycats): Cats instances and classes which are outlaws, miscreants, and ne'er-do-wells.
+ 
 Release notes for Cats are available in [CHANGES.md](CHANGES.md).
 
 *Cats is still under active development. While we don't anticipate any
@@ -141,10 +148,7 @@ language", and integrate with each other with ease.
 
 #### Generic libraries to support pure functional programming
 
- * [cats-effect](https://github.com/typelevel/cats-effect): `IO`, `Sync`, `Async` and `Effect` type classes for the cats ecosystem
- * [cats-mtl](https://github.com/edmundnoble/cats-mtl): transformer typeclasses for cats' Monads, Applicatives and Functors.
  * [Mouse](https://github.com/benhutchison/mouse): a small companion to cats that provides convenient syntax (aka extension methods)
- * [alleycats](https://github.com/non/alleycats): Cats instances and classes which are outlaws, miscreants, and ne'er-do-wells.
  * [Dogs](https://github.com/stew/dogs): pure functional collections and data structures.
  * [Kittens](https://github.com/milessabin/kittens): automatic type class derivation for Cats and generic utility functions
  * [eff](https://github.com/atnos-org/eff): functional effects and effect handlers (alternative to monad transformers).

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@ functionality, you can pick-and-choose from amongst these modules
  There are several other cats modules that are in separate repos so that they can 
  maintain independent release cycles. 
  
- * [cats-effect](https://github.com/typelevel/cats-effect): `IO`, `Sync`, `Async` and `Effect` type classes for the cats ecosystem
- * [cats-mtl](https://github.com/edmundnoble/cats-mtl): transformer typeclasses for cats' Monads, Applicatives and Functors.
- * [alleycats](https://github.com/non/alleycats): Cats instances and classes which are outlaws, miscreants, and ne'er-do-wells.
+ * [`cats-effect`](https://github.com/typelevel/cats-effect): `IO`, `Sync`, `Async` and `Effect` type classes for the cats ecosystem
+ * [`cats-mtl`](https://github.com/edmundnoble/cats-mtl): transformer typeclasses for cats' Monads, Applicatives and Functors.
+ * [`alleycats`](https://github.com/non/alleycats): Cats instances and classes which are outlaws, miscreants, and ne'er-do-wells.
  
 Release notes for Cats are available in [CHANGES.md](CHANGES.md).
 

--- a/README.md
+++ b/README.md
@@ -47,9 +47,10 @@ functionality, you can pick-and-choose from amongst these modules
  There are several other cats modules that are in separate repos so that they can 
  maintain independent release cycles. 
  
- * [`cats-effect`](https://github.com/typelevel/cats-effect): `IO`, `Sync`, `Async` and `Effect` type classes for the cats ecosystem
+ * [`cats-effect`](https://github.com/typelevel/cats-effect): standard `IO` type together with `Sync`, `Async` and `Effect` type classes 
  * [`cats-mtl`](https://github.com/edmundnoble/cats-mtl): transformer typeclasses for cats' Monads, Applicatives and Functors.
- * [`alleycats`](https://github.com/non/alleycats): Cats instances and classes which are outlaws, miscreants, and ne'er-do-wells.
+ * [`alleycats`](https://github.com/non/alleycats): cats instances and classes which are not lawful.
+ * [`mouse`](https://github.com/benhutchison/mouse): a small companion to cats that provides convenient syntax (aka extension methods) 
  
 Release notes for Cats are available in [CHANGES.md](CHANGES.md).
 
@@ -148,7 +149,6 @@ language", and integrate with each other with ease.
 
 #### Generic libraries to support pure functional programming
 
- * [Mouse](https://github.com/benhutchison/mouse): a small companion to cats that provides convenient syntax (aka extension methods)
  * [Dogs](https://github.com/stew/dogs): pure functional collections and data structures.
  * [Kittens](https://github.com/milessabin/kittens): automatic type class derivation for Cats and generic utility functions
  * [eff](https://github.com/atnos-org/eff): functional effects and effect handlers (alternative to monad transformers).

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -38,9 +38,10 @@ functionality, you can pick-and-choose from amongst these modules
  There are several other cats modules that are in separate repos so that they can 
  maintain independent release cycles. 
  
- * [`cats-effect`](https://github.com/typelevel/cats-effect): `IO`, `Sync`, `Async` and `Effect` type classes for the cats ecosystem
+ * [`cats-effect`](https://github.com/typelevel/cats-effect): standard `IO` type together with `Sync`, `Async` and `Effect` type classes 
  * [`cats-mtl`](https://github.com/edmundnoble/cats-mtl): transformer typeclasses for cats' Monads, Applicatives and Functors.
- * [`alleycats`](https://github.com/non/alleycats): Cats instances and classes which are outlaws, miscreants, and ne'er-do-wells.
+ * [`alleycats`](https://github.com/non/alleycats): cats instances and classes which are not lawful.
+ * [`mouse`](https://github.com/benhutchison/mouse): a small companion to cats that provides convenient syntax (aka extension methods) 
  
 Release notes for Cats are available in [CHANGES.md](https://github.com/typelevel/cats/blob/master/CHANGES.md).
 

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -13,29 +13,32 @@ The name is a playful shortening of the word *category*.
   guarantees about stability until a 1.0 release is made.</p></div>
 
 
-### <a name="getting-started" href="#getting-started"></a>Getting Started
+## <a name="getting-started" href="#getting-started"></a>Getting Started
 
 
-Cats is currently available for Scala 2.10, 2.11 and 2.12.
+Cats is currently available for Scala 2.10, 2.11, 2.12 and scala.js
 
 To get started with SBT, simply add the following to your build.sbt file:
 
-    libraryDependencies += "org.typelevel" %% "cats" % "0.9.0"
+```scala
+libraryDependencies += "org.typelevel" %% "cats-core" % "1.0.0-MF"
+```
 
-This will pull in all of Cats' modules. If you only require some
+This will pull in the cats-core module. If you require some other
 functionality, you can pick-and-choose from amongst these modules
-(used in place of `"cats"`):
+(used in place of `"cats-core"`):
 
  * `cats-macros`: Macros used by Cats syntax (*required*).
  * `cats-kernel`: Small set of basic type classes (*required*).
  * `cats-core`: Most core type classes and functionality (*required*).
  * `cats-laws`: Laws for testing type class instances.
  * `cats-free`: Free structures such as the free monad, and supporting type classes.
-
+ * `cats-testkit`: lib for writing tests for typeclass instances using laws. 
+ 
 Release notes for Cats are available in [CHANGES.md](https://github.com/typelevel/cats/blob/master/CHANGES.md).
 
 
-# <a name="motivations" href="#motivations"></a>Motivations
+## <a name="motivations" href="#motivations"></a>Motivations
 
 
 ### Approachability
@@ -80,7 +83,40 @@ we can without making unnecessary sacrifices of purity and
 usability. Where sacrifices have to be made, we will strive to make
 these obvious, and will keep them well documented.
 
-### <a name="copyright" href="#copyright"></a>Copyright and License
+
+## <a name="ecosystem" href="#ecosystem"></a>The cats ecosystem
+
+Many projects integrate with cats. By sharing the same set of 
+type classes, instances and data types, projects can speak the same "cats
+language", and integrate with each other with ease. 
+
+#### Generic libraries to support pure functional programming
+
+ * [cats-effect](https://github.com/typelevel/cats-effect): `IO`, `Sync`, `Async` and `Effect` type classes for the cats ecosystem
+ * [cats-mtl](https://github.com/edmundnoble/cats-mtl): transformer typeclasses for cats' Monads, Applicatives and Functors.
+ * [Mouse](https://github.com/benhutchison/mouse): a small companion to cats that provides convenient syntax (aka extension methods)
+ * [alleycats](https://github.com/non/alleycats): Cats instances and classes which are outlaws, miscreants, and ne'er-do-wells.
+ * [Dogs](https://github.com/stew/dogs): pure functional collections and data structures.
+ * [Kittens](https://github.com/milessabin/kittens): automatic type class derivation for Cats and generic utility functions
+ * [eff](https://github.com/atnos-org/eff): functional effects and effect handlers (alternative to monad transformers).
+ * [Freestyle](https://github.com/47deg/freestyle): pure functional framework for Free and Tagless Final apps & libs.
+ * [mainecoon](https://github.com/kailuowang/mainecoon): Transform and compose tagless final encoded algebras
+ * [iota](https://github.com/frees-io/iota): Fast [co]product types with a clean syntax
+  
+#### Libraries with more specific uses
+
+ * [Circe](https://github.com/circe/circe): pure functional JSON library.
+ * [Fetch](https://github.com/47deg/fetch): efficient data access to heterogeneous data sources.
+ * [Frameless](https://github.com/adelbertc/frameless): Expressive types for Spark.
+ * [FS2](https://github.com/functional-streams-for-scala): compositional, streaming I/O library
+ * [doobie](https://github.com/tpolecat/doobie): a pure functional JDBC layer for Scala
+ * [Monix](https://github.com/monixio/monix): high-performance library for composing asynchronous and event-based programs.
+ * [http4s](https://github.com/http4s/http4s): A minimal, idiomatic Scala interface for HTTP
+ * [hammock](https://github.com/pepegar/hammock): Purely functional HTTP client
+ * [atto](https://github.com/tpolecat/atto): friendly little text parsers
+
+
+## <a name="copyright" href="#copyright"></a>Copyright and License
 
 
 All code is available to you under the MIT license, available at

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -38,9 +38,9 @@ functionality, you can pick-and-choose from amongst these modules
  There are several other cats modules that are in separate repos so that they can 
  maintain independent release cycles. 
  
- * [cats-effect](https://github.com/typelevel/cats-effect): `IO`, `Sync`, `Async` and `Effect` type classes for the cats ecosystem
- * [cats-mtl](https://github.com/edmundnoble/cats-mtl): transformer typeclasses for cats' Monads, Applicatives and Functors.
- * [alleycats](https://github.com/non/alleycats): Cats instances and classes which are outlaws, miscreants, and ne'er-do-wells.
+ * [`cats-effect`](https://github.com/typelevel/cats-effect): `IO`, `Sync`, `Async` and `Effect` type classes for the cats ecosystem
+ * [`cats-mtl`](https://github.com/edmundnoble/cats-mtl): transformer typeclasses for cats' Monads, Applicatives and Functors.
+ * [`alleycats`](https://github.com/non/alleycats): Cats instances and classes which are outlaws, miscreants, and ne'er-do-wells.
  
 Release notes for Cats are available in [CHANGES.md](https://github.com/typelevel/cats/blob/master/CHANGES.md).
 

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -34,6 +34,13 @@ functionality, you can pick-and-choose from amongst these modules
  * `cats-laws`: Laws for testing type class instances.
  * `cats-free`: Free structures such as the free monad, and supporting type classes.
  * `cats-testkit`: lib for writing tests for typeclass instances using laws. 
+
+ There are several other cats modules that are in separate repos so that they can 
+ maintain independent release cycles. 
+ 
+ * [cats-effect](https://github.com/typelevel/cats-effect): `IO`, `Sync`, `Async` and `Effect` type classes for the cats ecosystem
+ * [cats-mtl](https://github.com/edmundnoble/cats-mtl): transformer typeclasses for cats' Monads, Applicatives and Functors.
+ * [alleycats](https://github.com/non/alleycats): Cats instances and classes which are outlaws, miscreants, and ne'er-do-wells.
  
 Release notes for Cats are available in [CHANGES.md](https://github.com/typelevel/cats/blob/master/CHANGES.md).
 
@@ -92,10 +99,7 @@ language", and integrate with each other with ease.
 
 #### Generic libraries to support pure functional programming
 
- * [cats-effect](https://github.com/typelevel/cats-effect): `IO`, `Sync`, `Async` and `Effect` type classes for the cats ecosystem
- * [cats-mtl](https://github.com/edmundnoble/cats-mtl): transformer typeclasses for cats' Monads, Applicatives and Functors.
  * [Mouse](https://github.com/benhutchison/mouse): a small companion to cats that provides convenient syntax (aka extension methods)
- * [alleycats](https://github.com/non/alleycats): Cats instances and classes which are outlaws, miscreants, and ne'er-do-wells.
  * [Dogs](https://github.com/stew/dogs): pure functional collections and data structures.
  * [Kittens](https://github.com/milessabin/kittens): automatic type class derivation for Cats and generic utility functions
  * [eff](https://github.com/atnos-org/eff): functional effects and effect handlers (alternative to monad transformers).


### PR DESCRIPTION
### Update: 
The process started July 27 and last for a couple of days, mainly due to the coordination needed between cats and cats-mtl). Here are the steps:
- [x] 1. release 1.0.0-MF binary to maven central
- [x] 2. build cats-mtl against it and release
- [x] 3. draft a mtl migration guide and incorporate it into the current migration guide in #1702
- [ ] 4. merge #1702 and update readme , publish website
- [ ] 5. announce the release.

----------------------

As mentioned in the description, 1.0.0-MF is a draft for the final API of cats 1.0. Our user community will have the next couple of months to validate this draft and propose changes. 

The merged changes are included in the CHANGES.md. Let's talk about the outstanding items. 

Here are the outstanding PRs scheduled for 1.0.0-MF

- [x] Stack-safe Coyoneda #1602 
- [x] Inject for either #1600
- [x] Adds an As class which represents subtyping relationships (Liskov)  #1564 continued w/ #1728 
- [x] Apply syntax for tuples #1487, continued on #1745
- [x] move instances into separate trait #1659
- [x] clean up RWST #1706
- [x] Add Traverse1 typeclass #1611
- [x] Rename `suspend` to `defer` #1709
- [x] `foldLeftM` without `Free`. #1117
- [x] stop publishing cats all bundle , start to publish cats-testkit #1758
- [x] correct type parameter seq in RWST #1765
- [x] Replace Split with Commutative Arrow. Introduces Commutative Monad. #1719 continued w/ #1766
- [x] MTL is dead, long live MTL #1751 
- [x] Stack-safe FreeAp #1748

Maintainers, if you have time, please help review, we can push them over the finish line. 

Here are the outstanding issues scheduled for 1.0.0-MF

- [x] MTL removal plan #1616  PR in #1751
- [x] 1.0.0 packaging #1682 
- [x] standardize between `Eval.defer` and `Free.suspend`  #1635 
- [x] StateT law violations  #1714
- [x] SplitLaw doesn't hold in general #1567 - //continued on #1719
- [x] `Foldable` instance for `List` breaks substitution #1716 
- [x] `ReaderWriterStateT` type parameter order #1763

The ones with "?" are the ones that I'm uncertain if they should or can go into 1.0.0-MF. Also obviously, these aren't the complete set of outstanding issues and PRs. It was mostly just me scheduling them based on their impacts and my personal taste. So please chime in if you see anything you would like to go in 1.0.0-MF but not in this list. I would prioritize API changes over others, since this release is a draft for the final API for cats 1.0. 

Let the party begins.


UPDATEs: 
* removed https://github.com/typelevel/cats/issues/992 due to consensus 
* removed #1662 according to discussion. 
* removed #1560 according to discussion
* removed #107 and #1297 which will be continued in the next release. 

