### PR TITLE
Add NEL/NEV one

### DIFF
--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -227,8 +227,8 @@ private[data] sealed trait IorFunctions {
   def left[A, B](a: A): A Ior B = Ior.Left(a)
   def right[A, B](b: B): A Ior B = Ior.Right(b)
   def both[A, B](a: A, b: B): A Ior B = Ior.Both(a, b)
-  def leftNel[A, B](a: A): IorNel[A, B] = left(NonEmptyList.of(a))
-  def bothNel[A, B](a: A, b: B): IorNel[A, B] = both(NonEmptyList.of(a), b)
+  def leftNel[A, B](a: A): IorNel[A, B] = left(NonEmptyList.one(a))
+  def bothNel[A, B](a: A, b: B): IorNel[A, B] = both(NonEmptyList.one(a), b)
 
   /**
    * Create an `Ior` from two Options if at least one of them is defined.

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -327,6 +327,8 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) {
 object NonEmptyList extends NonEmptyListInstances {
   def of[A](head: A, tail: A*): NonEmptyList[A] = NonEmptyList(head, tail.toList)
 
+  def one[A](head: A): NonEmptyList[A] = NonEmptyList(head, Nil)
+
   /**
    * Create a `NonEmptyList` from a `List`.
    *
@@ -384,7 +386,7 @@ private[data] sealed trait NonEmptyListInstances extends NonEmptyListInstances0 
         fa map f
 
       def pure[A](x: A): NonEmptyList[A] =
-        NonEmptyList(x, List.empty)
+        NonEmptyList.one(x)
 
       def flatMap[A, B](fa: NonEmptyList[A])(f: A => NonEmptyList[B]): NonEmptyList[B] =
         fa flatMap f

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -210,7 +210,7 @@ private[data] sealed trait NonEmptyVectorInstances {
         fa map f
 
       def pure[A](x: A): NonEmptyVector[A] =
-        NonEmptyVector(x, Vector.empty)
+        NonEmptyVector.one(x)
 
       def flatMap[A, B](fa: NonEmptyVector[A])(f: A => NonEmptyVector[B]): NonEmptyVector[B] =
         fa flatMap f
@@ -298,6 +298,8 @@ object NonEmptyVector extends NonEmptyVectorInstances {
     tail.foreach(buf += _)
     new NonEmptyVector(buf.result)
   }
+
+  def one[A](head: A): NonEmptyVector[A] = apply(head, Vector.empty[A])
 
   def unapply[A](nev: NonEmptyVector[A]): Some[(A, Vector[A])] = Some((nev.head, nev.tail))
 

--- a/free/src/test/scala/cats/free/CofreeTests.scala
+++ b/free/src/test/scala/cats/free/CofreeTests.scala
@@ -67,10 +67,8 @@ class CofreeTests extends CatsSuite {
 
   test("Cofree.mapBranchingRoot") {
     val unfoldedHundred: CofreeNel[Int] = Cofree.unfold[Option, Int](0)(i => if (i == 100) None else Some(i + 1))
-    val withNoneRoot = unfoldedHundred.mapBranchingRoot(new (Option ~> Option) {
-      override def apply[A](opt: Option[A]): Option[A] = None
-    })
-    val nelUnfoldedOne: NonEmptyList[Int] = NonEmptyList.of(0)
+    val withNoneRoot = unfoldedHundred.mapBranchingRoot(λ[Option ~> Option](_ => None))
+    val nelUnfoldedOne: NonEmptyList[Int] = NonEmptyList.one(0)
     cofNelToNel(withNoneRoot) should ===(nelUnfoldedOne)
   }
 

--- a/tests/src/test/scala/cats/tests/IorTests.scala
+++ b/tests/src/test/scala/cats/tests/IorTests.scala
@@ -214,13 +214,13 @@ class IorTests extends CatsSuite {
 
   test("leftNel") {
     forAll { (x: String) =>
-      Ior.leftNel(x).left should === (Some(NonEmptyList.of(x)))
+      Ior.leftNel(x).left should === (Some(NonEmptyList.one(x)))
     }
   }
 
   test("bothNel") {
     forAll { (x: Int, y: String) =>
-      Ior.bothNel(y, x).onlyBoth should === (Some((NonEmptyList.of(y), x)))
+      Ior.bothNel(y, x).onlyBoth should === (Some((NonEmptyList.one(y), x)))
     }
   }
 

--- a/tests/src/test/scala/cats/tests/NonEmptyVectorTests.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyVectorTests.scala
@@ -212,7 +212,7 @@ class NonEmptyVectorTests extends CatsSuite {
 
   test("+: is consistent with concatNev") {
     forAll { (nonEmptyVector: NonEmptyVector[Int], i: Int) =>
-      i +: nonEmptyVector should === (NonEmptyVector.of(i).concatNev(nonEmptyVector))
+      i +: nonEmptyVector should === (NonEmptyVector.one(i).concatNev(nonEmptyVector))
     }
   }
   test("prepend is consistent with +:") {


### PR DESCRIPTION
`NonEmptyList.one(x)` is analogous to `x.pure[NonEmptyList]`.

Alternative for `NonEmptyList.of(x)` where you don't pay the price of the varargs, which isn't used.

Benchmark for `.of(1)` and `.one(1)`:
```
[info] Benchmark           Mode  Cnt          Score          Error  Units
[info] NelOfBench.nelOf   thrpt   20   14153921.124 ±    71083.406  ops/s
[info] NelOfBench.nelOne  thrpt   20  122074571.622 ± 25745302.862  ops/s
[info] NelOfBench.nevOf   thrpt   20   19260517.026 ±  2714989.060  ops/s
[info] NelOfBench.nevOne  thrpt   20   28379095.763 ±  3294357.173  ops/s
```