### PR TITLE
StateT violates laws

### DIFF
--- a/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
@@ -164,8 +164,8 @@ object arbitrary extends ArbitraryInstances0 {
 
 private[discipline] sealed trait ArbitraryInstances0 {
 
-  implicit def catsLawArbitraryForStateT[F[_]: Applicative, S, A](implicit AS: Arbitrary[S], CS: Cogen[S], F: Arbitrary[F[(S, A)]]): Arbitrary[StateT[F, S, A]] =
-    Arbitrary(Arbitrary.arbitrary[S => F[(S, A)]].map(StateT(_)))
+  implicit def catsLawArbitraryForStateT[F[_], S, A](implicit F: Arbitrary[F[S => F[(S, A)]]]): Arbitrary[StateT[F, S, A]] =
+    Arbitrary(F.arbitrary.map(StateT.applyF))
 
   implicit def catsLawsArbitraryForWriterT[F[_], L, V](implicit F: Arbitrary[F[(L, V)]]): Arbitrary[WriterT[F, L, V]] =
     Arbitrary(F.arbitrary.map(WriterT(_)))


### PR DESCRIPTION
As pointed out [here](https://github.com/typelevel/cats/issues/1640#issuecomment-298125906)

This reveals law violations in `StateT`. It looks like `flatMap`/`ap`
consistency does not hold, as well as `MonadCombine`
right-distributivity. It's not immediately clear to me how to fix this,
so I'm opening this up in case somebody else gets to it first.