### PR TITLE
Added StackSafeMonad mixin

### DIFF
--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -329,16 +329,12 @@ object Eval extends EvalInstances {
 private[cats] trait EvalInstances extends EvalInstances0 {
 
   implicit val catsBimonadForEval: Bimonad[Eval] =
-    new Bimonad[Eval] {
+    new Bimonad[Eval] with StackSafeMonad[Eval] {
       override def map[A, B](fa: Eval[A])(f: A => B): Eval[B] = fa.map(f)
       def pure[A](a: A): Eval[A] = Now(a)
       def flatMap[A, B](fa: Eval[A])(f: A => Eval[B]): Eval[B] = fa.flatMap(f)
       def extract[A](la: Eval[A]): A = la.value
       def coflatMap[A, B](fa: Eval[A])(f: Eval[A] => B): Eval[B] = Later(f(fa))
-      def tailRecM[A, B](a: A)(f: A => Eval[Either[A, B]]): Eval[B] = f(a).flatMap { // OK because Eval is trampolined
-        case Left(nextA) => tailRecM(nextA)(f)
-        case Right(b)    => pure(b)
-      }
     }
 
   implicit val catsReducibleForEval: Reducible[Eval] =

--- a/core/src/main/scala/cats/StackSafeMonad.scala
+++ b/core/src/main/scala/cats/StackSafeMonad.scala
@@ -1,0 +1,19 @@
+package cats
+
+import scala.util.{Either, Left, Right}
+
+/**
+ * A mix-in for inheriting tailRecM on monads which define a stack-safe flatMap.  This is
+ * ''not'' an appropriate trait to use unless you are 100% certain your monad is stack-safe
+ * by definition!  If your monad is not stack-safe, then the tailRecM implementation you
+ * will inherit will not be sound, and will result in unexpected stack overflows.  This
+ * trait is only provided because a large number of monads ''do'' define a stack-safe
+ * flatMap, and so this particular implementation was being repeated over and over again.
+ */
+trait StackSafeMonad[F[_]] extends Monad[F] {
+
+  override def tailRecM[A, B](a: A)(f: A => F[Either[A, B]]): F[B] = flatMap(f(a)) {
+    case Left(a) => tailRecM(a)(f)
+    case Right(b) => pure(b)
+  }
+}

--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -244,15 +244,10 @@ object Free {
    * `Free[S, ?]` has a monad for any type constructor `S[_]`.
    */
   implicit def catsFreeMonadForFree[S[_]]: Monad[Free[S, ?]] =
-    new Monad[Free[S, ?]] {
+    new Monad[Free[S, ?]] with StackSafeMonad[Free[S, ?]] {
       def pure[A](a: A): Free[S, A] = Free.pure(a)
       override def map[A, B](fa: Free[S, A])(f: A => B): Free[S, B] = fa.map(f)
       def flatMap[A, B](a: Free[S, A])(f: A => Free[S, B]): Free[S, B] = a.flatMap(f)
-      def tailRecM[A, B](a: A)(f: A => Free[S, Either[A, B]]): Free[S, B] =
-        f(a).flatMap {
-          case Left(a1) => tailRecM(a1)(f) // recursion OK here, since Free is lazy
-          case Right(b) => pure(b)
-        }
     }
 
   /**

--- a/tests/src/test/scala/cats/tests/RegressionTests.scala
+++ b/tests/src/test/scala/cats/tests/RegressionTests.scala
@@ -17,15 +17,10 @@ class RegressionTests extends CatsSuite {
   }
 
   object State {
-    implicit def instance[S]: Monad[State[S, ?]] = new Monad[State[S, ?]] {
+    implicit def instance[S]: Monad[State[S, ?]] = new Monad[State[S, ?]] with StackSafeMonad[State[S, ?]] {    // lies!
       def pure[A](a: A): State[S, A] = State(s => (a, s))
       def flatMap[A, B](sa: State[S, A])(f: A => State[S, B]): State[S, B] = sa.flatMap(f)
-      def tailRecM[A, B](a: A)(fn: A => State[S, Either[A, B]]): State[S, B] =
-        flatMap(fn(a)) {
-          case Left(a)  => tailRecM(a)(fn)
-          case Right(b) => pure(b)
-        }
-      }
+    }
   }
 
   // used to test side-effects


### PR DESCRIPTION
I'm tired of defining the same `tailRecM` over and over again when the underlying monad is already known to be stack-safe.  This mixin provides a more convenient way of achieving this goal.  Obviously, the implementation is only valid if the underlying monad has a stack-safe `flatMap`, but *if* it has a stack-safe `flatMap`, then this is almost certainly going to be the implementation.  May as well reduce some of the boilerplate in that case.