### PR TITLE
Add EitherNel type alias for Either[NonEmptyList[E], A]

### DIFF
--- a/core/src/main/scala/cats/data/package.scala
+++ b/core/src/main/scala/cats/data/package.scala
@@ -4,6 +4,7 @@ package object data {
   type NonEmptyStream[A] = OneAnd[Stream, A]
   type ValidatedNel[+E, +A] = Validated[NonEmptyList[E], A]
   type IorNel[+B, +A] = Ior[NonEmptyList[B], A]
+  type EitherNel[+E, +A] = Either[NonEmptyList[E], A]
 
   def NonEmptyStream[A](head: A, tail: Stream[A] = Stream.empty): NonEmptyStream[A] =
     OneAnd(head, tail)


### PR DESCRIPTION
Often when doing validations using `ValidatedNel`, the result is converted to `Either` when returning to a higher level where steps are sequenced. It'd be convenient to represent this type as `EitherNel` instead of `Either[NonEmptyList[...`