### PR TITLE
Add Align typeclass (#1263)

### DIFF
--- a/core/src/main/scala/cats/Align.scala
+++ b/core/src/main/scala/cats/Align.scala
@@ -1,0 +1,52 @@
+package cats
+
+import simulacrum.typeclass
+
+import cats.data.Ior
+
+/**
+  * `Align` supports zipping together structures with different shapes,
+  * holding the results from either or both structures in an `Ior`.
+  *
+  * Must obey the laws in cats.laws.AlignLaws
+  */
+@typeclass trait Align[F[_]] extends Functor[F] { self =>
+
+  /**
+    * An empty structure. `align`ing with `nil` will produce the same structure as the original, mod `Ior.Left` or `Ior.Right`.
+    *
+    * Align[Option].nil[Int] = None
+    */
+  def nil[A]: F[A]
+
+  /**
+    * Pairs elements of two structures along the union of their shapes, using `Ior` to hold the results.
+    *
+    * Align[List].align(List(1, 2), List(10, 11, 12)) = List(Ior.Both(1, 10), Ior.Both(2, 11), Ior.Right(12))
+    */
+  def align[A, B](fa: F[A], fb: F[B]): F[Ior[A, B]]
+
+  /**
+    * Combines elements similarly to `align`, using the provided function to compute the results.
+    */
+  def alignWith[A, B, C](fa: F[A], fb: F[B])(f: Ior[A, B] => C): F[C] =
+    map(align(fa, fb))(f)
+
+  /**
+    * Align two structures with the same element, combining results according to their semigroup instances.
+    */
+  def salign[A : Semigroup](fa1: F[A], fa2: F[A]): F[A] =
+    alignWith(fa1, fa2)(_.merge)
+
+  /**
+    * Same as `align`, but forgets from the type that one of the two elements must be present.
+    */
+  def padZip[A, B](fa: F[A], fb: F[B]): F[(Option[A], Option[B])] =
+    alignWith(fa, fb)(_.pad)
+
+  /**
+    * Same as `alignWith`, but forgets from the type that one of the two elements must be present.
+    */
+  def padZipWith[A, B, C](fa: F[A], fb: F[B])(f: (Option[A], Option[B]) => C): F[C] =
+    alignWith(fa, fb)(ior => Function.tupled(f)(ior.pad))
+}

--- a/core/src/main/scala/cats/instances/option.scala
+++ b/core/src/main/scala/cats/instances/option.scala
@@ -3,10 +3,12 @@ package instances
 
 import scala.annotation.tailrec
 
+import cats.data.Ior
+
 trait OptionInstances extends cats.kernel.instances.OptionInstances {
 
-  implicit val catsStdInstancesForOption: TraverseFilter[Option] with MonadError[Option, Unit] with MonadCombine[Option] with Monad[Option] with CoflatMap[Option] with Alternative[Option] =
-    new TraverseFilter[Option] with MonadError[Option, Unit]  with MonadCombine[Option] with Monad[Option] with CoflatMap[Option] with Alternative[Option] {
+  implicit val catsStdInstancesForOption: TraverseFilter[Option] with MonadError[Option, Unit] with MonadCombine[Option] with Monad[Option] with CoflatMap[Option] with Alternative[Option] with Align[Option] =
+    new TraverseFilter[Option] with MonadError[Option, Unit]  with MonadCombine[Option] with Monad[Option] with CoflatMap[Option] with Alternative[Option] with Align[Option] {
 
       def empty[A]: Option[A] = None
 
@@ -116,6 +118,16 @@ trait OptionInstances extends cats.kernel.instances.OptionInstances {
 
       override def isEmpty[A](fa: Option[A]): Boolean =
         fa.isEmpty
+
+      override def nil[A]: Option[A] = None
+
+      override def align[A, B](fa: Option[A], fb: Option[B]): Option[A Ior B] =
+        (fa, fb) match {
+          case (None, None) => None
+          case (Some(a), None) => Some(Ior.left(a))
+          case (None, Some(b)) => Some(Ior.right(b))
+          case (Some(a), Some(b)) => Some(Ior.both(a, b))
+        }
     }
 
   implicit def catsStdShowForOption[A](implicit A: Show[A]): Show[Option[A]] =

--- a/core/src/main/scala/cats/syntax/align.scala
+++ b/core/src/main/scala/cats/syntax/align.scala
@@ -1,0 +1,10 @@
+package cats
+package syntax
+
+trait AlignSyntax {
+  implicit final def catsSyntaxAlign[F[_], A](fa: F[A])(implicit F: Align[F]): Align.Ops[F, A] =
+    new Align.Ops[F, A] {
+      val self = fa
+      val typeClassInstance = F
+    }
+}

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -2,7 +2,8 @@ package cats
 package syntax
 
 trait AllSyntax
-    extends ApplicativeSyntax
+    extends AlignSyntax
+    with ApplicativeSyntax
     with ApplicativeErrorSyntax
     with ApplySyntax
     with BifunctorSyntax

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -2,6 +2,7 @@ package cats
 
 package object syntax {
   object all extends AllSyntax
+  object align extends AlignSyntax
   object applicative extends ApplicativeSyntax
   object applicativeError extends ApplicativeErrorSyntax
   object apply extends ApplySyntax

--- a/laws/src/main/scala/cats/laws/AlignLaws.scala
+++ b/laws/src/main/scala/cats/laws/AlignLaws.scala
@@ -1,0 +1,34 @@
+package cats
+package laws
+
+import cats.syntax.align._
+import cats.syntax.functor._
+
+import cats.data.Ior
+
+/**
+ * Laws that must be obeyed by any `Align`.
+ */
+trait AlignLaws[F[_]] extends FunctorLaws[F] {
+  implicit override def F: Align[F]
+
+  def nilLeftIdentity[A, B](fb: F[B]): IsEq[F[A Ior B]] =
+    F.nil[A].align(fb) <-> fb.map(Ior.right)
+
+  def nilRightIdentity[A, B](fa: F[A]): IsEq[F[A Ior B]] =
+    fa.align(F.nil[B]) <-> fa.map(Ior.left)
+
+  def alignSelfBoth[A](fa: F[A]): IsEq[F[A Ior A]] =
+    fa.align(fa) <-> fa.map(a => Ior.both(a, a))
+
+  def alignHomomorphism[A, B, C, D](fa: F[A], fb: F[B], f: A => C, g: B => D): IsEq[F[C Ior D]] =
+    fa.map(f).align(fb.map(g)) <-> fa.align(fb).map(_.bimap(f, g))
+
+  def alignWithConsistent[A, B, C](fa: F[A], fb: F[B], f: A Ior B => C): IsEq[F[C]] =
+    fa.alignWith(fb)(f) <-> fa.align(fb).map(f)
+}
+
+object AlignLaws {
+  def apply[F[_]](implicit ev: Align[F]): AlignLaws[F] =
+    new AlignLaws[F] { def F: Align[F] = ev }
+}

--- a/laws/src/main/scala/cats/laws/discipline/AlignTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/AlignTests.scala
@@ -32,8 +32,12 @@ trait AlignTests[F[_]] extends FunctorTests[F] {
     "nil left identity" -> forAll(laws.nilLeftIdentity[A, B] _),
     "nil right identity" -> forAll(laws.nilRightIdentity[A, B] _),
     "align self both" -> forAll(laws.alignSelfBoth[A] _),
-    "align homomorphism" -> forAll(laws.alignHomomorphism[A, B, C, D](_, _, _, _)),
-    "alignWith consistent" -> forAll(laws.alignWithConsistent[A, B, C](_, _, _)))
+    "align homomorphism" -> forAll { (fa: F[A], fb: F[B], f: A => C, g: B => D) =>
+      laws.alignHomomorphism[A, B, C, D](fa, fb, f, g)
+    },
+    "alignWith consistent" -> forAll { (fa: F[A], fb: F[B], f: A Ior B => C) =>
+      laws.alignWithConsistent[A, B, C](fa, fb, f)
+    })
 }
 
 object AlignTests {

--- a/laws/src/main/scala/cats/laws/discipline/AlignTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/AlignTests.scala
@@ -1,0 +1,42 @@
+package cats
+package laws
+package discipline
+
+import org.scalacheck.{Arbitrary, Cogen, Prop}
+import Prop._
+
+import cats.data.Ior
+
+trait AlignTests[F[_]] extends FunctorTests[F] {
+  def laws: AlignLaws[F]
+
+  def align[A: Arbitrary, B: Arbitrary, C: Arbitrary, D: Arbitrary](
+    implicit ArbFA: Arbitrary[F[A]],
+    ArbFB: Arbitrary[F[B]],
+    ArbFC: Arbitrary[F[C]],
+    ArbFAtoB: Arbitrary[A => C],
+    ArbFBtoC: Arbitrary[B => D],
+    ArbIorABtoC: Arbitrary[A Ior B => C],
+    CogenA: Cogen[A],
+    CogenB: Cogen[B],
+    CogenC: Cogen[C],
+    EqFA: Eq[F[A]],
+    EqFB: Eq[F[B]],
+    EqFC: Eq[F[C]],
+    EqFIorAA: Eq[F[A Ior A]],
+    EqFIorAB: Eq[F[A Ior B]],
+    EqFIorCD: Eq[F[C Ior D]]
+  ): RuleSet = new DefaultRuleSet(
+    name = "align",
+    parent = Some(functor[A, B, C]),
+    "nil left identity" -> forAll(laws.nilLeftIdentity[A, B] _),
+    "nil right identity" -> forAll(laws.nilRightIdentity[A, B] _),
+    "align self both" -> forAll(laws.alignSelfBoth[A] _),
+    "align homomorphism" -> forAll(laws.alignHomomorphism[A, B, C, D](_, _, _, _)),
+    "alignWith consistent" -> forAll(laws.alignWithConsistent[A, B, C](_, _, _)))
+}
+
+object AlignTests {
+  def apply[F[_]: Align]: AlignTests[F] =
+    new AlignTests[F] { def laws: AlignLaws[F] = AlignLaws[F] }
+}

--- a/tests/src/test/scala/cats/tests/ListTests.scala
+++ b/tests/src/test/scala/cats/tests/ListTests.scala
@@ -2,7 +2,7 @@ package cats
 package tests
 
 import cats.data.NonEmptyList
-import cats.laws.discipline.{TraverseFilterTests, CoflatMapTests, MonadCombineTests, SerializableTests, CartesianTests}
+import cats.laws.discipline.{AlignTests, TraverseFilterTests, CoflatMapTests, MonadCombineTests, SerializableTests, CartesianTests}
 import cats.laws.discipline.arbitrary._
 
 class ListTests extends CatsSuite {
@@ -18,6 +18,9 @@ class ListTests extends CatsSuite {
 
   checkAll("List[Int] with Option", TraverseFilterTests[List].traverseFilter[Int, Int, Int, List[Int], Option, Option])
   checkAll("TraverseFilter[List]", SerializableTests.serializable(TraverseFilter[List]))
+
+  checkAll("List[Int]", AlignTests[List].align[Int, Int, Int, Int])
+  checkAll("Align[List]", SerializableTests.serializable(Align[List]))
 
   test("nel => list => nel returns original nel")(
     forAll { fa: NonEmptyList[Int] =>

--- a/tests/src/test/scala/cats/tests/MapTests.scala
+++ b/tests/src/test/scala/cats/tests/MapTests.scala
@@ -1,7 +1,8 @@
 package cats
 package tests
 
-import cats.laws.discipline.{TraverseFilterTests, FlatMapTests, SerializableTests, CartesianTests}
+import cats.laws.discipline.{AlignTests, TraverseFilterTests, FlatMapTests, SerializableTests, CartesianTests}
+import cats.laws.discipline.arbitrary._
 
 class MapTests extends CatsSuite {
   implicit val iso = CartesianTests.Isomorphisms.invariant[Map[Int, ?]]
@@ -14,6 +15,9 @@ class MapTests extends CatsSuite {
 
   checkAll("Map[Int, Int] with Option", TraverseFilterTests[Map[Int, ?]].traverseFilter[Int, Int, Int, Int, Option, Option])
   checkAll("TraverseFilter[Map[Int, ?]]", SerializableTests.serializable(TraverseFilter[Map[Int, ?]]))
+
+  checkAll("Map[Int, Int]", AlignTests[Map[Int, ?]].align[Int, Int, Int, Int])
+  checkAll("Align[Map]", SerializableTests.serializable(Align[Map[Int, ?]]))
 
   test("show isn't empty and is formatted as expected") {
     forAll { (map: Map[Int, String]) =>

--- a/tests/src/test/scala/cats/tests/OptionTests.scala
+++ b/tests/src/test/scala/cats/tests/OptionTests.scala
@@ -3,6 +3,7 @@ package tests
 
 import cats.laws.{ApplicativeLaws, CoflatMapLaws, FlatMapLaws, MonadLaws}
 import cats.laws.discipline._
+import cats.laws.discipline.arbitrary._
 
 class OptionTests extends CatsSuite {
   checkAll("Option[Int]", CartesianTests[Option].cartesian[Int, Int, Int])
@@ -22,6 +23,9 @@ class OptionTests extends CatsSuite {
 
   checkAll("Option with Unit", MonadErrorTests[Option, Unit].monadError[Int, Int, Int])
   checkAll("MonadError[Option, Unit]", SerializableTests.serializable(MonadError[Option, Unit]))
+
+  checkAll("Option[Int]", AlignTests[Option].align[Int, Int, Int, Int])
+  checkAll("Align[Option]", SerializableTests.serializable(Align[Option]))
 
   test("show") {
     none[Int].show should === ("None")

--- a/tests/src/test/scala/cats/tests/StreamTests.scala
+++ b/tests/src/test/scala/cats/tests/StreamTests.scala
@@ -1,7 +1,8 @@
 package cats
 package tests
 
-import cats.laws.discipline.{CoflatMapTests, MonadCombineTests, SerializableTests, TraverseFilterTests, CartesianTests}
+import cats.laws.discipline.{AlignTests, CoflatMapTests, MonadCombineTests, SerializableTests, TraverseFilterTests, CartesianTests}
+import cats.laws.discipline.arbitrary._
 
 class StreamTests extends CatsSuite {
   checkAll("Stream[Int]", CartesianTests[Stream].cartesian[Int, Int, Int])
@@ -15,6 +16,9 @@ class StreamTests extends CatsSuite {
 
   checkAll("Stream[Int] with Option", TraverseFilterTests[Stream].traverseFilter[Int, Int, Int, List[Int], Option, Option])
   checkAll("TraverseFilter[Stream]", SerializableTests.serializable(TraverseFilter[Stream]))
+
+  checkAll("Stream[Int]", AlignTests[Stream].align[Int, Int, Int, Int])
+  checkAll("Align[Stream]", SerializableTests.serializable(Align[Stream]))
 
   test("show") {
     Stream(1, 2, 3).show should === ("Stream(1, ?)")

--- a/tests/src/test/scala/cats/tests/SyntaxTests.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxTests.scala
@@ -325,6 +325,23 @@ object SyntaxTests extends AllInstances with AllSyntax {
     thabcde.imap5(f5)(g5)
     (ha, hb, hc, hd, he).imap5(f5)(g5)
   }
+
+  def testAlign[F[_] : Align, A, B, C]: Unit = {
+    import cats.data.Ior
+    val fa = mock[F[A]]
+    val fb = mock[F[B]]
+    val f = mock[A Ior B => C]
+    val f2 = mock[(Option[A], Option[B]) => C]
+
+    val fab = fa.align(fb)
+    val fc = fa.alignWith(fb)(f)
+
+    val padZipped = fa.padZip(fb)
+    val padZippedWith = fa.padZipWith(fb)(f2)
+
+    implicit val sa = mock[Semigroup[A]]
+    val fa2 = fa.salign(fa)
+  }
 }
 
 /**

--- a/tests/src/test/scala/cats/tests/VectorTests.scala
+++ b/tests/src/test/scala/cats/tests/VectorTests.scala
@@ -2,7 +2,7 @@ package cats
 package tests
 
 import cats.data.NonEmptyVector
-import cats.laws.discipline.{MonadCombineTests, CoflatMapTests, SerializableTests, TraverseFilterTests, CartesianTests}
+import cats.laws.discipline.{AlignTests, MonadCombineTests, CoflatMapTests, SerializableTests, TraverseFilterTests, CartesianTests}
 import cats.laws.discipline.arbitrary._
 
 class VectorTests extends CatsSuite {
@@ -17,6 +17,9 @@ class VectorTests extends CatsSuite {
 
   checkAll("Vector[Int] with Option", TraverseFilterTests[Vector].traverseFilter[Int, Int, Int, List[Int], Option, Option])
   checkAll("TraverseFilter[Vector]", SerializableTests.serializable(TraverseFilter[Vector]))
+
+  checkAll("Vector[Int]", AlignTests[Vector].align[Int, Int, Int, Int])
+  checkAll("Align[Vector]", SerializableTests.serializable(Align[Vector]))
 
   test("show") {
     Vector(1, 2, 3).show should === ("Vector(1, 2, 3)")


### PR DESCRIPTION
Addresses #1263.

Design taken from the [Data.Align](https://hackage.haskell.org/package/these-0.7.4/docs/Data-Align.html) Haskell package. Implementing this raised some issues:

* If we have both FunctorFilter and Align, we have a reasonable implementation of `zip` and `zipWith`. I haven't tried to prove it, but you might even be able to show that the resulting implementation of `zip` satisfies the [reasonable law](http://comonad.com/reader/2008/zipping-and-unzipping-functors/) of being a left inverse to `unzip`.
* `nil` seems redundant with `empty` in MonadFilter and MonoidK. Probably it should also be called `empty`... but notably it just adds to the [weirdness](https://github.com/typelevel/cats/issues/1336) of having several different "empties", some of which are forced to converge to the same thing. On that note, we probably want another law saying that these empties have to coincide.

It seems there has been [some](https://github.com/typelevel/cats/issues/1336) [discussion](https://github.com/typelevel/cats/pull/1751) both of adding `empty` to FunctorFilter and removing FunctorFilter entirely. I think it might be nice to have a Zip typeclass, in which case retaining FunctorFilter might be useful for relating the two, though maybe that should just be done with MonadCombine or something.

On the subject of zipping, if in the future we wished to have [Naperian functors](http://www.cs.ox.ac.uk/people/jeremy.gibbons/publications/aplicative.pdf) (which I think would be nice too, though maybe that's more the kind of thing to leave in a third-party lib), then Align would only be able to serve as a generalization of it if we removed `nil` from the typeclass. Furthermore, in the Haskell [documentation](https://hackage.haskell.org/package/these-0.7.4/docs/Data-Align.html) there is the observation that an Align instance makes a functor F lax monoidal wrt the cartesian monoidal structure on Kleisli[Option, ?, ?] if the functor already admits a function `(A -> Option[B]) -> F[A] -> F[B]`, which basically means FunctorFilter. But in that case, we basically already get our `nil` value too; you just need to ensure the extra law that `nil` is an identity of `align`.

So maybe it'd be best to remove `nil` from Align and add a Zip typeclass that inherits from it and FunctorFilter, which adds `empty` and the relevant laws as well as `zip` and `zipWith`. This captures the familiar notion of zipping from lists, etc. quite well, so I think it's appropriate to use the name `zip` for it. For other notions of zipping, we already have Applicative functors, and could potentially add Naperian functors for a sort of "guaranteed full zip" where the shape of both arguments and the result is always the same.

Thoughts on this? I'm especially unsure about it because the FunctorFilter/MonadCombine situation seems to be changing.