### PR TITLE
Faster tests by reducing the size of lists

### DIFF
--- a/tests/src/test/scala/cats/tests/CokleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/CokleisliTests.scala
@@ -12,7 +12,9 @@ import org.scalacheck.Arbitrary
 class CokleisliTests extends SlowCatsSuite {
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
-    slowCheckConfiguration.copy(sizeRange = slowCheckConfiguration.sizeRange.min(5))
+    slowCheckConfiguration.copy(
+      sizeRange = slowCheckConfiguration.sizeRange.min(5),
+      minSuccessful = slowCheckConfiguration.minSuccessful.min(20))
 
   implicit def cokleisliEq[F[_], A, B](implicit A: Arbitrary[F[A]], FB: Eq[B]): Eq[Cokleisli[F, A, B]] =
     Eq.by[Cokleisli[F, A, B], F[A] => B](_.run)

--- a/tests/src/test/scala/cats/tests/CokleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/CokleisliTests.scala
@@ -11,6 +11,9 @@ import org.scalacheck.Arbitrary
 
 class CokleisliTests extends SlowCatsSuite {
 
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    slowCheckConfiguration.copy(sizeRange = slowCheckConfiguration.sizeRange.min(5))
+
   implicit def cokleisliEq[F[_], A, B](implicit A: Arbitrary[F[A]], FB: Eq[B]): Eq[Cokleisli[F, A, B]] =
     Eq.by[Cokleisli[F, A, B], F[A] => B](_.run)
 
@@ -34,30 +37,14 @@ class CokleisliTests extends SlowCatsSuite {
   checkAll("Cokleisli[Option, Int, Int]", ContravariantTests[Cokleisli[Option, ?, Int]].contravariant[Int, Int, Int])
   checkAll("Contravariant[Cokleisli[Option, ?, Int]]", SerializableTests.serializable(Contravariant[Cokleisli[Option, ?, Int]]))
 
-  {
-    // Ceremony to help scalac to do the right thing, see also #267.
-    type CokleisliNEL[A, B] = Cokleisli[NonEmptyList, A, B]
+  checkAll("Cokleisli[NonEmptyList, Int, Int]", ArrowTests[Cokleisli[NonEmptyList, ?, ?]].arrow[Int, Int, Int, Int, Int, Int])
+  checkAll("Arrow[Cokleisli[NonEmptyList, ?, ?]]", SerializableTests.serializable(Arrow[Cokleisli[NonEmptyList, ?, ?]]))
 
-    checkAll("Cokleisli[NonEmptyList, Int, Int]", ArrowTests[CokleisliNEL].arrow[Int, Int, Int, Int, Int, Int])
-    checkAll("Arrow[Cokleisli[NonEmptyList, ?, ?]]", SerializableTests.serializable(Arrow[CokleisliNEL]))
-  }
+  checkAll("Cokleisli[NonEmptyList, Int, Int]", MonoidKTests[λ[α => Cokleisli[NonEmptyList, α, α]]].monoidK[Int])
+  checkAll("MonoidK[λ[α => Cokleisli[NonEmptyList, α, α]]]", SerializableTests.serializable(MonoidK[λ[α => Cokleisli[NonEmptyList, α, α]]]))
 
-  {
-    // More ceremony, see above
-    type CokleisliNELE[A] = Cokleisli[NonEmptyList, A, A]
-
-    {
-      implicit val cokleisliMonoidK = Cokleisli.catsDataMonoidKForCokleisli[NonEmptyList]
-      checkAll("Cokleisli[NonEmptyList, Int, Int]", MonoidKTests[CokleisliNELE].monoidK[Int])
-      checkAll("MonoidK[λ[α => Cokleisli[NonEmptyList, α, α]]]", SerializableTests.serializable(cokleisliMonoidK))
-    }
-
-    {
-      implicit val cokleisliSemigroupK = Cokleisli.catsDataSemigroupKForCokleisli[NonEmptyList]
-      checkAll("Cokleisli[NonEmptyList, Int, Int]", SemigroupKTests[CokleisliNELE].semigroupK[Int])
-      checkAll("SemigroupK[λ[α => Cokleisli[NonEmptyList, α, α]]]", SerializableTests.serializable(cokleisliSemigroupK))
-    }
-  }
+  checkAll("Cokleisli[List, Int, Int]", SemigroupKTests[λ[α => Cokleisli[List, α, α]]].semigroupK[Int])
+  checkAll("SemigroupK[λ[α => Cokleisli[List, α, α]]]", SerializableTests.serializable(SemigroupK[λ[α => Cokleisli[List, α, α]]]))
 
   test("contramapValue with Id consistent with lmap"){
     forAll { (c: Cokleisli[Id, Int, Long], f: Char => Int) =>

--- a/tests/src/test/scala/cats/tests/ReaderWriterStateTTests.scala
+++ b/tests/src/test/scala/cats/tests/ReaderWriterStateTTests.scala
@@ -23,7 +23,7 @@ class ReaderWriterStateTTests extends CatsSuite {
 
   test("Traversing with ReaderWriterState is stack-safe") {
     val ns = (0 to 100000).toList
-    val rws = ns.traverse(_ => addAndLog(1))
+    val rws = ns.traverse(_ => addLogUnit(1))
 
     rws.runS("context", 0).value should === (100001)
   }
@@ -392,6 +392,12 @@ object ReaderWriterStateTTests {
     ReaderWriterState { (context, state) =>
       (Vector(s"${context}: Added ${i}"), state + i, state + i)
     }
+  }
+
+  def addLogUnit(i: Int): ReaderWriterState[String, Int, Unit, Int] = {
+    import cats.kernel.instances.unit._
+
+    ReaderWriterState { (context, state) => ((), state + i, state + i) }
   }
 
   implicit def RWSTEq[F[_], E, S, L, A](implicit S: Arbitrary[S], E: Arbitrary[E], FLSA: Eq[F[(L, S, A)]],

--- a/tests/src/test/scala/cats/tests/StateTTests.scala
+++ b/tests/src/test/scala/cats/tests/StateTTests.scala
@@ -9,6 +9,10 @@ import cats.laws.discipline.arbitrary._
 import org.scalacheck.Arbitrary
 
 class StateTTests extends CatsSuite {
+
+  implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
+    checkConfiguration.copy(sizeRange = 5)
+
   import StateTTests._
 
   test("basic state usage"){

--- a/tests/src/test/scala/cats/tests/WriterTTests.scala
+++ b/tests/src/test/scala/cats/tests/WriterTTests.scala
@@ -16,7 +16,7 @@ class WriterTTests extends CatsSuite {
   // Scalacheck to calm down a bit so we don't hit memory and test duration
   // issues.
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
-    PropertyCheckConfiguration(minSuccessful = 20, sizeRange = 5)
+    checkConfiguration.copy(sizeRange = 5)
 
   checkAll("WriterT[List, Int, Int]", OrderLaws[WriterT[List, Int, Int]].eqv)
   checkAll("Eq[WriterT[List, Int, Int]]", SerializableTests.serializable(Eq[WriterT[List, Int, Int]]))


### PR DESCRIPTION
(Partial) fix for #1757.

This doesn't help to speed up the associativity laws in `CokleisliTests` (or not very much).