### PR TITLE
Decrease stack-safety test size

### DIFF
--- a/tests/src/test/scala/cats/tests/ReaderWriterStateTTests.scala
+++ b/tests/src/test/scala/cats/tests/ReaderWriterStateTTests.scala
@@ -22,10 +22,10 @@ class ReaderWriterStateTTests extends CatsSuite {
   }
 
   test("Traversing with ReaderWriterState is stack-safe") {
-    val ns = (0 to 100000).toList
+    val ns = (0 to 70000).toList
     val rws = ns.traverse(_ => addLogUnit(1))
 
-    rws.runS("context", 0).value should === (100001)
+    rws.runS("context", 0).value should === (70001)
   }
 
   test("map2 combines logs") {

--- a/tests/src/test/scala/cats/tests/StateTTests.scala
+++ b/tests/src/test/scala/cats/tests/StateTTests.scala
@@ -20,9 +20,9 @@ class StateTTests extends CatsSuite {
   }
 
   test("traversing state is stack-safe"){
-    val ns = (0 to 100000).toList
+    val ns = (0 to 70000).toList
     val x = ns.traverse(_ => add1)
-    x.runS(0).value should === (100001)
+    x.runS(0).value should === (70001)
   }
 
   test("State.pure and StateT.pure are consistent"){


### PR DESCRIPTION
Locally looping 60000-deep in a recursive function is enough to blow my stack; as it is, these tests still fail on my machine with `Eval` swapped for `Id`.