### PR TITLE
Add index related helpers to Traverse

### DIFF
--- a/core/src/main/scala/cats/Traverse.scala
+++ b/core/src/main/scala/cats/Traverse.scala
@@ -1,6 +1,7 @@
 package cats
 
 import cats.data.State
+import cats.data.StateT
 
 import simulacrum.typeclass
 
@@ -111,8 +112,18 @@ import simulacrum.typeclass
     mapWithIndex(fa)((a, i) => (a, i))
 
   /**
-   * Akin to [[map]], but also provides the value's index in structure `F`.
+   * Akin to [[map]], but also provides the value's index in structure
+   * F when calling the function.
    */
   def mapWithIndex[A, B](fa: F[A])(f: (A, Int) => B): F[B] =
-    traverse(fa)(a => State((s: Int) => (s + 1, f(a, s)))).runA(0).value
+    traverse(fa)(a =>
+      State((s: Int) => (s + 1, f(a, s)))).runA(0).value
+
+  /**
+   * Akin to [[traverse]], but also provides the value's index in
+   * structure F when calling the function.
+   */
+  def traverseWithIndex[G[_], A, B](fa: F[A])(f: (A, Int) => G[B])(implicit G: Monad[G]): G[F[B]] =
+    traverse(fa)(a =>
+      StateT((s: Int) => G.map(f(a, s))(b => (s + 1, b)))).runA(0)
 }

--- a/core/src/main/scala/cats/Traverse.scala
+++ b/core/src/main/scala/cats/Traverse.scala
@@ -1,5 +1,7 @@
 package cats
 
+import cats.data.State
+
 import simulacrum.typeclass
 
 /**
@@ -97,4 +99,14 @@ import simulacrum.typeclass
 
   override def map[A, B](fa: F[A])(f: A => B): F[B] =
     traverse[Id, A, B](fa)(f)
+
+  /**
+   * Traverses through the structure F, pairing the values with
+   * assigned indices.
+   *
+   * The behavior is consistent with the Scala collection library's
+   * `zipWithIndex` for collections such as `List`.
+   */
+  def indexed[A](fa: F[A]): F[(A, Int)] =
+    traverse(fa)(a => State((s: Int) => (s + 1, (a, s)))).runA(0).value
 }

--- a/core/src/main/scala/cats/Traverse.scala
+++ b/core/src/main/scala/cats/Traverse.scala
@@ -108,5 +108,11 @@ import simulacrum.typeclass
    * `zipWithIndex` for collections such as `List`.
    */
   def indexed[A](fa: F[A]): F[(A, Int)] =
-    traverse(fa)(a => State((s: Int) => (s + 1, (a, s)))).runA(0).value
+    mapWithIndex(fa)((a, i) => (a, i))
+
+  /**
+   * Akin to [[map]], but also provides the value's index in structure `F`.
+   */
+  def mapWithIndex[A, B](fa: F[A])(f: (A, Int) => B): F[B] =
+    traverse(fa)(a => State((s: Int) => (s + 1, f(a, s)))).runA(0).value
 }

--- a/core/src/main/scala/cats/Traverse.scala
+++ b/core/src/main/scala/cats/Traverse.scala
@@ -102,16 +102,6 @@ import simulacrum.typeclass
     traverse[Id, A, B](fa)(f)
 
   /**
-   * Traverses through the structure F, pairing the values with
-   * assigned indices.
-   *
-   * The behavior is consistent with the Scala collection library's
-   * `zipWithIndex` for collections such as `List`.
-   */
-  def indexed[A](fa: F[A]): F[(A, Int)] =
-    mapWithIndex(fa)((a, i) => (a, i))
-
-  /**
    * Akin to [[map]], but also provides the value's index in structure
    * F when calling the function.
    */
@@ -126,4 +116,14 @@ import simulacrum.typeclass
   def traverseWithIndex[G[_], A, B](fa: F[A])(f: (A, Int) => G[B])(implicit G: Monad[G]): G[F[B]] =
     traverse(fa)(a =>
       StateT((s: Int) => G.map(f(a, s))(b => (s + 1, b)))).runA(0)
+
+  /**
+   * Traverses through the structure F, pairing the values with
+   * assigned indices.
+   *
+   * The behavior is consistent with the Scala collection library's
+   * `zipWithIndex` for collections such as `List`.
+   */
+  def zipWithIndex[A](fa: F[A]): F[(A, Int)] =
+    mapWithIndex(fa)((a, i) => (a, i))
 }

--- a/core/src/main/scala/cats/Traverse.scala
+++ b/core/src/main/scala/cats/Traverse.scala
@@ -112,8 +112,12 @@ import simulacrum.typeclass
   /**
    * Akin to [[traverse]], but also provides the value's index in
    * structure F when calling the function.
+   *
+   * This performs the traversal in a single pass but requires that
+   * effect G is monadic. An applicative traveral can be performed in
+   * two passes using [[zipWithIndex]] followed by [[traverse]].
    */
-  def traverseWithIndex[G[_], A, B](fa: F[A])(f: (A, Int) => G[B])(implicit G: Monad[G]): G[F[B]] =
+  def traverseWithIndexM[G[_], A, B](fa: F[A])(f: (A, Int) => G[B])(implicit G: Monad[G]): G[F[B]] =
     traverse(fa)(a =>
       StateT((s: Int) => G.map(f(a, s))(b => (s + 1, b)))).runA(0)
 

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -71,7 +71,7 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
         }.value
 
       override def mapWithIndex[A, B](fa: List[A])(f: (A, Int) => B): List[B] =
-        fa.view.zipWithIndex.map(ai => f(ai._1, ai._2)).toList
+        fa.iterator.zipWithIndex.map(ai => f(ai._1, ai._2)).toList
 
       override def zipWithIndex[A](fa: List[A]): List[(A, Int)] =
         fa.zipWithIndex

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -70,6 +70,12 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
           G.map2Eval(f(a), lglb)(_ :: _)
         }.value
 
+      override def mapWithIndex[A, B](fa: List[A])(f: (A, Int) => B): List[B] =
+        fa.view.zipWithIndex.map(ai => f(ai._1, ai._2)).toList
+
+      override def zipWithIndex[A](fa: List[A]): List[(A, Int)] =
+        fa.zipWithIndex
+
       @tailrec
       override def get[A](fa: List[A])(idx: Long): Option[A] =
         fa match {

--- a/core/src/main/scala/cats/instances/stream.scala
+++ b/core/src/main/scala/cats/instances/stream.scala
@@ -55,6 +55,12 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
         }.value
       }
 
+      override def mapWithIndex[A, B](fa: Stream[A])(f: (A, Int) => B): Stream[B] =
+        fa.zipWithIndex.map(ai => f(ai._1, ai._2))
+
+      override def zipWithIndex[A](fa: Stream[A]): Stream[(A, Int)] =
+        fa.zipWithIndex
+
       def tailRecM[A, B](a: A)(fn: A => Stream[Either[A, B]]): Stream[B] = {
         val it: Iterator[B] = new Iterator[B] {
           var stack: Stream[Either[A, B]] = fn(a)

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -83,7 +83,7 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
         }.value
 
       override def mapWithIndex[A, B](fa: Vector[A])(f: (A, Int) => B): Vector[B] =
-        fa.view.zipWithIndex.map(ai => f(ai._1, ai._2)).toVector
+        fa.iterator.zipWithIndex.map(ai => f(ai._1, ai._2)).toVector
 
       override def zipWithIndex[A](fa: Vector[A]): Vector[(A, Int)] =
         fa.zipWithIndex

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -82,6 +82,12 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
           G.map2Eval(f(a), lgvb)(_ +: _)
         }.value
 
+      override def mapWithIndex[A, B](fa: Vector[A])(f: (A, Int) => B): Vector[B] =
+        fa.view.zipWithIndex.map(ai => f(ai._1, ai._2)).toVector
+
+      override def zipWithIndex[A](fa: Vector[A]): Vector[(A, Int)] =
+        fa.zipWithIndex
+
       override def exists[A](fa: Vector[A])(p: A => Boolean): Boolean =
         fa.exists(p)
 

--- a/tests/src/test/scala/cats/tests/TraverseTests.scala
+++ b/tests/src/test/scala/cats/tests/TraverseTests.scala
@@ -14,6 +14,12 @@ abstract class TraverseCheck[F[_]: Traverse](name: String)(implicit ArbFInt: Arb
     }
   }
 
+  test(s"Traverse[$name].mapWithIndex") {
+    forAll { (fa: F[Int]) =>
+      fa.mapWithIndex((a, i) => (a, i)).toList should === (fa.toList.zipWithIndex)
+    }
+  }
+
 }
 
 class TraverseListCheck extends TraverseCheck[List]("list")

--- a/tests/src/test/scala/cats/tests/TraverseTests.scala
+++ b/tests/src/test/scala/cats/tests/TraverseTests.scala
@@ -20,6 +20,12 @@ abstract class TraverseCheck[F[_]: Traverse](name: String)(implicit ArbFInt: Arb
     }
   }
 
+  test(s"Traverse[$name].traverseWithIndex") {
+    forAll { (fa: F[Int]) =>
+      fa.traverseWithIndex((a, i) => Option((a, i))).map(_.toList) should === (Option(fa.toList.zipWithIndex))
+    }
+  }
+
 }
 
 class TraverseListCheck extends TraverseCheck[List]("list")

--- a/tests/src/test/scala/cats/tests/TraverseTests.scala
+++ b/tests/src/test/scala/cats/tests/TraverseTests.scala
@@ -23,7 +23,7 @@ class TraverseVectorCheck extends TraverseCheck[Vector]("vector")
 class TraverseTestsAdditional extends CatsSuite {
 
   def checkIndexedStackSafety[F[_]](fromRange: Range => F[Int])(implicit F: Traverse[F]): Unit = {
-    F.indexed(fromRange(1 to 500000))
+    F.indexed(fromRange(1 to 70000))
     ()
   }
 

--- a/tests/src/test/scala/cats/tests/TraverseTests.scala
+++ b/tests/src/test/scala/cats/tests/TraverseTests.scala
@@ -20,9 +20,9 @@ abstract class TraverseCheck[F[_]: Traverse](name: String)(implicit ArbFInt: Arb
     }
   }
 
-  test(s"Traverse[$name].traverseWithIndex") {
+  test(s"Traverse[$name].traverseWithIndexM") {
     forAll { (fa: F[Int], fn: ((Int, Int)) => (Int, Int)) =>
-      val left = fa.traverseWithIndex((a, i) => fn((a, i))).map(_.toList)
+      val left = fa.traverseWithIndexM((a, i) => fn((a, i))).map(_.toList)
       val (xs, values) = fa.toList.zipWithIndex.map(fn).unzip
       left should === ((xs.combineAll, values))
     }

--- a/tests/src/test/scala/cats/tests/TraverseTests.scala
+++ b/tests/src/test/scala/cats/tests/TraverseTests.scala
@@ -1,0 +1,41 @@
+package cats
+package tests
+
+import org.scalatest.prop.PropertyChecks
+import org.scalacheck.Arbitrary
+
+import cats.instances.all._
+
+abstract class TraverseCheck[F[_]: Traverse](name: String)(implicit ArbFInt: Arbitrary[F[Int]]) extends CatsSuite with PropertyChecks {
+
+  test(s"Traverse[$name].indexed") {
+    forAll { (fa: F[Int]) =>
+      fa.indexed.toList should === (fa.toList.zipWithIndex)
+    }
+  }
+
+}
+
+class TraverseListCheck extends TraverseCheck[List]("list")
+class TraverseStreamCheck extends TraverseCheck[Stream]("stream")
+class TraverseVectorCheck extends TraverseCheck[Vector]("vector")
+
+class TraverseTestsAdditional extends CatsSuite {
+
+  def checkIndexedStackSafety[F[_]](fromRange: Range => F[Int])(implicit F: Traverse[F]): Unit = {
+    F.indexed(fromRange(1 to 500000))
+    ()
+  }
+
+  test("Traverse[List].indexed stack safety") {
+    checkIndexedStackSafety[List](_.toList)
+  }
+
+  test("Traverse[Stream].indexed stack safety") {
+    checkIndexedStackSafety[Stream](_.toStream)
+  }
+
+  test("Traverse[Vector].indexed stack safety") {
+    checkIndexedStackSafety[Vector](_.toVector)
+  }
+}


### PR DESCRIPTION
This adds `traverseWithIndex`, `mapWithIndex` and `zipWithIndex` to `Traverse`.
- `traverseWithIndexM` is akin to `traverse`, but includes the index of the value in the structure `F`. This requires the effect to be monadic.
- `mapWithIndex` is akin to `map`, but includes the index of the value in the structure `F`.
- `zipWithIndex` returns F, with values tupled with their indices, just like Scala collection's zipWithIndex.

Instances for `List`, `Vector`, and `Stream` have overridden `mapWithIndex` and `zipWithIndex` that delegate to related underlying collections methods. `mapWithIndex` on `List` and `Vector` uses `.iterator` to avoid building an intermediate collection when first zipping with indices.