### PR TITLE
Add traverseWithStateM to Traverse

### DIFF
--- a/tests/src/test/scala/cats/tests/TraverseTests.scala
+++ b/tests/src/test/scala/cats/tests/TraverseTests.scala
@@ -28,6 +28,25 @@ abstract class TraverseCheck[F[_]: Traverse](name: String)(implicit ArbFInt: Arb
     }
   }
 
+  test(s"Traverse[$name].traverseWithStateM") {
+    forAll { (fa: F[Int]) =>
+      val left = fa.traverseWithStateM(Set.empty[Int])(
+        (a, s) => if (s.contains(a)) Eval.now("duplicate") else Eval.later(a.toString))(
+        (a, s, _) => s + a)
+      val fal = fa.toList
+      left.value.map(_.toList.filterNot(_ == "duplicate")) should === (fal.toSet -> fal.distinct.map(_.toString))
+    }
+  }
+
+  test(s"Traverse[$name].traverseWithStateMA") {
+    forAll { (fa: F[Int]) =>
+      val left = fa.traverseWithStateMA(Set.empty[Int])(
+        (a, s) => if (s.contains(a)) Eval.now("duplicate") else Eval.later(a.toString))(
+        (a, s, _) => s + a)
+      left.value.toList.filterNot(_ == "duplicate") should === (fa.toList.distinct.map(_.toString))
+    }
+  }
+
 }
 
 object TraverseCheck {


### PR DESCRIPTION
Add `traverseWithStateM` and `traverseWithStateMA` to Traverse.

This allows you to carry a value through a computation without having to deal with the state monad directly. I have been using this perform multiple stateful computations at once, such as carrying the index value while also marking duplicates. The test I added demonstrates marking for duplicates.

For method naming, I chose `traverseWithStateM` because the "traverse" prefix seems most important. My only minor concern is that the "state" suffix implies the state monad being exposed.