### PR TITLE
Remove docs for old mtl type classes

### DIFF
--- a/docs/src/main/tut/typeclasses/monadcombine.md
+++ b/docs/src/main/tut/typeclasses/monadcombine.md
@@ -1,9 +1,0 @@
----
-layout: docs
-title:  "MonadCombine"
-section: "typeclasses"
-source: "core/src/main/scala/cats/MonadCombine.scala"
-scaladoc: "#cats.MonadCombine"
----
-# MonadCombine
-

--- a/docs/src/main/tut/typeclasses/monadfilter.md
+++ b/docs/src/main/tut/typeclasses/monadfilter.md
@@ -1,9 +1,0 @@
----
-layout: docs
-title:  "MonadFilter"
-section: "typeclasses"
-source: "core/src/main/scala/cats/MonadFilter.scala"
-scaladoc: "#cats.MonadFilter"
----
-# MonadFilter
-


### PR DESCRIPTION
This PR removes the `MonadCombine` and `MonadFilter` sections from the docs, as they have been moved to `cats-mtl` (they were empty before anyway). 