### PR TITLE
Add RenameInjectProdAndCoproduct, RenameTupleApplySyntax and RemoveSplit Scalafix rewrites

### DIFF
--- a/scalafix/README.md
+++ b/scalafix/README.md
@@ -5,7 +5,7 @@
 Install the scalafix sbt plugin (globally or in a specific project):
 
 ```scala
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.5.0-M2")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.5.0-M3")
 ```
 
 run
@@ -26,11 +26,11 @@ sbt scalafix github:typelevel/cats/v1.0.0
 
 - [x] traverse1_, intercalate1 and sequence1_ in Reducible were renamed to nonEmptyTraverse_, nonEmptyIntercalate and nonEmptySequence_ respectively.
 
+- [x] cats.free.Inject is moved from cats-free to cats-core and renamed to cats.InjectK; cats.data.Prod is renamed to cats.data.Tuple2K; cats.data.Coproduct is renamed to cats.data.EitherK
+
 # WIP
 
 - [ ] cats no longer publishes the all-inclusive bundle package "org.typelevel" % "cats", use cats-core, cats-free, or cats-law accordingly instead. If you need cats.free, use "org.typelevel" % "cats-free", if you need cats-laws use "org.typelevel" % "cats-laws", if neither, use "org.typelevel" % "cats-core".
-
-- [ ] cats.free.Inject is moved from cats-free to cats-core and renamed to cats.InjectK; cats.data.Prod is renamed to cats.data.Tuple2K; cats.data.Coproduct is renamed to cats.data.EitherK
 
 - [ ] FunctorFilter, MonadCombine, MonadFilter, MonadReader, MonadState, MonadTrans, MonadWriter and TraverseFilter are no longer in cats, the functionalities they provided are inhereted by the new cats-mtl project. Please check here for migration guide.
 

--- a/scalafix/README.md
+++ b/scalafix/README.md
@@ -28,13 +28,13 @@ sbt scalafix github:typelevel/cats/v1.0.0
 
 - [x] cats.free.Inject is moved from cats-free to cats-core and renamed to cats.InjectK; cats.data.Prod is renamed to cats.data.Tuple2K; cats.data.Coproduct is renamed to cats.data.EitherK
 
+- [x] Apply syntax on tuple (e.g. (x, y, z).map3(...)) was moved from cats.syntax.tuple._ to cats.syntax.apply._ and renamed to mapN, contramapN and imapN respectively.
+
 # WIP
 
 - [ ] cats no longer publishes the all-inclusive bundle package "org.typelevel" % "cats", use cats-core, cats-free, or cats-law accordingly instead. If you need cats.free, use "org.typelevel" % "cats-free", if you need cats-laws use "org.typelevel" % "cats-laws", if neither, use "org.typelevel" % "cats-core".
 
 - [ ] FunctorFilter, MonadCombine, MonadFilter, MonadReader, MonadState, MonadTrans, MonadWriter and TraverseFilter are no longer in cats, the functionalities they provided are inhereted by the new cats-mtl project. Please check here for migration guide.
-
-- [ ] Apply syntax on tuple (e.g. (x, y, z).map3(...)) was moved from cats.syntax.tuple._ to cats.syntax.apply._ and renamed to mapN, contramapN and imapN respectively.
 
 - [ ] Several cats-core type class instances for cats.kernel were moved from their companion objects to separate traits and thus require imports from cats.instances.xxx._ (or the recommended import cats.implicits._) now. See #1659 for more details.
 

--- a/scalafix/README.md
+++ b/scalafix/README.md
@@ -30,6 +30,7 @@ sbt scalafix github:typelevel/cats/v1.0.0
 
 - [x] Apply syntax on tuple (e.g. (x, y, z).map3(...)) was moved from cats.syntax.tuple._ to cats.syntax.apply._ and renamed to mapN, contramapN and imapN respectively.
 
+- [x] Split is removed, and the method split is moved to Arrow. Note that only under CommutativeArrow does it guarantee the non-interference between the effects. see #1567
 # WIP
 
 - [ ] cats no longer publishes the all-inclusive bundle package "org.typelevel" % "cats", use cats-core, cats-free, or cats-law accordingly instead. If you need cats.free, use "org.typelevel" % "cats-free", if you need cats-laws use "org.typelevel" % "cats-laws", if neither, use "org.typelevel" % "cats-core".
@@ -41,5 +42,3 @@ sbt scalafix github:typelevel/cats/v1.0.0
 - [ ] foldLeftM is removed from Free, use foldM on Foldable instead, see #1117 for detail.
 
 - [ ] iteratorFoldM was removed from Foldable due to #1716
-
-- [ ] Split is removed, and the method split is moved to Arrow. Note that only under CommutativeArrow does it guarantee the non-interference between the effects. see #1567

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -1,12 +1,13 @@
 // Use a scala version supported by scalafix.
-scalaVersion in ThisBuild := org.scalameta.BuildInfo.supportedScalaVersions.last
+val V = _root_.scalafix.Versions
+scalaVersion in ThisBuild := V.scala212
 
 lazy val rewrites = project.settings(
-  libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % "0.5.0-M2"
+  libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % V.version
 )
 
 lazy val input = project.settings(
-  scalametaSourceroot := sourceDirectory.in(Compile).value,
+  scalafixSourceroot := sourceDirectory.in(Compile).value,
   libraryDependencies ++= Seq(
     "org.typelevel" %% "cats" % "0.9.0"
   )
@@ -21,7 +22,7 @@ lazy val output = project.settings(
 
 lazy val tests = project
   .settings(
-    libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % "0.5.0-M2" % Test cross CrossVersion.full,
+    libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % V.version % Test cross CrossVersion.full,
     buildInfoPackage := "fix",
     buildInfoKeys := Seq[BuildInfoKey](
       "inputSourceroot" ->

--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -10,14 +10,16 @@ lazy val input = project.settings(
   scalafixSourceroot := sourceDirectory.in(Compile).value,
   libraryDependencies ++= Seq(
     "org.typelevel" %% "cats" % "0.9.0"
-  )
+  ),
+  scalacOptions += "-language:higherKinds"
 )
 
 lazy val output = project.settings(
   libraryDependencies ++= Seq(
     "org.typelevel" %% "cats-core" % "1.0.0-MF",
     "org.typelevel" %% "cats-free" % "1.0.0-MF"
-  )
+  ),
+  scalacOptions += "-language:higherKinds"
 )
 
 lazy val tests = project

--- a/scalafix/input/src/main/scala/fix/v1_0_0/RemoveCartesianBuilder2.scala
+++ b/scalafix/input/src/main/scala/fix/v1_0_0/RemoveCartesianBuilder2.scala
@@ -1,4 +1,4 @@
-/* ONLY
+/*
 rewrite = "scala:fix.v1_0_0.RemoveCartesianBuilder"
  */
 package fix

--- a/scalafix/input/src/main/scala/fix/v1_0_0/RemoveSplit.scala
+++ b/scalafix/input/src/main/scala/fix/v1_0_0/RemoveSplit.scala
@@ -1,0 +1,17 @@
+/*
+rewrite = "scala:fix.v1_0_0.RemoveSplit"
+ */
+package fix
+package to1_0_0
+
+import cats.implicits._
+import cats.arrow.Split
+import cats.syntax.split._
+
+object RemoveSplitTests {
+  val toLong: Int => Long = _.toLong
+  val toDouble: Float => Double = _.toDouble
+  val f: ((Int, Float)) => (Long, Double) =
+    Split[Function1].split(toLong, toDouble)
+  f((3, 4.0f))
+}

--- a/scalafix/input/src/main/scala/fix/v1_0_0/RemoveSplit.scala
+++ b/scalafix/input/src/main/scala/fix/v1_0_0/RemoveSplit.scala
@@ -6,7 +6,6 @@ package to1_0_0
 
 import cats.implicits._
 import cats.arrow.Split
-import cats.syntax.split._
 
 object RemoveSplitTests {
   val toLong: Int => Long = _.toLong
@@ -14,4 +13,9 @@ object RemoveSplitTests {
   val f: ((Int, Float)) => (Long, Double) =
     Split[Function1].split(toLong, toDouble)
   f((3, 4.0f))
+
+  {
+    import cats.syntax.split._
+    toLong split toDouble
+  }
 }

--- a/scalafix/input/src/main/scala/fix/v1_0_0/RenameInjectProdAndCoproduct.scala
+++ b/scalafix/input/src/main/scala/fix/v1_0_0/RenameInjectProdAndCoproduct.scala
@@ -1,0 +1,14 @@
+/* 
+rewrite = "scala:fix.v1_0_0.RenameInjectProdAndCoproduct"
+ */
+package fix
+package to1_0_0
+
+import cats.free.Inject
+import cats.data.{ Coproduct, Prod }
+
+object RenameInjectProdAndCoproductTests {
+  def inject[F[_], G[_]](implicit inj: Inject[F, G]) = ???
+  def prod[F[_], G[_], A](implicit prod: Prod[F, G, A]) = ???
+  def coprod[F[_], G[_], A](implicit coprod: Coproduct[F, G, A]) = ???
+}

--- a/scalafix/input/src/main/scala/fix/v1_0_0/RenameTupleApplySyntax.scala
+++ b/scalafix/input/src/main/scala/fix/v1_0_0/RenameTupleApplySyntax.scala
@@ -1,0 +1,31 @@
+/* 
+rewrite = "scala:fix.v1_0_0.RenameTupleApplySyntax"
+ */
+package fix
+package to1_0_0
+
+object RenameTupleApplySyntaxTests {
+  import cats.{Eq, Semigroup}
+  import cats.instances.all._
+  import cats.syntax.tuple._
+
+  (Option(1), Option(2)).map2(_ + _)
+  (Option(1), Option(2), Option(3)).map3(_ + _ + _)
+  (Option(1), Option(2), Option(3), Option(4)).map4(_ + _ + _ + _)
+
+  case class Foo2(a: Int, b: Int)
+  case class Foo3(a: Int, b: Int, c: Int)
+  case class Foo4(a: Int, b: Int, c: Int, d: Int)
+
+  (Eq[Int], Eq[Int]).contramap2((f: Foo2) => (f.a, f.b))
+  (Eq[Int], Eq[Int], Eq[Int]).contramap3((f: Foo3) => (f.a, f.b, f.c))
+  (Eq[Int], Eq[Int], Eq[Int], Eq[Int]).contramap4((f: Foo4) =>
+    (f.a, f.b, f.c, f.d))
+
+  (Semigroup[Int], Semigroup[Int])
+    .imap2(Foo2.apply)(Function.unlift(Foo2.unapply))
+  (Semigroup[Int], Semigroup[Int], Semigroup[Int])
+    .imap3(Foo3.apply)(Function.unlift(Foo3.unapply))
+  (Semigroup[Int], Semigroup[Int], Semigroup[Int], Semigroup[Int])
+    .imap4(Foo4.apply)(Function.unlift(Foo4.unapply))
+}

--- a/scalafix/input/src/main/scala/fix/v1_0_0/RenameTupleApplySyntax.scala
+++ b/scalafix/input/src/main/scala/fix/v1_0_0/RenameTupleApplySyntax.scala
@@ -1,4 +1,4 @@
-/* 
+/*
 rewrite = "scala:fix.v1_0_0.RenameTupleApplySyntax"
  */
 package fix

--- a/scalafix/output/src/main/scala/fix/v1_0_0/RemoveSplit.scala
+++ b/scalafix/output/src/main/scala/fix/v1_0_0/RemoveSplit.scala
@@ -1,0 +1,13 @@
+package fix
+package to1_0_0
+
+import cats.implicits._
+import cats.arrow.Arrow
+
+object RemoveSplitTests {
+  val toLong: Int => Long = _.toLong
+  val toDouble: Float => Double = _.toDouble
+  val f: ((Int, Float)) => (Long, Double) =
+    Arrow[Function1].split(toLong, toDouble)
+  f((3, 4.0f))
+}

--- a/scalafix/output/src/main/scala/fix/v1_0_0/RemoveSplit.scala
+++ b/scalafix/output/src/main/scala/fix/v1_0_0/RemoveSplit.scala
@@ -10,4 +10,9 @@ object RemoveSplitTests {
   val f: ((Int, Float)) => (Long, Double) =
     Arrow[Function1].split(toLong, toDouble)
   f((3, 4.0f))
+
+  {
+    import cats.syntax.arrow._
+    toLong split toDouble
+  }
 }

--- a/scalafix/output/src/main/scala/fix/v1_0_0/RenameInjectProdAndCoproduct.scala
+++ b/scalafix/output/src/main/scala/fix/v1_0_0/RenameInjectProdAndCoproduct.scala
@@ -1,0 +1,11 @@
+package fix
+package to1_0_0
+
+import cats.InjectK
+import cats.data.{ EitherK, Tuple2K }
+
+object RenameInjectProdAndCoproductTests {
+  def inject[F[_], G[_]](implicit inj: InjectK[F, G]) = ???
+  def prod[F[_], G[_], A](implicit prod: Tuple2K[F, G, A]) = ???
+  def coprod[F[_], G[_], A](implicit coprod: EitherK[F, G, A]) = ???
+}

--- a/scalafix/output/src/main/scala/fix/v1_0_0/RenameTupleApplySyntax.scala
+++ b/scalafix/output/src/main/scala/fix/v1_0_0/RenameTupleApplySyntax.scala
@@ -1,0 +1,28 @@
+package fix
+package to1_0_0
+
+object RenameTupleApplySyntaxTests {
+  import cats.{Eq, Semigroup}
+  import cats.instances.all._
+  import cats.syntax.apply._
+
+  (Option(1), Option(2)).mapN(_ + _)
+  (Option(1), Option(2), Option(3)).mapN(_ + _ + _)
+  (Option(1), Option(2), Option(3), Option(4)).mapN(_ + _ + _ + _)
+
+  case class Foo2(a: Int, b: Int)
+  case class Foo3(a: Int, b: Int, c: Int)
+  case class Foo4(a: Int, b: Int, c: Int, d: Int)
+
+  (Eq[Int], Eq[Int]).contramapN((f: Foo2) => (f.a, f.b))
+  (Eq[Int], Eq[Int], Eq[Int]).contramapN((f: Foo3) => (f.a, f.b, f.c))
+  (Eq[Int], Eq[Int], Eq[Int], Eq[Int]).contramapN((f: Foo4) =>
+    (f.a, f.b, f.c, f.d))
+
+  (Semigroup[Int], Semigroup[Int])
+    .imapN(Foo2.apply)(Function.unlift(Foo2.unapply))
+  (Semigroup[Int], Semigroup[Int], Semigroup[Int])
+    .imapN(Foo3.apply)(Function.unlift(Foo3.unapply))
+  (Semigroup[Int], Semigroup[Int], Semigroup[Int], Semigroup[Int])
+    .imapN(Foo4.apply)(Function.unlift(Foo4.unapply))
+}

--- a/scalafix/project/plugins.sbt
+++ b/scalafix/project/plugins.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.5.0-M2")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.5.0-M3")
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-RC3")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
 addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.0.0")

--- a/scalafix/rewrites/src/main/scala/fix/Cats_v1_0_0.scala
+++ b/scalafix/rewrites/src/main/scala/fix/Cats_v1_0_0.scala
@@ -255,3 +255,14 @@ case class RenameTupleApplySyntax(semanticCtx: SemanticCtx) extends SemanticRewr
     }.asPatch
   }
 }
+
+// ref: https://github.com/typelevel/cats/pull/1766
+case class RemoveSplit(semanticCtx: SemanticCtx) extends SemanticRewrite(semanticCtx) {
+
+  def rewrite(ctx: RewriteCtx): Patch = {
+    ctx.replaceSymbols(
+      "_root_.cats.arrow.Split." -> "_root_.cats.arrow.Arrow."
+    )
+  }
+
+}

--- a/scalafix/rewrites/src/main/scala/fix/Cats_v1_0_0.scala
+++ b/scalafix/rewrites/src/main/scala/fix/Cats_v1_0_0.scala
@@ -262,7 +262,10 @@ case class RemoveSplit(semanticCtx: SemanticCtx) extends SemanticRewrite(semanti
   def rewrite(ctx: RewriteCtx): Patch = {
     ctx.replaceSymbols(
       "_root_.cats.arrow.Split." -> "_root_.cats.arrow.Arrow."
-    )
+    ) + ctx.tree.collect {
+      case t @ q"import cats.syntax.split._" =>
+        ctx.replaceTree(t, "import cats.syntax.arrow._")
+    }.asPatch
   }
 
 }


### PR DESCRIPTION
This PR adds these rewrites:

- `RenameInjectProdAndCoproduct`
- `RenameTupleApplySyntax`
- `RemoveSplit`

Two of them are super easy thanks to a feature recently landed in Scalafix (`replaceSymbol`). For this reason I also upgraded Scalafix to the latest milestone release for 0.5.0.
