### PR TITLE
Add fromFuture and fromRecoverable to EitherT companion object

### DIFF
--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -355,12 +355,13 @@ object EitherT extends EitherTInstances {
     * Uses the [[http://typelevel.org/cats/guidelines.html#partially-applied-type-params Partially Applied Type Params technique]] for ergonomics.
     */
   private[data] final class FromRecoverablePartiallyApplied[F[_], E](val dummy: Boolean = true) extends AnyVal {
-    def apply[A, B](f: F[B])(pf: PartialFunction[E, B])(implicit me: MonadError[F, E]): EitherT[F, A, B] =
-      EitherT.right[A](me.recover(f)(pf))
+    def apply[A, B](f: F[B])(pf: PartialFunction[E, B])(implicit ae: ApplicativeError[F, E]): EitherT[F, A, B] =
+      EitherT.right[A](ae.recover(f)(pf))
   }
 
   /** Creates an `EitherT` from a Future, recovers its error into a Either.Left.
-    *
+    * Catches any non-fatal exception in the future and always returns a successful
+    * future with the error in a Left.
     * {{{
     * scala> import scala.concurrent.Future
     * scala> import scala.concurrent.duration.Duration

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -374,19 +374,12 @@ object EitherT extends EitherTInstances {
     * res1: Either[Throwable, Int] = Left(java.lang.Throwable: error)
     * }}}
     */
-  final def fromFuture: FromFuturePartiallyApplied = new FromFuturePartiallyApplied
-
-  /**
-    * Uses the [[http://typelevel.org/cats/guidelines.html#partially-applied-type-params Partially Applied Type Params technique]] for ergonomics.
-    */
-  private[data] final class FromFuturePartiallyApplied(val dummy: Boolean = true) extends AnyVal {
-    def apply[B](future: Future[B])(implicit ec: ExecutionContext): EitherT[Future, Throwable, B] =
-      EitherT {
-        future.map(Right(_)).recoverWith {
-          case ex => Future.successful(Left(ex))
-        }
+  final def fromFuture[B](future: Future[B])(implicit ec: ExecutionContext): EitherT[Future, Throwable, B] =
+    EitherT {
+      future.map(Right(_)).recoverWith {
+        case ex => Future.successful(Left(ex))
       }
-  }
+    }
 
   /** Transforms an `Either` into an `EitherT`, lifted into the specified `Applicative`.
    *


### PR DESCRIPTION
This PR adds the capability of creating EitherT's instances with a default recovery for errors in `Future`, also adds `fromRecoverable` that allows create an instance with an error recovery in `F[_]` given a `ApplicativeError`.