### PR TITLE
Adding the origami project to the list of Typelevel projects using cats

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ language", and integrate with each other with ease.
  * [Freestyle](https://github.com/47deg/freestyle): pure functional framework for Free and Tagless Final apps & libs.
  * [mainecoon](https://github.com/kailuowang/mainecoon): Transform and compose tagless final encoded algebras
  * [iota](https://github.com/frees-io/iota): Fast [co]product types with a clean syntax
+ * [origami](https://github.com/atnos-org/origami): monadic folds
 
 #### Libraries with more specific uses
 


### PR DESCRIPTION
This is a proposal to add `origami` to the list of Typelevel projects using cats. However if I remember correctly one of the criteria for being part of the system is to have a compiler-checked documentation which doesn't exist anymore (it was there on a previous version of the library). I will add it and maybe then we can merge in this PR? Is anything else needed?