### PR TITLE
Add `grafter` to the list of Typelevel projects using cats

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ language", and integrate with each other with ease.
  * [atto](https://github.com/tpolecat/atto): friendly little text parsers
  * [decline](https://github.com/bkirwi/decline): A composable command-line parser
  * [seals](https://github.com/durban/seals): tools for schema evolution and language-integrated schemata
+ * [grafter](https://github.com/zalando/grafter): dependency-injection library using the `Reader` pattern
 
 *Feel free to submit a PR if you want a project you maintain to be added to this list.*
 


### PR DESCRIPTION
This is for your consideration. Grafter uses `Reader` instances for component dependencies and `Eval` for actions starting-up the application graph.