### PR TITLE
Remove mtl docs from menu

### DIFF
--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -80,14 +80,6 @@ options:
     url: typeclasses/foldable.html
     menu_type: typeclasses
 
-  - title: MonadCombine
-    url: typeclasses/monadcombine.html
-    menu_type: typeclasses
-
-  - title: MonadFilter
-    url: typeclasses/monadfilter.html
-    menu_type: typeclasses
-
   - title: MonoidK
     url: typeclasses/monoidk.html
     menu_type: typeclasses

--- a/docs/src/main/tut/typeclasses/monadcombine.md
+++ b/docs/src/main/tut/typeclasses/monadcombine.md
@@ -1,9 +1,0 @@
----
-layout: docs
-title:  "MonadCombine"
-section: "typeclasses"
-source: "core/src/main/scala/cats/MonadCombine.scala"
-scaladoc: "#cats.MonadCombine"
----
-# MonadCombine
-

--- a/docs/src/main/tut/typeclasses/monadfilter.md
+++ b/docs/src/main/tut/typeclasses/monadfilter.md
@@ -1,9 +1,0 @@
----
-layout: docs
-title:  "MonadFilter"
-section: "typeclasses"
-source: "core/src/main/scala/cats/MonadFilter.scala"
-scaladoc: "#cats.MonadFilter"
----
-# MonadFilter
-


### PR DESCRIPTION
Currently getting a 404, when selecting MonadCombine or MonadFilter.