### PR TITLE
Remove mtl classes from menu

### DIFF
--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -80,14 +80,6 @@ options:
     url: typeclasses/foldable.html
     menu_type: typeclasses
 
-  - title: MonadCombine
-    url: typeclasses/monadcombine.html
-    menu_type: typeclasses
-
-  - title: MonadFilter
-    url: typeclasses/monadfilter.html
-    menu_type: typeclasses
-
   - title: MonoidK
     url: typeclasses/monoidk.html
     menu_type: typeclasses


### PR DESCRIPTION
Currently getting a 404 when selecting MonadCombine or MonadFilter.