### PR TITLE
Set scalaz version to 7.2.15

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -338,7 +338,7 @@ lazy val bench = project.dependsOn(macrosJVM, coreJVM, freeJVM, lawsJVM)
   .settings(commonJvmSettings)
   .settings(coverageEnabled := false)
   .settings(libraryDependencies ++= Seq(
-    "org.scalaz" %% "scalaz-core" % "7.2.7"))
+    "org.scalaz" %% "scalaz-core" % "7.2.15"))
   .enablePlugins(JmhPlugin)
 
 // cats-js is JS-only


### PR DESCRIPTION
This is required to compile cats for scala 2.13.0-M1.
