### PR TITLE
Set simulacrum version to 0.11.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val commonSettings = Seq(
     Resolver.sonatypeRepo("snapshots")
   ),
   libraryDependencies ++= Seq(
-    "com.github.mpilquist" %%% "simulacrum" % "0.10.0" % "compile-time",
+    "com.github.mpilquist" %%% "simulacrum" % "0.11.0" % "compile-time",
     "org.typelevel" %%% "machinist" % "0.6.2",
     compilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.patch),
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.3")

--- a/core/src/main/scala/cats/syntax/apply.scala
+++ b/core/src/main/scala/cats/syntax/apply.scala
@@ -4,6 +4,8 @@ package syntax
 trait ApplySyntax extends TupleCartesianSyntax {
   implicit final def catsSyntaxApply[F[_], A](fa: F[A])(implicit F: Apply[F]): Apply.Ops[F, A] =
     new Apply.Ops[F, A] {
+      type TypeClassType = Apply[F]
+
       val self = fa
       val typeClassInstance = F
     }

--- a/core/src/main/scala/cats/syntax/cartesian.scala
+++ b/core/src/main/scala/cats/syntax/cartesian.scala
@@ -4,6 +4,8 @@ package syntax
 trait CartesianSyntax {
   implicit final def catsSyntaxCartesian[F[_], A](fa: F[A])(implicit F: Cartesian[F]): CartesianOps[F, A] =
     new CartesianOps[F, A] {
+      type TypeClassType = Cartesian[F]
+
       val self = fa
       val typeClassInstance = F
     }


### PR DESCRIPTION
This is required to compile cats for scala 2.13.0-M1.
 
see https://gitter.im/typelevel/cats-dev?at=59a03515a7b406262dc7722b

See also https://gitter.im/scala/community-builds?at=59a2c72eba0f0f6e38ea700c and links from there as well.

tldr is we wanted to check with scala team if these are known issues on 2.13.0-M1 as well.

This PR will override https://github.com/typelevel/cats/pull/1863, so sorry to @shokohara but thanks too!!