### PR TITLE
Revert scalatest to 3.0.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -108,7 +108,7 @@ lazy val includeGeneratedSrc: Setting[_] = {
 lazy val catsSettings = commonSettings ++ publishSettings ++ scoverageSettings ++ javadocSettings
 
 lazy val scalaCheckVersion = "1.13.5"
-lazy val scalaTestVersion = "3.0.4"
+lazy val scalaTestVersion = "3.0.3"
 lazy val disciplineVersion = "0.8"
 lazy val catalystsVersion = "0.0.5"
 


### PR DESCRIPTION
Scalatest 3.0.4 is not [published for 2.13.0-M1](http://central.maven.org/maven2/org/scalatest/scalatest_2.13.0-M1/) so we need to revert to 3.0.3 to compile cats for 2.13

3.0.4 is also [not mentioned in releases](https://github.com/scalatest/scalatest/releases) - we can track this and always re-bump later