### PR TITLE
Remove unused parameters from methods

### DIFF
--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -278,7 +278,7 @@ object Validated extends ValidatedInstances with ValidatedFunctions{
    * Uses the [[http://typelevel.org/cats/guidelines.html#partially-applied-type-params Partially Applied Type Params technique]] for ergonomics.
    */
   private[data] final class CatchOnlyPartiallyApplied[T](val dummy: Boolean = true ) extends AnyVal{
-    def apply[A](f: => A)(implicit T: ClassTag[T], NT: NotNull[T]): Validated[T, A] =
+    def apply[A](f: => A)(implicit T: ClassTag[T]): Validated[T, A] =
       try {
         valid(f)
       } catch {

--- a/core/src/main/scala/cats/syntax/either.scala
+++ b/core/src/main/scala/cats/syntax/either.scala
@@ -24,7 +24,7 @@ object EitherSyntax {
    * Uses the [[http://typelevel.org/cats/guidelines.html#partially-applied-type-params Partially Applied Type Params technique]] for ergonomics.
    */
   private[syntax] final class CatchOnlyPartiallyApplied[T](val dummy: Boolean = true ) extends AnyVal {
-    def apply[A](f: => A)(implicit CT: ClassTag[T], NT: NotNull[T]): Either[T, A] =
+    def apply[A](f: => A)(implicit CT: ClassTag[T]): Either[T, A] =
       try {
         Right(f)
       } catch {

--- a/core/src/main/scala/cats/syntax/monadError.scala
+++ b/core/src/main/scala/cats/syntax/monadError.scala
@@ -2,7 +2,7 @@ package cats
 package syntax
 
 trait MonadErrorSyntax {
-  implicit final def catsSyntaxMonadError[F[_], E, A](fa: F[A])(implicit F: MonadError[F, E]): MonadErrorOps[F, E, A] =
+  implicit final def catsSyntaxMonadError[F[_], E, A](fa: F[A]): MonadErrorOps[F, E, A] =
     new MonadErrorOps(fa)
 }
 

--- a/core/src/main/scala/cats/syntax/monadError.scala
+++ b/core/src/main/scala/cats/syntax/monadError.scala
@@ -2,7 +2,7 @@ package cats
 package syntax
 
 trait MonadErrorSyntax {
-  implicit final def catsSyntaxMonadError[F[_], E, A](fa: F[A]): MonadErrorOps[F, E, A] =
+  implicit final def catsSyntaxMonadError[F[_], E, A](fa: F[A])(implicit F: MonadError[F, E]): MonadErrorOps[F, E, A] =
     new MonadErrorOps(fa)
 }
 

--- a/core/src/main/scala/cats/syntax/partialOrder.scala
+++ b/core/src/main/scala/cats/syntax/partialOrder.scala
@@ -8,7 +8,7 @@ trait PartialOrderSyntax extends EqSyntax {
     new PartialOrderOps[A](a)
 }
 
-final class PartialOrderOps[A](lhs: A)(implicit A: PartialOrder[A]) {
+final class PartialOrderOps[A](lhs: A) {
   def >(rhs: A): Boolean = macro Ops.binop[A, Boolean]
   def >=(rhs: A): Boolean = macro Ops.binop[A, Boolean]
   def <(rhs: A): Boolean = macro Ops.binop[A, Boolean]


### PR DESCRIPTION
see also https://github.com/typelevel/cats/pull/1632#pullrequestreview-34456144
https://github.com/scala/scala/pull/5402#issuecomment-295261637
scala/scala#5876

See https://github.com/typelevel/cats/pull/1669 for related work on `MonadError` and `ApplicativeError`