### PR TITLE
build: use curly braces for disabling tasks

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -464,8 +464,8 @@ addCommandAlias("validate", ";clean;validateJS;validateKernelJS;validateFreeJS;v
 addCommandAlias("gitSnapshots", ";set version in ThisBuild := git.gitDescribedVersion.value.get + \"-SNAPSHOT\"")
 
 lazy val noPublishSettings = Seq(
-  publish := (),
-  publishLocal := (),
+  publish := {},
+  publishLocal := {},
   publishArtifact := false
 )
 


### PR DESCRIPTION
Using parentheses for disabling tasks with sbt 1.0 will issue the
following deprecation warning:
```
warning: Adaptation of argument list by inserting () is deprecated: this
is unlikely to be what you want.
        signature: DefinableTask.:=(v: S): sbt.Def.Setting[sbt.Task[S]]
  given arguments: <none>
 after adaptation: DefinableTask.:=((): Unit)
  publish := (),
          ^
```

This can be fixed with curly braces which is also perfectly fine with
sbt 0.13. So this can be merged right now and will make the actual
upgrade to sbt 1.0 easier.