### PR TITLE
Rename typeclass => type class in Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ functionality, you can pick-and-choose from amongst these modules
  * `cats-core`: Most core type classes and functionality (*required*).
  * `cats-laws`: Laws for testing type class instances.
  * `cats-free`: Free structures such as the free monad, and supporting type classes.
- * `cats-testkit`: lib for writing tests for typeclass instances using laws. 
+ * `cats-testkit`: lib for writing tests for type class instances using laws.
  
  There are several other cats modules that are in separate repos so that they can 
  maintain independent release cycles. 

--- a/docs/src/main/tut/index.md
+++ b/docs/src/main/tut/index.md
@@ -33,7 +33,7 @@ functionality, you can pick-and-choose from amongst these modules
  * `cats-core`: Most core type classes and functionality (*required*).
  * `cats-laws`: Laws for testing type class instances.
  * `cats-free`: Free structures such as the free monad, and supporting type classes.
- * `cats-testkit`: lib for writing tests for typeclass instances using laws. 
+ * `cats-testkit`: lib for writing tests for type class instances using laws.
 
  There are several other cats modules that are in separate repos so that they can 
  maintain independent release cycles. 


### PR DESCRIPTION
I think we have settled on "type class" being two words in all of our docs, so should be the same way here :)