### PR TITLE
Add val for "compile-time" sbt Configuration

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,8 @@ lazy val scoverageSettings = Seq(
 
 organization in ThisBuild := "org.typelevel"
 
+val CompileTime = config("compile-time").hide
+
 lazy val kernelSettings = Seq(
   // don't warn on value discarding because it's broken on 2.10 with @sp(Unit)
   scalacOptions ++= commonScalacOptions.filter(_ != "-Ywarn-value-discard"),
@@ -36,7 +38,7 @@ lazy val commonSettings = Seq(
     Resolver.sonatypeRepo("snapshots")
   ),
   libraryDependencies ++= Seq(
-    "com.github.mpilquist" %%% "simulacrum" % "0.11.0" % "compile-time",
+    "com.github.mpilquist" %%% "simulacrum" % "0.11.0" % CompileTime,
     "org.typelevel" %%% "machinist" % "0.6.2",
     compilerPlugin("org.scalamacros" %% "paradise" % "2.1.0" cross CrossVersion.patch),
     compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.4")
@@ -44,8 +46,8 @@ lazy val commonSettings = Seq(
   fork in test := true,
   parallelExecution in Test := false,
   scalacOptions in (Compile, doc) := (scalacOptions in (Compile, doc)).value.filter(_ != "-Xfatal-warnings"),
-  ivyConfigurations += config("compile-time").hide,
-  unmanagedClasspath in Compile ++= update.value.select(configurationFilter("compile-time")),
+  ivyConfigurations += CompileTime,
+  unmanagedClasspath in Compile ++= update.value.select(configurationFilter(CompileTime.name)),
   unmanagedSourceDirectories in Test ++= {
     val bd = baseDirectory.value
     if (CrossVersion.partialVersion(scalaVersion.value) exists (_._2 >= 11))


### PR DESCRIPTION
This is another change that makes upgrading to sbt 1.0 easier
and which is compatible with sbt 0.13.

With sbt 1.0 the following line in `commonSettings`:
```
ivyConfigurations += config("compile-time").hide
```
leads to this exception:
```
[info] Loading settings from build.sbt,version.sbt ...
[info] Resolving key references (15580 settings) ...
[error] java.lang.IllegalArgumentException: requirement failed: id must be capitalized: commonSettings
[error]         at scala.Predef$.require(Predef.scala:277)
[error]         at sbt.librarymanagement.Configuration.<init>(Configuration.scala:19)
[error]         at sbt.librarymanagement.Configuration$.of(Configuration.scala:72)
[error]         at $61255add5b0123fd7403$.$anonfun$commonSettings$9(build.sbt:47)
```

The reason why `commonSettings` is used as `id` for this "compile-time"
configuration can be found in [this sbt-librarymanagement macro](https://github.com/sbt/librarymanagement/blob/53c80f076a5e9ab469037f352a4d68173140e216/core/src/main/scala/sbt/librarymanagement/ConfigurationExtra.scala#L109-L114).

As the macro suggests, extracting the defintion of the `Configuration`
and assigning it to a `val` fixes the error.

The "compile-time" configuration was added in
https://github.com/typelevel/cats/pull/1638 to remove simulacrum from
the dependencies in the POM. I therefore checked that simulacrum is
still not present in the POM after this change.