### PR TITLE
Remove deprecated requiresDOM setting

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,6 @@ lazy val commonJsSettings = Seq(
   },
   scalaJSStage in Global := FastOptStage,
   parallelExecution := false,
-  requiresDOM := false,
   jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv(),
   // batch mode decreases the amount of memory needed to compile scala.js code
   scalaJSOptimizerOptions := scalaJSOptimizerOptions.value.withBatchMode(isTravisBuild.value),


### PR DESCRIPTION
Since Scala.js 0.6.20 our build displays this deprecation warning:

```
build.sbt:74: warning: value requiresDOM in object AutoImport is
deprecated: Requesting a DOM-enabled JS env with `jsDependencies +=
RuntimeDOM` or `requiresDOM := true` will not be supported in Scala.js
1.x. Instead, explicitly select a suitable JS with `jsEnv`, e.g., `jsEnv
:= new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv`.
  requiresDOM := false,
  ^
```

Since we are already selecting a DOM-disabled JS environment with
```sbt
jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv()
```
it seems to be enough to remove `requiresDOM` to get rid of this
deprecation warning.