### PR TITLE
Fix Alternative law checking for IndexedStateT

### DIFF
--- a/tests/src/test/scala/cats/tests/IndexedStateTTests.scala
+++ b/tests/src/test/scala/cats/tests/IndexedStateTTests.scala
@@ -350,7 +350,7 @@ class IndexedStateTTests extends CatsSuite {
     implicit val F = ListWrapper.alternative
     val SA = IndexedStateT.catsDataAlternativeForIndexedStateT[ListWrapper, Int](ListWrapper.monad, ListWrapper.alternative)
 
-    checkAll("IndexedStateT[ListWrapper, Int, Int, Int]", AlternativeTests[IndexedStateT[ListWrapper, Int, Int, ?]](SA).monoidK[Int])
+    checkAll("IndexedStateT[ListWrapper, Int, Int, Int]", AlternativeTests[IndexedStateT[ListWrapper, Int, Int, ?]](SA).alternative[Int, Int, Int])
     checkAll("Alternative[IndexedStateT[ListWrapper, Int, Int, ?]]", SerializableTests.serializable(SA))
 
     Monad[IndexedStateT[ListWrapper, Int, Int, ?]]


### PR DESCRIPTION
`MonoidK` laws were being checked instead of `Alternative`.