### PR TITLE
temporarily disable MiMa check on kernel

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -231,7 +231,18 @@ lazy val macros = crossProject.crossType(CrossType.Pure)
 lazy val macrosJVM = macros.jvm
 lazy val macrosJS = macros.js
 
-val binaryCompatibleVersion = "1.0.0-RC1"
+val binaryCompatibleVersion = "0.8.0"
+
+val binaryCompatibleExceptions = {
+  import com.typesafe.tools.mima.core._
+  import com.typesafe.tools.mima.core.ProblemFilters._
+  Seq(
+    exclude[InheritedNewAbstractMethodProblem]("cats.kernel.instances.QueueInstances.*"),
+    exclude[InheritedNewAbstractMethodProblem]("cats.kernel.instances.QueueInstances1.*"),
+    exclude[InheritedNewAbstractMethodProblem]("cats.kernel.instances.QueueInstances2.*"),
+    exclude[InheritedNewAbstractMethodProblem]("cats.kernel.instances.DurationInstances.*")
+  )
+}
 
 lazy val kernel = crossProject.crossType(CrossType.Pure)
   .in(file("kernel"))
@@ -242,14 +253,15 @@ lazy val kernel = crossProject.crossType(CrossType.Pure)
   .settings(sourceGenerators in Compile += (sourceManaged in Compile).map(KernelBoiler.gen).taskValue)
   .settings(includeGeneratedSrc)
   .jsSettings(commonJsSettings)
-  .jvmSettings(commonJvmSettings)
-// temporarily disable to allow several approved PRs to pass build, should reenable after 1.0.0-RC1
-//   ++ (mimaPreviousArtifacts := {
-//      if (scalaVersion.value startsWith "2.12")
-//        Set()
-//      else
-//        Set("org.typelevel" %% "cats-kernel" % binaryCompatibleVersion)
-//    })))
+  .jvmSettings(commonJvmSettings ++ Seq(
+    mimaPreviousArtifacts := {
+      if (scalaVersion.value startsWith "2.12")
+        Set()
+      else
+        Set("org.typelevel" %% "cats-kernel" % binaryCompatibleVersion)
+    },
+    mimaBinaryIssueFilters ++= binaryCompatibleExceptions
+  ))
 
 lazy val kernelJVM = kernel.jvm
 lazy val kernelJS = kernel.js

--- a/build.sbt
+++ b/build.sbt
@@ -231,7 +231,7 @@ lazy val macros = crossProject.crossType(CrossType.Pure)
 lazy val macrosJVM = macros.jvm
 lazy val macrosJS = macros.js
 
-val binaryCompatibleVersion = "0.8.0"
+val binaryCompatibleVersion = "1.0.0-RC1"
 
 lazy val kernel = crossProject.crossType(CrossType.Pure)
   .in(file("kernel"))
@@ -242,13 +242,14 @@ lazy val kernel = crossProject.crossType(CrossType.Pure)
   .settings(sourceGenerators in Compile += (sourceManaged in Compile).map(KernelBoiler.gen).taskValue)
   .settings(includeGeneratedSrc)
   .jsSettings(commonJsSettings)
-  .jvmSettings((commonJvmSettings ++
-    (mimaPreviousArtifacts := {
-      if (scalaVersion.value startsWith "2.12")
-        Set()
-      else
-        Set("org.typelevel" %% "cats-kernel" % binaryCompatibleVersion)
-    })))
+  .jvmSettings(commonJvmSettings)
+// temporarily disable to allow several approved PRs to pass build, should reenable after 1.0.0-RC1
+//   ++ (mimaPreviousArtifacts := {
+//      if (scalaVersion.value startsWith "2.12")
+//        Set()
+//      else
+//        Set("org.typelevel" %% "cats-kernel" % binaryCompatibleVersion)
+//    })))
 
 lazy val kernelJVM = kernel.jvm
 lazy val kernelJS = kernel.js

--- a/build.sbt
+++ b/build.sbt
@@ -236,7 +236,7 @@ val binaryCompatibleVersion = "0.8.0"
 val binaryCompatibleExceptions = {
   import com.typesafe.tools.mima.core._
   import com.typesafe.tools.mima.core.ProblemFilters._
-  Seq(
+  Seq( //todo: remove these once we release 1.0.0-RC1
     exclude[InheritedNewAbstractMethodProblem]("cats.kernel.instances.QueueInstances.*"),
     exclude[InheritedNewAbstractMethodProblem]("cats.kernel.instances.QueueInstances1.*"),
     exclude[InheritedNewAbstractMethodProblem]("cats.kernel.instances.QueueInstances2.*"),

--- a/kernel-laws/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -6,9 +6,6 @@ import catalysts.macros.TypeTagM
 
 import cats.kernel.instances.all._
 
-// these aren't included in all due to bincompat
-import cats.kernel.instances.duration._
-import cats.kernel.instances.queue._
 
 import org.typelevel.discipline.{ Laws }
 import org.typelevel.discipline.scalatest.Discipline

--- a/kernel/src/main/scala/cats/kernel/instances/all.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/all.scala
@@ -11,7 +11,7 @@ trait AllInstances
     with ByteInstances
     with CharInstances
     with DoubleInstances
-    with DurationInstances 
+    with DurationInstances
     with FloatInstances
     with FunctionInstances
     with IntInstances

--- a/kernel/src/main/scala/cats/kernel/instances/all.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/all.scala
@@ -11,7 +11,7 @@ trait AllInstances
     with ByteInstances
     with CharInstances
     with DoubleInstances
-    // with DurationInstances // left out for bincompat
+    with DurationInstances 
     with FloatInstances
     with FunctionInstances
     with IntInstances
@@ -19,7 +19,7 @@ trait AllInstances
     with LongInstances
     with MapInstances
     with OptionInstances
-    // with QueueInstances // left out for bincompat
+    with QueueInstances
     with SetInstances
     with ShortInstances
     with StreamInstances


### PR DESCRIPTION
temporarily disable to allow a couple of approved PRs (#1712 #1527) to pass build, should reenable after 1.0.0-RC1.
Also added `QueueInstances` and `DurationInstances` to `all` imports