### PR TITLE
Add Luka Jacobowitz as a maintainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ The current maintainers (people who can merge pull requests) are:
  * [johnynek](https://github.com/johnynek) P. Oscar Boykin
  * [travisbrown](https://github.com/travisbrown) Travis Brown
  * [adelbertc](https://github.com/adelbertc) Adelbert Chang
+ * [LukaJCB](https://github.com/LukaJCB) Luka Jacobowitz
  * [peterneyens](https://github.com/peterneyens) Peter Neyens
  * [edmundnoble](https://github.com/edmundnoble) Edmund Noble
  * [tpolecat](https://github.com/tpolecat) Rob Norris


### PR DESCRIPTION
Approvals from current maintainers were already given offline.  This is to make it official.
Welcome @LukaJCB! 