### PR TITLE
Add syntax for ApplicativeError.fromEither

### DIFF
--- a/core/src/main/scala/cats/syntax/either.scala
+++ b/core/src/main/scala/cats/syntax/either.scala
@@ -263,6 +263,10 @@ final class EitherOps[A, B](val eab: Either[A, B]) extends AnyVal {
    * }}}
    */
   def toEitherT[F[_]: Applicative]: EitherT[F, A, B] = EitherT.fromEither(eab)
+
+  def raiseOrPure[F[_]](implicit ev: ApplicativeError[F, A]): F[B] =
+    ev.fromEither(eab)
+
 }
 
 final class EitherObjectOps(val either: Either.type) extends AnyVal { // scalastyle:off ensure.single.space.after.token

--- a/tests/src/test/scala/cats/tests/EitherTests.scala
+++ b/tests/src/test/scala/cats/tests/EitherTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.data.EitherT
+import cats.data.{ EitherT, Validated }
 import cats.laws.discipline._
 import cats.kernel.laws.{GroupLaws, OrderLaws}
 import scala.util.Try
@@ -273,6 +273,13 @@ class EitherTests extends CatsSuite {
     forAll { (fa: Either[String, Int],
               f: Int => String) =>
       fa.ap(Either.right(f)) should === (fab.map(fa)(f))
+    }
+  }
+
+  test("raiseOrPure syntax consistent with fromEither") {
+    val ev = ApplicativeError[Validated[String, ?], String]
+    forAll { (fa: Either[String, Int]) =>
+      fa.raiseOrPure[Validated[String, ?]] should === (ev.fromEither(fa))
     }
   }
 


### PR DESCRIPTION
This adds syntax for `ApplicativeError.fromEither` as [discussed on gitter](https://gitter.im/typelevel/cats?at=59caa574614889d47540eba7).