### PR TITLE
Restruct functor

### DIFF
--- a/core/src/main/scala/cats/Bifunctor.scala
+++ b/core/src/main/scala/cats/Bifunctor.scala
@@ -1,8 +1,5 @@
 package cats
-package functor
-
 import simulacrum.typeclass
-
 /**
  * A type class of types which give rise to two independent, covariant
  * functors.
@@ -58,7 +55,7 @@ import simulacrum.typeclass
 }
 
 private[cats] trait ComposedBifunctor[F[_, _], G[_, _]]
-    extends Bifunctor[λ[(A, B) => F[G[A, B], G[A, B]]]] {
+  extends Bifunctor[λ[(A, B) => F[G[A, B], G[A, B]]]] {
   def F: Bifunctor[F]
   def G: Bifunctor[G]
 

--- a/core/src/main/scala/cats/Bitraverse.scala
+++ b/core/src/main/scala/cats/Bitraverse.scala
@@ -1,6 +1,6 @@
 package cats
 
-import cats.functor.{Bifunctor, ComposedBifunctor}
+
 
 import simulacrum.typeclass
 

--- a/core/src/main/scala/cats/Composed.scala
+++ b/core/src/main/scala/cats/Composed.scala
@@ -1,6 +1,5 @@
 package cats
 
-import cats.functor._
 
 private[cats] trait ComposedInvariant[F[_], G[_]] extends Invariant[λ[α => F[G[α]]]] { outer =>
   def F: Invariant[F]

--- a/core/src/main/scala/cats/Contravariant.scala
+++ b/core/src/main/scala/cats/Contravariant.scala
@@ -1,8 +1,5 @@
 package cats
-package functor
-
 import simulacrum.typeclass
-
 /**
  * Must obey the laws defined in cats.laws.ContravariantLaws.
  */

--- a/core/src/main/scala/cats/ContravariantCartesian.scala
+++ b/core/src/main/scala/cats/ContravariantCartesian.scala
@@ -1,6 +1,5 @@
 package cats
 
-import functor.Contravariant
 import simulacrum.typeclass
 
 /**

--- a/core/src/main/scala/cats/Functor.scala
+++ b/core/src/main/scala/cats/Functor.scala
@@ -1,7 +1,5 @@
 package cats
 
-import cats.functor.Contravariant
-
 import simulacrum.typeclass
 
 /**
@@ -11,10 +9,10 @@ import simulacrum.typeclass
  *
  * Must obey the laws defined in cats.laws.FunctorLaws.
  */
-@typeclass trait Functor[F[_]] extends functor.Invariant[F] { self =>
+@typeclass trait Functor[F[_]] extends Invariant[F] { self =>
   def map[A, B](fa: F[A])(f: A => B): F[B]
 
-  def imap[A, B](fa: F[A])(f: A => B)(fi: B => A): F[B] = map(fa)(f)
+  override def imap[A, B](fa: F[A])(f: A => B)(g: B => A): F[B] = map(fa)(f)
 
   // derived methods
 

--- a/core/src/main/scala/cats/Invariant.scala
+++ b/core/src/main/scala/cats/Invariant.scala
@@ -1,8 +1,6 @@
 package cats
-package functor
 
 import simulacrum.typeclass
-
 /**
  * Must obey the laws defined in cats.laws.InvariantLaws.
  */

--- a/core/src/main/scala/cats/InvariantMonoidal.scala
+++ b/core/src/main/scala/cats/InvariantMonoidal.scala
@@ -1,6 +1,5 @@
 package cats
 
-import cats.functor.Invariant
 import simulacrum.typeclass
 
 /**

--- a/core/src/main/scala/cats/Show.scala
+++ b/core/src/main/scala/cats/Show.scala
@@ -1,7 +1,5 @@
 package cats
 
-import cats.functor.Contravariant
-
 /**
  * A type class to provide textual representation. It is meant to be a
  * better "toString". Whereas toString exists for any Object,

--- a/core/src/main/scala/cats/arrow/Arrow.scala
+++ b/core/src/main/scala/cats/arrow/Arrow.scala
@@ -1,8 +1,6 @@
 package cats
 package arrow
 
-import cats.functor.Strong
-
 import simulacrum.typeclass
 
 /**

--- a/core/src/main/scala/cats/arrow/Profunctor.scala
+++ b/core/src/main/scala/cats/arrow/Profunctor.scala
@@ -1,5 +1,5 @@
 package cats
-package functor
+package arrow
 
 import simulacrum.typeclass
 

--- a/core/src/main/scala/cats/arrow/Profunctor.scala
+++ b/core/src/main/scala/cats/arrow/Profunctor.scala
@@ -17,7 +17,7 @@ import simulacrum.typeclass
    * Example:
    * {{{
    * scala> import cats.implicits._
-   * scala> import cats.functor.Profunctor
+   * scala> import cats.arrow.Profunctor
    * scala> val fab: Double => Double = x => x + 0.3
    * scala> val f: Int => Double = x => x.toDouble / 2
    * scala> val g: Double => Double = x => x * 3

--- a/core/src/main/scala/cats/arrow/Strong.scala
+++ b/core/src/main/scala/cats/arrow/Strong.scala
@@ -1,5 +1,5 @@
 package cats
-package functor
+package arrow
 
 import simulacrum.typeclass
 

--- a/core/src/main/scala/cats/arrow/Strong.scala
+++ b/core/src/main/scala/cats/arrow/Strong.scala
@@ -14,7 +14,7 @@ import simulacrum.typeclass
    * Example:
    * {{{
    * scala> import cats.implicits._
-   * scala> import cats.functor.Strong
+   * scala> import cats.arrow.Strong
    * scala> val f: Int => Int = _ * 2
    * scala> val fab = Strong[Function1].first[Int,Int,Int](f)
    * scala> fab((2,3))
@@ -29,7 +29,7 @@ import simulacrum.typeclass
    * Example:
    * {{{
    * scala> import cats.implicits._
-   * scala> import cats.functor.Strong
+   * scala> import cats.arrow.Strong
    * scala> val f: Int => Int = _ * 2
    * scala> val fab = Strong[Function1].second[Int,Int,Int](f)
    * scala> fab((2,3))

--- a/core/src/main/scala/cats/data/Cokleisli.scala
+++ b/core/src/main/scala/cats/data/Cokleisli.scala
@@ -1,9 +1,10 @@
 package cats
 package data
 
-import cats.arrow.{Arrow, Category, CommutativeArrow, Compose}
-import cats.functor.{Contravariant, Profunctor}
+import cats.arrow._
+import cats.functor.Contravariant
 import cats.{CoflatMap, Comonad, Functor, Monad}
+
 import scala.annotation.tailrec
 
 /**

--- a/core/src/main/scala/cats/data/Cokleisli.scala
+++ b/core/src/main/scala/cats/data/Cokleisli.scala
@@ -2,8 +2,7 @@ package cats
 package data
 
 import cats.arrow._
-import cats.functor.Contravariant
-import cats.{CoflatMap, Comonad, Functor, Monad}
+import cats.{CoflatMap, Comonad, Contravariant, Functor, Monad}
 
 import scala.annotation.tailrec
 

--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -1,7 +1,7 @@
 package cats
 package data
 
-import cats.functor.Contravariant
+import cats.Contravariant
 
 /**
  * [[Const]] is a phantom type, it does not contain a value of its second type parameter `B`

--- a/core/src/main/scala/cats/data/EitherK.scala
+++ b/core/src/main/scala/cats/data/EitherK.scala
@@ -1,8 +1,8 @@
 package cats
 package data
 
+import cats.Contravariant
 import cats.arrow.FunctionK
-import cats.functor.Contravariant
 import cats.syntax.either._
 
 /** `F` on the left and `G` on the right of `scala.util.Either`.

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -1,7 +1,7 @@
 package cats
 package data
 
-import cats.functor.Bifunctor
+import cats.Bifunctor
 import cats.instances.either._
 import cats.syntax.either._
 
@@ -426,7 +426,7 @@ private[data] abstract class EitherTInstances extends EitherTInstances1 {
     }
 
   implicit def catsDataShowForEitherT[F[_], L, R](implicit sh: Show[F[Either[L, R]]]): Show[EitherT[F, L, R]] =
-    functor.Contravariant[Show].contramap(sh)(_.value)
+    Contravariant[Show].contramap(sh)(_.value)
 
   implicit def catsDataBifunctorForEitherT[F[_]](implicit F: Functor[F]): Bifunctor[EitherT[F, ?, ?]] =
     new Bifunctor[EitherT[F, ?, ?]] {

--- a/core/src/main/scala/cats/data/Func.scala
+++ b/core/src/main/scala/cats/data/Func.scala
@@ -1,7 +1,7 @@
 package cats
 package data
 
-import cats.functor.Contravariant
+import cats.Contravariant
 
 /**
  * [[Func]] is a function `A => F[B]`.

--- a/core/src/main/scala/cats/data/IdT.scala
+++ b/core/src/main/scala/cats/data/IdT.scala
@@ -163,6 +163,6 @@ private[data] sealed abstract class IdTInstances extends IdTInstances0 {
     F.on(_.value)
 
   implicit def catsDataShowForIdT[F[_], A](implicit F: Show[F[A]]): Show[IdT[F, A]] =
-    functor.Contravariant[Show].contramap(F)(_.value)
+    Contravariant[Show].contramap(F)(_.value)
 
 }

--- a/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
@@ -2,7 +2,7 @@ package cats
 package data
 
 import cats.arrow.{Profunctor, Strong}
-import cats.functor.{Bifunctor, Contravariant}
+
 import cats.syntax.either._
 
 /**

--- a/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
@@ -1,7 +1,8 @@
 package cats
 package data
 
-import cats.functor.{ Bifunctor, Contravariant, Profunctor, Strong }
+import cats.arrow.{Profunctor, Strong}
+import cats.functor.{Bifunctor, Contravariant}
 import cats.syntax.either._
 
 /**

--- a/core/src/main/scala/cats/data/IndexedStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedStateT.scala
@@ -2,7 +2,7 @@ package cats
 package data
 
 import cats.arrow.{Profunctor, Strong}
-import cats.functor.{Bifunctor, Contravariant}
+
 import cats.syntax.either._
 
 /**

--- a/core/src/main/scala/cats/data/IndexedStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedStateT.scala
@@ -1,7 +1,8 @@
 package cats
 package data
 
-import cats.functor.{ Contravariant, Bifunctor, Profunctor, Strong }
+import cats.arrow.{Profunctor, Strong}
+import cats.functor.{Bifunctor, Contravariant}
 import cats.syntax.either._
 
 /**

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -1,8 +1,8 @@
 package cats
 package data
 
+import cats.Bifunctor
 import cats.data.Validated.{Invalid, Valid}
-import cats.functor.Bifunctor
 
 import scala.annotation.tailrec
 

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -1,8 +1,8 @@
 package cats
 package data
 
+import cats.Contravariant
 import cats.arrow._
-import cats.functor.Contravariant
 
 /**
  * Represents a function `A => F[B]`.

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -1,8 +1,8 @@
 package cats
 package data
 
-import cats.arrow.{Arrow, Category, Choice, CommutativeArrow, Compose, FunctionK}
-import cats.functor.{Contravariant, Strong}
+import cats.arrow._
+import cats.functor.Contravariant
 
 /**
  * Represents a function `A => F[B]`.

--- a/core/src/main/scala/cats/data/Nested.scala
+++ b/core/src/main/scala/cats/data/Nested.scala
@@ -1,7 +1,7 @@
 package cats
 package data
 
-import cats.functor._
+
 
 /** Similar to [[cats.data.Tuple2K]], but for nested composition.
  *

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -209,7 +209,7 @@ private[data] sealed abstract class OptionTInstances extends OptionTInstances0 {
     new OptionTOrder[F, A] { implicit val F = F0 }
 
   implicit def catsDataShowForOptionT[F[_], A](implicit F: Show[F[Option[A]]]): Show[OptionT[F, A]] =
-    functor.Contravariant[Show].contramap(F)(_.value)
+    Contravariant[Show].contramap(F)(_.value)
 }
 
 private[data] sealed abstract class OptionTInstances0 extends OptionTInstances1 {

--- a/core/src/main/scala/cats/data/Tuple2K.scala
+++ b/core/src/main/scala/cats/data/Tuple2K.scala
@@ -1,7 +1,7 @@
 package cats
 package data
 
-import cats.functor.Contravariant
+import cats.Contravariant
 
 /**
  * [[Tuple2K]] is a product to two independent functor values.

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -101,7 +101,7 @@ sealed abstract class Validated[+E, +A] extends Product with Serializable {
     Validated.fromEither(f(toEither))
 
   /**
-   * Validated is a [[functor.Bifunctor]], this method applies one of the
+   * Validated is a [[Bifunctor]], this method applies one of the
    * given functions.
    */
   def bimap[EE, AA](fe: E => EE, fa: A => AA): Validated[EE, AA] =

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -2,7 +2,7 @@ package cats
 package data
 
 import cats.kernel.instances.tuple._
-import cats.functor.{Bifunctor, Contravariant}
+
 import cats.kernel.CommutativeMonoid
 import cats.syntax.semigroup._
 

--- a/core/src/main/scala/cats/instances/function.scala
+++ b/core/src/main/scala/cats/instances/function.scala
@@ -1,8 +1,9 @@
 package cats
 package instances
 
-import cats.arrow.{CommutativeArrow, Category, Choice}
-import cats.functor.Contravariant
+import cats.Contravariant
+import cats.arrow.{Category, Choice, CommutativeArrow}
+
 import annotation.tailrec
 
 

--- a/core/src/main/scala/cats/syntax/bifunctor.scala
+++ b/core/src/main/scala/cats/syntax/bifunctor.scala
@@ -1,6 +1,6 @@
 package cats
 package syntax
 
-import cats.functor.Bifunctor
+import cats.Bifunctor
 
 trait BifunctorSyntax extends Bifunctor.ToBifunctorOps

--- a/core/src/main/scala/cats/syntax/contravariant.scala
+++ b/core/src/main/scala/cats/syntax/contravariant.scala
@@ -1,7 +1,7 @@
 package cats
 package syntax
 
-import cats.functor.Contravariant
+import cats.Contravariant
 
 trait ContravariantSyntax extends Contravariant.ToContravariantOps
 

--- a/core/src/main/scala/cats/syntax/invariant.scala
+++ b/core/src/main/scala/cats/syntax/invariant.scala
@@ -1,6 +1,6 @@
 package cats
 package syntax
 
-import cats.functor.Invariant
+import cats.Invariant
 
 trait InvariantSyntax extends Invariant.ToInvariantOps

--- a/core/src/main/scala/cats/syntax/profunctor.scala
+++ b/core/src/main/scala/cats/syntax/profunctor.scala
@@ -1,6 +1,6 @@
 package cats
 package syntax
 
-import cats.functor.Profunctor
+import cats.arrow.Profunctor
 
 trait ProfunctorSyntax extends Profunctor.ToProfunctorOps

--- a/core/src/main/scala/cats/syntax/strong.scala
+++ b/core/src/main/scala/cats/syntax/strong.scala
@@ -1,6 +1,6 @@
 package cats
 package syntax
 
-import cats.functor.Strong
+import cats.arrow.Strong
 
 trait StrongSyntax extends Strong.ToStrongOps

--- a/docs/src/main/tut/typeclasses/contravariant.md
+++ b/docs/src/main/tut/typeclasses/contravariant.md
@@ -3,7 +3,7 @@ layout: docs
 title:  "Contravariant"
 section: "typeclasses"
 source: "core/src/main/scala/cats/functor/Contravariant.scala"
-scaladoc: "#cats.functor.Contravariant"
+scaladoc: "#cats.Contravariant"
 ---
 # Contravariant
 
@@ -28,7 +28,7 @@ Say we have class `Money` with a `Show` instance, and `Salary` class.
 
 ```tut:silent
 import cats._
-import cats.functor._
+
 import cats.implicits._
 
 case class Money(amount: Int)

--- a/docs/src/main/tut/typeclasses/invariant.md
+++ b/docs/src/main/tut/typeclasses/invariant.md
@@ -3,7 +3,7 @@ layout: docs
 title:  "Invariant"
 section: "typeclasses"
 source: "core/src/main/scala/cats/functor/Invariant.scala"
-scaladoc: "#cats.functor.Invariant"
+scaladoc: "#cats.Invariant"
 ---
 # Invariant
 

--- a/laws/src/main/scala/cats/laws/BifunctorLaws.scala
+++ b/laws/src/main/scala/cats/laws/BifunctorLaws.scala
@@ -1,6 +1,6 @@
 package cats.laws
 
-import cats.functor.Bifunctor
+import cats.Bifunctor
 import cats.syntax.bifunctor._
 
 /**

--- a/laws/src/main/scala/cats/laws/ContravariantLaws.scala
+++ b/laws/src/main/scala/cats/laws/ContravariantLaws.scala
@@ -1,11 +1,11 @@
 package cats
 package laws
 
-import cats.functor.Contravariant
+import cats.Contravariant
 import cats.syntax.contravariant._
 
 /**
- * Laws that must be obeyed by any `cats.functor.Contravariant`.
+ * Laws that must be obeyed by any `cats.Contravariant`.
  */
 trait ContravariantLaws[F[_]] extends InvariantLaws[F] {
   implicit override def F: Contravariant[F]

--- a/laws/src/main/scala/cats/laws/InvariantLaws.scala
+++ b/laws/src/main/scala/cats/laws/InvariantLaws.scala
@@ -1,11 +1,11 @@
 package cats
 package laws
 
-import cats.functor.Invariant
+import cats.Invariant
 import cats.syntax.invariant._
 
 /**
- * Laws that must be obeyed by any `cats.functor.Invariant`.
+ * Laws that must be obeyed by any `cats.Invariant`.
  */
 trait InvariantLaws[F[_]] {
   implicit def F: Invariant[F]

--- a/laws/src/main/scala/cats/laws/ProfunctorLaws.scala
+++ b/laws/src/main/scala/cats/laws/ProfunctorLaws.scala
@@ -1,7 +1,7 @@
 package cats
 package laws
 
-import cats.functor.Profunctor
+import cats.arrow.Profunctor
 import cats.syntax.profunctor._
 
 /**

--- a/laws/src/main/scala/cats/laws/StrongLaws.scala
+++ b/laws/src/main/scala/cats/laws/StrongLaws.scala
@@ -1,7 +1,7 @@
 package cats
 package laws
 
-import cats.functor.Strong
+import cats.arrow.Strong
 import cats.syntax.profunctor._
 import cats.syntax.strong._
 import cats.instances.function._

--- a/laws/src/main/scala/cats/laws/discipline/BifunctorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/BifunctorTests.scala
@@ -1,7 +1,6 @@
 package cats.laws.discipline
 
-import cats.Eq
-import cats.functor.Bifunctor
+import cats.{Bifunctor, Eq}
 import cats.laws.BifunctorLaws
 import org.scalacheck.Arbitrary
 import org.scalacheck.Prop._

--- a/laws/src/main/scala/cats/laws/discipline/CartesianTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/CartesianTests.scala
@@ -38,7 +38,7 @@ object CartesianTests {
 
   object Isomorphisms {
     import cats.kernel.laws._
-    implicit def invariant[F[_]](implicit F: functor.Invariant[F]): Isomorphisms[F] =
+    implicit def invariant[F[_]](implicit F: Invariant[F]): Isomorphisms[F] =
       new Isomorphisms[F] {
         def associativity[A, B, C](fs: (F[(A, (B, C))], F[((A, B), C)]))(implicit EqFABC: Eq[F[(A, B, C)]]) =
           F.imap(fs._1) { case (a, (b, c)) => (a, b, c) } { case (a, b, c) => (a, (b, c)) } ?==

--- a/laws/src/main/scala/cats/laws/discipline/ContravariantTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ContravariantTests.scala
@@ -2,7 +2,7 @@ package cats
 package laws
 package discipline
 
-import cats.functor.Contravariant
+import cats.Contravariant
 import org.scalacheck.{Arbitrary, Cogen}
 import org.scalacheck.Prop._
 

--- a/laws/src/main/scala/cats/laws/discipline/InvariantTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/InvariantTests.scala
@@ -2,9 +2,9 @@ package cats
 package laws
 package discipline
 
-import cats.functor.Invariant
 import org.scalacheck.{Arbitrary, Cogen, Prop}
 import Prop._
+import cats.Invariant
 import org.typelevel.discipline.Laws
 
 trait InvariantTests[F[_]] extends Laws {

--- a/laws/src/main/scala/cats/laws/discipline/ProfunctorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ProfunctorTests.scala
@@ -2,9 +2,9 @@ package cats
 package laws
 package discipline
 
-import cats.functor.Profunctor
 import org.scalacheck.{Arbitrary, Cogen, Prop}
 import Prop._
+import cats.arrow.Profunctor
 import org.typelevel.discipline.Laws
 
 trait ProfunctorTests[F[_, _]] extends Laws {

--- a/laws/src/main/scala/cats/laws/discipline/StrongTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/StrongTests.scala
@@ -2,9 +2,9 @@ package cats
 package laws
 package discipline
 
-import cats.functor.Strong
 import org.scalacheck.{Arbitrary, Cogen, Prop}
 import Prop._
+import cats.arrow.Strong
 
 trait StrongTests[F[_, _]] extends ProfunctorTests[F] {
   def laws: StrongLaws[F]

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -134,7 +134,7 @@ object Boilerplate {
         |package cats
         |package syntax
         |
-        |import cats.functor.{Contravariant, Invariant}
+        |
         |
         |@deprecated("replaced by apply syntax", "1.0.0-MF")
         |private[syntax] final class CartesianBuilder[F[_]] {
@@ -211,11 +211,11 @@ object Boilerplate {
          |trait CartesianArityFunctions {
         -  def map$arity[F[_], ${`A..N`}, Z]($fparams)(f: (${`A..N`}) => Z)(implicit cartesian: Cartesian[F], functor: Functor[F]): F[Z] =
         -    functor.map($nestedProducts) { case ${`nested (a..n)`} => f(${`a..n`}) }
-        -  def contramap$arity[F[_], ${`A..N`}, Z]($fparams)(f: Z => (${`A..N`}))(implicit cartesian: Cartesian[F], contravariant: functor.Contravariant[F]):F[Z] =
+        -  def contramap$arity[F[_], ${`A..N`}, Z]($fparams)(f: Z => (${`A..N`}))(implicit cartesian: Cartesian[F], contravariant: Contravariant[F]):F[Z] =
         -    contravariant.contramap($nestedProducts) { z => val ${`(a..n)`} = f(z); ${`nested (a..n)`} }
-        -  def imap$arity[F[_], ${`A..N`}, Z]($fparams)(f: (${`A..N`}) => Z)(g: Z => (${`A..N`}))(implicit cartesian: Cartesian[F], invariant: functor.Invariant[F]):F[Z] =
+        -  def imap$arity[F[_], ${`A..N`}, Z]($fparams)(f: (${`A..N`}) => Z)(g: Z => (${`A..N`}))(implicit cartesian: Cartesian[F], invariant: Invariant[F]):F[Z] =
         -    invariant.imap($nestedProducts) { case ${`nested (a..n)`} => f(${`a..n`}) } { z => val ${`(a..n)`} = g(z); ${`nested (a..n)`} }
-        -  def tuple$arity[F[_], ${`A..N`}]($fparams)(implicit cartesian: Cartesian[F], invariant: functor.Invariant[F]):F[(${`A..N`})] =
+        -  def tuple$arity[F[_], ${`A..N`}]($fparams)(implicit cartesian: Cartesian[F], invariant: Invariant[F]):F[(${`A..N`})] =
         -    imap$arity($fargsS)((${`_.._`}))(identity)
          |}
       """
@@ -259,7 +259,7 @@ object Boilerplate {
         |package cats
         |package syntax
         |
-        |import cats.functor.{Contravariant, Invariant}
+        |
         |
         |trait TupleCartesianSyntax {
         -  implicit def catsSyntaxTuple${arity}Cartesian[F[_], ${`A..N`}]($tupleTpe): Tuple${arity}CartesianOps[F, ${`A..N`}] = new Tuple${arity}CartesianOps(t$arity)

--- a/tests/src/test/scala/cats/tests/AlgebraInvariantTests.scala
+++ b/tests/src/test/scala/cats/tests/AlgebraInvariantTests.scala
@@ -1,10 +1,9 @@
 package cats
 package tests
 
-import cats.functor.Invariant
-import cats.laws.discipline.{InvariantTests, InvariantMonoidalTests, SerializableTests}
+import cats.Invariant
+import cats.laws.discipline.{InvariantMonoidalTests, InvariantTests, SerializableTests}
 import cats.laws.discipline.eq._
-
 import org.scalacheck.{Arbitrary, Gen}
 
 class AlgebraInvariantTests extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/BifunctorTests.scala
+++ b/tests/src/test/scala/cats/tests/BifunctorTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.functor.Bifunctor
+import cats.Bifunctor
 import cats.laws.discipline.{BifunctorTests, FunctorTests, SerializableTests}
 
 class BifunctorTest extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/CokleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/CokleisliTests.scala
@@ -1,9 +1,9 @@
 package cats
 package tests
 
+import cats.Contravariant
 import cats.arrow._
 import cats.data.{Cokleisli, NonEmptyList}
-import cats.functor.Contravariant
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/CokleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/CokleisliTests.scala
@@ -1,9 +1,9 @@
 package cats
 package tests
 
-import cats.arrow.{Arrow, CommutativeArrow}
+import cats.arrow._
 import cats.data.{Cokleisli, NonEmptyList}
-import cats.functor.{Contravariant, Profunctor}
+import cats.functor.Contravariant
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/ConstTests.scala
+++ b/tests/src/test/scala/cats/tests/ConstTests.scala
@@ -1,10 +1,9 @@
 package cats
 package tests
 
+import cats.Contravariant
 import cats.kernel.laws.{GroupLaws, OrderLaws}
-
 import cats.data.{Const, NonEmptyList}
-import cats.functor.Contravariant
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 

--- a/tests/src/test/scala/cats/tests/EitherKTests.scala
+++ b/tests/src/test/scala/cats/tests/EitherKTests.scala
@@ -1,6 +1,6 @@
 package cats.tests
 
-import cats.{Contravariant, _}
+import cats._
 import cats.kernel.laws.OrderLaws
 import cats.data.EitherK
 import cats.laws.discipline._

--- a/tests/src/test/scala/cats/tests/EitherKTests.scala
+++ b/tests/src/test/scala/cats/tests/EitherKTests.scala
@@ -1,9 +1,8 @@
 package cats.tests
 
-import cats._
+import cats.{Contravariant, _}
 import cats.kernel.laws.OrderLaws
 import cats.data.EitherK
-import cats.functor.Contravariant
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/EitherTTests.scala
+++ b/tests/src/test/scala/cats/tests/EitherTTests.scala
@@ -1,9 +1,9 @@
 package cats
 package tests
 
+import cats.Bifunctor
 import cats.data.EitherT
-import cats.functor.Bifunctor
-import cats.functor._
+
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.kernel.laws.{GroupLaws, OrderLaws}

--- a/tests/src/test/scala/cats/tests/EqTests.scala
+++ b/tests/src/test/scala/cats/tests/EqTests.scala
@@ -3,7 +3,7 @@ package tests
 
 import org.scalatest._
 
-import cats.functor._
+
 
 class EqTests extends FunSuite {
   {

--- a/tests/src/test/scala/cats/tests/EquivTests.scala
+++ b/tests/src/test/scala/cats/tests/EquivTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.functor._
+
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/FuncTests.scala
+++ b/tests/src/test/scala/cats/tests/FuncTests.scala
@@ -1,9 +1,9 @@
 package cats
 package tests
 
-import cats.data.{ Func, AppFunc }
-import cats.functor.Contravariant
+import cats.data.{AppFunc, Func}
 import Func.appFunc
+import cats.Contravariant
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import org.scalacheck.Arbitrary

--- a/tests/src/test/scala/cats/tests/FunctionTests.scala
+++ b/tests/src/test/scala/cats/tests/FunctionTests.scala
@@ -1,14 +1,14 @@
 package cats
 package tests
 
-import cats.arrow.{CommutativeArrow, Choice}
-import cats.functor.Contravariant
+import cats.Contravariant
+import cats.arrow.{Choice, CommutativeArrow}
 import cats.laws.discipline._
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
-import cats.kernel.laws.{ GroupLaws, OrderLaws }
-import cats.kernel.{ CommutativeSemigroup, CommutativeMonoid, CommutativeGroup }
-import cats.kernel.{ Band, Semilattice, BoundedSemilattice }
+import cats.kernel.laws.{GroupLaws, OrderLaws}
+import cats.kernel.{CommutativeGroup, CommutativeMonoid, CommutativeSemigroup}
+import cats.kernel.{Band, BoundedSemilattice, Semilattice}
 
 class FunctionTests extends CatsSuite {
 

--- a/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTTests.scala
+++ b/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTTests.scala
@@ -2,11 +2,12 @@ package cats
 package tests
 
 import cats.data.{ IRWST, IndexedReaderWriterStateT, ReaderWriterStateT, ReaderWriterState, EitherT }
-import cats.functor.{ Contravariant, Bifunctor, Profunctor, Strong }
+import cats.functor.{ Contravariant, Bifunctor }
 import cats.laws.discipline._
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
 import org.scalacheck.Arbitrary
+import cats.arrow.{Strong, Profunctor}
 
 class ReaderWriterStateTTests extends CatsSuite {
   import ReaderWriterStateTTests._

--- a/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTTests.scala
+++ b/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTTests.scala
@@ -2,7 +2,7 @@ package cats
 package tests
 
 import cats.data.{ IRWST, IndexedReaderWriterStateT, ReaderWriterStateT, ReaderWriterState, EitherT }
-import cats.functor.{ Contravariant, Bifunctor }
+
 import cats.laws.discipline._
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/IndexedStateTTests.scala
+++ b/tests/src/test/scala/cats/tests/IndexedStateTTests.scala
@@ -3,7 +3,7 @@ package tests
 
 import cats.arrow.{Profunctor, Strong}
 import cats.data.{EitherT, IndexedStateT, State, StateT}
-import cats.functor.{Bifunctor, Contravariant}
+
 import cats.arrow.Profunctor
 import cats.kernel.instances.tuple._
 import cats.laws.discipline._

--- a/tests/src/test/scala/cats/tests/IndexedStateTTests.scala
+++ b/tests/src/test/scala/cats/tests/IndexedStateTTests.scala
@@ -1,8 +1,10 @@
 package cats
 package tests
 
-import cats.data.{State, StateT, IndexedStateT, EitherT}
-import cats.functor.{Contravariant, Bifunctor, Profunctor, Strong}
+import cats.arrow.{Profunctor, Strong}
+import cats.data.{EitherT, IndexedStateT, State, StateT}
+import cats.functor.{Bifunctor, Contravariant}
+import cats.arrow.Profunctor
 import cats.kernel.instances.tuple._
 import cats.laws.discipline._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/KernelContravariantTests.scala
+++ b/tests/src/test/scala/cats/tests/KernelContravariantTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.functor._
+
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/KleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/KleisliTests.scala
@@ -1,9 +1,9 @@
 package cats
 package tests
 
-import cats.arrow.{Arrow, Choice, CommutativeArrow, FunctionK}
+import cats.arrow._
 import cats.data.{EitherT, Kleisli, Reader}
-import cats.functor.{Contravariant, Strong}
+import cats.functor.Contravariant
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/KleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/KleisliTests.scala
@@ -1,15 +1,15 @@
 package cats
 package tests
 
+import cats.Contravariant
 import cats.arrow._
 import cats.data.{EitherT, Kleisli, Reader}
-import cats.functor.Contravariant
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
 import org.scalacheck.Arbitrary
 import cats.kernel.laws.GroupLaws
-import cats.laws.discipline.{SemigroupKTests, MonoidKTests}
+import cats.laws.discipline.{MonoidKTests, SemigroupKTests}
 
 class KleisliTests extends CatsSuite {
   implicit def kleisliEq[F[_], A, B](implicit A: Arbitrary[A], FB: Eq[F[B]]): Eq[Kleisli[F, A, B]] =

--- a/tests/src/test/scala/cats/tests/ListWrapper.scala
+++ b/tests/src/test/scala/cats/tests/ListWrapper.scala
@@ -1,9 +1,8 @@
 package cats
 package tests
 
-import cats.functor.Invariant
+import cats.Invariant
 import cats.instances.list._
-
 import org.scalacheck.{Arbitrary, Cogen}
 import org.scalacheck.Arbitrary.arbitrary
 

--- a/tests/src/test/scala/cats/tests/MonoidTests.scala
+++ b/tests/src/test/scala/cats/tests/MonoidTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.functor._
+
 
 class MonoidTests extends CatsSuite {
   {

--- a/tests/src/test/scala/cats/tests/NestedTests.scala
+++ b/tests/src/test/scala/cats/tests/NestedTests.scala
@@ -3,7 +3,7 @@ package tests
 
 import cats.Functor
 import cats.data._
-import cats.functor._
+
 import cats.laws.discipline._
 import cats.laws.discipline.CartesianTests.Isomorphisms._
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/OrderTests.scala
+++ b/tests/src/test/scala/cats/tests/OrderTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.functor._
+
 import cats.kernel.laws.OrderLaws
 
 class OrderTests extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/OrderingTests.scala
+++ b/tests/src/test/scala/cats/tests/OrderingTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.functor._
+
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/PartialOrderTests.scala
+++ b/tests/src/test/scala/cats/tests/PartialOrderTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.functor._
+
 
 class PartialOrderTests extends CatsSuite {
   {

--- a/tests/src/test/scala/cats/tests/PartialOrderingTests.scala
+++ b/tests/src/test/scala/cats/tests/PartialOrderingTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.functor._
+
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/SemigroupTests.scala
+++ b/tests/src/test/scala/cats/tests/SemigroupTests.scala
@@ -3,7 +3,7 @@ package tests
 
 import org.scalatest._
 
-import cats.functor._
+
 
 class SemigroupTests extends FunSuite {
   {

--- a/tests/src/test/scala/cats/tests/ShowTests.scala
+++ b/tests/src/test/scala/cats/tests/ShowTests.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.functor.Contravariant
+import cats.Contravariant
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.{ContravariantTests, SerializableTests}
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/SyntaxTests.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxTests.scala
@@ -4,7 +4,7 @@ package tests
 import cats.arrow.Compose
 import cats.instances.AllInstances
 import cats.syntax.AllSyntax
-import cats.functor.{Contravariant, Invariant}
+
 
 /**
  * Test that our syntax implicits are working.

--- a/tests/src/test/scala/cats/tests/Tuple2KTests.scala
+++ b/tests/src/test/scala/cats/tests/Tuple2KTests.scala
@@ -1,8 +1,8 @@
 package cats
 package tests
 
+import cats.Contravariant
 import cats.data.Tuple2K
-import cats.functor.Contravariant
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/WriterTTests.scala
+++ b/tests/src/test/scala/cats/tests/WriterTTests.scala
@@ -2,7 +2,7 @@ package cats
 package tests
 
 import cats.data.{EitherT, Validated, Writer, WriterT}
-import cats.functor.{Bifunctor, Contravariant}
+
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._


### PR DESCRIPTION
Big but rather mechanical changes according to #1930
1. Move `Profunctor` and `Strong` to the `arrow` package
1. Move `Bifunctor`, `Invariant` and `Contravariant` to root package
