### PR TITLE
Add a more direct tailRecM law

### DIFF
--- a/laws/src/main/scala/cats/laws/FlatMapLaws.scala
+++ b/laws/src/main/scala/cats/laws/FlatMapLaws.scala
@@ -50,6 +50,19 @@ trait FlatMapLaws[F[_]] extends ApplyLaws[F] {
      */
     bounce(1) <-> bounce(0).flatMap(f)
   }
+
+  /**
+   * It is possible to implement flatMap from tailRecM and map
+   * and it should agree with the flatMap implementation.
+   */
+  def flatMapFromTailRecMConsistency[A, B](fa: F[A], fn: A => F[B]): IsEq[F[B]] = {
+    val tailRecMFlatMap = F.tailRecM[Option[A], B](Option.empty[A]) {
+      case None => F.map(fa) { a => Left(Some(a)) }
+      case Some(a) => F.map(fn(a)) { b => Right(b) }
+    }
+
+    F.flatMap(fa)(fn) <-> tailRecMFlatMap
+  }
 }
 
 object FlatMapLaws {

--- a/laws/src/main/scala/cats/laws/discipline/FlatMapTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FlatMapTests.scala
@@ -35,6 +35,7 @@ trait FlatMapTests[F[_]] extends ApplyTests[F] {
       parent = Some(apply[A, B, C]),
       "flatMap associativity" -> forAll(laws.flatMapAssociativity[A, B, C] _),
       "flatMap consistent apply" -> forAll(laws.flatMapConsistentApply[A, B] _),
+      "flatMap from tailRecM consistency" -> forAll(laws.flatMapFromTailRecMConsistency[A, B] _),
       "followedBy consistent flatMap" -> forAll(laws.followedByConsistency[A, B] _),
       "forEffect consistent flatMap" -> forAll(laws.forEffectConsistency[A, B] _),
       "mproduct consistent flatMap" -> forAll(laws.mproductConsistency[A, B] _),


### PR DESCRIPTION
I noticed you can implement flatMap from tailRecM and map. This gives a more direct law for flatMap rather than the limited `A, A => F[A]` iterated law that we have currently (since we can take `F[A]` and `A => F[B]` we have less structure on the input, so it is a stronger law.

I'd like to add this even though it shouldn't increase test coverage or currently find any bugs, it is a nice documentation of thinking about tailRecM which I continue to think of as a very important method for FlatMap/Monad when thinking about implementations which use bounded stack such as the scala on the jvm.