### PR TITLE
Move followedBy/forEffect tests to ApplyTests

### DIFF
--- a/laws/src/main/scala/cats/laws/discipline/ApplyTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ApplyTests.scala
@@ -29,7 +29,9 @@ trait ApplyTests[F[_]] extends FunctorTests[F] with CartesianTests[F] {
     val props = Seq(
       "apply composition" -> forAll(laws.applyComposition[A, B, C] _),
       "map2/product-map consistency" -> forAll(laws.map2ProductConsistency[A, B, C] _),
-      "map2/map2Eval consistency" -> forAll(laws.map2EvalConsistency[A, B, C] _))
+      "map2/map2Eval consistency" -> forAll(laws.map2EvalConsistency[A, B, C] _),
+      "followedBy consistent map2" -> forAll(laws.followedByConsistency[A, C] _),
+      "forEffect consistent map2" -> forAll(laws.forEffectConsistency[A, C] _))
   }
 }
 

--- a/laws/src/main/scala/cats/laws/discipline/FlatMapTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FlatMapTests.scala
@@ -36,8 +36,6 @@ trait FlatMapTests[F[_]] extends ApplyTests[F] {
       "flatMap associativity" -> forAll(laws.flatMapAssociativity[A, B, C] _),
       "flatMap consistent apply" -> forAll(laws.flatMapConsistentApply[A, B] _),
       "flatMap from tailRecM consistency" -> forAll(laws.flatMapFromTailRecMConsistency[A, B] _),
-      "followedBy consistent flatMap" -> forAll(laws.followedByConsistency[A, B] _),
-      "forEffect consistent flatMap" -> forAll(laws.forEffectConsistency[A, B] _),
       "mproduct consistent flatMap" -> forAll(laws.mproductConsistency[A, B] _),
       "tailRecM consistent flatMap" -> forAll(laws.tailRecMConsistentFlatMap[A] _))
   }


### PR DESCRIPTION
Move the `followedBy` and `forEffect` consistency tests from `FlatMapTests` to `ApplyTests`.

Small follow up on #1955.