### PR TITLE
Require an Order instance for NonEmptyList's groupBy function

### DIFF
--- a/core/src/main/scala/cats/NonEmptyTraverse.scala
+++ b/core/src/main/scala/cats/NonEmptyTraverse.scala
@@ -53,9 +53,8 @@ import simulacrum.typeclass
     * {{{
     * scala> import cats.implicits._
     * scala> import cats.data.NonEmptyList
-    * scala> def countWords(words: List[String]): Map[String, Int] = words.groupBy(identity).mapValues(_.length)
     * scala> val x = NonEmptyList.of(List("How", "do", "you", "fly"), List("What", "do", "you", "do"))
-    * scala> x.nonEmptyFlatTraverse(_.groupByNel(identity))
+    * scala> x.nonEmptyFlatTraverse(_.groupByNel(identity) : Map[String, NonEmptyList[String]])
     * res0: Map[String,cats.data.NonEmptyList[String]] = Map(do -> NonEmptyList(do, do, do), you -> NonEmptyList(you, you))
     * }}}
     */

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -343,7 +343,7 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) {
       }
     }
 
-    m.mapValues(v => NonEmptyList.fromListUnsafe(v.result))
+    m.map { case (k, v) => (k, NonEmptyList.fromListUnsafe(v.result)) }
   }
 }
 

--- a/core/src/main/scala/cats/syntax/list.scala
+++ b/core/src/main/scala/cats/syntax/list.scala
@@ -27,6 +27,6 @@ final class ListOps[A](val la: List[A]) extends AnyVal {
     * }}}
     */
   def toNel: Option[NonEmptyList[A]] = NonEmptyList.fromList(la)
-  def groupByNel[B](f: A => B): Map[B, NonEmptyList[A]] =
+  def groupByNel[B : Order](f: A => B): Map[B, NonEmptyList[A]] =
     toNel.fold(Map.empty[B, NonEmptyList[A]])(_.groupBy(f))
 }

--- a/core/src/main/scala/cats/syntax/list.scala
+++ b/core/src/main/scala/cats/syntax/list.scala
@@ -1,6 +1,7 @@
 package cats
 package syntax
 
+import scala.collection.immutable.SortedMap
 import cats.data.NonEmptyList
 
 trait ListSyntax {
@@ -27,6 +28,8 @@ final class ListOps[A](val la: List[A]) extends AnyVal {
     * }}}
     */
   def toNel: Option[NonEmptyList[A]] = NonEmptyList.fromList(la)
-  def groupByNel[B : Order](f: A => B): Map[B, NonEmptyList[A]] =
-    toNel.fold(Map.empty[B, NonEmptyList[A]])(_.groupBy(f))
+  def groupByNel[B](f: A => B)(implicit B: Order[B]): SortedMap[B, NonEmptyList[A]] = {
+    implicit val ordering = B.toOrdering
+    toNel.fold(SortedMap.empty[B, NonEmptyList[A]])(_.groupBy(f))
+  }
 }


### PR DESCRIPTION
This addresses: #1959 

I didn't see a way to require just an `Eq` instance for `B` while preserving the performance characteristics. A `mutable.Map` uses more than just universal equality, it also uses the built-in JVM hashing. So, what I did was to switch to a `mutable.TreeMap` which requires a `scala.math.Ordering` instance, and we get that by constraining `B` to have a `cats.Order` instance.