### PR TITLE
Helper method to convert Kleisli[F, A, B] to Kleisli[Id, A, F[B]]

### DIFF
--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -68,8 +68,7 @@ final case class Kleisli[F[_], A, B](run: A => F[B]) { self =>
   def tapWith[C](f: (A, B) => C)(implicit F: Functor[F]): Kleisli[F, A, C] =
     Kleisli(a => F.map(run(a))(b => f(a, b)))
 
-  def toReader: Kleisli[Id, A, F[B]] =
-    mapF[Id, F[B]](scala.Predef.identity)
+  def toReader: Kleisli[Id, A, F[B]] = Kleisli[Id, A, F[B]](run)
 
   def apply(a: A): F[B] = run(a)
 }

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -1,7 +1,7 @@
 package cats
 package data
 
-import cats.Contravariant
+import cats.{Contravariant, Id}
 import cats.arrow._
 
 /**
@@ -67,6 +67,9 @@ final case class Kleisli[F[_], A, B](run: A => F[B]) { self =>
   /** Yield computed B combined with input value. */
   def tapWith[C](f: (A, B) => C)(implicit F: Functor[F]): Kleisli[F, A, C] =
     Kleisli(a => F.map(run(a))(b => f(a, b)))
+
+  def toReader: Kleisli[Id, A, F[B]] =
+    mapF[Id, F[B]](scala.Predef.identity)
 
   def apply(a: A): F[B] = run(a)
 }

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -68,7 +68,7 @@ final case class Kleisli[F[_], A, B](run: A => F[B]) { self =>
   def tapWith[C](f: (A, B) => C)(implicit F: Functor[F]): Kleisli[F, A, C] =
     Kleisli(a => F.map(run(a))(b => f(a, b)))
 
-  def toReader: Kleisli[Id, A, F[B]] = Kleisli[Id, A, F[B]](run)
+  def toReader: Reader[A, F[B]] = Kleisli[Id, A, F[B]](run)
 
   def apply(a: A): F[B] = run(a)
 }

--- a/tests/src/test/scala/cats/tests/KleisliTests.scala
+++ b/tests/src/test/scala/cats/tests/KleisliTests.scala
@@ -188,6 +188,12 @@ class KleisliTests extends CatsSuite {
     }
   }
 
+  test("toReader") {
+    forAll { (f: Kleisli[List, Int, String], i: Int) =>
+      f.run(i) should === (f.toReader.run(i))
+    }
+  }
+
   test("apply") {
     forAll { (f: Kleisli[List, Int, Int], i: Int) =>
       f.run(i) should === (f(i))


### PR DESCRIPTION
I'm not sure how common a use case this is but I find myself needing to do it occasionally.

The test I added feels a bit pointless. Can delete if people agree.

## A motivating example

Say I'm using `Kleisli[Either[String, ?], Context, ?]` in the core of my program:

```scala
case class Context()
case class User()
case class Thing()

def getUser(userId: String): Kleisli[Either[String, ?], Context, User] = ???
def getThing(user: User): Kleisli[Either[String, ?], Context, Thing] = ???

def getThingByUserId(userId: String): Kleisli[Either[String, ?], Context, Thing] =
  for {
    user  <- getUser(userId)
    thing <- getThing(user)
  } yield thing
```

Then on the edge of the program, say in an HTTP controller, I want to match on the `Either` in order to build an HTTP response:

```scala
def buildHttpResult(errorOrThing: Either[String, Thing]) = Kleisli[Id, Context, Result] { ctx =>
  errorOrThing match {
    case Left(e)      => Results.InternalServerError(s"oh no: $e")
    case Right(thing) => Results.Ok("yay")
  }
}
```

The new `toReader` method allows me to pass along the `Either` (rather than the value inside the `Either`) when doing monadic composition:

```scala
def action(userId: String): Result = {
  val context = Context()

  val kleisli: Kleisli[Id, Context, Result] =
    for {
      errorOrThing <- getThingByUserId(userId).toReader
      result       <- buildHttpResult(errorOrThing)
    } yield result

  kleisli.run(context)
}
```