### PR TITLE
Remove Edmund Noble as maintainer and author

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -58,7 +58,6 @@ possible:
  * Derek Wickern
  * Diego Esteban Alonso Blas
  * Earl St Sauver
- * Edmund Noble
  * Eric Torreborre
  * Erik LaBianca
  * Erik Osheim

--- a/README.md
+++ b/README.md
@@ -164,7 +164,6 @@ The current maintainers (people who can merge pull requests) are:
  * [travisbrown](https://github.com/travisbrown) Travis Brown
  * [adelbertc](https://github.com/adelbertc) Adelbert Chang
  * [peterneyens](https://github.com/peterneyens) Peter Neyens
- * [edmundnoble](https://github.com/edmundnoble) Edmund Noble
  * [tpolecat](https://github.com/tpolecat) Rob Norris
  * [stew](https://github.com/stew) Mike O'Connor
  * [non](https://github.com/non) Erik Osheim

--- a/build.sbt
+++ b/build.sbt
@@ -389,11 +389,6 @@ lazy val publishSettings = Seq(
         <url>https://github.com/peterneyens/</url>
       </developer>
       <developer>
-        <id>edmundnoble</id>
-        <name>Edmund Noble</name>
-        <url>https://github.com/edmundnoble/</url>
-      </developer>
-      <developer>
         <id>tpolecat</id>
         <name>Rob Norris</name>
         <url>https://github.com/tpolecat/</url>


### PR DESCRIPTION
In light of the recent admission of attempted career sabotage by @larsrh on Twitter, I'm resigning as maintainer on all typelevel and typelevel incubator projects. It was nice working with all of you, and I hope to work with you again in the future.