### PR TITLE
Fix order of comparison for EitherT.cond

### DIFF
--- a/tests/src/test/scala/cats/tests/EitherTSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherTSuite.scala
@@ -175,9 +175,9 @@ class EitherTSuite extends CatsSuite {
     }
   }
 
-  test("cond") {
+  test("cond consistent with Either.cond") {
     forAll { (cond: Boolean, s: String, i: Int) =>
-      Either.cond(cond, s, i) should === (EitherT.cond[Id](cond, s, i).value)
+      EitherT.cond[Id](cond, s, i).value should === (Either.cond(cond, s, i))
     }
   }
 


### PR DESCRIPTION
This is very minor, but the order of the comparison for the `EitherT.cond` test is swapped: if the test ever winds up catching a breaking change, it will output the incorrect "expected" value.

This fixes the order and also adjusts the test name to describe what's being checked.