### PR TITLE
Removed redundant Eq instance

### DIFF
--- a/kernel-laws/src/main/scala/cats/kernel/laws/SemigroupLaws.scala
+++ b/kernel-laws/src/main/scala/cats/kernel/laws/SemigroupLaws.scala
@@ -8,10 +8,10 @@ trait SemigroupLaws[A] {
   def semigroupAssociative(x: A, y: A, z: A): IsEq[A] =
     S.combine(S.combine(x, y), z) <-> S.combine(x, S.combine(y, z))
 
-  def repeat1(a: A, i: Int): IsEq[A] =
+  def repeat1(a: A): IsEq[A] =
     S.combineN(a, 1) <-> a
 
-  def repeat2(a: A, i: Int): IsEq[A] =
+  def repeat2(a: A): IsEq[A] =
     S.combineN(a, 2) <-> S.combine(a, a)
 
   def combineAllOption(xs: Vector[A]): IsEq[Option[A]] =

--- a/kernel-laws/src/main/scala/cats/kernel/laws/discipline/package.scala
+++ b/kernel-laws/src/main/scala/cats/kernel/laws/discipline/package.scala
@@ -4,6 +4,6 @@ import cats.kernel.Eq
 import org.scalacheck.Prop
 
 package object discipline {
-  implicit def catsLawsIsEqToProp[A: Eq](isEq: IsEq[A])(implicit ev: Eq[A]): Prop =
+  implicit def catsLawsIsEqToProp[A](isEq: IsEq[A])(implicit ev: Eq[A]): Prop =
     ev.eqv(isEq.lhs, isEq.rhs)
 }


### PR DESCRIPTION
Note: I just noticed the redundancy in this implicit conversion. As I'm working on something else, I did *not* check that all tests pass locally, I'll check the C.I. output later.