### PR TITLE
[WIP] Add an UnorderedFoldable that we can give instances for Set/Map/&c

### DIFF
--- a/core/src/main/scala/cats/CommutativeApplicative.scala
+++ b/core/src/main/scala/cats/CommutativeApplicative.scala
@@ -1,5 +1,6 @@
 package cats
 
+import cats.kernel.CommutativeMonoid
 import simulacrum.typeclass
 
 /**
@@ -12,3 +13,11 @@ import simulacrum.typeclass
   * Must obey the laws defined in cats.laws.CommutativeApplicativeLaws.
   */
 @typeclass trait CommutativeApplicative[F[_]] extends Applicative[F] with CommutativeApply[F]
+
+object CommutativeApplicative {
+  def monoid[F[_], A](implicit f: CommutativeApplicative[F], monoid: CommutativeMonoid[A]): CommutativeMonoid[F[A]] =
+    new CommutativeApplicativeMonoid[F, A](f, monoid)
+}
+
+private[cats] class CommutativeApplicativeMonoid[F[_], A](f: CommutativeApplicative[F], monoid: CommutativeMonoid[A])
+  extends ApplicativeMonoid[F, A](f, monoid) with CommutativeMonoid[F[A]]

--- a/core/src/main/scala/cats/Composed.scala
+++ b/core/src/main/scala/cats/Composed.scala
@@ -51,7 +51,15 @@ private[cats] trait ComposedAlternative[F[_], G[_]] extends Alternative[λ[α =>
   def F: Alternative[F]
 }
 
-private[cats] trait ComposedFoldable[F[_], G[_]] extends Foldable[λ[α => F[G[α]]]] { outer =>
+private[cats] trait ComposedUnorderedFoldable[F[_], G[_]] extends UnorderedFoldable[λ[α => F[G[α]]]] { outer =>
+  def F: UnorderedFoldable[F]
+  def G: UnorderedFoldable[G]
+
+  override def foldMapUnordered[A, B](fga: F[G[A]])(f: A => B)(implicit B: kernel.CommutativeMonoid[B]): B =
+    F.foldMapUnordered[G[A], B](fga)(ga => G.foldMapUnordered(ga)(f))
+}
+
+private[cats] trait ComposedFoldable[F[_], G[_]] extends Foldable[λ[α => F[G[α]]]] with ComposedUnorderedFoldable[F, G] { outer =>
   def F: Foldable[F]
   def G: Foldable[G]
 

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -2,7 +2,7 @@ package cats
 
 import scala.collection.mutable
 import cats.instances.either._
-import cats.instances.long._
+import cats.kernel.CommutativeMonoid
 import simulacrum.typeclass
 
 /**
@@ -26,7 +26,7 @@ import simulacrum.typeclass
  *
  * See: [[http://www.cs.nott.ac.uk/~pszgmh/fold.pdf A tutorial on the universality and expressiveness of fold]]
  */
-@typeclass trait Foldable[F[_]] { self =>
+@typeclass trait Foldable[F[_]] extends UnorderedFoldable[F] { self =>
 
   /**
    * Left associative fold on 'F' using the function 'f'.
@@ -145,16 +145,6 @@ import simulacrum.typeclass
     reduceLeftOption(fa)(A.max)
 
   /**
-   * The size of this Foldable.
-   *
-   * This is overriden in structures that have more efficient size implementations
-   * (e.g. Vector, Set, Map).
-   *
-   * Note: will not terminate for infinite-sized collections.
-   */
-  def size[A](fa: F[A]): Long = foldMap(fa)(_ => 1)
-
-  /**
     * Get the element at the index of the `Foldable`.
     */
   def get[A](fa: F[A])(idx: Long): Option[A] =
@@ -175,6 +165,9 @@ import simulacrum.typeclass
       A.combine(acc, a)
     }
 
+  override def foldUnordered[A](fa: F[A])(implicit A: CommutativeMonoid[A]): A =
+    fold(fa)
+
   /**
    * Alias for [[fold]].
    */
@@ -186,6 +179,9 @@ import simulacrum.typeclass
    */
   def foldMap[A, B](fa: F[A])(f: A => B)(implicit B: Monoid[B]): B =
     foldLeft(fa, B.empty)((b, a) => B.combine(b, f(a)))
+
+  override def foldMapUnordered[A, B](fa: F[A])(f: A => B)(implicit B: CommutativeMonoid[B]): B =
+    foldMap(fa)(f)
 
   /**
    * Perform a stack-safe monadic left fold from the source context `F`
@@ -262,6 +258,9 @@ import simulacrum.typeclass
       G.map2Eval(f(a), acc) { (_, _) => () }
     }.value
 
+  override def traverseUnordered_[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: CommutativeApplicative[G]): G[Unit] =
+    traverse_(fa)(f)
+
   /**
    * Sequence `F[G[A]]` using `Applicative[G]`.
    *
@@ -281,6 +280,9 @@ import simulacrum.typeclass
    */
   def sequence_[G[_]: Applicative, A](fga: F[G[A]]): G[Unit] =
     traverse_(fga)(identity)
+
+  override def sequenceUnordered_[G[_]: CommutativeApplicative, A](fga: F[G[A]]): G[Unit] =
+    sequence_(fga)
 
   /**
    * Fold implemented using the given `MonoidK[G]` instance.
@@ -306,26 +308,6 @@ import simulacrum.typeclass
   def find[A](fa: F[A])(f: A => Boolean): Option[A] =
     foldRight(fa, Now(Option.empty[A])) { (a, lb) =>
       if (f(a)) Now(Some(a)) else lb
-    }.value
-
-  /**
-   * Check whether at least one element satisfies the predicate.
-   *
-   * If there are no elements, the result is `false`.
-   */
-  def exists[A](fa: F[A])(p: A => Boolean): Boolean =
-    foldRight(fa, Eval.False) { (a, lb) =>
-      if (p(a)) Eval.True else lb
-    }.value
-
-  /**
-   * Check whether all elements satisfy the predicate.
-   *
-   * If there are no elements, the result is `true`.
-   */
-  def forall[A](fa: F[A])(p: A => Boolean): Boolean =
-    foldRight(fa, Eval.True) { (a, lb) =>
-      if (p(a)) lb else Eval.False
     }.value
 
   /**
@@ -462,11 +444,8 @@ import simulacrum.typeclass
   /**
    * Returns true if there are no elements. Otherwise false.
    */
-  def isEmpty[A](fa: F[A]): Boolean =
+  override def isEmpty[A](fa: F[A]): Boolean =
     foldRight(fa, Eval.True)((_, _) => Eval.False).value
-
-  def nonEmpty[A](fa: F[A]): Boolean =
-    !isEmpty(fa)
 
   /**
    * Intercalate/insert an element between the existing elements while folding.

--- a/core/src/main/scala/cats/UnorderedFoldable.scala
+++ b/core/src/main/scala/cats/UnorderedFoldable.scala
@@ -1,0 +1,136 @@
+package cats
+
+import cats.kernel.CommutativeMonoid
+import cats.kernel.instances.long._
+import cats.kernel.instances.unit._
+import simulacrum.typeclass
+
+/**
+  * A type class for potentially unordered data structures that can be folded.
+  * to a summary value.
+  *
+  * In the case of a collection (such as `List` or `Vector`), these
+  * methods will fold together (combine) the values contained in the
+  * collection to produce a single result.
+  *
+  * This is a weaker version of [[Foldable]] that requires that the target
+  * [[Monoid]] of the `foldMap` operation be commutative, so that the lack
+  * of an ordering constraint on the data structure cannot be observed via
+  * `foldMap`.
+  *
+  * Because the folding order is unspecified, `foldLeft` and `foldRight` are
+  * not able to be implemented, and the fundamental operation is `foldMapUnordered`.
+  *
+  * Every [[Foldable]] is an [[UnorderedFoldable]], as every [[CommutativeMonoid]]
+  * is a [[Monoid]].
+  */
+@typeclass trait UnorderedFoldable[F[_]] { self =>
+
+  /**
+    * Fold implemented by mapping `A` values into `B` and then
+    * combining them using the given `CommutativeMonoid[B]` instance.
+    *
+    * As `B` is a [[CommutativeMonoid]], callers should be unable to observe
+    * the possible lack of a consistent folding order.
+    *
+    * If this [[UnorderedFoldable]] is also a [[Foldable]], it is required
+    * that this method behave identically to [[Foldable.foldMap]].
+    */
+  def foldMapUnordered[A, B](fa: F[A])(f: A => B)(implicit B: CommutativeMonoid[B]): B
+
+  /**
+    * Fold implemented using the given Monoid[A] instance.
+    */
+  def foldUnordered[A](fa: F[A])(implicit A: CommutativeMonoid[A]): A =
+    foldMapUnordered(fa)(identity)
+
+  /**
+    * The size of this structure.
+    *
+    * This is overridden in structures that have more efficient size implementations
+    * (e.g. Vector, Set, Map).
+    *
+    * Note: will not terminate for infinite-sized collections.
+    *
+    * {{{
+    *   scala> import cats._, implicits._
+    *   scala> val F = Foldable[List]
+    *   scala> F.size(Nil)
+    *   res0: Long = 0
+    *   scala> F.size(1 :: 2 :: 3 :: Nil)
+    *   res0: Long = 3
+    * }}}
+    */
+  def size[A](fa: F[A]): Long = foldMapUnordered(fa)(_ => 1L)
+
+  /**
+    * Traverse `F[A]` using `CommutativeApplicative[G]`.
+    *
+    * `A` values will be mapped into `G[B]` and combined using
+    * `Applicative#map2`.
+    *
+    * This method is primarily useful when `G[_]` represents an action
+    * or effect, and the specific `A` aspect of `G[A]` is not otherwise
+    * needed.
+    */
+  def traverseUnordered_[G[_], A, B](fga: F[A])(f: A => G[B])(implicit G: CommutativeApplicative[G]): G[Unit] =
+    foldMapUnordered(fga)(_ => G.pure(()))(CommutativeApplicative.monoid[G, Unit])
+
+  /**
+    * Sequence `F[G[A]]` using `CommutativeApplicative[G]`.
+    *
+    * This is similar to `traverse_` except it operates on `F[G[A]]`
+    * values, so no additional functions are needed.
+    *
+    */
+  def sequenceUnordered_[G[_]: CommutativeApplicative, A](fga: F[G[A]]): G[Unit] =
+    traverseUnordered_(fga)(identity)
+
+  /**
+    * Check whether at least one element satisfies the predicate.
+    *
+    * If there are no elements, the result is `false`.
+    */
+  def exists[A](fa: F[A])(p: A => Boolean): Boolean =
+    foldMapUnordered(fa)(a => Eval.later(p(a)))(new CommutativeMonoid[Eval[Boolean]] {
+      def empty = Eval.False
+      def combine(x: Eval[Boolean], y: Eval[Boolean]): Eval[Boolean] =
+        x.flatMap(xv => if (xv) Eval.True else y)
+    }).value
+
+  /**
+    * Check whether all elements satisfy the predicate.
+    *
+    * If there are no elements, the result is `true`.
+    */
+  def forall[A](fa: F[A])(p: A => Boolean): Boolean =
+    foldMapUnordered(fa)(a => Eval.later(p(a)))(new CommutativeMonoid[Eval[Boolean]] {
+      def empty = Eval.True
+      def combine(x: Eval[Boolean], y: Eval[Boolean]): Eval[Boolean] =
+        x.flatMap(xv => if (xv) y else Eval.False)
+    }).value
+
+  /**
+    * Returns true if there are no elements. Otherwise false.
+    */
+  def isEmpty[A](fa: F[A]): Boolean =
+    forall(fa)(_ => false)
+
+  def nonEmpty[A](fa: F[A]): Boolean =
+    !isEmpty(fa)
+
+  def findAny[A](fa: F[A])(p: A => Boolean): Option[A] =
+    foldMapUnordered(fa)(a => Eval.later(Some(a).filter(p)))(new CommutativeMonoid[Eval[Option[A]]] {
+      def empty: Eval[Option[A]] = Eval.now(None)
+      def combine(x: Eval[Option[A]], y: Eval[Option[A]]): Eval[Option[A]] =
+        x.flatMap(_.fold(y)(_ => x))
+    }).value
+
+  def compose[G[_]: UnorderedFoldable]: UnorderedFoldable[λ[α => F[G[α]]]] =
+    new ComposedUnorderedFoldable[F, G] {
+      val F = self
+      val G = UnorderedFoldable[G]
+    }
+}
+
+object UnorderedFoldable

--- a/core/src/main/scala/cats/instances/map.scala
+++ b/core/src/main/scala/cats/instances/map.scala
@@ -1,6 +1,8 @@
 package cats
 package instances
 
+import cats.kernel.CommutativeMonoid
+
 import scala.annotation.tailrec
 
 trait MapInstances extends cats.kernel.instances.MapInstances {
@@ -14,8 +16,8 @@ trait MapInstances extends cats.kernel.instances.MapInstances {
     }
 
   // scalastyle:off method.length
-  implicit def catsStdInstancesForMap[K]: FlatMap[Map[K, ?]] =
-    new FlatMap[Map[K, ?]] {
+  implicit def catsStdInstancesForMap[K]: FlatMap[Map[K, ?]] with UnorderedFoldable[Map[K, ?]] =
+    new FlatMap[Map[K, ?]] with UnorderedFoldable[Map[K, ?]] {
 
       override def map[A, B](fa: Map[K, A])(f: A => B): Map[K, B] =
         fa.map { case (k, a) => (k, f(a)) }
@@ -57,6 +59,9 @@ trait MapInstances extends cats.kernel.instances.MapInstances {
         f(a).foreach { case (k, a) => descend(k, a) }
         bldr.result
       }
+
+      def foldMapUnordered[A, B](fa: Map[K, A])(f: A => B)(implicit B: CommutativeMonoid[B]): B =
+        fa.valuesIterator.foldLeft(B.empty)((b, a) => B.combine(b, f(a)))
     }
   // scalastyle:on method.length
 }

--- a/core/src/main/scala/cats/instances/set.scala
+++ b/core/src/main/scala/cats/instances/set.scala
@@ -1,17 +1,20 @@
 package cats
 package instances
 
+import cats.kernel.CommutativeMonoid
 import cats.syntax.show._
 
 trait SetInstances extends cats.kernel.instances.SetInstances {
 
-  implicit val catsStdInstancesForSet: MonoidK[Set] =
-    new MonoidK[Set] {
+  implicit val catsStdInstancesForSet: MonoidK[Set] with UnorderedFoldable[Set] =
+    new MonoidK[Set] with UnorderedFoldable[Set] {
 
       def empty[A]: Set[A] = Set.empty[A]
 
       def combineK[A](x: Set[A], y: Set[A]): Set[A] = x | y
 
+      def foldMapUnordered[A, B](fa: Set[A])(f: A => B)(implicit B: CommutativeMonoid[B]): B =
+        fa.foldLeft(B.empty)((b, a) => B.combine(b, f(a)))
     }
 
   implicit def catsStdShowForSet[A:Show]: Show[Set[A]] = new Show[Set[A]] {

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -41,6 +41,7 @@ trait AllSyntax
     with StrongSyntax
     with TraverseSyntax
     with NonEmptyTraverseSyntax
+    with UnorderedFoldableSyntax
     with ValidatedSyntax
     with VectorSyntax
     with WriterSyntax

--- a/core/src/main/scala/cats/syntax/unorderedFoldable.scala
+++ b/core/src/main/scala/cats/syntax/unorderedFoldable.scala
@@ -1,0 +1,5 @@
+package cats
+package syntax
+
+trait UnorderedFoldableSyntax extends UnorderedFoldable.ToUnorderedFoldableOps
+

--- a/laws/src/main/scala/cats/laws/FoldableLaws.scala
+++ b/laws/src/main/scala/cats/laws/FoldableLaws.scala
@@ -5,7 +5,7 @@ import cats.implicits._
 
 import scala.collection.mutable
 
-trait FoldableLaws[F[_]] {
+trait FoldableLaws[F[_]] extends UnorderedFoldableLaws[F] {
   implicit def F: Foldable[F]
 
   def leftFoldConsistentWithFoldMap[A, B](
@@ -33,48 +33,8 @@ trait FoldableLaws[F[_]] {
     F.exists(fa)(p) == F.find(fa)(p).isDefined
   }
 
-  def existsLazy[A](fa: F[A]): Boolean = {
-    var i = 0
-    F.exists(fa){ _ =>
-      i = i + 1
-      true
-    }
-    i == (if (F.isEmpty(fa)) 0 else 1)
-  }
-
-  def forallLazy[A](fa: F[A]): Boolean = {
-    var i = 0
-    F.forall(fa){ _ =>
-      i = i + 1
-      false
-    }
-    i == (if (F.isEmpty(fa)) 0 else 1)
-  }
-
-  def forallConsistentWithExists[A](
-    fa: F[A],
-    p: A => Boolean
-  ): Boolean = {
-    if (F.forall(fa)(p)) {
-      val negationExists = F.exists(fa)(a => !(p(a)))
-
-      // if p is true for all elements, then there cannot be an element for which
-      // it does not hold.
-      !negationExists &&
-        // if p is true for all elements, then either there must be no elements
-        // or there must exist an element for which it is true.
-        (F.isEmpty(fa) || F.exists(fa)(p))
-    } else true // can't test much in this case
-  }
-
-  /**
-   * If `F[A]` is empty, forall must return true.
-   */
-  def forallEmpty[A](
-    fa: F[A],
-    p: A => Boolean
-  ): Boolean = {
-    !F.isEmpty(fa) || F.forall(fa)(p)
+  def forallConsistentWithFind[A](fa: F[A], p: A => Boolean): Boolean = {
+    F.forall(fa)(a => !p(a)) == F.find(fa)(p).isEmpty
   }
 
   /**

--- a/laws/src/main/scala/cats/laws/UnorderedFoldableLaws.scala
+++ b/laws/src/main/scala/cats/laws/UnorderedFoldableLaws.scala
@@ -1,0 +1,85 @@
+package cats
+package laws
+
+import cats.kernel.CommutativeMonoid
+
+trait UnorderedFoldableLaws[F[_]] {
+  def F: UnorderedFoldable[F]
+
+  /**
+    * If `F[A]` is empty, forall must return true.
+    */
+  def forallEmpty[A](fa: F[A], p: A => Boolean): Boolean = {
+    !F.isEmpty(fa) || F.forall(fa)(p)
+  }
+
+  /**
+    * If `F[A]` is empty, exists must return false.
+    */
+  def existsEmpty[A](fa: F[A], p: A => Boolean): Boolean = {
+    !(F.isEmpty(fa) && F.exists(fa)(p))
+  }
+
+  /**
+    * If `F[A]` is empty, its size must be zero;
+    * if it is non-empty, its size must be positive.
+    */
+  def sizeEmpty[A](fa: F[A]): Boolean = {
+    if (F.isEmpty(fa)) F.size(fa) == 0
+    else F.size(fa) > 0
+  }
+
+  def forallConsistentWithExists[A](
+    fa: F[A],
+    p: A => Boolean
+  ): Boolean = {
+    if (F.forall(fa)(p)) {
+      val negationExists = F.exists(fa)(a => !(p(a)))
+
+      // if p is true for all elements, then there cannot be an element for which
+      // it does not hold.
+      !negationExists &&
+        // if p is true for all elements, then either there must be no elements
+        // or there must exist an element for which it is true.
+        (F.isEmpty(fa) || F.exists(fa)(p))
+    } else true // can't test much in this case
+  }
+
+  def foldUnorderedIsFoldMapUnorderedWithIdentity[A: CommutativeMonoid](fa: F[A]): IsEq[A] =
+    F.foldUnordered(fa) <-> F.foldMapUnordered(fa)(identity)
+
+  def sequenceUnordered_IsTraverseUnordered_WithIdentity[G[_]: CommutativeApplicative, A](fga: F[G[A]]): IsEq[G[Unit]] =
+    F.sequenceUnordered_(fga) <-> F.traverseUnordered_(fga)(identity)
+
+  def existsLazy[A](fa: F[A]): Boolean = {
+    var i = 0
+    F.exists(fa){ _ =>
+      i = i + 1
+      true
+    }
+    i == (if (F.isEmpty(fa)) 0 else 1)
+  }
+
+  def forallLazy[A](fa: F[A]): Boolean = {
+    var i = 0
+    F.forall(fa){ _ =>
+      i = i + 1
+      false
+    }
+    i == (if (F.isEmpty(fa)) 0 else 1)
+  }
+
+  def existsConsistentWithFindAny[A](fa: F[A], p: A => Boolean): Boolean = {
+    F.exists(fa)(p) == F.findAny(fa)(p).isDefined
+  }
+
+  def forallConsistentWithFindAny[A](fa: F[A], p: A => Boolean): Boolean = {
+    F.forall(fa)(a => !p(a)) == F.findAny(fa)(p).isEmpty
+  }
+
+}
+
+object UnorderedFoldableLaws {
+  def apply[F[_]](implicit ev: UnorderedFoldable[F]): UnorderedFoldableLaws[F] =
+    new UnorderedFoldableLaws[F] { def F: UnorderedFoldable[F] = ev }
+}

--- a/laws/src/main/scala/cats/laws/discipline/FoldableTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FoldableTests.scala
@@ -8,11 +8,12 @@ import org.typelevel.discipline.Laws
 
 import cats.instances.list._
 
-trait FoldableTests[F[_]] extends Laws {
+trait FoldableTests[F[_]] extends Laws with UnorderedFoldableTests[F] {
   def laws: FoldableLaws[F]
 
   def foldable[A: Arbitrary, B: Arbitrary](implicit
     ArbFA: Arbitrary[F[A]],
+    ArbFOptA: Arbitrary[F[Option[A]]],
     A: Monoid[A],
     B: Monoid[B],
     CogenA: Cogen[A],
@@ -24,15 +25,12 @@ trait FoldableTests[F[_]] extends Laws {
   ): RuleSet = {
     new DefaultRuleSet(
       name = "foldable",
-      parent = None,
+      parent = Some(unorderedFoldable[A, B]),
       "foldLeft consistent with foldMap" -> forAll(laws.leftFoldConsistentWithFoldMap[A, B] _),
       "foldRight consistent with foldMap" -> forAll(laws.rightFoldConsistentWithFoldMap[A, B] _),
       "ordered constistency" -> forAll(laws.orderedConsistency[A] _),
       "exists consistent with find" -> forAll(laws.existsConsistentWithFind[A] _),
-      "forall consistent with exists" -> forAll(laws.forallConsistentWithExists[A] _),
-      "forall true if empty" -> forAll(laws.forallEmpty[A] _),
-      "exists is lazy" -> forAll(laws.existsLazy[A] _),
-      "forall is lazy" -> forAll(laws.forallLazy[A] _),
+      "forall consistent with find" -> forAll(laws.forallConsistentWithFind[A] _),
       "foldM identity" -> forAll(laws.foldMIdentity[A, B] _),
       "reduceLeftOption consistent with reduceLeftToOption" ->
         forAll(laws.reduceLeftOptionConsistentWithReduceLeftToOption[A] _),

--- a/laws/src/main/scala/cats/laws/discipline/NonEmptyTraverseTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/NonEmptyTraverseTests.scala
@@ -18,6 +18,7 @@ trait NonEmptyTraverseTests[F[_]] extends TraverseTests[F] with ReducibleTests[F
     ArbFB: Arbitrary[F[B]],
     ArbFGA: Arbitrary[F[G[A]]],
     ArbGB: Arbitrary[G[B]],
+    ArbFOptA: Arbitrary[F[Option[A]]],
     CogenA: Cogen[A],
     CogenB: Cogen[B],
     CogenC: Cogen[C],

--- a/laws/src/main/scala/cats/laws/discipline/ReducibleTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ReducibleTests.scala
@@ -16,6 +16,7 @@ trait ReducibleTests[F[_]] extends FoldableTests[F] {
     ArbFB: Arbitrary[F[B]],
     ArbFGA: Arbitrary[F[G[A]]],
     ArbGB: Arbitrary[G[B]],
+    ArbFOptA: Arbitrary[F[Option[A]]],
     CogenA: Cogen[A],
     CogenB: Cogen[B],
     EqG: Eq[G[Unit]],

--- a/laws/src/main/scala/cats/laws/discipline/TraverseTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/TraverseTests.scala
@@ -16,6 +16,7 @@ trait TraverseTests[F[_]] extends FunctorTests[F] with FoldableTests[F] {
     ArbXB: Arbitrary[X[B]],
     ArbYB: Arbitrary[Y[B]],
     ArbYC: Arbitrary[Y[C]],
+    ArbFOptA: Arbitrary[F[Option[A]]],
     CogenA: Cogen[A],
     CogenB: Cogen[B],
     CogenC: Cogen[C],

--- a/laws/src/main/scala/cats/laws/discipline/UnorderedFoldableTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/UnorderedFoldableTests.scala
@@ -1,0 +1,47 @@
+package cats
+package laws
+package discipline
+
+import org.scalacheck.Prop._
+import org.scalacheck.{Arbitrary, Cogen}
+import org.typelevel.discipline.Laws
+import cats.instances.option._
+import cats.instances.unit._
+
+trait UnorderedFoldableTests[F[_]] extends Laws {
+  def laws: UnorderedFoldableLaws[F]
+
+  def unorderedFoldable[A: Arbitrary, B: Arbitrary](implicit
+    ArbFA: Arbitrary[F[A]],
+    ArbFOptA: Arbitrary[F[Option[A]]],
+    A: Monoid[A],
+    B: Monoid[B],
+    CogenA: Cogen[A],
+    CogenB: Cogen[B],
+    EqA: Eq[A],
+    EqFA: Eq[F[A]],
+    EqB: Eq[B],
+    EqOptionA: Eq[Option[A]]
+  ): RuleSet = {
+    new DefaultRuleSet(
+      name = "unorderedFoldable",
+      parent = None,
+      "forall true if empty" -> forAll(laws.forallEmpty[A] _),
+      "exists false if empty" -> forAll(laws.existsEmpty[A] _),
+      "size zero iff empty" -> forAll(laws.sizeEmpty[A] _),
+      "forall consistent with exists" -> forAll(laws.forallConsistentWithExists[A] _),
+      "sequenceUnordered_ consistent with traverseUnordered_ (Option)" ->
+        forAll(laws.sequenceUnordered_IsTraverseUnordered_WithIdentity[Option, A] _),
+      "exists is lazy" -> forAll(laws.existsLazy[A] _),
+      "forall is lazy" -> forAll(laws.forallLazy[A] _),
+      "exists consistent with findAny" -> forAll(laws.existsConsistentWithFindAny[A] _),
+      "forall consistent with findAny" -> forAll(laws.forallConsistentWithFindAny[A] _),
+    )
+  }
+}
+
+
+object UnorderedFoldableTests {
+  def apply[F[_]: UnorderedFoldable]: UnorderedFoldableTests[F] =
+    new UnorderedFoldableTests[F] { def laws: UnorderedFoldableLaws[F] = UnorderedFoldableLaws[F] }
+}

--- a/tests/src/test/scala/cats/tests/FoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/FoldableSuite.scala
@@ -3,6 +3,7 @@ package tests
 
 import org.scalatest.prop.PropertyChecks
 import org.scalacheck.Arbitrary
+
 import scala.util.Try
 import scala.collection.immutable._
 import cats.instances.all._

--- a/tests/src/test/scala/cats/tests/MapSuite.scala
+++ b/tests/src/test/scala/cats/tests/MapSuite.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.laws.discipline.{FlatMapTests, SerializableTests, SemigroupalTests}
+import cats.laws.discipline._
 
 class MapSuite extends CatsSuite {
   implicit val iso = SemigroupalTests.Isomorphisms.invariant[Map[Int, ?]]
@@ -11,6 +11,9 @@ class MapSuite extends CatsSuite {
 
   checkAll("Map[Int, Int]", FlatMapTests[Map[Int, ?]].flatMap[Int, Int, Int])
   checkAll("FlatMap[Map[Int, ?]]", SerializableTests.serializable(FlatMap[Map[Int, ?]]))
+
+  checkAll("Map[Int, Int]", UnorderedFoldableTests[Map[Int, ?]].unorderedFoldable[Int, String])
+  checkAll("UnorderedFoldable[Map[Int, Int]]", SerializableTests.serializable(UnorderedFoldable[Map[Int, ?]]))
 
   test("show isn't empty and is formatted as expected") {
     forAll { (map: Map[Int, String]) =>

--- a/tests/src/test/scala/cats/tests/SetSuite.scala
+++ b/tests/src/test/scala/cats/tests/SetSuite.scala
@@ -1,13 +1,16 @@
 package cats
 package tests
 
-import cats.laws.discipline.{MonoidKTests, SerializableTests}
+import cats.laws.discipline.{MonoidKTests, SerializableTests, UnorderedFoldableTests}
 import cats.kernel.laws.discipline.MonoidTests
 class SetSuite extends CatsSuite {
   checkAll("Set[Int]", MonoidTests[Set[Int]].monoid)
 
   checkAll("Set[Int]", MonoidKTests[Set].monoidK[Int])
   checkAll("MonoidK[Set]", SerializableTests.serializable(MonoidK[Set]))
+
+  checkAll("Set[Int]", UnorderedFoldableTests[Set].unorderedFoldable[Int, String])
+  checkAll("UnorderedFoldable[Set]", SerializableTests.serializable(UnorderedFoldable[Set[Int]]))
 
   test("show"){
     Set(1, 1, 2, 3).show should === ("Set(1, 2, 3)")


### PR DESCRIPTION
`Set`, e.g., is not a lawful `Foldable`, since iteration order between multiple sets can be observed via `toList`. If we promise never to observe the order in which elements are folded, by strengthening the `Monoid` required by `foldMap` to a `CommutativeMonoid`, we can have a broader type class `UnorderedFoldable` that contains such unordered collections.

I mentioned this on gitter and no one said no. It's a work in progress: 
- The name is ~~bikesheddable~~ debatable
- I need to add more tests, and possibly more instances
- We presumably need an `UnorderedFoldableSuite` somewhere in there
- Does this imply a ~~`TraverseRandomly`~~ `UnorderedTraverse`?

but I'm making a PR so people can say what they think about the idea _before_ I put any more effort into it, rather than after.