### PR TITLE
Correctly close a tut:silent block in faq

### DIFF
--- a/docs/src/main/tut/faq.md
+++ b/docs/src/main/tut/faq.md
@@ -111,6 +111,7 @@ We can even perform more complicated operations, such as a `traverse` of the nes
 import cats.data.ValidatedNel
 type ErrorsOr[A] = ValidatedNel[String, A]
 def even(i: Int): ErrorsOr[Int] = if (i % 2 == 0) i.validNel else s"$i is odd".invalidNel
+```
 
 ```tut:book
 nl.traverse(even)


### PR DESCRIPTION
Here's how it looks like for me currently:

![image](https://user-images.githubusercontent.com/199499/32722078-03d44590-c869-11e7-91c6-467e11ddb003.png)
