### PR TITLE
standardise on `liftF` and add `liftK` to transformers

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -205,11 +205,16 @@ def mimaSettings(moduleName: String) = Seq(
       exclude[ReversedMissingMethodProblem]("cats.instances.ParallelInstances.catsStdNonEmptyParallelForZipList"),
       exclude[ReversedMissingMethodProblem]("cats.instances.ParallelInstances.catsStdParallelForFailFastFuture"),
       exclude[DirectMissingMethodProblem]("cats.data.EitherTInstances2.catsDataMonadErrorForEitherT"),
-      exclude[DirectMissingMethodProblem]("cats.data.EitherTInstances2.catsDataMonadErrorForEitherT"),
       exclude[ReversedMissingMethodProblem]("cats.Foldable.collectFirstSome"),
       exclude[ReversedMissingMethodProblem]("cats.Foldable.collectFirst"),
       exclude[ReversedMissingMethodProblem]("cats.Foldable#Ops.collectFirstSome"),
-      exclude[ReversedMissingMethodProblem]("cats.Foldable#Ops.collectFirst")
+      exclude[ReversedMissingMethodProblem]("cats.Foldable#Ops.collectFirst"),
+      exclude[ReversedMissingMethodProblem]("cats.data.CommonIRWSTConstructors.liftF"),
+      exclude[ReversedMissingMethodProblem]("cats.data.CommonIRWSTConstructors.liftK"),
+      exclude[ReversedMissingMethodProblem]("cats.data.KleisliFunctions.liftF"),
+      exclude[ReversedMissingMethodProblem]("cats.data.KleisliFunctions.liftK"),
+      exclude[ReversedMissingMethodProblem]("cats.data.CommonStateTConstructors.liftF"),
+      exclude[ReversedMissingMethodProblem]("cats.data.CommonStateTConstructors.liftK")
     )
   }
 )

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -352,6 +352,21 @@ object EitherT extends EitherTInstances {
    */
   final def liftF[F[_], A, B](fb: F[B])(implicit F: Functor[F]): EitherT[F, A, B] = right(fb)
 
+  /**
+   * Same as [[liftF]], but expressed as a FunctionK for use with [[mapK]]
+   * {{{
+   * scala> import cats._, data._, implicits._
+   * scala> val a: OptionT[Eval, Int] = 1.pure[OptionT[Eval, ?]]
+   * scala> val b: OptionT[EitherT[Eval, String, ?], Int] = a.mapK(EitherT.liftK)
+   * scala> b.value.value.value
+   * res0: Either[String,Option[Int]] = Right(Some(1))
+   * }}}
+   */
+  final def liftK[F[_], A](implicit F: Functor[F]): F ~> EitherT[F, A, ?] =
+    new (F ~> EitherT[F, A, ?]) {
+      def apply[B](fb: F[B]): EitherT[F, A, B] = right(fb)
+    }
+
   @deprecated("Use EitherT.liftF.", "1.0.0-RC1")
   final def liftT[F[_], A, B](fb: F[B])(implicit F: Functor[F]): EitherT[F, A, B] = right(fb)
 

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -353,7 +353,7 @@ object EitherT extends EitherTInstances {
   final def liftF[F[_], A, B](fb: F[B])(implicit F: Functor[F]): EitherT[F, A, B] = right(fb)
 
   /**
-   * Same as [[liftF]], but expressed as a FunctionK for use with [[mapK]]
+   * Same as [[liftF]], but expressed as a FunctionK for use with mapK
    * {{{
    * scala> import cats._, data._, implicits._
    * scala> val a: OptionT[Eval, Int] = 1.pure[OptionT[Eval, ?]]

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -363,9 +363,7 @@ object EitherT extends EitherTInstances {
    * }}}
    */
   final def liftK[F[_], A](implicit F: Functor[F]): F ~> EitherT[F, A, ?] =
-    new (F ~> EitherT[F, A, ?]) {
-      def apply[B](fb: F[B]): EitherT[F, A, B] = right(fb)
-    }
+    λ[F ~> EitherT[F, A, ?]](right(_))
 
   @deprecated("Use EitherT.liftF.", "1.0.0-RC1")
   final def liftT[F[_], A, B](fb: F[B])(implicit F: Functor[F]): EitherT[F, A, B] = right(fb)

--- a/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
@@ -266,6 +266,10 @@ private[data] sealed trait CommonIRWSTConstructors {
   /**
    * Return an effectful `a` and an empty log without modifying the input state.
    */
+  def liftF[F[_], E, L, S, A](fa: F[A])(implicit F: Applicative[F], L: Monoid[L]): IndexedReaderWriterStateT[F, E, L, S, S, A] =
+    IndexedReaderWriterStateT((_, s) => F.map(fa)((L.empty, s, _)))
+
+  @deprecated("Use liftF instead", "1.0.0-RC2")
   def lift[F[_], E, L, S, A](fa: F[A])(implicit F: Applicative[F], L: Monoid[L]): IndexedReaderWriterStateT[F, E, L, S, S, A] =
     IndexedReaderWriterStateT((_, s) => F.map(fa)((L.empty, s, _)))
 
@@ -570,7 +574,7 @@ private[data] sealed abstract class RWSTAlternative[F[_], E, L, S]
       G.combineK(x.run(e, sa), y.run(e, sa))
     }
 
-  def empty[A]: ReaderWriterStateT[F, E, L, S, A] = ReaderWriterStateT.lift(G.empty[A])
+  def empty[A]: ReaderWriterStateT[F, E, L, S, A] = ReaderWriterStateT.liftF(G.empty[A])
 
   def pure[A](a: A): ReaderWriterStateT[F, E, L, S, A] = ReaderWriterStateT.pure[F, E, L, S, A](a)
 
@@ -584,7 +588,7 @@ private[data] sealed abstract class RWSTMonadError[F[_], E, L, S, R]
 
   implicit def F: MonadError[F, R]
 
-  def raiseError[A](r: R): ReaderWriterStateT[F, E, L, S, A] = ReaderWriterStateT.lift(F.raiseError(r))
+  def raiseError[A](r: R): ReaderWriterStateT[F, E, L, S, A] = ReaderWriterStateT.liftF(F.raiseError(r))
 
   def handleErrorWith[A](fa: ReaderWriterStateT[F, E, L, S, A])(f: R => ReaderWriterStateT[F, E, L, S, A]): ReaderWriterStateT[F, E, L, S, A] =
     ReaderWriterStateT { (e, s) =>

--- a/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
@@ -284,7 +284,7 @@ private[data] sealed trait CommonIRWSTConstructors {
       def apply[A](fa: F[A]): IndexedReaderWriterStateT[F, E, L, S, S, A] = IndexedReaderWriterStateT.liftF(fa)
     }
 
-  @deprecated("Use liftF instead", "1.0.0-RC2")
+  @deprecated("Use liftF instead", "1.0.0")
   def lift[F[_], E, L, S, A](fa: F[A])(implicit F: Applicative[F], L: Monoid[L]): IndexedReaderWriterStateT[F, E, L, S, S, A] =
     IndexedReaderWriterStateT((_, s) => F.map(fa)((L.empty, s, _)))
 

--- a/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
@@ -269,6 +269,21 @@ private[data] sealed trait CommonIRWSTConstructors {
   def liftF[F[_], E, L, S, A](fa: F[A])(implicit F: Applicative[F], L: Monoid[L]): IndexedReaderWriterStateT[F, E, L, S, S, A] =
     IndexedReaderWriterStateT((_, s) => F.map(fa)((L.empty, s, _)))
 
+  /**
+   * Same as [[liftF]], but expressed as a FunctionK for use with [[mapK]]
+   * {{{
+   * scala> import cats._, data._, implicits._
+   * scala> val a: OptionT[Eval, Int] = 1.pure[OptionT[Eval, ?]]
+   * scala> val b: OptionT[RWST[Eval, Boolean, List[String], String, ?], Int] = a.mapK(RWST.liftK)
+   * scala> b.value.runEmpty(true).value
+   * res0: (List[String], String, Option[Int]) = (List(),"",Some(1))
+   * }}}
+   */
+  def liftK[F[_], E, L, S](implicit F: Applicative[F], L: Monoid[L]): F ~> IndexedReaderWriterStateT[F, E, L, S, S, ?] =
+    new (F ~> IndexedReaderWriterStateT[F, E, L, S, S, ?]) {
+      def apply[A](fa: F[A]): IndexedReaderWriterStateT[F, E, L, S, S, A] = IndexedReaderWriterStateT.liftF(fa)
+    }
+
   @deprecated("Use liftF instead", "1.0.0-RC2")
   def lift[F[_], E, L, S, A](fa: F[A])(implicit F: Applicative[F], L: Monoid[L]): IndexedReaderWriterStateT[F, E, L, S, S, A] =
     IndexedReaderWriterStateT((_, s) => F.map(fa)((L.empty, s, _)))

--- a/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
@@ -280,9 +280,7 @@ private[data] sealed trait CommonIRWSTConstructors {
    * }}}
    */
   def liftK[F[_], E, L, S](implicit F: Applicative[F], L: Monoid[L]): F ~> IndexedReaderWriterStateT[F, E, L, S, S, ?] =
-    new (F ~> IndexedReaderWriterStateT[F, E, L, S, S, ?]) {
-      def apply[A](fa: F[A]): IndexedReaderWriterStateT[F, E, L, S, S, A] = IndexedReaderWriterStateT.liftF(fa)
-    }
+    λ[F ~> IndexedReaderWriterStateT[F, E, L, S, S, ?]](IndexedReaderWriterStateT.liftF(_))
 
   @deprecated("Use liftF instead", "1.0.0")
   def lift[F[_], E, L, S, A](fa: F[A])(implicit F: Applicative[F], L: Monoid[L]): IndexedReaderWriterStateT[F, E, L, S, S, A] =

--- a/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
@@ -270,7 +270,7 @@ private[data] sealed trait CommonIRWSTConstructors {
     IndexedReaderWriterStateT((_, s) => F.map(fa)((L.empty, s, _)))
 
   /**
-   * Same as [[liftF]], but expressed as a FunctionK for use with [[mapK]]
+   * Same as [[liftF]], but expressed as a FunctionK for use with mapK
    * {{{
    * scala> import cats._, data._, implicits._
    * scala> val a: OptionT[Eval, Int] = 1.pure[OptionT[Eval, ?]]

--- a/core/src/main/scala/cats/data/IndexedStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedStateT.scala
@@ -176,6 +176,21 @@ private[data] trait CommonStateTConstructors {
   def liftF[F[_], S, A](fa: F[A])(implicit F: Applicative[F]): IndexedStateT[F, S, S, A] =
     IndexedStateT(s => F.map(fa)(a => (s, a)))
 
+  /**
+   * Same as [[liftF]], but expressed as a FunctionK for use with [[mapK]]
+   * {{{
+   * scala> import cats._, data._, implicits._
+   * scala> val a: OptionT[Eval, Int] = 1.pure[OptionT[Eval, ?]]
+   * scala> val b: OptionT[StateT[Eval, String, ?], Int] = a.mapK(StateT.liftK)
+   * scala> b.value.runEmpty.value
+   * res0: (String, Option[Int]) = ("",Some(1))
+   * }}}
+   */
+  def liftK[F[_], S](implicit F: Applicative[F]): F ~> IndexedStateT[F, S, S, ?] =
+    new (F ~> IndexedStateT[F, S, S, ?]) {
+      def apply[A](fa: F[A]): IndexedStateT[F, S, S, A] = IndexedStateT.liftF(fa)
+    }
+
   @deprecated("Use liftF instead", "1.0.0-RC2")
   def lift[F[_], S, A](fa: F[A])(implicit F: Applicative[F]): IndexedStateT[F, S, S, A] =
     IndexedStateT(s => F.map(fa)(a => (s, a)))

--- a/core/src/main/scala/cats/data/IndexedStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedStateT.scala
@@ -177,7 +177,7 @@ private[data] trait CommonStateTConstructors {
     IndexedStateT(s => F.map(fa)(a => (s, a)))
 
   /**
-   * Same as [[liftF]], but expressed as a FunctionK for use with [[mapK]]
+   * Same as [[liftF]], but expressed as a FunctionK for use with mapK
    * {{{
    * scala> import cats._, data._, implicits._
    * scala> val a: OptionT[Eval, Int] = 1.pure[OptionT[Eval, ?]]

--- a/core/src/main/scala/cats/data/IndexedStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedStateT.scala
@@ -191,7 +191,7 @@ private[data] trait CommonStateTConstructors {
       def apply[A](fa: F[A]): IndexedStateT[F, S, S, A] = IndexedStateT.liftF(fa)
     }
 
-  @deprecated("Use liftF instead", "1.0.0-RC2")
+  @deprecated("Use liftF instead", "1.0.0")
   def lift[F[_], S, A](fa: F[A])(implicit F: Applicative[F]): IndexedStateT[F, S, S, A] =
     IndexedStateT(s => F.map(fa)(a => (s, a)))
 

--- a/core/src/main/scala/cats/data/IndexedStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedStateT.scala
@@ -187,9 +187,7 @@ private[data] trait CommonStateTConstructors {
    * }}}
    */
   def liftK[F[_], S](implicit F: Applicative[F]): F ~> IndexedStateT[F, S, S, ?] =
-    new (F ~> IndexedStateT[F, S, S, ?]) {
-      def apply[A](fa: F[A]): IndexedStateT[F, S, S, A] = IndexedStateT.liftF(fa)
-    }
+    λ[F ~> IndexedStateT[F, S, S, ?]](IndexedStateT.liftF(_))
 
   @deprecated("Use liftF instead", "1.0.0")
   def lift[F[_], S, A](fa: F[A])(implicit F: Applicative[F]): IndexedStateT[F, S, S, A] =

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -87,6 +87,21 @@ private[data] sealed trait KleisliFunctions {
   def liftF[F[_], A, B](x: F[B]): Kleisli[F, A, B] =
     Kleisli(_ => x)
 
+  /**
+   * Same as [[liftF]], but expressed as a FunctionK for use with [[mapK]]
+   * {{{
+   * scala> import cats._, data._, implicits._
+   * scala> val a: Kleisli[Eval, String, Int] = 1.pure[Kleisli[Eval, String, ?]]
+   * scala> val b: Kleisli[OptionT[Eval, ?], String, Int] = a.mapK(OptionT.liftK)
+   * scala> b.run("").value.value
+   * res0: Option[Int] = Some(1)
+   * }}}
+   */
+  def liftK[F[_], A]: F ~> Kleisli[F, A, ?] = new (F ~> Kleisli[F, A, ?]) {
+    def apply[B](x: F[B]): Kleisli[F, A, B] =
+      Kleisli(_ => x)
+  }
+
   @deprecated("Use liftF instead", "1.0.0-RC2")
   def lift[F[_], A, B](x: F[B]): Kleisli[F, A, B] =
     Kleisli(_ => x)

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -84,6 +84,10 @@ object Kleisli extends KleisliInstances with KleisliFunctions with KleisliExplic
 
 private[data] sealed trait KleisliFunctions {
 
+  def liftF[F[_], A, B](x: F[B]): Kleisli[F, A, B] =
+    Kleisli(_ => x)
+
+  @deprecated("Use liftF instead", "1.0.0-RC2")
   def lift[F[_], A, B](x: F[B]): Kleisli[F, A, B] =
     Kleisli(_ => x)
 
@@ -287,7 +291,7 @@ private[data] sealed trait KleisliSemigroupK[F[_], A] extends SemigroupK[Kleisli
 private[data] sealed trait KleisliMonoidK[F[_], A] extends MonoidK[Kleisli[F, A, ?]] with KleisliSemigroupK[F, A] {
   implicit def F: MonoidK[F]
 
-  override def empty[B]: Kleisli[F, A, B] = Kleisli.lift(F.empty[B])
+  override def empty[B]: Kleisli[F, A, B] = Kleisli.liftF(F.empty[B])
 }
 
 private[data] trait KleisliAlternative[F[_], A] extends Alternative[Kleisli[F, A, ?]] with KleisliApplicative[F, A] with KleisliMonoidK[F, A] {

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -88,7 +88,7 @@ private[data] sealed trait KleisliFunctions {
     Kleisli(_ => x)
 
   /**
-   * Same as [[liftF]], but expressed as a FunctionK for use with [[mapK]]
+   * Same as [[liftF]], but expressed as a FunctionK for use with mapK
    * {{{
    * scala> import cats._, data._, implicits._
    * scala> val a: Kleisli[Eval, String, Int] = 1.pure[Kleisli[Eval, String, ?]]

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -91,9 +91,9 @@ private[data] sealed trait KleisliFunctions {
    * Same as [[liftF]], but expressed as a FunctionK for use with mapK
    * {{{
    * scala> import cats._, data._, implicits._
-   * scala> val a: Kleisli[Eval, String, Int] = 1.pure[Kleisli[Eval, String, ?]]
-   * scala> val b: Kleisli[OptionT[Eval, ?], String, Int] = a.mapK(OptionT.liftK)
-   * scala> b.run("").value.value
+   * scala> val a: OptionT[Eval, Int] = 1.pure[OptionT[Eval, ?]]
+   * scala> val b: OptionT[Kleisli[Eval, String, ?], Int] = a.mapK(Kleisli.liftK)
+   * scala> b.value.run("").value
    * res0: Option[Int] = Some(1)
    * }}}
    */

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -102,7 +102,7 @@ private[data] sealed trait KleisliFunctions {
       Kleisli(_ => x)
   }
 
-  @deprecated("Use liftF instead", "1.0.0-RC2")
+  @deprecated("Use liftF instead", "1.0.0")
   def lift[F[_], A, B](x: F[B]): Kleisli[F, A, B] =
     Kleisli(_ => x)
 

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -97,10 +97,8 @@ private[data] sealed trait KleisliFunctions {
    * res0: Option[Int] = Some(1)
    * }}}
    */
-  def liftK[F[_], A]: F ~> Kleisli[F, A, ?] = new (F ~> Kleisli[F, A, ?]) {
-    def apply[B](x: F[B]): Kleisli[F, A, B] =
-      Kleisli(_ => x)
-  }
+  def liftK[F[_], A]: F ~> Kleisli[F, A, ?] =
+    λ[F ~> Kleisli[F, A, ?]](Kleisli.liftF(_))
 
   @deprecated("Use liftF instead", "1.0.0")
   def lift[F[_], A, B](x: F[B]): Kleisli[F, A, B] =

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -209,9 +209,8 @@ object OptionT extends OptionTInstances {
    * res0: Option[Either[String,Int]] = Some(Right(1))
    * }}}
    */
-  def liftK[F[_]](implicit F: Functor[F]): F ~> OptionT[F, ?] = new (F ~> OptionT[F, ?]) {
-      def apply[A](fa: F[A]): OptionT[F, A] = OptionT.liftF(fa)
-    }
+  def liftK[F[_]](implicit F: Functor[F]): F ~> OptionT[F, ?] =
+    λ[F ~> OptionT[F, ?]](OptionT.liftF(_))
 }
 
 private[data] sealed abstract class OptionTInstances extends OptionTInstances0 {

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -198,6 +198,20 @@ object OptionT extends OptionTInstances {
    * Lifts the `F[A]` Functor into an `OptionT[F, A]`.
    */
   def liftF[F[_], A](fa: F[A])(implicit F: Functor[F]): OptionT[F, A] = OptionT(F.map(fa)(Some(_)))
+
+  /**
+   * Same as [[liftF]], but expressed as a FunctionK for use with [[mapK]]
+   * {{{
+   * scala> import cats._, data._,  implicits._
+   * scala> val a: EitherT[Eval, String, Int] = 1.pure[EitherT[Eval, String, ?]]
+   * scala> val b: EitherT[OptionT[Eval, ?], String, Int] = a.mapK(OptionT.liftK)
+   * scala> b.value.value.value
+   * res0: Option[Either[String,Int]] = Some(Right(1))
+   * }}}
+   */
+  def liftK[F[_]](implicit F: Functor[F]): F ~> OptionT[F, ?] = new (F ~> OptionT[F, ?]) {
+      def apply[A](fa: F[A]): OptionT[F, A] = OptionT.liftF(fa)
+    }
 }
 
 private[data] sealed abstract class OptionTInstances extends OptionTInstances0 {

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -200,7 +200,7 @@ object OptionT extends OptionTInstances {
   def liftF[F[_], A](fa: F[A])(implicit F: Functor[F]): OptionT[F, A] = OptionT(F.map(fa)(Some(_)))
 
   /**
-   * Same as [[liftF]], but expressed as a FunctionK for use with [[mapK]]
+   * Same as [[liftF]], but expressed as a FunctionK for use with mapK
    * {{{
    * scala> import cats._, data._,  implicits._
    * scala> val a: EitherT[Eval, String, Int] = 1.pure[EitherT[Eval, String, ?]]

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -85,7 +85,7 @@ object WriterT extends WriterTInstances with WriterTFunctions {
       def apply[V](fa: F[V]): WriterT[F, L, V] = WriterT.liftF(fa)
     }
 
-  @deprecated("Use liftF instead", "1.0.0-RC2")
+  @deprecated("Use liftF instead", "1.0.0")
   def lift[F[_], L, V](fv: F[V])(implicit monoidL: Monoid[L], F: Applicative[F]): WriterT[F, L, V] =
     WriterT(F.map(fv)(v => (monoidL.empty, v)))
 

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -81,9 +81,7 @@ object WriterT extends WriterTInstances with WriterTFunctions {
    * }}}
    */
   def liftK[F[_], L](implicit monoidL: Monoid[L], F: Applicative[F]): F ~> WriterT[F, L, ?] =
-    new (F ~> WriterT[F, L, ?]) {
-      def apply[V](fa: F[V]): WriterT[F, L, V] = WriterT.liftF(fa)
-    }
+    λ[F ~> WriterT[F, L, ?]](WriterT.liftF(_))
 
   @deprecated("Use liftF instead", "1.0.0")
   def lift[F[_], L, V](fv: F[V])(implicit monoidL: Monoid[L], F: Applicative[F]): WriterT[F, L, V] =

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -71,7 +71,7 @@ object WriterT extends WriterTInstances with WriterTFunctions {
     WriterT(F.map(fv)(v => (monoidL.empty, v)))
 
   /**
-   * Same as [[liftF]], but expressed as a FunctionK for use with [[mapK]]
+   * Same as [[liftF]], but expressed as a FunctionK for use with mapK
    * {{{
    * scala> import cats._, data._, implicits._
    * scala> val a: OptionT[Eval, Int] = 1.pure[OptionT[Eval, ?]]

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -67,6 +67,10 @@ final case class WriterT[F[_], L, V](run: F[(L, V)]) {
 
 object WriterT extends WriterTInstances with WriterTFunctions {
 
+  def liftF[F[_], L, V](fv: F[V])(implicit monoidL: Monoid[L], F: Applicative[F]): WriterT[F, L, V] =
+    WriterT(F.map(fv)(v => (monoidL.empty, v)))
+
+  @deprecated("Use liftF instead", "1.0.0-RC2")
   def lift[F[_], L, V](fv: F[V])(implicit monoidL: Monoid[L], F: Applicative[F]): WriterT[F, L, V] =
     WriterT(F.map(fv)(v => (monoidL.empty, v)))
 

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -70,6 +70,21 @@ object WriterT extends WriterTInstances with WriterTFunctions {
   def liftF[F[_], L, V](fv: F[V])(implicit monoidL: Monoid[L], F: Applicative[F]): WriterT[F, L, V] =
     WriterT(F.map(fv)(v => (monoidL.empty, v)))
 
+  /**
+   * Same as [[liftF]], but expressed as a FunctionK for use with [[mapK]]
+   * {{{
+   * scala> import cats._, data._, implicits._
+   * scala> val a: OptionT[Eval, Int] = 1.pure[OptionT[Eval, ?]]
+   * scala> val b: OptionT[WriterT[Eval, String, ?], Int] = a.mapK(WriterT.liftK)
+   * scala> b.value.run.value
+   * res0: (String, Option[Int]) = ("",Some(1))
+   * }}}
+   */
+  def liftK[F[_], L](implicit monoidL: Monoid[L], F: Applicative[F]): F ~> WriterT[F, L, ?] =
+    new (F ~> WriterT[F, L, ?]) {
+      def apply[V](fa: F[V]): WriterT[F, L, V] = WriterT.liftF(fa)
+    }
+
   @deprecated("Use liftF instead", "1.0.0-RC2")
   def lift[F[_], L, V](fv: F[V])(implicit monoidL: Monoid[L], F: Applicative[F]): WriterT[F, L, V] =
     WriterT(F.map(fv)(v => (monoidL.empty, v)))

--- a/scalafix/README.md
+++ b/scalafix/README.md
@@ -24,6 +24,8 @@ sbt scalafix github:typelevel/cats/v1.0.0
 
 - [x] EitherT.liftT was renamed to EitherT.liftF
 
+- [x] the lift method on WriterT, StateT, RWST and Kleisli was renamed to liftF
+
 - [x] CartesianBuilder (i.e. |@|) syntax is deprecated, use the apply syntax on tuples instead. E.g. (x |@| y |@| z).map(...) should be replaced by (x, y, z).mapN(...)
 
 - [x] Free.suspend is renamed to Free.defer for consistency.

--- a/scalafix/input/src/main/scala/fix/v1_0_0/RenameTransformersLift.scala
+++ b/scalafix/input/src/main/scala/fix/v1_0_0/RenameTransformersLift.scala
@@ -1,0 +1,17 @@
+/*
+rule = "scala:fix.v1_0_0.RenameTransformersLift"
+ */
+package fix
+package to1_0_0
+
+object RenameTransformersLiftTests {
+  import cats.instances.option._
+  import cats.instances.string._
+  import cats.data.{Kleisli, StateT, RWST, WriterT}
+
+  val fa: Option[Int] = Some(42)
+  val k: Kleisli[Option, Nothing, Int] = Kleisli.lift(fa)
+  val w: WriterT[Option, String, Int] = WriterT.lift(fa)
+  val s: StateT[Option, Nothing, Int] = StateT.lift(fa)
+  val rws: RWST[Option, Nothing, String, Nothing, Int] = RWST.lift(fa)
+}

--- a/scalafix/input/src/main/scala/fix/v1_0_0/RenameTransformersLift.scala
+++ b/scalafix/input/src/main/scala/fix/v1_0_0/RenameTransformersLift.scala
@@ -7,11 +7,10 @@ package to1_0_0
 object RenameTransformersLiftTests {
   import cats.instances.option._
   import cats.instances.string._
-  import cats.data.{Kleisli, StateT, RWST, WriterT}
+  import cats.data.{Kleisli, StateT, WriterT}
 
   val fa: Option[Int] = Some(42)
   val k: Kleisli[Option, Nothing, Int] = Kleisli.lift(fa)
   val w: WriterT[Option, String, Int] = WriterT.lift(fa)
   val s: StateT[Option, Nothing, Int] = StateT.lift(fa)
-  val rws: RWST[Option, Nothing, String, Nothing, Int] = RWST.lift(fa)
 }

--- a/scalafix/output/src/main/scala/fix/v1_0_0/RenameTransformersLift.scala
+++ b/scalafix/output/src/main/scala/fix/v1_0_0/RenameTransformersLift.scala
@@ -1,17 +1,13 @@
-/*
-rule = "scala:fix.v1_0_0.RenameTransformersLift"
- */
 package fix
 package to1_0_0
 
 object RenameTransformersLiftTests {
   import cats.instances.option._
   import cats.instances.string._
-  import cats.data.{Kleisli, StateT, RWST, WriterT}
+  import cats.data.{Kleisli, StateT, WriterT}
 
   val fa: Option[Int] = Some(42)
   val k: Kleisli[Option, Nothing, Int] = Kleisli.liftF(fa)
   val w: WriterT[Option, String, Int] = WriterT.liftF(fa)
   val s: StateT[Option, Nothing, Int] = StateT.liftF(fa)
-  val rws: RWST[Option, Nothing, String, Nothing, Int] = RWST.liftF(fa)
 }

--- a/scalafix/output/src/main/scala/fix/v1_0_0/RenameTransformersLift.scala
+++ b/scalafix/output/src/main/scala/fix/v1_0_0/RenameTransformersLift.scala
@@ -1,0 +1,17 @@
+/*
+rule = "scala:fix.v1_0_0.RenameTransformersLift"
+ */
+package fix
+package to1_0_0
+
+object RenameTransformersLiftTests {
+  import cats.instances.option._
+  import cats.instances.string._
+  import cats.data.{Kleisli, StateT, RWST, WriterT}
+
+  val fa: Option[Int] = Some(42)
+  val k: Kleisli[Option, Nothing, Int] = Kleisli.liftF(fa)
+  val w: WriterT[Option, String, Int] = WriterT.liftF(fa)
+  val s: StateT[Option, Nothing, Int] = StateT.liftF(fa)
+  val rws: RWST[Option, Nothing, String, Nothing, Int] = RWST.liftF(fa)
+}

--- a/scalafix/rules/src/main/scala/fix/Cats_v1_0_0.scala
+++ b/scalafix/rules/src/main/scala/fix/Cats_v1_0_0.scala
@@ -234,6 +234,7 @@ case class RenameTransformersLift(index: SemanticdbIndex)
   override def fix(ctx: RuleCtx): Patch =
     ctx.replaceSymbols(
       "_root_.cats.data.WriterT.lift." -> "liftF",
+      "_root_.cats.data.StateT.lift." -> "liftF",
       "_root_.cats.data.CommonStateTConstructors.lift." -> "liftF",
       "_root_.cats.data.CommonIRWSTConstructors.lift." -> "liftF",
       "_root_.cats.data.KleisliFunctions.lift." -> "liftF"

--- a/scalafix/rules/src/main/scala/fix/Cats_v1_0_0.scala
+++ b/scalafix/rules/src/main/scala/fix/Cats_v1_0_0.scala
@@ -227,6 +227,21 @@ case class RenameEitherTLiftT(index: SemanticdbIndex)
 
 }
 
+// ref: https://github.com/typelevel/cats/pull/2033
+case class RenameTransformersLift(index: SemanticdbIndex)
+  extends SemanticRule(index, "RenameTransformersLift") {
+
+  override def fix(ctx: RuleCtx): Patch =
+    ctx.replaceSymbols(
+      "_root_.cats.data.WriterT.lift." -> "liftF",
+      "_root_.cats.data.CommonStateTConstructors.lift." -> "liftF",
+      "_root_.cats.data.CommonIRWSTConstructors.lift." -> "liftF",
+      "_root_.cats.data.KleisliFunctions.lift." -> "liftF"
+    )
+
+}
+
+
 // ref: https://github.com/typelevel/cats/pull/1961
 case class RenameCartesian(index: SemanticdbIndex)
   extends SemanticRule(index, "RenameCartesian") {

--- a/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTSuite.scala
@@ -138,11 +138,11 @@ class ReaderWriterStateTSuite extends CatsSuite {
     }
   }
 
-  test("ReaderWriterState.pure, ReaderWriterStateT.lift and IndexedReaderWriterStateT.lift are consistent") {
+  test("ReaderWriterState.pure, ReaderWriterStateT.liftF and IndexedReaderWriterStateT.liftF are consistent") {
     forAll { (value: Int) =>
       val rws: ReaderWriterState[String, Vector[String], Int, Int] = ReaderWriterState.pure(value)
-      val rwst: ReaderWriterState[String, Vector[String], Int, Int] = ReaderWriterStateT.lift(Eval.now(value))
-      val irwst: ReaderWriterState[String, Vector[String], Int, Int] = IndexedReaderWriterStateT.lift(Eval.now(value))
+      val rwst: ReaderWriterState[String, Vector[String], Int, Int] = ReaderWriterStateT.liftF(Eval.now(value))
+      val irwst: ReaderWriterState[String, Vector[String], Int, Int] = IndexedReaderWriterStateT.liftF(Eval.now(value))
 
       rws should === (rwst)
       rwst should === (irwst)

--- a/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
@@ -110,11 +110,11 @@ class IndexedStateTSuite extends CatsSuite {
     }
   }
 
-  test("State.pure, StateT.lift and IndexedStateT.lift are consistent") {
+  test("State.pure, StateT.liftF and IndexedStateT.liftF are consistent") {
     forAll { (s: String, i: Int) =>
       val state: State[String, Int] = State.pure(i)
-      val stateT: State[String, Int] = StateT.lift(Eval.now(i))
-      val indexedStateT: State[String, Int] = IndexedStateT.lift(Eval.now(i))
+      val stateT: State[String, Int] = StateT.liftF(Eval.now(i))
+      val indexedStateT: State[String, Int] = IndexedStateT.liftF(Eval.now(i))
 
       state.run(s) should === (stateT.run(s))
       state.run(s) should === (indexedStateT.run(s))

--- a/tests/src/test/scala/cats/tests/ParallelSuite.scala
+++ b/tests/src/test/scala/cats/tests/ParallelSuite.scala
@@ -98,8 +98,8 @@ class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest {
   }
 
   test("WriterT with Either should accumulate errors") {
-    val w1: WriterT[Either[String, ?], String, Int] = WriterT.lift(Left("Too "))
-    val w2: WriterT[Either[String, ?], String, Int] = WriterT.lift(Left("bad."))
+    val w1: WriterT[Either[String, ?], String, Int] = WriterT.liftF(Left("Too "))
+    val w2: WriterT[Either[String, ?], String, Int] = WriterT.liftF(Left("bad."))
 
     ((w1,w2).parMapN(_ + _).value) should === (Left("Too bad."))
 

--- a/tests/src/test/scala/cats/tests/WriterTSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterTSuite.scala
@@ -65,10 +65,10 @@ class WriterTSuite extends CatsSuite {
     }
   }
 
-  test("Writer.pure and WriterT.lift are consistent") {
+  test("Writer.pure and WriterT.liftF are consistent") {
     forAll { (i: Int) =>
       val writer: Writer[String, Int] = Writer.value(i)
-      val writerT: WriterT[Option, String, Int] = WriterT.lift(Some(i))
+      val writerT: WriterT[Option, String, Int] = WriterT.liftF(Some(i))
       writer.run.some should === (writerT.run)
     }
   }


### PR DESCRIPTION
This PR deprecates `lift` on all transformers in favour of `liftF`, and adds a FunctionK version named `liftK` (for use with `mapK`).

I'm leaving a possible scalafix to a separate PR.
