### PR TITLE
Do redirect to look into cats-mtl for MonadCombine

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -205,7 +205,8 @@ as many breaking changes as possible in this release before we lock down the API
  * All `Unapply` enabled methods, e.g. `sequenceU`, `traverseU`, etc. are removed. `Unapply`
    enabled syntax ops are also removed. Please use the partial unification SI-2712 fix
    instead. The easiest way might be this [sbt-plugin](https://github.com/fiadliel/sbt-partial-unification).
- *  `FunctorFilter`, `MonadCombine`, `MonadFilter`, `MonadReader`, `MonadState`, `MonadTrans`, `MonadWriter` and `TraverseFilter` are no longer in `cats`, the functionalities they provided are inherited by the new [cats-mtl](https://github.com/typelevel/cats-mtl) project. Please check [here](https://github.com/typelevel/cats-mtl#migration-guide) for migration guide.
+ *  `FunctorFilter`, `MonadFilter`, `MonadReader`, `MonadState`, `MonadTrans`, `MonadWriter` and `TraverseFilter` are no longer in `cats`, the functionalities they provided are inherited by the new [cats-mtl](https://github.com/typelevel/cats-mtl) project. Please check [here](https://github.com/typelevel/cats-mtl#migration-guide) for migration guide.
+ *  `MonadCombine` is no longer in cats. Use `Alternative` or `Monad` + `MonoidK` instead.
  * `CartesianBuilder` (i.e. `|@|`) syntax is deprecated, use the apply syntax on tuples instead. E.g. `(x |@| y |@| z).map(...)` should be replaced by `(x, y, z).mapN(...)`. If you are getting "`mapN` not found" error message, it could be due to SI-2712, see the 3rd migration item above. 
  * Apply syntax on tuple (e.g. `(x, y, z).map3(...)`)  was moved from `cats.syntax.tuple._` to `cats.syntax.apply._` and renamed to `mapN`, `contramapN` and `imapN` respectively.
  * The creation methods (`left`, `right`, `apply`, `pure`, etc.) in `EitherT` were improved to take less


### PR DESCRIPTION
...Because it's not there. @LukaJCB++ on gitter pointed out that the use cases for MonadCombine are handled using `Alternative` or `Monad` + `MonoidK` now.


Note: it appears there's a [MonadCombineSuite](https://github.com/typelevel/cats/blob/master/tests/src/test/scala/cats/tests/MonadCombineSuite.scala), which provides a test for a single method of `Alternative`. If I can get some time I'll rename it & add the missing tests.