### PR TITLE
Add &> and <& as syntax for Parallel

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -209,7 +209,10 @@ def mimaSettings(moduleName: String) = Seq(
       exclude[ReversedMissingMethodProblem]("cats.Foldable.collectFirstSome"),
       exclude[ReversedMissingMethodProblem]("cats.Foldable.collectFirst"),
       exclude[ReversedMissingMethodProblem]("cats.Foldable#Ops.collectFirstSome"),
-      exclude[ReversedMissingMethodProblem]("cats.Foldable#Ops.collectFirst")
+      exclude[ReversedMissingMethodProblem]("cats.Foldable#Ops.collectFirst"),
+      exclude[ReversedMissingMethodProblem]("cats.NonEmptyParallel.parForEffect"),
+      exclude[ReversedMissingMethodProblem]("cats.NonEmptyParallel.parFollowedBy"),
+      exclude[ReversedMissingMethodProblem]("cats.syntax.ParallelSyntax.catsSyntaxParallelAp")
     )
   }
 )

--- a/core/src/main/scala/cats/Parallel.scala
+++ b/core/src/main/scala/cats/Parallel.scala
@@ -27,6 +27,22 @@ trait NonEmptyParallel[M[_], F[_]] extends Serializable {
     */
   def parallel: M ~> F
 
+
+  /**
+    * Like `Apply[F].followedBy`, but uses the apply instance
+    * corresponding to the Parallel instance instead.
+    */
+  def parFollowedBy[A, B](ma: M[A])(mb: M[B]): M[B] =
+    Parallel.parMap2(ma, mb)((_, b) => b)(this)
+
+
+  /**
+    * Like `Apply[F].forEffect`, but uses the apply instance
+    * corresponding to the Parallel instance instead.
+    */
+  def parForEffect[A, B](ma: M[A])(mb: M[B]): M[A] =
+    Parallel.parMap2(ma, mb)((a, _) => a)(this)
+
 }
 
 /**

--- a/tests/src/test/scala/cats/tests/SyntaxSuite.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxSuite.scala
@@ -171,6 +171,12 @@ object SyntaxSuite extends AllInstances with AllSyntax {
 
     val tma = mock[T[M[A]]]
     val mta = tma.parSequence
+
+    val ma = mock[M[A]]
+    val mb = mock[M[B]]
+
+    val mb2: M[B] = ma &> mb
+    val ma2: M[A] = ma <& mb
   }
 
   def testParallelTuple[M[_]: Monad, F[_], A, B, C, Z](implicit P: NonEmptyParallel[M, F]) = {


### PR DESCRIPTION
Should fix #2015. I chose `&>` and `<&` seemingly at random. I wanted to use `!>` before, but it appears that's illegal, as it's XML or something. If someone has better names for these operations, I'd be glad to hear! :)