### PR TITLE
Removed deprecation of >> and changed its param to be a by-name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -247,7 +247,15 @@ def mimaSettings(moduleName: String) = Seq(
       exclude[ReversedMissingMethodProblem]("cats.Foldable#Ops.collectFirst"),
       exclude[ReversedMissingMethodProblem]("cats.NonEmptyParallel.parForEffect"),
       exclude[ReversedMissingMethodProblem]("cats.NonEmptyParallel.parFollowedBy"),
-      exclude[ReversedMissingMethodProblem]("cats.syntax.ParallelSyntax.catsSyntaxParallelAp")
+      exclude[ReversedMissingMethodProblem]("cats.syntax.ParallelSyntax.catsSyntaxParallelAp"),
+      exclude[DirectMissingMethodProblem]("cats.FlatMap.>>="),
+      exclude[DirectMissingMethodProblem]("cats.FlatMap#Ops.>>="),
+      exclude[IncompatibleMethTypeProblem]("cats.syntax.FlatMapOps.>>"),
+      exclude[IncompatibleMethTypeProblem]("cats.syntax.FlatMapOps.>>$extension"),
+      exclude[DirectMissingMethodProblem]("cats.data.IndexedStateTMonad.>>="),
+      exclude[DirectMissingMethodProblem]("cats.data.RWSTMonad.>>="),
+      exclude[DirectMissingMethodProblem]("cats.data.CokleisliMonad.>>="),
+      exclude[DirectMissingMethodProblem]("cats.instances.FlatMapTuple2.>>=")
     )
   }
 )

--- a/core/src/main/scala/cats/FlatMap.scala
+++ b/core/src/main/scala/cats/FlatMap.scala
@@ -21,11 +21,6 @@ import simulacrum.typeclass
   def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B]
 
   /**
-   * Alias for [[flatMap]].
-   */
-  def >>=[A, B](fa: F[A])(f: A => F[B]): F[B] = flatMap(fa)(f)
-
-  /**
    * "flatten" a nested `F` of `F` structure into a single-layer `F` structure.
    *
    * This is also commonly called `join`.

--- a/core/src/main/scala/cats/syntax/flatMap.scala
+++ b/core/src/main/scala/cats/syntax/flatMap.scala
@@ -18,8 +18,19 @@ trait FlatMapSyntax extends FlatMap.ToFlatMapOps {
 
 final class FlatMapOps[F[_], A](val fa: F[A]) extends AnyVal {
 
-  @deprecated("Use *> instead", "1.0.0-RC1")
-  def >>[B](fb: F[B])(implicit F: FlatMap[F]): F[B] = F.followedBy(fa)(fb)
+  /**
+   * Alias for [[flatMap]].
+   */
+  def >>=[B](f: A => F[B])(implicit F: FlatMap[F]): F[B] = F.flatMap(fa)(f)
+
+  /**
+   * Alias for `fa.flatMap(_ => fb)`.
+   *
+   * Unlike `*>`, `fb` is defined as a by-name parameter, allowing this
+   * method to be used in cases where computing `fb` is not stack safe
+   * unless suspended in a `flatMap`.
+   */
+  def >>[B](fb: => F[B])(implicit F: FlatMap[F]): F[B] = F.flatMap(fa)(_ => fb)
 
   @deprecated("Use <* instead", "1.0.0-RC1")
   def <<[B](fb: F[B])(implicit F: FlatMap[F]): F[A] = F.forEffect(fa)(fb)


### PR DESCRIPTION
In FS2, we rely heavily on recursive functions that return values of type `Pull[F,O,R]`. These functions typically take a form similar to:

```scala
def foo: Pull[F,O,R] =
  if (guard) Pull.done else doSomeWork *> foo
```

Recently, @pchlupacek noticed that FS2 defines `*>` with a by-name param whereas cats defines `*>` with a strict param. Such recursive programs are broken if we use a strict param. Hence, we are going to change the FS2 definition of `*>` to be strict and reintroduce `>>` with a by-name param and then use `>>` in all recursive pulls.

Ideally, cats would have the same definition for `>>`, so in this PR I removed the deprecation of `>>` and defined it with a by-name param, making it a true alias for `flatMap(_ => fb)`. Note that we already have `followedByEval` and `forEffectEval`, though the syntax overhead of using those is way too high IMO.