### PR TITLE
Get ready for RC2

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -90,6 +90,7 @@ possible:
  * Ionuț G. Stan
  * Israel Pérez González
  * Itamar Ravid
+ * Jacob Barber
  * Jakub Kozłowski
  * Jan-Hendrik Zab
  * Jean-Rémi Desjardins
@@ -113,7 +114,7 @@ possible:
  * Long Cao
  * Luis Angel Vicente Sanchez
  * Luis Sanchez
- * LukaJCB
+ * Luka Jacobowitz
  * Luke Wyman
  * Madder
  * Marc Siegel

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -48,6 +48,7 @@ possible:
  * Cary Robbins
  * Chris Birchall
  * Cody Allen
+ * Colin Woodbury
  * Colt Frederickson
  * Connie Chen
  * Csongor Kiss
@@ -116,6 +117,7 @@ possible:
  * Madder
  * Marc Siegel
  * Marcin Rzeźnicki
+ * Marco Battaglia
  * Mark de Jong
  * Markus Hauck
  * mathhun

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -47,6 +47,7 @@ possible:
  * Bryan Tan
  * Cary Robbins
  * Chris Birchall
+ * Christopher Davenport
  * Cody Allen
  * Colin Woodbury
  * Colt Frederickson

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -25,6 +25,7 @@ possible:
  * Alexey Levan
  * Alissa Pajer
  * Alistair Johnson
+ * Alonso Dominguez
  * Amir Mohammad Saied
  * Andrea Fiore
  * Andrew Jones
@@ -36,6 +37,7 @@ possible:
  * Aλ
  * Ben Fradet
  * Ben Hutchison
+ * Ben Kirwin
  * Benjamin Thuillier
  * Binh Nguyen
  * Bjørn Madsen
@@ -43,6 +45,7 @@ possible:
  * Brendan McAdams
  * Brian McKenna
  * Bryan Tan
+ * Cary Robbins
  * Chris Birchall
  * Cody Allen
  * Colt Frederickson
@@ -68,9 +71,11 @@ possible:
  * Erik Osheim
  * Eugene Burmako
  * Eugene Yokota
+ * Fabian Gutierrez
  * Fabian Schmitthenner
  * Fabio Labella
  * Feynman Liang
+ * Filipe Oliveira
  * Frank S. Thomas
  * Gabriele Petronella
  * Giulio De Luise
@@ -83,6 +88,7 @@ possible:
  * Ionuț G. Stan
  * Israel Pérez González
  * Itamar Ravid
+ * Jakub Kozłowski
  * Jan-Hendrik Zab
  * Jean-Rémi Desjardins
  * Jens
@@ -98,6 +104,7 @@ possible:
  * Julien Truffaut
  * Jun Tomioka
  * Kailuo Wang
+ * kellen
  * Kenji Yoshida
  * Leandro Bolivar
  * Lars Hupel
@@ -120,6 +127,7 @@ possible:
  * Michael Pilquist
  * Mike Curry
  * Miles Sabin
+ * nigredo-tori
  * n4to4
  * Olivier Blanvillain
  * Olli Helenius
@@ -146,6 +154,7 @@ possible:
  * Ross A. Baker
  * Rüdiger Klaehn
  * Ryan Case
+ * rsoeldner
  * Sam Ritchie
  * Sarunas Valaskevicius
  * Sho Kohara
@@ -155,6 +164,7 @@ possible:
  * Sinisa Louc
  * Stephen Carman
  * Stephen Judkins
+ * Stephen Lazaro
  * Stew O'Connor
  * Suhas Gaddam
  * Sumedh Mungee

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -172,6 +172,7 @@ possible:
  * Stephen Lazaro
  * Stew O'Connor
  * Suhas Gaddam
+ * sullis
  * Sumedh Mungee
  * Takayuki Sakai
  * Taylor Brown

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -71,6 +71,7 @@ possible:
  * Erik LaBianca
  * Erik Osheim
  * Eugene Burmako
+ * Eugene Platonov
  * Eugene Yokota
  * Fabian Gutierrez
  * Fabian Schmitthenner

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -37,6 +37,7 @@
 * [#2104](https://github.com/typelevel/cats/pull/2104) Add Commutative{Monad, FlatMap} instances for IdT by @ceedubs
 * [#2105](https://github.com/typelevel/cats/pull/2105) Some Kleisli instance cleanup by @ceedubs
 * [#2110](https://github.com/typelevel/cats/pull/2110) add `Comparison` to `cats` package by @kailuowang
+* [#2112](https://github.com/typelevel/cats/pull/2112) CoflatMap Instance for Applicative by @ChristopherDavenport
 
 
 ### Bug fixes:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,4 @@
-## Version 1.0.0
+## Version 1.0.0-RC2
 
 > 2017 Nov 25
 
@@ -6,6 +6,7 @@
 
 * [#2039](https://github.com/typelevel/cats/pull/2039) Remove `Applicative#traverse` and `Applicative#sequence` by @kubukoz
 * [#2033](https://github.com/typelevel/cats/pull/2033) standardise on `liftF` and add `liftK` to transformers by @SystemFw
+* [#2083](https://github.com/typelevel/cats/pull/2083) Change forEffect/followedBy to productL/productR by @Jacoby6000
 
 ### New features / enhancements (API, instances, data types, etc.):
 
@@ -34,7 +35,8 @@
 * [#2101](https://github.com/typelevel/cats/pull/2101) Add Semigroup.instance method by @jozic
 * [#2103](https://github.com/typelevel/cats/pull/2103) CommutativeMonad for Eval by @ceedubs
 * [#2104](https://github.com/typelevel/cats/pull/2104) Add Commutative{Monad, FlatMap} instances for IdT by @ceedubs
-
+* [#2105](https://github.com/typelevel/cats/pull/2105) Some Kleisli instance cleanup by @ceedubs
+* [#2110](https://github.com/typelevel/cats/pull/2110) add `Comparison` to `cats` package by @kailuowang
 
 
 ### Bug fixes:
@@ -67,6 +69,7 @@
 * [#2077](https://github.com/typelevel/cats/pull/2077) Add some doctest examples for SemigroupK/MonoidK by @ceedubs
 * [#2079](https://github.com/typelevel/cats/pull/2079) Add doctest examples for Applicative by @ceedubs
 * [#2095](https://github.com/typelevel/cats/pull/2095) Update guidelines.md by @kailuowang
+* [#2108](https://github.com/typelevel/cats/pull/2108) Update version of deprecation to 1.0.0-RC2 by @rossabaker
 
 
 ### Build improvements/dependency updates

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,13 @@
 * [#2072](https://github.com/typelevel/cats/pull/2072) added a default id for Arrow by @kailuowang
 * [#2063](https://github.com/typelevel/cats/pull/2063) Added `merge` (product) to `Arrow` for arrows composition by @marcobattaglia
 * [#2060](https://github.com/typelevel/cats/pull/2060) Add parallel instance for IorT by @andyscott
+* [#2046](https://github.com/typelevel/cats/pull/2046) Add distributive typeclass and some instances by @coltfred
+* [#2099](https://github.com/typelevel/cats/pull/2099) CommutativeMonad and CommutativeFlatMap instances for Tuple2 by @ceedubs
+* [#2096](https://github.com/typelevel/cats/pull/2096) Add Arrow Choice by @stephen-lazaro
+* [#2098](https://github.com/typelevel/cats/pull/2098) Add a CommutativeMonoid for Map by @ceedubs
+* [#2101](https://github.com/typelevel/cats/pull/2101) Add Semigroup.instance method by @jozic
+* [#2103](https://github.com/typelevel/cats/pull/2103) CommutativeMonad for Eval by @ceedubs
+* [#2104](https://github.com/typelevel/cats/pull/2104) Add Commutative{Monad, FlatMap} instances for IdT by @ceedubs
 
 
 
@@ -59,6 +66,7 @@
 * [#2073](https://github.com/typelevel/cats/pull/2073) Add doctests for `Ior.fromOptions` by @markus1189
 * [#2077](https://github.com/typelevel/cats/pull/2077) Add some doctest examples for SemigroupK/MonoidK by @ceedubs
 * [#2079](https://github.com/typelevel/cats/pull/2079) Add doctest examples for Applicative by @ceedubs
+* [#2095](https://github.com/typelevel/cats/pull/2095) Update guidelines.md by @kailuowang
 
 
 ### Build improvements/dependency updates
@@ -72,6 +80,7 @@
 * [#2052](https://github.com/typelevel/cats/pull/2052) Add labels to prop produced from IsEq by @nigredo-tori
 * [#2053](https://github.com/typelevel/cats/pull/2053) Fix #2051, Remove superfluous implicit by @rsoeldner
 * [#2081](https://github.com/typelevel/cats/pull/2081) Reduce redundancy in Semigroup and Eq test names by @ceedubs
+* [#2097](https://github.com/typelevel/cats/pull/2097) added distributeIdentityLaw by @kailuowang
 
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@
 * [#2039](https://github.com/typelevel/cats/pull/2039) Remove `Applicative#traverse` and `Applicative#sequence` by @kubukoz
 * [#2033](https://github.com/typelevel/cats/pull/2033) standardise on `liftF` and add `liftK` to transformers by @SystemFw
 * [#2083](https://github.com/typelevel/cats/pull/2083) Change forEffect/followedBy to productL/productR by @Jacoby6000
+* [#2088](https://github.com/typelevel/cats/pull/2088) Add `InvariantSemigroupal` and `ability` to turn `Monoidal`s to `Monoid`s by @LukaJCB
 
 ### New features / enhancements (API, instances, data types, etc.):
 
@@ -38,6 +39,8 @@
 * [#2105](https://github.com/typelevel/cats/pull/2105) Some Kleisli instance cleanup by @ceedubs
 * [#2110](https://github.com/typelevel/cats/pull/2110) add `Comparison` to `cats` package by @kailuowang
 * [#2112](https://github.com/typelevel/cats/pull/2112) CoflatMap Instance for Applicative by @ChristopherDavenport
+* [#2116](https://github.com/typelevel/cats/pull/2116) conversion `PartialOrder` to `PartialOrdering` and `Hash` to `Hashing`  by @kailuowang
+* [#2100](https://github.com/typelevel/cats/pull/2100) Add `comparison` method in `Order` companion object by @ceedubs
 
 
 ### Bug fixes:
@@ -78,6 +81,7 @@
 * [#2028](https://github.com/typelevel/cats/pull/2028) Lawtesting: Update scalacheck-shapeless and cats by @vendethiel
 * [#2065](https://github.com/typelevel/cats/pull/2065) improve build by not displaying each success test by @kailuowang
 * [#2106](https://github.com/typelevel/cats/pull/2106) Update to latest patch versions of scala by @ceedubs
+* [#2114](https://github.com/typelevel/cats/pull/2114) sbt-coursier 1.0.0 by @sullis
 
 ### Testing improvements
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -53,7 +53,8 @@
 ### Testing improvements
 
 * [#2037](https://github.com/typelevel/cats/pull/2037) Tests: MonadCombine->Alternative, add missing ones by @vendethiel 
-* [#2052](https://github.com/typelevel/cats/pull/2052) Add labels to prop produced from IsEq by @nigredo-tori 
+* [#2052](https://github.com/typelevel/cats/pull/2052) Add labels to prop produced from IsEq by @nigredo-tori
+* [#2053](https://github.com/typelevel/cats/pull/2053) Fix #2051, Remove superfluous implicit by @rsoeldner
 
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,49 @@
+## Version 1.0.0
+
+> 2017 Nov 25
+
+### Breaking changes and migration
+
+
+### New features / enhancements (API, instances, data types, etc.):
+
+* [#1949](https://github.com/typelevel/cats/pull/1949) Add ::: to NonEmptyList by @jcranky
+* [#2020](https://github.com/typelevel/cats/pull/2020) Add `foldl` and `foldr` aliases to `Foldable` by @felixmulder
+* [#2024](https://github.com/typelevel/cats/pull/2024) Optimize foldMap implementations with combineAll by @carymrobbins
+* [#1938](https://github.com/typelevel/cats/pull/1938) Add more Parallel instances by @LukaJCB
+* [#2030](https://github.com/typelevel/cats/pull/2030) added `collectFirst` and `collectFirstSome` to `Foldable` by @kailuowang
+* [#1977](https://github.com/typelevel/cats/pull/1977) Add Ior Monad Transformer by @frroliveira
+* [#2038](https://github.com/typelevel/cats/pull/2038) Add &> and <& as syntax for Parallel by @LukaJCB
+* [#1981](https://github.com/typelevel/cats/pull/1981) Add UnorderedFoldable and UnorderedTraverse by @LukaJCB
+
+
+
+### Bug fixes:
+
+* [#2011](https://github.com/typelevel/cats/pull/2011) Rename ContravariantCartesian.scala to ContravariantSemigroupal.scala by @iravid
+* [#2016](https://github.com/typelevel/cats/pull/2016) Removed redundant Eq instance by @denisrosset
+* [#2029](https://github.com/typelevel/cats/pull/2029) make sure that EitherT MonadError syntax works the old way by @kailuowang
+
+
+### Documentation Improvements/Additions:
+
+* [#2007](https://github.com/typelevel/cats/pull/2007) move alleycats in readme by @kailuowang
+* [#2008](https://github.com/typelevel/cats/pull/2008) Upgrade Scalafix instructions by @gabro
+* [#2009](https://github.com/typelevel/cats/pull/2009) Correct it's -> its documentation errors by @kellen
+* [#2017](https://github.com/typelevel/cats/pull/2017) Fix alleycats module name by @benhutchison
+* [#2023](https://github.com/typelevel/cats/pull/2023) Fixes in Arrow docs by @Jasper-M
+* [#2026](https://github.com/typelevel/cats/pull/2026) Correctly close a tut:silent block in faq by @vendethiel
+* [#2027](https://github.com/typelevel/cats/pull/2027) Rename Validation to Validated in Validated docs by @Ttcao
+* [#2036](https://github.com/typelevel/cats/pull/2036) Clean up applicative syntax doc by @bkirwi
+* [#2035](https://github.com/typelevel/cats/pull/2035) Do not redirect to cats-mtl for MonadCombine by @vendethiel
+
+
+### Build improvements/dependency updates
+
+* [#2028](https://github.com/typelevel/cats/pull/2028) Lawtesting: Update scalacheck-shapeless and cats by @vendethiel
+
+
+
 ## Version 1.0.0-RC1
 
 > 2017 Oct 21 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,6 +77,7 @@
 
 * [#2028](https://github.com/typelevel/cats/pull/2028) Lawtesting: Update scalacheck-shapeless and cats by @vendethiel
 * [#2065](https://github.com/typelevel/cats/pull/2065) improve build by not displaying each success test by @kailuowang
+* [#2106](https://github.com/typelevel/cats/pull/2106) Update to latest patch versions of scala by @ceedubs
 
 ### Testing improvements
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
 ### Breaking changes and migration
 
 * [#2039](https://github.com/typelevel/cats/pull/2039) Remove `Applicative#traverse` and `Applicative#sequence` by @kubukoz
+* [#2033](https://github.com/typelevel/cats/pull/2033) standardise on `liftF` and add `liftK` to transformers by @SystemFw
 
 ### New features / enhancements (API, instances, data types, etc.):
 
@@ -17,6 +18,7 @@
 * [#2038](https://github.com/typelevel/cats/pull/2038) Add &> and <& as syntax for Parallel by @LukaJCB
 * [#1981](https://github.com/typelevel/cats/pull/1981) Add UnorderedFoldable and UnorderedTraverse by @LukaJCB
 * [#2047](https://github.com/typelevel/cats/pull/2047) CommutativeMonoid instance for SortedMap by @alonsodomin
+* [#2043](https://github.com/typelevel/cats/pull/2043) Removed deprecation of >> and changed its param to be a by-name by @mpilquist
 
 
 
@@ -38,6 +40,7 @@
 * [#2027](https://github.com/typelevel/cats/pull/2027) Rename Validation to Validated in Validated docs by @Ttcao
 * [#2036](https://github.com/typelevel/cats/pull/2036) Clean up applicative syntax doc by @bkirwi
 * [#2035](https://github.com/typelevel/cats/pull/2035) Do not redirect to cats-mtl for MonadCombine by @vendethiel
+* [#2048](https://github.com/typelevel/cats/pull/2048) Add direct link to the scaladoc (#2048) by @fagossa
 
 
 ### Build improvements/dependency updates

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -43,6 +43,7 @@
 * [#2048](https://github.com/typelevel/cats/pull/2048) Add direct link to the scaladoc by @fagossa
 * [#2050](https://github.com/typelevel/cats/pull/2050) Link Directly to Cats Package in ScalaDoc by @stephen-lazaro 
 * [#2031](https://github.com/typelevel/cats/pull/2031) Add parallel docs by @LukaJCB
+* [#2045](https://github.com/typelevel/cats/pull/2045) Fix scalafix testing instructions by @kubukoz
 
 
 ### Build improvements/dependency updates
@@ -52,6 +53,7 @@
 ### Testing improvements
 
 * [#2037](https://github.com/typelevel/cats/pull/2037) Tests: MonadCombine->Alternative, add missing ones by @vendethiel 
+* [#2052](https://github.com/typelevel/cats/pull/2052) Add labels to prop produced from IsEq by @nigredo-tori 
 
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,12 +40,18 @@
 * [#2027](https://github.com/typelevel/cats/pull/2027) Rename Validation to Validated in Validated docs by @Ttcao
 * [#2036](https://github.com/typelevel/cats/pull/2036) Clean up applicative syntax doc by @bkirwi
 * [#2035](https://github.com/typelevel/cats/pull/2035) Do not redirect to cats-mtl for MonadCombine by @vendethiel
-* [#2048](https://github.com/typelevel/cats/pull/2048) Add direct link to the scaladoc (#2048) by @fagossa
+* [#2048](https://github.com/typelevel/cats/pull/2048) Add direct link to the scaladoc by @fagossa
+* [#2050](https://github.com/typelevel/cats/pull/2050) Link Directly to Cats Package in ScalaDoc by @stephen-lazaro 
+* [#2031](https://github.com/typelevel/cats/pull/2031) Add parallel docs by @LukaJCB
 
 
 ### Build improvements/dependency updates
 
 * [#2028](https://github.com/typelevel/cats/pull/2028) Lawtesting: Update scalacheck-shapeless and cats by @vendethiel
+
+### Testing improvements
+
+* [#2037](https://github.com/typelevel/cats/pull/2037) Tests: MonadCombine->Alternative, add missing ones by @vendethiel 
 
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,14 @@
 * [#1981](https://github.com/typelevel/cats/pull/1981) Add UnorderedFoldable and UnorderedTraverse by @LukaJCB
 * [#2047](https://github.com/typelevel/cats/pull/2047) CommutativeMonoid instance for SortedMap by @alonsodomin
 * [#2043](https://github.com/typelevel/cats/pull/2043) Removed deprecation of >> and changed its param to be a by-name by @mpilquist
+* [#2034](https://github.com/typelevel/cats/pull/2034) Add ContravariantMonoidal by @stephen-lazaro
+* [#2057](https://github.com/typelevel/cats/pull/2057) Add `Ior.fromEither` by @markus1189
+* [#2056](https://github.com/typelevel/cats/pull/2056) Functor.fmap by @fosskers
+* [#2059](https://github.com/typelevel/cats/pull/2059) Add Parallel instance for Ior by @andyscott
+* [#2061](https://github.com/typelevel/cats/pull/2061) Add `MonadError.rethrow` by @SystemFw
+* [#2072](https://github.com/typelevel/cats/pull/2072) added a default id for Arrow by @kailuowang
+* [#2063](https://github.com/typelevel/cats/pull/2063) Added `merge` (product) to `Arrow` for arrows composition by @marcobattaglia
+* [#2060](https://github.com/typelevel/cats/pull/2060) Add parallel instance for IorT by @andyscott
 
 
 
@@ -41,20 +49,29 @@
 * [#2036](https://github.com/typelevel/cats/pull/2036) Clean up applicative syntax doc by @bkirwi
 * [#2035](https://github.com/typelevel/cats/pull/2035) Do not redirect to cats-mtl for MonadCombine by @vendethiel
 * [#2048](https://github.com/typelevel/cats/pull/2048) Add direct link to the scaladoc by @fagossa
-* [#2050](https://github.com/typelevel/cats/pull/2050) Link Directly to Cats Package in ScalaDoc by @stephen-lazaro 
+* [#2050](https://github.com/typelevel/cats/pull/2050) Link Directly to Cats Package in ScalaDoc by @stephen-lazaro
 * [#2031](https://github.com/typelevel/cats/pull/2031) Add parallel docs by @LukaJCB
 * [#2045](https://github.com/typelevel/cats/pull/2045) Fix scalafix testing instructions by @kubukoz
+* [#2068](https://github.com/typelevel/cats/pull/2068) Update symbols table by @stephen-lazaro
+* [#2070](https://github.com/typelevel/cats/pull/2070) Add some doctest examples for Alternative methods by @ceedubs
+* [#2065](https://github.com/typelevel/cats/pull/2065) added entry for sbt-catalysts by @kailuowang
+* [#2071](https://github.com/typelevel/cats/pull/2071) Add doc example for imap by @ceedubs
+* [#2073](https://github.com/typelevel/cats/pull/2073) Add doctests for `Ior.fromOptions` by @markus1189
+* [#2077](https://github.com/typelevel/cats/pull/2077) Add some doctest examples for SemigroupK/MonoidK by @ceedubs
+* [#2079](https://github.com/typelevel/cats/pull/2079) Add doctest examples for Applicative by @ceedubs
 
 
 ### Build improvements/dependency updates
 
 * [#2028](https://github.com/typelevel/cats/pull/2028) Lawtesting: Update scalacheck-shapeless and cats by @vendethiel
+* [#2065](https://github.com/typelevel/cats/pull/2065) improve build by not displaying each success test by @kailuowang
 
 ### Testing improvements
 
 * [#2037](https://github.com/typelevel/cats/pull/2037) Tests: MonadCombine->Alternative, add missing ones by @vendethiel 
 * [#2052](https://github.com/typelevel/cats/pull/2052) Add labels to prop produced from IsEq by @nigredo-tori
 * [#2053](https://github.com/typelevel/cats/pull/2053) Fix #2051, Remove superfluous implicit by @rsoeldner
+* [#2081](https://github.com/typelevel/cats/pull/2081) Reduce redundancy in Semigroup and Eq test names by @ceedubs
 
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,7 +6,6 @@
 
 * [#2039](https://github.com/typelevel/cats/pull/2039) Remove `Applicative#traverse` and `Applicative#sequence` by @kubukoz
 
-
 ### New features / enhancements (API, instances, data types, etc.):
 
 * [#1949](https://github.com/typelevel/cats/pull/1949) Add ::: to NonEmptyList by @jcranky
@@ -17,6 +16,7 @@
 * [#1977](https://github.com/typelevel/cats/pull/1977) Add Ior Monad Transformer by @frroliveira
 * [#2038](https://github.com/typelevel/cats/pull/2038) Add &> and <& as syntax for Parallel by @LukaJCB
 * [#1981](https://github.com/typelevel/cats/pull/1981) Add UnorderedFoldable and UnorderedTraverse by @LukaJCB
+* [#2047](https://github.com/typelevel/cats/pull/2047) CommutativeMonoid instance for SortedMap by @alonsodomin
 
 
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -4,6 +4,8 @@
 
 ### Breaking changes and migration
 
+* [#2039](https://github.com/typelevel/cats/pull/2039) Remove `Applicative#traverse` and `Applicative#sequence` by @kubukoz
+
 
 ### New features / enhancements (API, instances, data types, etc.):
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.0")
 And then create the cats dependency, by adding the following to your `build.sbt`:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats-core" % "1.0.0-RC1"
+libraryDependencies += "org.typelevel" %% "cats-core" % "1.0.0"
 ```
 
 This will pull in the cats-core module. If you require some other

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.0")
 And then create the cats dependency, by adding the following to your `build.sbt`:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats-core" % "1.0.0"
+libraryDependencies += "org.typelevel" %% "cats-core" % "1.0.0-RC2"
 ```
 
 This will pull in the cats-core module. If you require some other


### PR DESCRIPTION
We're really close to 1.0, so I decided to draft some release notes. I think it'd be great if we could also get a blog post on typelevel.org in time as well. :)

Only have a couple of tickets still open:

- [x] standardise on `liftF` and add `liftK` to transformers #2033
- [x] Add ContravariantMonoidal #2034

And then we have a couple of others that break bincompat so we should think about including them in 1.0.0

- [x] Add distributive typeclass and some instances #2046