### PR TITLE
CommutativeMonoid instance for SortedMap

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -229,6 +229,8 @@ def mimaSettings(moduleName: String) = Seq(
       exclude[IncompatibleResultTypeProblem]("cats.instances.package#map.catsStdInstancesForMap"),
       exclude[IncompatibleResultTypeProblem]("cats.instances.package#set.catsStdInstancesForSet"),
       exclude[IncompatibleResultTypeProblem]("cats.instances.MapInstances.catsStdInstancesForMap"),
+      exclude[ReversedMissingMethodProblem]("cats.instances.SortedMapInstances.catsStdCommutativeMonoidForSortedMap"),
+      exclude[UpdateForwarderBodyProblem]("cats.instances.SortedMapInstances.catsStdMonoidForSortedMap"),      
       exclude[DirectMissingMethodProblem]("cats.data.EitherTInstances2.catsDataMonadErrorForEitherT"),
       exclude[MissingTypesProblem]("cats.data.OneAndLowPriority3"),
       exclude[MissingTypesProblem]("cats.data.OneAndLowPriority2"),

--- a/core/src/main/scala/cats/instances/sortedMap.scala
+++ b/core/src/main/scala/cats/instances/sortedMap.scala
@@ -7,13 +7,13 @@ import cats.kernel.instances.StaticMethods
 import scala.annotation.tailrec
 import scala.collection.immutable.SortedMap
 
-trait SortedMapInstances extends SortedMapInstances1 {
+trait SortedMapInstances extends SortedMapInstances2 {
 
   implicit def catsStdHashForSortedMap[K: Hash: Order, V: Hash]: Hash[SortedMap[K, V]] =
     new SortedMapHash[K, V]
 
-  implicit def catsStdMonoidForSortedMap[K: Order, V: Semigroup]: Monoid[SortedMap[K, V]] =
-    new SortedMapMonoid[K, V]
+  implicit def catsStdCommutativeMonoidForSortedMap[K: Order, V: CommutativeSemigroup]: CommutativeMonoid[SortedMap[K, V]] =
+    new SortedMapCommutativeMonoid[K, V]
 
   implicit def catsStdShowForSortedMap[A: Order, B](implicit showA: Show[A], showB: Show[B]): Show[SortedMap[A, B]] =
     new Show[SortedMap[A, B]] {
@@ -109,6 +109,11 @@ trait SortedMapInstances1 {
     new SortedMapEq[K, V]
 }
 
+trait SortedMapInstances2 extends SortedMapInstances1 {
+  implicit def catsStdMonoidForSortedMap[K: Order, V: Semigroup]: Monoid[SortedMap[K, V]] =
+    new SortedMapMonoid[K, V]
+}
+
 class SortedMapHash[K, V](implicit V: Hash[V], O: Order[K], K: Hash[K]) extends SortedMapEq[K, V]()(V, O) with Hash[SortedMap[K, V]] {
   // adapted from [[scala.util.hashing.MurmurHash3]],
   // but modified standard `Any#hashCode` to `ev.hash`.
@@ -141,6 +146,9 @@ class SortedMapEq[K, V](implicit V: Eq[V], O: Order[K]) extends Eq[SortedMap[K, 
       }
     }
 }
+
+class SortedMapCommutativeMonoid[K, V](implicit V: CommutativeSemigroup[V], O: Order[K])
+  extends SortedMapMonoid[K, V] with CommutativeMonoid[SortedMap[K, V]]
 
 class SortedMapMonoid[K, V](implicit V: Semigroup[V], O: Order[K]) extends Monoid[SortedMap[K, V]]  {
 

--- a/tests/src/test/scala/cats/tests/SortedMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/SortedMapSuite.scala
@@ -1,6 +1,7 @@
 package cats
 package tests
 
+import cats.kernel.CommutativeMonoid
 import cats.kernel.laws.discipline.{HashTests, CommutativeMonoidTests, MonoidTests}
 import cats.laws.discipline.{FlatMapTests, SemigroupalTests, SerializableTests, TraverseTests}
 import cats.laws.discipline.arbitrary._
@@ -29,6 +30,7 @@ class SortedMapSuite extends CatsSuite {
 
   checkAll("Hash[SortedMap[Int, String]]" , HashTests[SortedMap[Int, String]].hash)
   checkAll("CommutativeMonoid[SortedMap[String, Int]]", CommutativeMonoidTests[SortedMap[String, Int]].commutativeMonoid)
+  checkAll("CommutativeMonoid[SortedMap[String, Int]]", SerializableTests.serializable(CommutativeMonoid[SortedMap[String, Int]]))
   checkAll("Monoid[SortedMap[String, String]]", MonoidTests[SortedMap[String, String]].monoid)
-  checkAll("Monoid[SortedMap[String, Int]]", SerializableTests.serializable(Monoid[SortedMap[String, Int]]))
+  checkAll("Monoid[SortedMap[String, String]]", SerializableTests.serializable(Monoid[SortedMap[String, String]]))
 }

--- a/tests/src/test/scala/cats/tests/SortedMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/SortedMapSuite.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.kernel.laws.discipline.{HashTests, MonoidTests}
+import cats.kernel.laws.discipline.{HashTests, CommutativeMonoidTests, MonoidTests}
 import cats.laws.discipline.{FlatMapTests, SemigroupalTests, SerializableTests, TraverseTests}
 import cats.laws.discipline.arbitrary._
 
@@ -28,6 +28,7 @@ class SortedMapSuite extends CatsSuite {
   }
 
   checkAll("Hash[SortedMap[Int, String]]" , HashTests[SortedMap[Int, String]].hash)
-  checkAll("Monoid[SortedMap[String, Int]]", MonoidTests[SortedMap[String, Int]].monoid)
+  checkAll("CommutativeMonoid[SortedMap[String, Int]]", CommutativeMonoidTests[SortedMap[String, Int]].commutativeMonoid)
+  checkAll("Monoid[SortedMap[String, String]]", MonoidTests[SortedMap[String, String]].monoid)
   checkAll("Monoid[SortedMap[String, Int]]", SerializableTests.serializable(Monoid[SortedMap[String, Int]]))
 }


### PR DESCRIPTION
This PR adds a `CommutativeMonoid` instance for `SortedMap` when there is a `CommutativeSemigroup` instance for the value type.

Besides adding a test for `CommutativeMonoid[SortedMap[String, Int]]`, I also modified the test for `Monoid[SortedMap[String, Int]]` to be a `Monoid[SortedMap[String, String]]`, such that I can ensure that the `Monoid` instance can still be resolved when there is not a `CommutativeSemigroup` for the value type.