### PR TITLE
 Add direct link to the scaladoc in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ standard library. Cats strives to provide functional programming abstractions th
 
 For more detail about Cats' motivations, go [here](http://typelevel.org/cats/motivations).
 
+You can read the API Documentation, [here](https://typelevel.org/cats/api/cats/index.html).
 
 ### Getting Started
 


### PR DESCRIPTION
This PR fixes #2003 by adding a direct link to the [scaladoc](https://typelevel.github.io/cats/api/cats/index.html) in README.md.
