### PR TITLE
Link Directly to Cats Package in ScalaDoc

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -141,7 +141,7 @@ lazy val docSettings = Seq(
   micrositeHighlightTheme := "atom-one-light",
   micrositeHomepage := "http://typelevel.org/cats/",
   micrositeBaseUrl := "cats",
-  micrositeDocumentationUrl := "api/",
+  micrositeDocumentationUrl := "api/cats/index.html",
   micrositeGithubOwner := "typelevel",
   micrositeExtraMdFiles := Map(
     file("CONTRIBUTING.md") -> ExtraMdFileConfig(

--- a/docs/src/main/tut/typeclasses/contravariant.md
+++ b/docs/src/main/tut/typeclasses/contravariant.md
@@ -2,7 +2,7 @@
 layout: docs
 title:  "Contravariant"
 section: "typeclasses"
-source: "core/src/main/scala/cats/functor/Contravariant.scala"
+source: "core/src/main/scala/cats/Contravariant.scala"
 scaladoc: "#cats.Contravariant"
 ---
 # Contravariant

--- a/docs/src/main/tut/typeclasses/invariant.md
+++ b/docs/src/main/tut/typeclasses/invariant.md
@@ -2,7 +2,7 @@
 layout: docs
 title:  "Invariant"
 section: "typeclasses"
-source: "core/src/main/scala/cats/functor/Invariant.scala"
+source: "core/src/main/scala/cats/Invariant.scala"
 scaladoc: "#cats.Invariant"
 ---
 # Invariant


### PR DESCRIPTION
This resolves https://github.com/typelevel/cats/issues/2005 providing link directly to the `cats` package in the ScalaDoc.

Rider: Fix some Scala source links in microSite sources that were killed when `Contravariant` and `Invariant` were moved out of `functor` package.