### PR TITLE
Add labels to prop produced from IsEq

### DIFF
--- a/kernel-laws/src/main/scala/cats/kernel/laws/discipline/package.scala
+++ b/kernel-laws/src/main/scala/cats/kernel/laws/discipline/package.scala
@@ -2,8 +2,15 @@ package cats.kernel.laws
 
 import cats.kernel.Eq
 import org.scalacheck.Prop
+import org.scalacheck.util.Pretty
 
 package object discipline {
-  implicit def catsLawsIsEqToProp[A](isEq: IsEq[A])(implicit ev: Eq[A]): Prop =
-    ev.eqv(isEq.lhs, isEq.rhs)
+  implicit def catsLawsIsEqToProp[A](isEq: IsEq[A])(implicit ev: Eq[A], pp: A => Pretty): Prop =
+    isEq match { case IsEq(x, y) =>
+      if (ev.eqv(x, y)) Prop.proved else Prop.falsified :| {
+        val exp = Pretty.pretty[A](y, Pretty.Params(0))
+        val act = Pretty.pretty[A](x, Pretty.Params(0))
+        s"Expected: $exp\n" + s"Received: $act"
+      }
+    }
 }

--- a/laws/src/main/scala/cats/laws/discipline/package.scala
+++ b/laws/src/main/scala/cats/laws/discipline/package.scala
@@ -2,11 +2,12 @@ package cats
 package laws
 
 import org.scalacheck.Prop
+import org.scalacheck.util.Pretty
 
 package object discipline {
 
   val SerializableTests = cats.kernel.laws.discipline.SerializableTests
 
-  implicit def catsLawsIsEqToProp[A: Eq](isEq: IsEq[A]): Prop =
+  implicit def catsLawsIsEqToProp[A: Eq](isEq: IsEq[A])(implicit pp: A => Pretty): Prop =
     cats.kernel.laws.discipline.catsLawsIsEqToProp[A](isEq)
 }


### PR DESCRIPTION
For failed `IsEq` produce labels with both values to simplify debugging.

The implementation was borrowed from `org.scalacheck.Prop.?=` with minimal changes. No changes to `*Test` traits were made, so the default pretty-printer will be used in most cases, which shouldn't cause any problems. Changes to pass a pretty-printer through would be trivial, but would require a lot of small changes (and would be fragile unless we convert `IsEq` to `Prop` explicitly everywhere, since we always have implicit pretty-printer for `Any`).