### PR TITLE
Add `Ior.fromEither`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -275,6 +275,7 @@ def mimaSettings(moduleName: String) = Seq(
       exclude[DirectMissingMethodProblem]("cats.data.NestedApplicativeError.sequence"),
       exclude[DirectMissingMethodProblem]("cats.data.ValidatedApplicative.traverse"),
       exclude[DirectMissingMethodProblem]("cats.data.ValidatedApplicative.sequence"),
+      exclude[ReversedMissingMethodProblem]("cats.data.IorFunctions.fromEither"),
       exclude[DirectMissingMethodProblem]("cats.data.RWSTAlternative.traverse"),
       exclude[DirectMissingMethodProblem]("cats.data.RWSTAlternative.sequence")
 

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -257,4 +257,25 @@ private[data] sealed trait IorFunctions {
         case None => None
       }
     }
+
+  /**
+   * Create an `Ior` from an `Either`.
+   * @param eab an `Either` from which the `Ior` should be created
+   *
+   * @return [[Ior.Left]] if the `Either` was a `Left`,
+   *         or [[Ior.Right]] if the `Either` was a `Right`
+   *
+   * Example:
+   * {{{
+   * scala> Ior.fromEither(Left(1))
+   * res0: Ior[Int, Nothing] = Left(1)
+   * scala> Ior.fromEither(Right('1'))
+   * res1: Ior[Nothing, Char] = Right(1)
+   * }}}
+   */
+  def fromEither[A, B](eab: Either[A, B]): A Ior B =
+    eab match {
+      case Left(a) => left(a)
+      case Right(b) => right(b)
+    }
 }

--- a/core/src/main/scala/cats/syntax/either.scala
+++ b/core/src/main/scala/cats/syntax/either.scala
@@ -85,10 +85,7 @@ final class EitherOps[A, B](val eab: Either[A, B]) extends AnyVal {
     case Right(b) => if (f(b)) eab else Left(onFailure(b))
   }
 
-  def toIor: A Ior B = eab match {
-    case Left(a)  => Ior.left(a)
-    case Right(b) => Ior.right(b)
-  }
+  def toIor: A Ior B = Ior.fromEither(eab)
 
   def toOption: Option[B] = eab match {
     case Left(_)  => None


### PR DESCRIPTION
Adds the `Ior.fromEither` method.  I am aware that there is a `toIor` provided via `EitherOps`, but this one is harder to find for newcomers (IMHO :D) and needs the import of the `EitherSyntax`.

So I added the `Ior.fromEither` which does not require any import and is easily discoverable on the `Ior` companion.

### 24 Pull Requests (https://24pullrequests.com) ###
![https://24pullrequests.com](https://24pullrequests.com/assets/logo-8a77737f86fec8def19a1c9a605c9841dbd44e59f243ed3bf64bbdf3214d6fa1.png
)