### PR TITLE
improve build by not displaying each success test

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,10 @@ lazy val commonJsSettings = Seq(
 )
 
 lazy val commonJvmSettings = Seq(
-  testOptions in Test += Tests.Argument(TestFrameworks.ScalaTest, "-oDF")
+  testOptions in Test += {
+    val flag = if ((isTravisBuild in Global).value) "-oCI" else "-oDF"
+    Tests.Argument(TestFrameworks.ScalaTest, flag)
+  }
 )
 
 lazy val includeGeneratedSrc: Setting[_] = {

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -41,7 +41,7 @@ jvm="$sbt_cmd coverage validateJVM coverageReport && codecov"
 if [[ $TRAVIS_SCALA_VERSION == *"2.12"* ]]; then
 scalafix="sbt ';coreJVM/publishLocal;freeJVM/publishLocal' && cd scalafix && sbt tests/test && cd .. &&"
 else
-scalafix = ""
+scalafix=""
 fi
 
 if [[ $JS_BUILD == "true" ]]; then

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -29,7 +29,7 @@ fi
 
 sbt_cmd="sbt ++$TRAVIS_SCALA_VERSION"
 
-set COURSIER_VERBOSITY=0
+export COURSIER_VERBOSITY=0
 
 core_js="$sbt_cmd validateJS"
 kernel_js="$sbt_cmd validateKernelJS"

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -29,6 +29,8 @@ fi
 
 sbt_cmd="sbt ++$TRAVIS_SCALA_VERSION"
 
+set COURSIER_VERBOSITY=0
+
 core_js="$sbt_cmd validateJS"
 kernel_js="$sbt_cmd validateKernelJS"
 free_js="$sbt_cmd validateFreeJS"

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -1,6 +1,5 @@
 #!/bin/bash
 
-set -e
 
 # Build Overview:
 # The overall build is split into a number of parts
@@ -37,15 +36,12 @@ free_js="$sbt_cmd validateFreeJS"
 js="$core_js && $free_js && $kernel_js"
 jvm="$sbt_cmd coverage validateJVM coverageReport && codecov"
 
-sbt ;coreJVM/publishLocal;freeJVM/publishLocal
-cd scalafix
-sbt tests/test
-cd ..
+scalafix="$sbt_cmd ';coreJVM/publishLocal;freeJVM/publishLocal' && cd scalafix && $sbt_cmd tests/test && cd .."
 
 if [[ $JS_BUILD == "true" ]]; then
 run_cmd="$js"
 else
-run_cmd="$jvm && $sbt_cmd $publish_cmd"
+run_cmd="$scalafix && $jvm && $sbt_cmd $publish_cmd"
 fi
 
 eval $run_cmd

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -e
+
 # Build Overview:
 # The overall build is split into a number of parts
 # 1. The build for coverage is performed. This:

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -36,12 +36,16 @@ free_js="$sbt_cmd validateFreeJS"
 js="$core_js && $free_js && $kernel_js"
 jvm="$sbt_cmd coverage validateJVM coverageReport && codecov"
 
-scalafix="$sbt_cmd ';coreJVM/publishLocal;freeJVM/publishLocal' && cd scalafix && $sbt_cmd tests/test && cd .."
+if [[ $TRAVIS_SCALA_VERSION == *"2.12"* ]]; then
+scalafix="sbt ';coreJVM/publishLocal;freeJVM/publishLocal' && cd scalafix && sbt tests/test && cd .. &&"
+else
+scalafix = ""
+fi
 
 if [[ $JS_BUILD == "true" ]]; then
 run_cmd="$js"
 else
-run_cmd="$scalafix && $jvm && $sbt_cmd $publish_cmd"
+run_cmd="$scalafix $jvm && $sbt_cmd $publish_cmd"
 fi
 
 eval $run_cmd


### PR DESCRIPTION
Our test log is always too long to display inside travis, the raw log downloaded is a really a pain to read. 
This change will make it only display success TestSuite names in JVM tests. So with this change it should be a lot easier to see where build fails. 