### PR TITLE
added a default id for Arrow

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -316,7 +316,8 @@ def mimaSettings(moduleName: String) = Seq(
       exclude[DirectMissingMethodProblem]("cats.data.RWSTAlternative.sequence"),
       exclude[ReversedMissingMethodProblem]("cats.MonadError.rethrow"),
       exclude[ReversedMissingMethodProblem]("cats.syntax.MonadErrorSyntax.catsSyntaxMonadErrorRethrow"),
-      exclude[DirectMissingMethodProblem]("cats.data.CokleisliArrow.id")
+      exclude[DirectMissingMethodProblem]("cats.data.CokleisliArrow.id"),
+      exclude[IncompatibleResultTypeProblem]("cats.data.CokleisliArrow.id")
     )
   }
 )

--- a/build.sbt
+++ b/build.sbt
@@ -315,7 +315,8 @@ def mimaSettings(moduleName: String) = Seq(
       exclude[DirectMissingMethodProblem]("cats.data.RWSTAlternative.traverse"),
       exclude[DirectMissingMethodProblem]("cats.data.RWSTAlternative.sequence"),
       exclude[ReversedMissingMethodProblem]("cats.MonadError.rethrow"),
-      exclude[ReversedMissingMethodProblem]("cats.syntax.MonadErrorSyntax.catsSyntaxMonadErrorRethrow")
+      exclude[ReversedMissingMethodProblem]("cats.syntax.MonadErrorSyntax.catsSyntaxMonadErrorRethrow"),
+      exclude[DirectMissingMethodProblem]("cats.data.CokleisliArrow.id")
     )
   }
 )

--- a/core/src/main/scala/cats/arrow/Arrow.scala
+++ b/core/src/main/scala/cats/arrow/Arrow.scala
@@ -15,7 +15,9 @@ import simulacrum.typeclass
    * library `Control.Arrow`, this function is called `arr`.
    */
   def lift[A, B](f: A => B): F[A, B]
-
+  
+  override def id[A]: F[A, A] = lift(identity)
+  
   override def dimap[A, B, C, D](fab: F[A, B])(f: C => A)(g: B => D): F[C, D] =
     compose(lift(g), andThen(lift(f), fab))
 

--- a/core/src/main/scala/cats/arrow/Arrow.scala
+++ b/core/src/main/scala/cats/arrow/Arrow.scala
@@ -15,9 +15,9 @@ import simulacrum.typeclass
    * library `Control.Arrow`, this function is called `arr`.
    */
   def lift[A, B](f: A => B): F[A, B]
-  
+
   override def id[A]: F[A, A] = lift(identity)
-  
+
   override def dimap[A, B, C, D](fab: F[A, B])(f: C => A)(g: B => D): F[C, D] =
     compose(lift(g), andThen(lift(f), fab))
 

--- a/core/src/main/scala/cats/data/Cokleisli.scala
+++ b/core/src/main/scala/cats/data/Cokleisli.scala
@@ -142,9 +142,6 @@ private trait CokleisliArrow[F[_]] extends Arrow[Cokleisli[F, ?, ?]] with Coklei
   def lift[A, B](f: A => B): Cokleisli[F, A, B] =
     Cokleisli(fa => f(F.extract(fa)))
 
-  def id[A]: Cokleisli[F, A, A] =
-    Cokleisli(fa => F.extract(fa))
-
   def first[A, B, C](fa: Cokleisli[F, A, B]): Cokleisli[F, (A, C), (B, C)] =
     fa.first[C]
 

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -274,7 +274,7 @@ private[data] trait KleisliChoice[F[_]] extends Choice[Kleisli[F, ?, ?]] with Kl
 private[data] trait KleisliCategory[F[_]] extends Category[Kleisli[F, ?, ?]] with KleisliCompose[F] {
   implicit def F: Monad[F]
 
-  def id[A]: Kleisli[F, A, A] = Kleisli.ask[F, A]
+  override def id[A]: Kleisli[F, A, A] = Kleisli.ask[F, A]
 }
 
 private[data] trait KleisliCompose[F[_]] extends Compose[Kleisli[F, ?, ?]] {

--- a/core/src/main/scala/cats/instances/function.scala
+++ b/core/src/main/scala/cats/instances/function.scala
@@ -81,8 +81,6 @@ private[instances] sealed trait Function1Instances extends Function1Instances0 {
         case (a, c) => (fa(a), c)
       }
 
-      def id[A]: A => A = a => a
-
       override def split[A, B, C, D](f: A => B, g: C => D): ((A, C)) => (B, D) = {
         case (a, c) => (f(a), g(c))
       }


### PR DESCRIPTION
we already have a law 
```
    F.lift(identity[A]) <-> F.id[A]
```
so it's hard to see why this shouldn't be given as a default.