### PR TITLE
Add Applicative for Arrow

### DIFF
--- a/core/src/main/scala/cats/Applicative.scala
+++ b/core/src/main/scala/cats/Applicative.scala
@@ -93,59 +93,10 @@ private[cats] class ApplicativeMonoid[F[_], A](f: Applicative[F], monoid: Monoid
 }
 
 private[cats] class ArrowApplicative[F[_, _], A](F: Arrow[F]) extends Applicative[F[A, ?]] {
-  /**
-   * Pure for Arrows lifts the constant function at that value.
-   * Example:
-   * {{{
-   * scala> import cats.implicits._
-   * scala> import cats.Applicative.catsApplicativeForArrow
-   * scala> val g: Int => String = catsApplicativeForArrow.pure("hello")
-   * scala> g(5)
-   * res0: String = hello
-   * }}}
-   */
   def pure[B](b: B): F[A, B] = F.lift[A, B](_ => b)
-  /**
-   * Example:
-   * {{{
-   * scala> import cats.implicits._
-   * scala> import cats.Applicative.catsApplicativeForArrow
-   * scala> val double: Int => Int = 2*_
-   * scala> val triple: Int => Int = 3*_
-   * scala> val sextuple: Int => Int = catsApplicativeForArrow.map(double)(triple)
-   * scala> sextuple(6)
-   * res0: Int = 36
-   * }}}
-   */
   override def map[B, C](fb: F[A, B])(f: B => C): F[A, C] = F.rmap(fb)(f)
-  /**
-   * Example:
-   * {{{
-   * scala> import cats.implicits._
-   * scala> import cats.Applicative.catsApplicativeForArrow
-   * scala> val multiplyBy: Int => (Int => Int) = x => (y => x*y)
-   * scala> val triple: Int => Int = 3*_
-   * scala> val threeTimesTheSquare = catsApplicativeForArrow.ap(multiplyBy)(triple)
-   * scala> threeTimesTheSquare(5)
-   * res0: Int = 75
-   * }}}
-   */
   def ap[B, C](ff: F[A, B => C])(fb: F[A, B]): F[A, C] =
     F.rmap(F.andThen(F.lift((x: A) => (x, x)), F.split(ff, fb)))(tup => tup._1(tup._2))
-  /**
-   * Product is given by composing diagonal with split of given arrows
-   * Example::
-   * {{{
-   * scala> import cats.implicits._
-   * scala> import cats.Applicative.catsApplicativeForArrow
-   * scala> val double: Int => Long = 2*_.toLong
-   * scala> val triple: Int => Long = 3*_.toLong
-   * scala> val h: Int => (Long, Long) = catsApplicativeForArrow.product(double, triple)
-   * scala> h(4)
-   * res0: (Long, Long) = (8,12)
-   * }}}
-   *
-   */
   override def product[B, C](fb: F[A, B], fc: F[A, C]): F[A, (B, C)] =
     F.andThen(F.lift((x: A) => (x, x)), F.split(fb, fc))
 }

--- a/core/src/main/scala/cats/Applicative.scala
+++ b/core/src/main/scala/cats/Applicative.scala
@@ -1,5 +1,6 @@
 package cats
 
+import cats.arrow.Arrow
 import cats.instances.list._
 import simulacrum.typeclass
 
@@ -67,8 +68,35 @@ import simulacrum.typeclass
 object Applicative {
   def monoid[F[_], A](implicit f: Applicative[F], monoid: Monoid[A]): Monoid[F[A]] =
     new ApplicativeMonoid[F, A](f, monoid)
+
+  /**
+   * Creates a semigroupal functor for `F`, holding domain fixed and combining
+   * over the codomain.
+   *
+   * Example:
+   * {{{
+   * scala> import cats.implicits._
+   * scala> import cats.Applicative.catsApplicativeForArrow
+   * scala> val toLong: Int => Long = _.toLong
+   * scala> val double: Int => Int = 2*_
+   * scala> val f: Int => (Long, Int) = catsApplicativeForArrow.product(toLong, double)
+   * scala> f(3)
+   * res0: (Long, Int) = (3,6)
+   * }}}
+   */
+  implicit def catsApplicativeForArrow[F[_, _], A](implicit F: Arrow[F]): Applicative[F[A, ?]] =
+    new ArrowApplicative[F, A](F)
 }
 
 private[cats] class ApplicativeMonoid[F[_], A](f: Applicative[F], monoid: Monoid[A]) extends ApplySemigroup(f, monoid) with Monoid[F[A]] {
   def empty: F[A] = f.pure(monoid.empty)
+}
+
+private[cats] class ArrowApplicative[F[_, _], A](F: Arrow[F]) extends Applicative[F[A, ?]] {
+  def pure[B](b: B): F[A, B] = F.lift[A, B](_ => b)
+  override def map[B, C](fb: F[A, B])(f: B => C): F[A, C] = F.rmap(fb)(f)
+  def ap[B, C](ff: F[A, B => C])(fb: F[A, B]): F[A, C] =
+    F.rmap(F.andThen(F.lift((x: A) => (x, x)), F.split(ff, fb)))(tup => tup._1(tup._2))
+  override def product[B, C](fb: F[A, B], fc: F[A, C]): F[A, (B, C)] =
+    F.andThen(F.lift((x: A) => (x, x)), F.split(fb, fc))
 }

--- a/core/src/main/scala/cats/arrow/Arrow.scala
+++ b/core/src/main/scala/cats/arrow/Arrow.scala
@@ -48,25 +48,3 @@ import simulacrum.typeclass
   def split[A, B, C, D](f: F[A, B], g: F[C, D]): F[(A, C), (B, D)] =
     andThen(first(f), second(g))
 }
-object Arrow {
-  /**
-   * Creates a semigroupal functor for `F`, holding domain fixed and combining
-   * over the codomain.
-   *
-   * Example:
-   * {{{
-   * scala> import cats.implicits._
-   * scala> import cats.arrow.Arrow.catsSemigroupalForArrow
-   * scala> val toLong: Int => Long = _.toLong
-   * scala> val double: Int => Int = 2*_
-   * scala> val f: Int => (Long, Int) = catsSemigroupalForArrow.product(toLong, double)
-   * scala> f(3)
-   * res0: (Long, Int) = (3,6)
-   * }}}
-   */
-  implicit def catsSemigroupalForArrow[F[_, _], A](implicit F: Arrow[F]): Semigroupal[F[A, ?]] = new Apply[F[A, ?]] {
-    def map[B, C](fb: F[A, B])(f: B => C): F[A, C] = F.rmap(fb)(f)
-    def ap[B, C](ff: F[A, B => C])(fb: F[A, B]): F[A, C] =
-      F.rmap(F.andThen(F.lift((x: A) => (x, x)), F.split(ff, fb)))(tup => tup._1(tup._2))
-  }
-}

--- a/tests/src/test/scala/cats/tests/FunctionSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctionSuite.scala
@@ -75,6 +75,9 @@ class FunctionSuite extends CatsSuite {
     }
   }
 
+  // Test for Arrow applicative
+  Applicative[String => ?]
+  checkAll("Function1[String, ?]", ApplicativeTests[Function1[String, ?]].applicative [Int, Int, Int])
 
   // serialization tests for the various Function0-related instances
   checkAll("Eq[() => Eqed]", SerializableTests.serializable(Eq[() => Eqed]))

--- a/tests/src/test/scala/cats/tests/FunctionSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctionSuite.scala
@@ -77,7 +77,8 @@ class FunctionSuite extends CatsSuite {
 
   // Test for Arrow applicative
   Applicative[String => ?]
-  checkAll("Function1[String, ?]", ApplicativeTests[Function1[String, ?]].applicative [Int, Int, Int])
+  checkAll("Function1[String, ?]",
+    ApplicativeTests[Function1[String, ?]](Applicative.catsApplicativeForArrow[Function1, String]).applicative[Int, Int, Int])
 
   // serialization tests for the various Function0-related instances
   checkAll("Eq[() => Eqed]", SerializableTests.serializable(Eq[() => Eqed]))


### PR DESCRIPTION
Adds an `Apply` instance as discussed in https://github.com/typelevel/cats/issues/2069
It can be weakened to `Semigroupal` if we don't buy the `Apply`.
Currently, it is implicit. There was discussion in the issue on whether it should be explicit or implicit. Either answer seems reasonable so I wrote the doctest to be compatible with either way people end up preferring.
Do we need additional tests over the doctest?