### PR TITLE
Reduce redundancy in Semigroup and Eq test names

### DIFF
--- a/kernel-laws/src/main/scala/cats/kernel/laws/discipline/EqTests.scala
+++ b/kernel-laws/src/main/scala/cats/kernel/laws/discipline/EqTests.scala
@@ -17,10 +17,10 @@ trait EqTests[A] extends Laws {
     new DefaultRuleSet(
       "eq",
       None,
-      "eq reflexitivity" -> forAll(laws.reflexitivityEq _),
-      "eq symmetry" -> forAll(laws.symmetryEq _),
-      "eq antisymmetry" -> forAll(laws.antiSymmetryEq _),
-      "eq transitivity" -> forAll(laws.transitivityEq _))
+      "reflexitivity" -> forAll(laws.reflexitivityEq _),
+      "symmetry" -> forAll(laws.symmetryEq _),
+      "antisymmetry" -> forAll(laws.antiSymmetryEq _),
+      "transitivity" -> forAll(laws.transitivityEq _))
   }
 }
 

--- a/kernel-laws/src/main/scala/cats/kernel/laws/discipline/SemigroupTests.scala
+++ b/kernel-laws/src/main/scala/cats/kernel/laws/discipline/SemigroupTests.scala
@@ -15,10 +15,10 @@ trait SemigroupTests[A] extends Laws {
     new DefaultRuleSet(
       "semigroup",
       None,
-      "semigroup associative" -> forAll(laws.semigroupAssociative _),
-      "semigroup repeat1" -> forAll(laws.repeat1 _),
-      "semigroup repeat2" -> forAll(laws.repeat2 _),
-      "semigroup combineAllOption" -> forAll(laws.combineAllOption _))
+      "associative" -> forAll(laws.semigroupAssociative _),
+      "repeat1" -> forAll(laws.repeat1 _),
+      "repeat2" -> forAll(laws.repeat2 _),
+      "combineAllOption" -> forAll(laws.combineAllOption _))
 }
 
 object SemigroupTests {


### PR DESCRIPTION
Previously if you ran the `CommutativeSemigroup` tests on a type (`Mean`
in this example) you would see something like:

```
MeanTests:
- Mean.commutativeSemigroup.commutative
- Mean.commutativeSemigroup.semigroup associative
- Mean.commutativeSemigroup.semigroup combineAllOption
- Mean.commutativeSemigroup.semigroup repeat1
- Mean.commutativeSemigroup.semigroup repeat2
```

The extra `semigroup` in the name seems redundant to me, and as far as I
can tell, it's inconsistent with tests for other type classes. `Eq` had
a similar issue.