### PR TITLE
Add Parallel instance for free monad/applicative

### DIFF
--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -334,4 +334,21 @@ sealed private[free] abstract class FreeInstances {
     new FreeTraverse[F] {
       val TraversableF = traversableF
     }
+
+  implicit def catsFreeParallelForFreeFreeApplicative[F[_], G[_]](
+    implicit FG: Parallel[F, G]
+  ): Parallel[Free[F, ?], FreeApplicative[G, ?]] =
+    new Parallel[Free[F, ?], FreeApplicative[G, ?]] {
+      val parallel: Free[F, ?] ~> FreeApplicative[G, ?] =
+        λ[Free[F, ?] ~> FreeApplicative[G, ?]](fa =>
+          FreeApplicative.lift(FG.parallel(fa.runTailRec(FG.monad))))
+
+      val sequential: FreeApplicative[G, ?] ~> Free[F, ?] =
+        λ[FreeApplicative[G, ?] ~> Free[F, ?]](fa =>
+          Free.liftF(FG.sequential(fa.fold(FG.applicative))))
+
+      val applicative: Applicative[FreeApplicative[G, ?]] = implicitly
+
+      val monad: Monad[Free[F, ?]] = implicitly
+    }
 }

--- a/free/src/test/scala/cats/free/FreeApplicativeSuite.scala
+++ b/free/src/test/scala/cats/free/FreeApplicativeSuite.scala
@@ -131,7 +131,7 @@ class FreeApplicativeSuite extends CatsSuite {
 }
 
 object FreeApplicativeSuite {
-  private def freeGen[F[_], A](maxDepth: Int)(implicit F: Arbitrary[F[A]], FF: Arbitrary[(A, A) => A], A: Arbitrary[A]): Gen[FreeApplicative[F, A]] = {
+  private def freeApplicativeGen[F[_], A](maxDepth: Int)(implicit F: Arbitrary[F[A]], FF: Arbitrary[(A, A) => A], A: Arbitrary[A]): Gen[FreeApplicative[F, A]] = {
     val noFlatMapped = Gen.oneOf(
       A.arbitrary.map(FreeApplicative.pure[F, A]),
       F.arbitrary.map(FreeApplicative.lift[F, A]))
@@ -142,16 +142,16 @@ object FreeApplicativeSuite {
       fDepth <- nextDepth
       freeDepth <- nextDepth
       ff <- FF.arbitrary
-      f <- freeGen[F, A](fDepth).map(_.map(l => (u: A) => ff(l, u)))
-      freeFA <- freeGen[F, A](freeDepth)
+      f <- freeApplicativeGen[F, A](fDepth).map(_.map(l => (u: A) => ff(l, u)))
+      freeFA <- freeApplicativeGen[F, A](freeDepth)
     } yield freeFA.ap(f)
 
     if (maxDepth <= 1) noFlatMapped
     else Gen.oneOf(noFlatMapped, withFlatMapped)
   }
 
-  implicit def freeArbitrary[F[_], A](implicit F: Arbitrary[F[A]], FF: Arbitrary[(A, A) => A], A: Arbitrary[A]): Arbitrary[FreeApplicative[F, A]] =
-    Arbitrary(freeGen[F, A](4))
+  implicit def freeApplicativeArbitrary[F[_], A](implicit F: Arbitrary[F[A]], FF: Arbitrary[(A, A) => A], A: Arbitrary[A]): Arbitrary[FreeApplicative[F, A]] =
+    Arbitrary(freeApplicativeGen[F, A](4))
 
   implicit def freeApplicativeEq[S[_]: Applicative, A](implicit SA: Eq[S[A]]): Eq[FreeApplicative[S, A]] =
     new Eq[FreeApplicative[S, A]] {

--- a/free/src/test/scala/cats/free/FreeSuite.scala
+++ b/free/src/test/scala/cats/free/FreeSuite.scala
@@ -2,9 +2,9 @@ package cats
 package free
 
 import cats.arrow.FunctionK
-import cats.data.EitherK
-import cats.laws.discipline.{SemigroupalTests, FoldableTests, MonadTests, SerializableTests, TraverseTests}
-import cats.laws.discipline.arbitrary.catsLawsArbitraryForFn0
+import cats.data.{EitherK, Validated}
+import cats.laws.discipline.{ParallelTests, SemigroupalTests, FoldableTests, MonadTests, SerializableTests, TraverseTests}
+import cats.laws.discipline.arbitrary._
 import cats.tests.CatsSuite
 
 import org.scalacheck.{Arbitrary, Gen, Cogen}
@@ -12,11 +12,15 @@ import Arbitrary.arbFunction1
 
 class FreeSuite extends CatsSuite {
   import FreeSuite._
+  import FreeApplicativeSuite._
 
   implicit val iso = SemigroupalTests.Isomorphisms.invariant[Free[Option, ?]]
 
   checkAll("Free[Option, ?]", MonadTests[Free[Option, ?]].monad[Int, Int, Int])
   checkAll("Monad[Free[Option, ?]]", SerializableTests.serializable(Monad[Free[Option, ?]]))
+
+  checkAll("Free[Either[String, ?], ?], FreeApplicative[Validated[String, ?], ?]", ParallelTests[Free[Either[String, ?], ?], FreeApplicative[Validated[String, ?], ?]].parallel[Int, String])
+  checkAll("Parallel[Free[Either[String, ?], ?], FreeApplicative[Validated[String, ?], ?]]", SerializableTests.serializable(Parallel[Free[Either[String, ?], ?], FreeApplicative[Validated[String, ?], ?]]))
 
   locally {
     implicit val instance = Free.catsFreeFoldableForFree[Option]


### PR DESCRIPTION
This implementation feels a little counter to the usual FP paradigm, as
to convert between`Free[M, ?]` and `FreeApplicative[F, ?]`, you "run"
(`runTailRec`/`fold`) to get an `M`/`A` and then lift it into the
appropriate type. Usually you just transform the free structure until
you are ready to run it at the end of the day. However, here I think
that you need to do this so that the `F` instances are combined with the
`Applicative[F]` `ap` instead of being translated to `Free[M, ?]`
structures that would then be combined with `M`'s sequential `ap`. My
first attempt at this was less eager with calling `fold`/`runTailRec`
and violated the parallel laws.

I _think_ that this implementation is legitimate, but someone else may
know better.

Even if this is legitimate, I don't know if it's all that _useful_. It
works for working with `Free[Either[A, ?], ?]` and `Free[Validation[A,
?], ?]`. But often people use `Free` for something like `Free[MyDsl,
?]`, and they probably won't have a `Parallel` instance for `MyDsl`. I
thought that I would throw this out into the world to see whether or not
anyone else thought that it was useful.