### PR TITLE
Test that Vector's traverse short-circuits

### DIFF
--- a/tests/src/test/scala/cats/tests/RegressionSuite.scala
+++ b/tests/src/test/scala/cats/tests/RegressionSuite.scala
@@ -113,7 +113,16 @@ class RegressionSuite extends CatsSuite {
     NonEmptyList.of(6,8).traverse(validate) should === (Either.left("6 is greater than 5"))
     checkAndResetCount(1)
 
+    Vector(1,2,6,8).traverse(validate) should === (Either.left("6 is greater than 5"))
+    checkAndResetCount(3)
+
     List(1,2,6,8).traverse_(validate) should === (Either.left("6 is greater than 5"))
+    checkAndResetCount(3)
+
+    Stream(1,2,6,8).traverse_(validate) should === (Either.left("6 is greater than 5"))
+    checkAndResetCount(3)
+
+    Vector(1,2,6,8).traverse_(validate) should === (Either.left("6 is greater than 5"))
     checkAndResetCount(3)
 
     NonEmptyList.of(1,2,6,7,8).traverse_(validate) should === (Either.left("6 is greater than 5"))


### PR DESCRIPTION
This adds a test case that the `traverse` implementation for `Vector`
short-circuits the traversal when possible. This would have failed the build
in #2091.

See #1015 for when similar tests were added for similar structures.