### PR TITLE
Add a CommutativeMonoid for Map

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -334,7 +334,8 @@ def mimaSettings(moduleName: String) = Seq(
       exclude[InheritedNewAbstractMethodProblem]("cats.instances.Function0Instances0.function0Distributive"),
       exclude[InheritedNewAbstractMethodProblem]("cats.instances.Function1Instances0.catsStdDistributiveForFunction1"),
       exclude[InheritedNewAbstractMethodProblem]("cats.instances.Function1Instances0.catsStdDistributiveForFunction1"),
-      exclude[InheritedNewAbstractMethodProblem]("cats.instances.Function1Instances0.catsStdDistributiveForFunction1")
+      exclude[InheritedNewAbstractMethodProblem]("cats.instances.Function1Instances0.catsStdDistributiveForFunction1"),
+      exclude[ReversedMissingMethodProblem]("cats.kernel.instances.MapInstances.catsKernelStdCommutativeMonoidForMap")
     )
   }
 )

--- a/kernel-laws/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -153,8 +153,8 @@ class Tests extends FunSuite with Discipline {
   checkAll("Monoid[Stream[Int]]", SerializableTests.serializable(Monoid[Stream[Int]]))
   checkAll("Monoid[List[String]]", MonoidTests[List[String]].monoid)
   checkAll("Monoid[List[String]]", SerializableTests.serializable(Monoid[List[String]]))
-  checkAll("Monoid[Map[String, Int]]", MonoidTests[Map[String, Int]].monoid)
-  checkAll("Monoid[Map[String, Int]]", SerializableTests.serializable(Monoid[Map[String, Int]]))
+  checkAll("Monoid[Map[String, String]]", MonoidTests[Map[String, String]].monoid)
+  checkAll("Monoid[Map[String, String]]", SerializableTests.serializable(Monoid[Map[String, String]]))
   checkAll("Monoid[Queue[Int]]", MonoidTests[Queue[Int]].monoid)
   checkAll("Monoid[Queue[Int]]", SerializableTests.serializable(Monoid[Queue[Int]]))
 

--- a/kernel-laws/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -158,6 +158,9 @@ class Tests extends FunSuite with Discipline {
   checkAll("Monoid[Queue[Int]]", MonoidTests[Queue[Int]].monoid)
   checkAll("Monoid[Queue[Int]]", SerializableTests.serializable(Monoid[Queue[Int]]))
 
+  checkAll("CommutativeMonoid[Map[String, Int]]", CommutativeMonoidTests[Map[String, Int]].commutativeMonoid)
+  checkAll("CommutativeMonoid[Map[String, Int]]", SerializableTests.serializable(CommutativeMonoid[Map[String, Int]]))
+
   checkAll("BoundedSemilattice[BitSet]", BoundedSemilatticeTests[BitSet].boundedSemilattice)
   checkAll("BoundedSemilattice[BitSet]", SerializableTests.serializable(BoundedSemilattice[BitSet]))
   checkAll("BoundedSemilattice[Set[Int]]", BoundedSemilatticeTests[Set[Int]].boundedSemilattice)

--- a/kernel/src/main/scala/cats/kernel/instances/map.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/map.scala
@@ -8,6 +8,9 @@ package object map extends MapInstances
 trait MapInstances extends MapInstances1 {
   implicit def catsKernelStdHashForMap[K: Hash, V: Hash]: Hash[Map[K, V]] =
     new MapHash[K, V]
+
+  implicit def catsKernelStdCommutativeMonoidForMap[K, V: CommutativeSemigroup]: CommutativeMonoid[Map[K, V]] =
+    new MapMonoid[K, V] with CommutativeMonoid[Map[K, V]]
 }
 
 trait MapInstances1 {


### PR DESCRIPTION
Since we already have a `Monoid` instance for `Map`, it seems natural to
have a `CommutativeMonoid` when the value type has a commutative
semigroup.

Note: Unfortunately, I believe that this is a binary-incompatible change in cats kernel. cc @johnynek