### PR TITLE
Add comparison method in Order companion object

### DIFF
--- a/kernel/src/main/scala/cats/kernel/Order.scala
+++ b/kernel/src/main/scala/cats/kernel/Order.scala
@@ -103,6 +103,9 @@ abstract class OrderFunctions[O[T] <: Order[T]] extends PartialOrderFunctions[O]
 
   def max[@sp A](x: A, y: A)(implicit ev: O[A]): A =
     ev.max(x, y)
+
+  def comparison[@sp A](x: A, y: A)(implicit ev: O[A]): Comparison =
+    ev.comparison(x, y)
 }
 
 trait OrderToOrderingConversion {

--- a/tests/src/test/scala/cats/tests/OrderSuite.scala
+++ b/tests/src/test/scala/cats/tests/OrderSuite.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-
+import Helpers.Ord
 import cats.kernel.laws.discipline.OrderTests
 
 class OrderSuite extends CatsSuite {
@@ -15,6 +15,25 @@ class OrderSuite extends CatsSuite {
   checkAll("Double", OrderTests[Double].order)
   checkAll("Float", OrderTests[Float].order)
   checkAll("Long", OrderTests[Long].order)
+
+  test("order ops syntax"){
+    forAll { (i: Ord, j: Ord) =>
+      (i compare j) should ===(Order.compare(i, j))
+      (i min j) should ===(Order.min(i, j))
+      (i max j) should === (Order.max(i, j))
+      (i comparison j) should ===(Order.comparison(i, j))
+
+      // partial order syntax should also work when an Order instance exists
+      (i > j) should ===(PartialOrder.gt(i, j))
+      (i >= j) should ===(PartialOrder.gteqv(i, j))
+      (i < j) should ===(PartialOrder.lt(i, j))
+      (i <= j) should ===(PartialOrder.lteqv(i, j))
+      (i partialCompare j) should ===(PartialOrder.partialCompare(i, j))
+      (i tryCompare j) should ===(PartialOrder.tryCompare(i, j))
+      (i pmin j) should ===(PartialOrder.pmin(i, j))
+      (i pmax j) should ===(PartialOrder.pmax(i, j))
+    }
+  }
 }
 
 object OrderSuite {

--- a/tests/src/test/scala/cats/tests/PartialOrderSuite.scala
+++ b/tests/src/test/scala/cats/tests/PartialOrderSuite.scala
@@ -2,8 +2,18 @@ package cats
 package tests
 
 import Helpers.POrd
+import org.scalatest.Assertion
 
 class PartialOrderSuite extends CatsSuite {
+
+  /**
+   * Check that two partial compare results are "the same".
+   * This works around the fact that `NaN` is not equal to itself.
+   */
+  def checkPartialCompare(res1: Double, res2: Double): Assertion = {
+    (res1 == res2 || (res1.isNaN && res2.isNaN)) should ===(true)
+  }
+
   {
     Invariant[PartialOrder]
     Contravariant[PartialOrder]
@@ -11,7 +21,7 @@ class PartialOrderSuite extends CatsSuite {
 
   test("companion object syntax") {
     forAll { (i: Int, j: Int) =>
-      PartialOrder.partialCompare(i, j) should ===(catsKernelStdOrderForInt.partialCompare(i, j))
+      checkPartialCompare(PartialOrder.partialCompare(i, j), catsKernelStdOrderForInt.partialCompare(i, j))
       PartialOrder.tryCompare(i, j) should ===(catsKernelStdOrderForInt.tryCompare(i, j))
       PartialOrder.pmin(i, j) should ===(catsKernelStdOrderForInt.pmin(i, j))
       PartialOrder.pmax(i, j) should ===(catsKernelStdOrderForInt.pmax(i, j))
@@ -29,7 +39,7 @@ class PartialOrderSuite extends CatsSuite {
       (i < j) should ===(PartialOrder.lt(i, j))
       (i <= j) should ===(PartialOrder.lteqv(i, j))
 
-      (i partialCompare j) should ===(PartialOrder.partialCompare(i, j))
+      checkPartialCompare(i partialCompare j, PartialOrder.partialCompare(i, j))
       (i tryCompare j) should ===(PartialOrder.tryCompare(i, j))
       (i pmin j) should ===(PartialOrder.pmin(i, j))
       (i pmax j) should ===(PartialOrder.pmax(i, j))

--- a/tests/src/test/scala/cats/tests/PartialOrderSuite.scala
+++ b/tests/src/test/scala/cats/tests/PartialOrderSuite.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-
+import Helpers.POrd
 
 class PartialOrderSuite extends CatsSuite {
   {
@@ -19,6 +19,20 @@ class PartialOrderSuite extends CatsSuite {
       PartialOrder.lt(i, j) should ===(catsKernelStdOrderForInt.lt(i, j))
       PartialOrder.gteqv(i, j) should ===(catsKernelStdOrderForInt.gteqv(i, j))
       PartialOrder.gt(i, j) should ===(catsKernelStdOrderForInt.gt(i, j))
+    }
+  }
+
+  test("partial order ops syntax") {
+    forAll { (i: POrd, j: POrd) =>
+      (i > j) should ===(PartialOrder.gt(i, j))
+      (i >= j) should ===(PartialOrder.gteqv(i, j))
+      (i < j) should ===(PartialOrder.lt(i, j))
+      (i <= j) should ===(PartialOrder.lteqv(i, j))
+
+      (i partialCompare j) should ===(PartialOrder.partialCompare(i, j))
+      (i tryCompare j) should ===(PartialOrder.tryCompare(i, j))
+      (i pmin j) should ===(PartialOrder.pmin(i, j))
+      (i pmax j) should ===(PartialOrder.pmax(i, j))
     }
   }
 }


### PR DESCRIPTION
The main goal of this PR was to add syntax tests for the `Order` and
`PartialOrder` syntax (provided via machinist ops) to address [this comment](https://github.com/typelevel/cats/pull/1867#discussion_r138765045).

In the process I noticed that the Order companion object didn't have a
`comparison` function to forward through to the type class instance like
it did for other methods, so I added that.

I did notice that the `Order`/`PartialOrder` syntax does work whether or
not you take the `Order`/`PartialOrder` instances as implicit parameters
to the ops classes. I think that only @non understands quite what's
going on with the machinist syntax macros, so I didn't make the changes
to take away those implicit parameters without knowing the implications.
The tests pass either way, so I think that end-code should work for
users either way.