### PR TITLE
Make instances of `Kleisli` interchangeable with functions

### DIFF
--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -7,7 +7,8 @@ import cats.arrow._
 /**
  * Represents a function `A => F[B]`.
  */
-final case class Kleisli[F[_], A, B](run: A => F[B]) { self =>
+final case class Kleisli[F[_], A, B](run: A => F[B])
+  extends (A => F[B]) { self =>
 
   def ap[C](f: Kleisli[F, A, B => C])(implicit F: Apply[F]): Kleisli[F, A, C] =
     Kleisli(a => F.ap(f.run(a))(run(a)))
@@ -77,7 +78,7 @@ final case class Kleisli[F[_], A, B](run: A => F[B]) { self =>
 
   def toReader: Reader[A, F[B]] = Kleisli[Id, A, F[B]](run)
 
-  def apply(a: A): F[B] = run(a)
+  override def apply(a: A): F[B] = run(a)
 }
 
 object Kleisli extends KleisliInstances with KleisliFunctions with KleisliExplicitInstances


### PR DESCRIPTION
`Kleisli[F[_], A, B]` holds a function `A => F[B]`, and has an `apply` method, which means it can be used as a function:

```scala
val nonZero = Kleisli[Option, Int, Int](a => if (a != 0) Some(a) else None)

nonZero(0) // None
nonZero(1) // Some(1)
```

However, it can't be passed to another function that expects a function:

```scala
def runOne(f: Int => Option[Int]): Option[Int] = f(1)

runOne(nonZero) // Does not compile
```

By changing `Kleisli` to extend `A => F[B]`, the example above should work as expected