### PR TITLE
CommutativeMonad for Eval

### DIFF
--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -375,8 +375,8 @@ object Eval extends EvalInstances {
 
 private[cats] sealed abstract class EvalInstances extends EvalInstances0 {
 
-  implicit val catsBimonadForEval: Bimonad[Eval] =
-    new Bimonad[Eval] with StackSafeMonad[Eval] {
+  implicit val catsBimonadForEval: Bimonad[Eval] with CommutativeMonad[Eval] =
+    new Bimonad[Eval] with StackSafeMonad[Eval] with CommutativeMonad[Eval] {
       override def map[A, B](fa: Eval[A])(f: A => B): Eval[B] = fa.map(f)
       def pure[A](a: A): Eval[A] = Now(a)
       def flatMap[A, B](fa: Eval[A])(f: A => Eval[B]): Eval[B] = fa.flatMap(f)

--- a/tests/src/test/scala/cats/tests/EvalSuite.scala
+++ b/tests/src/test/scala/cats/tests/EvalSuite.scala
@@ -2,7 +2,7 @@ package cats
 package tests
 
 import cats.laws.ComonadLaws
-import cats.laws.discipline.{BimonadTests, SemigroupalTests, ReducibleTests, SerializableTests}
+import cats.laws.discipline.{BimonadTests, CommutativeMonadTests, SemigroupalTests, ReducibleTests, SerializableTests}
 import cats.laws.discipline.arbitrary._
 import cats.kernel.laws.discipline.{EqTests, GroupTests, MonoidTests, OrderTests, PartialOrderTests, SemigroupTests}
 import org.scalacheck.{Arbitrary, Cogen, Gen}
@@ -92,6 +92,9 @@ class EvalSuite extends CatsSuite {
     implicit val iso = SemigroupalTests.Isomorphisms.invariant[Eval]
     checkAll("Eval[Int]", BimonadTests[Eval].bimonad[Int, Int, Int])
   }
+
+  checkAll("Eval[Int]", CommutativeMonadTests[Eval].commutativeMonad[Int, Int, Int])
+  checkAll("CommutativeMonad[Eval]", SerializableTests.serializable(CommutativeMonad[Eval]))
 
   checkAll("Bimonad[Eval]", SerializableTests.serializable(Bimonad[Eval]))
 


### PR DESCRIPTION
I believe (and the law tests seem to agree) that the existing monad
instance for `Eval` is a valid `CommutativeMonad`, so we might as well
expose it as one.