### PR TITLE
conversion `PartialOrder` to `PartialOrdering` and `Hash` to `Hashing`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -394,7 +394,8 @@ def mimaSettings(moduleName: String) = Seq(
       exclude[IncompatibleResultTypeProblem]("cats.data.KleisliInstances0.catsDataMonadForKleisliId"),
       exclude[InheritedNewAbstractMethodProblem]("cats.kernel.PartialOrderToPartialOrderingConversion.catsKernelPartialOrderingForPartialOrder"),
       exclude[InheritedNewAbstractMethodProblem]("cats.kernel.EqToEquivConversion.catsKernelEquivForEq"),
-      exclude[InheritedNewAbstractMethodProblem]("cats.kernel.OrderToOrderingConversion.catsKernelOrderingForOrder")
+      exclude[InheritedNewAbstractMethodProblem]("cats.kernel.OrderToOrderingConversion.catsKernelOrderingForOrder"),
+      exclude[InheritedNewAbstractMethodProblem]("cats.kernel.HashToHashingConversion.catsKernelHashToHashing")
     )
   }
 )

--- a/build.sbt
+++ b/build.sbt
@@ -391,7 +391,11 @@ def mimaSettings(moduleName: String) = Seq(
       exclude[InheritedNewAbstractMethodProblem]("cats.instances.Function1Instances0.catsStdDistributiveForFunction1"),
       exclude[InheritedNewAbstractMethodProblem]("cats.instances.Function1Instances0.catsStdDistributiveForFunction1"),
       exclude[ReversedMissingMethodProblem]("cats.kernel.instances.MapInstances.catsKernelStdCommutativeMonoidForMap"),
-      exclude[IncompatibleResultTypeProblem]("cats.data.KleisliInstances0.catsDataMonadForKleisliId")
+      exclude[IncompatibleResultTypeProblem]("cats.data.KleisliInstances0.catsDataMonadForKleisliId"),
+      exclude[InheritedNewAbstractMethodProblem]("cats.kernel.PartialOrderToPartialOrderingConversion.catsKernelPartialOrderingForPartialOrder"),
+      exclude[InheritedNewAbstractMethodProblem]("cats.kernel.HashToHashingConversion.catsKernelHashToHashing"),
+      exclude[InheritedNewAbstractMethodProblem]("cats.kernel.PartialOrderToPartialOrderingConversion.catsKernelPartialOrderingForPartialOrder"),
+      exclude[InheritedNewAbstractMethodProblem]("cats.kernel.HashToHashingConversion.catsKernelHashToHashing")
     )
   }
 )

--- a/build.sbt
+++ b/build.sbt
@@ -393,9 +393,8 @@ def mimaSettings(moduleName: String) = Seq(
       exclude[ReversedMissingMethodProblem]("cats.kernel.instances.MapInstances.catsKernelStdCommutativeMonoidForMap"),
       exclude[IncompatibleResultTypeProblem]("cats.data.KleisliInstances0.catsDataMonadForKleisliId"),
       exclude[InheritedNewAbstractMethodProblem]("cats.kernel.PartialOrderToPartialOrderingConversion.catsKernelPartialOrderingForPartialOrder"),
-      exclude[InheritedNewAbstractMethodProblem]("cats.kernel.HashToHashingConversion.catsKernelHashToHashing"),
-      exclude[InheritedNewAbstractMethodProblem]("cats.kernel.PartialOrderToPartialOrderingConversion.catsKernelPartialOrderingForPartialOrder"),
-      exclude[InheritedNewAbstractMethodProblem]("cats.kernel.HashToHashingConversion.catsKernelHashToHashing")
+      exclude[InheritedNewAbstractMethodProblem]("cats.kernel.EqToEquivConversion.catsKernelEquivForEq"),
+      exclude[InheritedNewAbstractMethodProblem]("cats.kernel.OrderToOrderingConversion.catsKernelOrderingForOrder")
     )
   }
 )

--- a/core/src/main/scala/cats/instances/eq.scala
+++ b/core/src/main/scala/cats/instances/eq.scala
@@ -1,7 +1,7 @@
 package cats
 package instances
 
-trait EqInstances {
+trait EqInstances extends kernel.instances.EqInstances {
   implicit val catsContravariantMonoidalForEq: ContravariantMonoidal[Eq] =
     new ContravariantMonoidal[Eq] {
       /**

--- a/core/src/main/scala/cats/instances/hash.scala
+++ b/core/src/main/scala/cats/instances/hash.scala
@@ -2,7 +2,7 @@ package cats
 package instances
 
 
-trait HashInstances {
+trait HashInstances extends kernel.instances.HashInstances {
 
   implicit val catsContravariantForHash: Contravariant[Hash] =
     new Contravariant[Hash] {

--- a/core/src/main/scala/cats/instances/hash.scala
+++ b/core/src/main/scala/cats/instances/hash.scala
@@ -2,7 +2,7 @@ package cats
 package instances
 
 
-trait HashInstances extends kernel.HashToHashingConversion {
+trait HashInstances {
 
   implicit val catsContravariantForHash: Contravariant[Hash] =
     new Contravariant[Hash] {

--- a/core/src/main/scala/cats/instances/hash.scala
+++ b/core/src/main/scala/cats/instances/hash.scala
@@ -2,7 +2,7 @@ package cats
 package instances
 
 
-trait HashInstances {
+trait HashInstances extends kernel.HashToHashingConversion {
 
   implicit val catsContravariantForHash: Contravariant[Hash] =
     new Contravariant[Hash] {

--- a/core/src/main/scala/cats/instances/order.scala
+++ b/core/src/main/scala/cats/instances/order.scala
@@ -1,7 +1,7 @@
 package cats
 package instances
 
-trait OrderInstances extends cats.kernel.OrderToOrderingConversion {
+trait OrderInstances extends kernel.instances.OrderInstances {
   implicit val catsContravariantMonoidalForOrder: ContravariantMonoidal[Order] =
     new ContravariantMonoidal[Order] {
       /**

--- a/core/src/main/scala/cats/instances/partialOrder.scala
+++ b/core/src/main/scala/cats/instances/partialOrder.scala
@@ -1,7 +1,7 @@
 package cats
 package instances
 
-trait PartialOrderInstances {
+trait PartialOrderInstances extends kernel.instances.PartialOrderInstances {
   implicit val catsContravariantSemigroupalForPartialOrder: ContravariantSemigroupal[PartialOrder] =
     new ContravariantSemigroupal[PartialOrder] {
       /** Derive a `PartialOrder` for `B` given a `PartialOrder[A]` and a function `B => A`.

--- a/core/src/main/scala/cats/instances/partialOrdering.scala
+++ b/core/src/main/scala/cats/instances/partialOrdering.scala
@@ -1,7 +1,7 @@
 package cats
 package instances
 
-trait PartialOrderingInstances extends kernel.PartialOrderToPartialOrderingConversion {
+trait PartialOrderingInstances {
   implicit val catsContravariantSemigroupalForPartialOrdering: ContravariantSemigroupal[PartialOrdering] =
     new ContravariantSemigroupal[PartialOrdering] {
       /** Derive a `PartialOrdering` for `B` given a `PartialOrdering[A]` and a function `B => A`.

--- a/core/src/main/scala/cats/instances/partialOrdering.scala
+++ b/core/src/main/scala/cats/instances/partialOrdering.scala
@@ -1,7 +1,7 @@
 package cats
 package instances
 
-trait PartialOrderingInstances {
+trait PartialOrderingInstances extends kernel.PartialOrderToPartialOrderingConversion {
   implicit val catsContravariantSemigroupalForPartialOrdering: ContravariantSemigroupal[PartialOrdering] =
     new ContravariantSemigroupal[PartialOrdering] {
       /** Derive a `PartialOrdering` for `B` given a `PartialOrdering[A]` and a function `B => A`.

--- a/kernel-laws/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -243,6 +243,21 @@ class Tests extends FunSuite with Discipline {
 
   checkAll("subsetPartialOrder[Int]", PartialOrderTests(subsetPartialOrder[Int]).partialOrder)
 
+  {
+    implicit def subsetPartialOrdering[A]: PartialOrdering[Set[A]] = new PartialOrdering[Set[A]] {
+
+      override def tryCompare(x: Set[A], y: Set[A]): Option[Int] = {
+        if (x == y) Some(0)
+        else if (x subsetOf y) Some(-1)
+        else if (y subsetOf x) Some(1)
+        else None
+      }
+
+      override def lteq(x: Set[A], y: Set[A]): Boolean = (x subsetOf y) || (x == y)
+    }
+    checkAll("fromPartialOrdering[Int]", PartialOrderTests(PartialOrder.fromPartialOrdering[Set[Int]]).partialOrder)
+  }
+
   implicit val arbitraryComparison: Arbitrary[Comparison] =
     Arbitrary(Gen.oneOf(Comparison.GreaterThan, Comparison.EqualTo, Comparison.LessThan))
 

--- a/kernel/src/main/scala/cats/kernel/Eq.scala
+++ b/kernel/src/main/scala/cats/kernel/Eq.scala
@@ -32,7 +32,17 @@ abstract class EqFunctions[E[T] <: Eq[T]] {
 
 }
 
-object Eq extends EqFunctions[Eq] {
+trait EqToEquivConversion {
+  /**
+   * Implicitly derive a `scala.math.Equiv[A]` from a `Eq[A]`
+   * instance.
+   */
+  implicit def catsKernelEquivForEq[A](implicit ev: Eq[A]): Equiv[A] = new Equiv[A] {
+    def equiv(a: A, b: A) = ev.eqv(a, b)
+  }
+}
+
+object Eq extends EqFunctions[Eq] with EqToEquivConversion {
 
   /**
    * Access an implicit `Eq[A]`.
@@ -66,13 +76,6 @@ object Eq extends EqFunctions[Eq] {
       def eqv(x: A, y: A) = eq1.eqv(x, y) || eq2.eqv(x, y)
     }
 
-  /**
-   * This gives compatibility with scala's Equiv trait
-   */
-  implicit def catsKernelEquivForEq[A](implicit ev: Eq[A]): Equiv[A] =
-    new Equiv[A] {
-      def equiv(a: A, b: A) = ev.eqv(a, b)
-    }
 
   /**
    * Create an `Eq` instance from an `eqv` implementation.

--- a/kernel/src/main/scala/cats/kernel/Hash.scala
+++ b/kernel/src/main/scala/cats/kernel/Hash.scala
@@ -54,9 +54,3 @@ object Hash extends HashFunctions[Hash] {
     }
 
 }
-
-trait HashToHashingConversion {
-  implicit def catsKernelHashToHashing[A](implicit ev: Hash[A]): Hashing[A] = new Hashing[A] {
-    override def hash(x: A): Int = ev.hash(x)
-  }
-}

--- a/kernel/src/main/scala/cats/kernel/Hash.scala
+++ b/kernel/src/main/scala/cats/kernel/Hash.scala
@@ -54,3 +54,9 @@ object Hash extends HashFunctions[Hash] {
     }
 
 }
+
+trait HashToHashingConversion {
+  implicit def catsKernelHashToHashing[A](implicit ev: Hash[A]): Hashing[A] = new Hashing[A] {
+    override def hash(x: A): Int = ev.hash(x)
+  }
+}

--- a/kernel/src/main/scala/cats/kernel/Order.scala
+++ b/kernel/src/main/scala/cats/kernel/Order.scala
@@ -112,9 +112,10 @@ trait OrderToOrderingConversion {
    */
   implicit def catsKernelOrderingForOrder[A](implicit ev: Order[A]): Ordering[A] =
     ev.toOrdering
+
 }
 
-object Order extends OrderFunctions[Order] {
+object Order extends OrderFunctions[Order] with OrderToOrderingConversion {
   /**
    * Access an implicit `Order[A]`.
    */
@@ -160,13 +161,6 @@ object Order extends OrderFunctions[Order] {
     new Order[A] {
       def compare(x: A, y: A) = f(x, y)
     }
-
-  /**
-   * Implicitly convert a `Order[A]` to a `scala.math.Ordering[A]`
-   * instance.
-   */
-  implicit def catsKernelOrderingForOrder[A](implicit ev: Order[A]): Ordering[A] =
-    ev.toOrdering
 
   /**
    * An `Order` instance that considers all `A` instances to be equal.

--- a/kernel/src/main/scala/cats/kernel/PartialOrder.scala
+++ b/kernel/src/main/scala/cats/kernel/PartialOrder.scala
@@ -123,7 +123,7 @@ abstract class PartialOrderFunctions[P[T] <: PartialOrder[T]] extends EqFunction
     ev.gt(x, y)
 }
 
-object PartialOrder extends PartialOrderFunctions[PartialOrder] {
+object PartialOrder extends PartialOrderFunctions[PartialOrder] with PartialOrderToPartialOrderingConversion {
   /**
    * Access an implicit `PartialOrder[A]`.
    */
@@ -154,10 +154,10 @@ object PartialOrder extends PartialOrderFunctions[PartialOrder] {
       def partialCompare(x: A, y: A) = f(x, y)
     }
 
-  /**
-   * Implicitly convert a `PartialOrder[A]` to a
-   * `scala.math.PartialOrdering[A]` instance.
-   */
+}
+
+
+trait PartialOrderToPartialOrderingConversion {
   implicit def catsKernelPartialOrderingForPartialOrder[A](implicit ev: PartialOrder[A]): PartialOrdering[A] =
     new PartialOrdering[A] {
       def tryCompare(x: A, y: A): Option[Int] = ev.tryCompare(x, y)

--- a/kernel/src/main/scala/cats/kernel/PartialOrder.scala
+++ b/kernel/src/main/scala/cats/kernel/PartialOrder.scala
@@ -154,8 +154,9 @@ object PartialOrder extends PartialOrderFunctions[PartialOrder] with PartialOrde
       def partialCompare(x: A, y: A) = f(x, y)
     }
 
-  def fromPartialOrdering[A](implicit ev: PartialOrdering[A]): PartialOrder[A] = from[A] { (a, b) =>
-    ev.tryCompare(a, b).fold(Double.NaN)(_.toDouble)
+  def fromPartialOrdering[A](implicit ev: PartialOrdering[A]): PartialOrder[A] = new PartialOrder[A] {
+    def partialCompare(x: A, y: A): Double =
+      ev.tryCompare(x, y).fold(Double.NaN)(_.toDouble)
   }
 }
 

--- a/kernel/src/main/scala/cats/kernel/PartialOrder.scala
+++ b/kernel/src/main/scala/cats/kernel/PartialOrder.scala
@@ -154,6 +154,9 @@ object PartialOrder extends PartialOrderFunctions[PartialOrder] with PartialOrde
       def partialCompare(x: A, y: A) = f(x, y)
     }
 
+  def fromPartialOrdering[A](implicit ev: PartialOrdering[A]): PartialOrder[A] = from[A] { (a, b) =>
+    ev.tryCompare(a, b).fold(Double.NaN)(_.toDouble)
+  }
 }
 
 

--- a/kernel/src/main/scala/cats/kernel/instances/all.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/all.scala
@@ -11,6 +11,7 @@ trait AllInstances
     with ByteInstances
     with CharInstances
     with DoubleInstances
+    with EqInstances
     with EitherInstances
     with DurationInstances
     with FloatInstances
@@ -20,6 +21,8 @@ trait AllInstances
     with LongInstances
     with MapInstances
     with OptionInstances
+    with OrderInstances
+    with PartialOrderInstances
     with QueueInstances
     with SetInstances
     with ShortInstances

--- a/kernel/src/main/scala/cats/kernel/instances/all.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/all.scala
@@ -16,6 +16,7 @@ trait AllInstances
     with DurationInstances
     with FloatInstances
     with FunctionInstances
+    with HashInstances
     with IntInstances
     with ListInstances
     with LongInstances

--- a/kernel/src/main/scala/cats/kernel/instances/eq.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/eq.scala
@@ -1,0 +1,6 @@
+package cats.kernel
+package instances
+
+trait EqInstances extends EqToEquivConversion
+
+object eq extends EqInstances

--- a/kernel/src/main/scala/cats/kernel/instances/hash.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/hash.scala
@@ -1,0 +1,6 @@
+package cats.kernel
+package instances
+
+trait HashInstances extends HashToHashingConversion
+
+object hash extends HashInstances

--- a/kernel/src/main/scala/cats/kernel/instances/order.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/order.scala
@@ -1,0 +1,6 @@
+package cats.kernel
+package instances
+
+trait OrderInstances extends OrderToOrderingConversion
+
+object order extends OrderInstances

--- a/kernel/src/main/scala/cats/kernel/instances/partialOrder.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/partialOrder.scala
@@ -1,0 +1,6 @@
+package cats.kernel
+package instances
+
+trait PartialOrderInstances extends PartialOrderToPartialOrderingConversion
+
+object partialOrder extends PartialOrderInstances


### PR DESCRIPTION
To address some items in #2093
Note that this code change is binary compatible in kernel  (I tested Mima without any of the exceptions I added) but not binary compatible in core. 