### PR TITLE
Fixed a typo in the ScalaDoc for the combine method (Semigroup)

### DIFF
--- a/kernel/src/main/scala/cats/kernel/Semigroup.scala
+++ b/kernel/src/main/scala/cats/kernel/Semigroup.scala
@@ -9,7 +9,7 @@ import scala.annotation.tailrec
 trait Semigroup[@sp(Int, Long, Float, Double) A] extends Any with Serializable {
 
   /**
-   * Associative operation taking which combines two values.
+   * Associative operation which combines two values.
    */
   def combine(x: A, y: A): A
 


### PR DESCRIPTION
Fixed a typo in the ScalaDoc for the `combine` method of `Semigroup`.