### PR TITLE
try new travis settings to address memory issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ sudo: required
 
 dist: trusty
 
-group: edge
+group: deprecated-2017Q4
 
 git:
   depth: 9999


### PR DESCRIPTION
recently build has become unstable, see errors below. I suspect it's caused by [this change from travis](https://blog.travis-ci.com/2017-12-12-new-trusty-images-q4-launch)
> Java HotSpot(TM) 64-Bit Server VM warning: INFO: os::commit_memory(0x000000079f465000, 549040128, 0) failed; error='Cannot allocate memory' (errno=12)
There is insufficient memory for the Java Runtime Environment to continue.
Native memory allocation (mmap) failed to map 549040128 bytes for committing reserved memory.
anyone happen to have some advice on a solution


> /usr/local/bin/sbt: line 219:  6051 Killed                  "$@" < /dev/null
restoring stty: 500:5:bf:8a3b:3:1c:7f:15:4:0:1:0:11:13:1a:0:12:f:17:16:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0:0
The command "scripts/travis-publish.sh" exited with 137.