### PR TITLE
To either extensions

### DIFF
--- a/core/src/main/scala/cats/implicits.scala
+++ b/core/src/main/scala/cats/implicits.scala
@@ -1,3 +1,3 @@
 package cats
 
-object implicits extends syntax.AllSyntax with instances.AllInstances
+object implicits extends syntax.AllSyntax with instances.AllInstances with syntax.TrySyntax

--- a/core/src/main/scala/cats/syntax/TrySyntax.scala
+++ b/core/src/main/scala/cats/syntax/TrySyntax.scala
@@ -1,0 +1,29 @@
+package cats.syntax
+
+import cats.Applicative
+import cats.data.EitherT
+
+import scala.util.{ Failure, Success, Try }
+
+trait TrySyntax {
+  implicit final def catsSyntaxTry[A](t: Try[A]): TryOps[A] = new TryOps[A](t)
+}
+
+final class TryOps[A](val t: Try[A]) extends AnyVal {
+
+  /**
+    * Converts a `Try[A]` to a `Either[Throwable, A]`.
+    *
+    * @see [[cats.syntax.EitherObjectOps#fromTry]]
+    */
+  def toEither: Either[Throwable, A] = t match {
+    case Failure(e) => Left(e)
+    case Success(v) => Right(v)
+  }
+
+  /**
+    * Converts a `Try[A]` to a `EitherT[F, Throwable, A]`.
+    */
+  def toEitherT[F[_]](implicit F: Applicative[F]): EitherT[F, Throwable, A] =
+    EitherT.fromEither[F](toEither)
+}

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -1,7 +1,7 @@
 package cats
 
 package object syntax {
-  object all extends AllSyntax
+  object all extends AllSyntax with TrySyntax
   object alternative extends AlternativeSyntax
   object applicative extends ApplicativeSyntax
   object applicativeError extends ApplicativeErrorSyntax
@@ -45,6 +45,7 @@ package object syntax {
   object show extends ShowSyntax
   object strong extends StrongSyntax
   object traverse extends TraverseSyntax
+  object trySyntax extends TrySyntax
   object nonEmptyTraverse extends NonEmptyTraverseSyntax
   object validated extends ValidatedSyntax
   object vector extends VectorSyntax


### PR DESCRIPTION
Enables writing code like:
```scala
Try(...).toEither

Option(...).toEither(...)
```
instead of
```scala
Either.fromTry(Try(...))

Either.fromOption(Some(...), ...)
```

I find this a bit easier to read and more natural to write.