### PR TITLE
Set micrositeDocumentationUrl as root-relative

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -144,7 +144,7 @@ lazy val docSettings = Seq(
   micrositeHighlightTheme := "atom-one-light",
   micrositeHomepage := "http://typelevel.org/cats/",
   micrositeBaseUrl := "cats",
-  micrositeDocumentationUrl := "api/cats/index.html",
+  micrositeDocumentationUrl := "/cats/api/cats/index.html",
   micrositeGithubOwner := "typelevel",
   micrositeExtraMdFiles := Map(
     file("CONTRIBUTING.md") -> ExtraMdFileConfig(


### PR DESCRIPTION
This change is due to to the documentation URL not being properly formed depending on the base href. By setting it as root-relative, we can be totally sure where we are pointing the link to.

Info related to this can be found on https://github.com/47deg/sbt-microsites/issues/251