### PR TITLE
Add missing UnorderedTraverse syntax

### DIFF
--- a/core/src/main/scala/cats/implicits.scala
+++ b/core/src/main/scala/cats/implicits.scala
@@ -1,3 +1,6 @@
 package cats
 
-object implicits extends syntax.AllSyntax with instances.AllInstances
+object implicits
+    extends syntax.AllSyntax
+    with syntax.AllSyntaxBinCompat0
+    with instances.AllInstances

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -1,6 +1,10 @@
 package cats
 package syntax
 
+abstract class AllSyntaxBinCompat
+    extends AllSyntax
+    with AllSyntaxBinCompat0
+
 trait AllSyntax
     extends AlternativeSyntax
     with ApplicativeSyntax
@@ -48,3 +52,6 @@ trait AllSyntax
     with ValidatedSyntax
     with VectorSyntax
     with WriterSyntax
+
+trait AllSyntaxBinCompat0
+    extends UnorderedTraverseSyntax

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -1,7 +1,7 @@
 package cats
 
 package object syntax {
-  object all extends AllSyntax
+  object all extends AllSyntaxBinCompat
   object alternative extends AlternativeSyntax
   object applicative extends ApplicativeSyntax
   object applicativeError extends ApplicativeErrorSyntax
@@ -46,6 +46,7 @@ package object syntax {
   object strong extends StrongSyntax
   object traverse extends TraverseSyntax
   object nonEmptyTraverse extends NonEmptyTraverseSyntax
+  object unorderedTraverse extends UnorderedTraverseSyntax
   object validated extends ValidatedSyntax
   object vector extends VectorSyntax
   object writer extends WriterSyntax

--- a/core/src/main/scala/cats/syntax/unorderedTraverse.scala
+++ b/core/src/main/scala/cats/syntax/unorderedTraverse.scala
@@ -1,0 +1,4 @@
+package cats
+package syntax
+
+trait UnorderedTraverseSyntax extends UnorderedTraverse.ToUnorderedTraverseOps

--- a/testkit/src/main/scala/cats/tests/CatsSuite.scala
+++ b/testkit/src/main/scala/cats/tests/CatsSuite.scala
@@ -4,7 +4,7 @@ package tests
 import catalysts.Platform
 
 import cats.instances.AllInstances
-import cats.syntax.{AllSyntax, EqOps}
+import cats.syntax.{AllSyntax, AllSyntaxBinCompat0, EqOps}
 
 import org.scalactic.anyvals.{PosZDouble, PosInt, PosZInt}
 import org.scalatest.{FunSuite, FunSuiteLike, Matchers}
@@ -36,7 +36,7 @@ trait CatsSuite extends FunSuite
     with Discipline
     with TestSettings
     with AllInstances
-    with AllSyntax
+    with AllSyntax with AllSyntaxBinCompat0
     with StrictCatsEquality { self: FunSuiteLike =>
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =

--- a/tests/src/test/scala/cats/tests/UnorderedTraverseSuite.scala
+++ b/tests/src/test/scala/cats/tests/UnorderedTraverseSuite.scala
@@ -1,0 +1,10 @@
+package cats
+package tests
+
+class UnorderedTraverseSuite extends CatsSuite {
+  test("UnorderedTraverse[Set[Int]].unorderedTraverse via syntax") {
+    forAll { (ins: Set[Int]) =>
+      ins.unorderedTraverse(in => in: Id[Int]).toList.sorted should === (ins.toList.sorted)
+    }
+  }
+}


### PR DESCRIPTION
Addresses #2147:
>The import cats.syntax.traverse._ doesn't provide the .unorderedTraverse. This is inconsistent, as the import cats.syntax.foldable._ does provide the unorderedFold syntax.