### PR TITLE
Add leftFlatMap to Either

### DIFF
--- a/core/src/main/scala/cats/syntax/either.scala
+++ b/core/src/main/scala/cats/syntax/either.scala
@@ -148,6 +148,11 @@ final class EitherOps[A, B](val eab: Either[A, B]) extends AnyVal {
     case Right(b)    => f(b)
   }
 
+  def leftFlatMap[C, BB >: B](f: A => Either[C, BB]): Either[C, BB] = eab match {
+    case Left(a)      => f(a)
+    case r @ Right(_) => EitherUtil.leftCast(r)
+  }
+
   def compare[AA >: A, BB >: B](that: Either[AA, BB])(implicit AA: Order[AA], BB: Order[BB]): Int = eab match {
     case Left(a1)  =>
       that match {

--- a/tests/src/test/scala/cats/tests/EitherSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherSuite.scala
@@ -282,4 +282,16 @@ class EitherSuite extends CatsSuite {
     }
   }
 
+  test("leftFlatMap consistent with leftMap") {
+    forAll { (either: Either[String, Int], f: String => String) =>
+      either.leftFlatMap(v => Left(f(v))) should === (either.leftMap(f))
+    }
+  }
+
+  test("leftFlatMap consistent with swap and then flatMap") {
+    forAll { (either: Either[String, Int], f: String => Either[String, Int]) =>
+      either.leftFlatMap(f) should === (either.swap.flatMap(a => f(a).swap).swap)
+    }
+  }
+
 }


### PR DESCRIPTION
### Motivation

`Either` should have `leftFlatMap` for cases when you want to `leftMap` a function that returns an `Either` and flatten the total result.