### PR TITLE
contravariant.md [reversing roles of A and B in commentary to match the code]

### DIFF
--- a/docs/src/main/tut/typeclasses/contravariant.md
+++ b/docs/src/main/tut/typeclasses/contravariant.md
@@ -93,4 +93,4 @@ val showB3: Show[B] = Contravariant[Show].narrow[A, B](showA)
 ```
 
 Subtyping relationships are "lifted backwards" by contravariant functors, such that if `F` is a
-lawful contravariant functor and `A <: B` then `F[B] <: F[A]`, which is expressed by `Contravariant.narrow`.
+lawful contravariant functor and `B <: A` then `F[A] <: F[B]`, which is expressed by `Contravariant.narrow`.


### PR DESCRIPTION
 that says that B is subtype of A.

See also gitter discussion with @tpolecat on Jan 14 2017.