### PR TITLE
Added Bitraverse for Ior (#2144)

### DIFF
--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -149,17 +149,25 @@ private[data] sealed abstract class IorInstances extends IorInstances0 {
   implicit val catsBitraverseForIor: Bitraverse[Ior] = new Bitraverse[Ior] {
 
     def bitraverse[G[_], A, B, C, D](fab: Ior[A, B])(f: A => G[C], g: B => G[D])(implicit G: Applicative[G]): G[Ior[C, D]] =
-      fab.fold(
-        a => G.map(f(a))(Ior.Left(_)),
-        b => G.map(g(b))(Ior.Right(_)),
-        (a, b) => G.map2(f(a), g(b))(Ior.Both(_, _))
-      )
+      fab match {
+        case Ior.Left(a) => G.map(f(a))(Ior.Left(_))
+        case Ior.Right(b) => G.map(g(b))(Ior.Right(_))
+        case Ior.Both(a, b) => G.map2(f(a), g(b))(Ior.Both(_, _))
+      }
 
     def bifoldLeft[A, B, C](fab: Ior[A, B], c: C)(f: (C, A) => C, g: (C, B) => C): C =
-      fab.fold(f(c, _), g(c, _), (a, b) => g(f(c, a), b))
+      fab match {
+        case Ior.Left(a) => f(c, a)
+        case Ior.Right(b) => g(c, b)
+        case Ior.Both(a, b) => g(f(c, a), b)
+      }
 
     def bifoldRight[A, B, C](fab: Ior[A, B], c: Eval[C])(f: (A, Eval[C]) => Eval[C], g: (B, Eval[C]) => Eval[C]): Eval[C] =
-      fab.fold(f(_, c), g(_, c), (a, b) => g(b, f(a, c)))
+      fab match {
+        case Ior.Left(a) => f(a, c)
+        case Ior.Right(b) => g(b, c)
+        case Ior.Both(a, b) => g(b, f(a, c))
+      }
   }
 
   implicit def catsDataEqForIor[A: Eq, B: Eq]: Eq[A Ior B] = new Eq[A Ior B] {

--- a/tests/src/test/scala/cats/tests/IorSuite.scala
+++ b/tests/src/test/scala/cats/tests/IorSuite.scala
@@ -2,7 +2,7 @@ package cats
 package tests
 
 import cats.kernel.laws.discipline.SemigroupTests
-import cats.laws.discipline.{BifunctorTests, SemigroupalTests, MonadErrorTests, SerializableTests, TraverseTests}
+import cats.laws.discipline.{BifunctorTests, BitraverseTests, SemigroupalTests, MonadErrorTests, SerializableTests, TraverseTests}
 import cats.data.{Ior, NonEmptyList, EitherT}
 import cats.laws.discipline.arbitrary._
 import org.scalacheck.Arbitrary._
@@ -22,6 +22,9 @@ class IorSuite extends CatsSuite {
   checkAll("Ior[String, Int] with Option", TraverseTests[String Ior ?].traverse[Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[String Ior ?]", SerializableTests.serializable(Traverse[String Ior ?]))
   checkAll("? Ior ?", BifunctorTests[Ior].bifunctor[Int, Int, Int, String, String, String])
+
+  checkAll("Ior[?, ?]", BitraverseTests[Ior].bitraverse[Option, Int, Int, Int, String, String, String])
+  checkAll("Bitraverse[Ior]", SerializableTests.serializable(Bitraverse[Ior]))
 
   checkAll("Semigroup[Ior[A: Semigroup, B: Semigroup]]", SemigroupTests[Ior[List[Int], List[Int]]].semigroup)
   checkAll("SerializableTest Semigroup[Ior[A: Semigroup, B: Semigroup]]", SerializableTests.serializable(Semigroup[Ior[List[Int], List[Int]]]))


### PR DESCRIPTION
Added `Bitraverse[Ior]`, as discussed in #2144 

For the testing part, I followed the pattern found in for testing `Bitraverse[Either]`, within `cats.tests.EitherSuite`

This is my first PR, let me know if I need do something around this.
...and thanks for all the good work!