### PR TITLE
remove java 7 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,17 +15,7 @@ scala:
   - 2.12.4
 
 jdk:
-  - oraclejdk7
   - oraclejdk8
-
-matrix:
-  exclude:
-  - scala: 2.12.4
-    jdk: oraclejdk7
-  - scala: 2.10.7
-    jdk: oraclejdk8
-  - scala: 2.11.12
-    jdk: oraclejdk8
 
 before_install:
  - export PATH=${PATH}:./vendor/bundle


### PR DESCRIPTION
- sbt 1.x does not work with Java 7
- travis-ci no longer support oraclejdk7 https://github.com/travis-ci/travis-ci/issues/7884#issuecomment-308451879