### PR TITLE
[iffy] Add Ior Monoid instance

### DIFF
--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -178,9 +178,14 @@ private[data] sealed abstract class IorInstances extends IorInstances0 {
     def show(f: A Ior B): String = f.show
   }
 
-  implicit def catsDataSemigroupForIor[A: Semigroup, B: Semigroup]: Semigroup[Ior[A, B]] = new Semigroup[Ior[A, B]] {
-    def combine(x: Ior[A, B], y: Ior[A, B]) = x.combine(y)
-  }
+  implicit def catsDataMonoidForIor[A: Semigroup, B: Monoid]: Monoid[Ior[A, B]] =
+    new Monoid[Ior[A, B]] {
+      lazy val empty: Ior[A, B] = Ior.right(Monoid[B].empty)
+      def combine(x: Ior[A, B], y: Ior[A, B]) =
+        if (x == empty) y
+        else if (y == empty) x
+        else x.combine(y)
+    }
 
   implicit def catsDataMonadErrorForIor[A: Semigroup]: MonadError[Ior[A, ?], A] =
     new MonadError[Ior[A, ?], A] {
@@ -289,6 +294,10 @@ private[data] sealed abstract class IorInstances0 {
 
     override def map[B, C](fa: A Ior B)(f: B => C): A Ior C =
       fa.map(f)
+  }
+
+  implicit def catsDataSemigroupForIor[A: Semigroup, B: Semigroup]: Semigroup[Ior[A, B]] = new Semigroup[Ior[A, B]] {
+    def combine(x: Ior[A, B], y: Ior[A, B]) = x.combine(y)
   }
 }
 

--- a/tests/src/test/scala/cats/tests/IorSuite.scala
+++ b/tests/src/test/scala/cats/tests/IorSuite.scala
@@ -1,6 +1,7 @@
 package cats
 package tests
 
+import cats.kernel.laws.discipline.MonoidTests
 import cats.kernel.laws.discipline.SemigroupTests
 import cats.laws.discipline.{BifunctorTests, BitraverseTests, SemigroupalTests, MonadErrorTests, SerializableTests, TraverseTests}
 import cats.data.{Ior, NonEmptyList, EitherT}
@@ -26,6 +27,7 @@ class IorSuite extends CatsSuite {
   checkAll("Ior[?, ?]", BitraverseTests[Ior].bitraverse[Option, Int, Int, Int, String, String, String])
   checkAll("Bitraverse[Ior]", SerializableTests.serializable(Bitraverse[Ior]))
 
+  checkAll("Monoid[Ior[A: Semigroup, B: Monoid]]", MonoidTests[Ior[List[Int], List[Int]]].monoid)
   checkAll("Semigroup[Ior[A: Semigroup, B: Semigroup]]", SemigroupTests[Ior[List[Int], List[Int]]].semigroup)
   checkAll("SerializableTest Semigroup[Ior[A: Semigroup, B: Semigroup]]", SerializableTests.serializable(Semigroup[Ior[List[Int], List[Int]]]))
 


### PR DESCRIPTION
Adds an Monoid instance for Ior. It's a bit peculiar-- so I'm sure if it's a good candidate for merging-- but it works nonetheless.

This allows structures of Ior to be combined on both sides simultaneously:

```scala
val in: List[IorNel[String, Int]] = List(
  Ior.right(1),
  Ior.leftNel("foo"),
  Ior.bothNel("bar", 2))

in.map(_.map(_ :: Nil)).combineAll
// Both(NonEmptyList(foo, bar),List(1, 2))
```