### PR TITLE
Remove redundant Monad requirement when Parallel is provided

### DIFF
--- a/core/src/main/scala/cats/syntax/parallel.scala
+++ b/core/src/main/scala/cats/syntax/parallel.scala
@@ -16,7 +16,7 @@ trait ParallelSyntax extends TupleParallelSyntax {
 
 final class ParallelTraversableOps[T[_], A](val ta: T[A]) extends AnyVal {
 
-  def parTraverse[M[_]: Monad, F[_], B]
+  def parTraverse[M[_], F[_], B]
   (f: A => M[B])(implicit T: Traverse[T], P: Parallel[M, F]): M[T[B]] =
     Parallel.parTraverse(ta)(f)
 
@@ -24,7 +24,7 @@ final class ParallelTraversableOps[T[_], A](val ta: T[A]) extends AnyVal {
 
 final class ParallelSequenceOps[T[_], M[_], A](val tma: T[M[A]]) extends AnyVal {
   def parSequence[F[_]]
-  (implicit M: Monad[M], T: Traverse[T], P: Parallel[M, F]): M[T[A]] =
+  (implicit T: Traverse[T], P: Parallel[M, F]): M[T[A]] =
     Parallel.parSequence(tma)
 
 }


### PR DESCRIPTION
I believe this will break binary compatibility, so it probably won't
be able to make it in until the eventual Cats 2.0. I'm not sure what the
current branch strategy is for this sort of thing (if we have one yet).