### PR TITLE
Add `Foldable`, `Traverse` and `Comonad` instances to `WriterT`

### DIFF
--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -134,7 +134,7 @@ private[data] sealed abstract class ConstInstances0 extends ConstInstances1 {
   }
 }
 
-private[data] sealed abstract class ConstInstances1 extends ConstInstances2 {
+private[data] sealed abstract class ConstInstances1 {
 
   implicit def catsDataEqForConst[A: Eq, B]: Eq[Const[A, B]] = new Eq[Const[A, B]] {
     def eqv(x: Const[A, B], y: Const[A, B]): Boolean =
@@ -151,14 +151,4 @@ private[data] sealed abstract class ConstInstances1 extends ConstInstances2 {
     def map[A, B](fa: Const[C, A])(f: A => B): Const[C, B] =
       fa.retag[B]
   }
-}
-
-private[data] sealed abstract class ConstInstances2 {
-
-  implicit def catsDataComonadForConst[C]: Comonad[Const[C, ?]] =
-    new Comonad[Const[C, ?]] {
-      def coflatMap[A, B](fa: Const[C,A])(f: Const[C,A] => B): Const[C,B] = ???
-      def extract[A](x: Const[C,A]): A = ???
-      def map[A, B](fa: Const[C,A])(f: A => B): Const[C,B] = ???
-    }
 }

--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -134,7 +134,7 @@ private[data] sealed abstract class ConstInstances0 extends ConstInstances1 {
   }
 }
 
-private[data] sealed abstract class ConstInstances1 {
+private[data] sealed abstract class ConstInstances1 extends ConstInstances2 {
 
   implicit def catsDataEqForConst[A: Eq, B]: Eq[Const[A, B]] = new Eq[Const[A, B]] {
     def eqv(x: Const[A, B], y: Const[A, B]): Boolean =
@@ -151,4 +151,14 @@ private[data] sealed abstract class ConstInstances1 {
     def map[A, B](fa: Const[C, A])(f: A => B): Const[C, B] =
       fa.retag[B]
   }
+}
+
+private[data] sealed abstract class ConstInstances2 {
+
+  implicit def catsDataComonadForConst[C]: Comonad[Const[C, ?]] =
+    new Comonad[Const[C, ?]] {
+      def coflatMap[A, B](fa: Const[C,A])(f: Const[C,A] => B): Const[C,B] = ???
+      def extract[A](x: Const[C,A]): A = ???
+      def map[A, B](fa: Const[C,A])(f: A => B): Const[C,B] = ???
+    }
 }

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -106,13 +106,20 @@ private[data] sealed abstract class WriterTInstances extends WriterTInstances0 {
       implicit val F0: Monad[F] = F
       implicit val L0: Monoid[L] = L
     }
+
+  implicit def catsDataTraverseForWriterTId[L](implicit F: Traverse[Id]): Traverse[WriterT[Id, L, ?]] =
+    catsDataTraverseForWriterT[Id, L]
 }
 
 private[data] sealed abstract class WriterTInstances0 extends WriterTInstances1 {
-  implicit def catsDataTraverseForWriterT[F[_], L, V](implicit F: Traverse[F]): Traverse[WriterT[F, L, ?]] =
+
+  implicit def catsDataTraverseForWriterT[F[_], L](implicit F: Traverse[F]): Traverse[WriterT[F, L, ?]] =
     new WriterTTraverse[F, L] {
       val F0: Traverse[F] = F
     }
+
+  implicit def catsDataFoldableForWriterTId[L](implicit F: Foldable[Id]): Foldable[WriterT[Id, L, ?]] =
+    catsDataFoldableForWriterT[Id, L]
 }
 
 private[data] sealed abstract class WriterTInstances1 extends WriterTInstances2 {
@@ -153,7 +160,7 @@ private[data] sealed abstract class WriterTInstances1 extends WriterTInstances2 
   implicit def catsDataMonoidForWriterTId[L:Monoid, V:Monoid]: Monoid[WriterT[Id, L, V]] =
     catsDataMonoidForWriterT[Id, L, V]
 
-  implicit def catsDataFoldableForWriterT[F[_], L, V](implicit F: Foldable[F]): Foldable[WriterT[F, L, ?]] =
+  implicit def catsDataFoldableForWriterT[F[_], L](implicit F: Foldable[F]): Foldable[WriterT[F, L, ?]] =
     new WriterTFoldable[F, L]{
       val F0: Foldable[F] = F
     }
@@ -168,6 +175,9 @@ private[data] sealed abstract class WriterTInstances2 extends WriterTInstances3 
 
   implicit def catsDataSemigroupForWriterTId[L:Semigroup, V:Semigroup]: Semigroup[WriterT[Id, L, V]] =
     catsDataSemigroupForWriterT[Id, L, V]
+
+  implicit def catsDataComonadForWriterTId[L](implicit F: Comonad[Id]): Comonad[WriterT[Id, L, ?]] =
+    catsDataComonadForWriterT[Id, L]
 }
 
 private[data] sealed abstract class WriterTInstances3 extends WriterTInstances4 {

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -65,10 +65,10 @@ final case class WriterT[F[_], L, V](run: F[(L, V)]) {
   def show(implicit F: Show[F[(L, V)]]): String = F.show(run)
 
   def foldLeft[C](c: C)(f: (C, V) => C)(implicit F: Foldable[F]): C =
-    F.foldLeft(run, c)((z, v) => f(z, v._2))
+    F.foldLeft(run, c)((z, lv) => f(z, lv._2))
 
   def foldRight[C](lc: Eval[C])(f: (V, Eval[C]) => Eval[C])(implicit F: Foldable[F]): Eval[C] =
-    F.foldRight(run, lc)((v, z) => f(v._2, z))
+    F.foldRight(run, lc)((lv, z) => f(lv._2, z))
 
   def traverse[G[_], V1](f: V => G[V1])(implicit F: Traverse[F], G: Applicative[G]): G[WriterT[F, L, V1]] =
     G.map(

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -70,7 +70,10 @@ final case class WriterT[F[_], L, V](run: F[(L, V)]) {
   def foldRight[C](lc: Eval[C])(f: (V, Eval[C]) => Eval[C])(implicit F: Foldable[F]): Eval[C] =
     F.foldRight(run, lc)((v, z) => f(v._2, z))
 
-  def traverse[G[_], V1](f: V => G[V1])(implicit F: Traverse[F], G: Applicative[G]): G[WriterT[F, L, V1]] = ???
+  def traverse[G[_], V1](f: V => G[V1])(implicit F: Traverse[F], G: Applicative[G]): G[WriterT[F, L, V1]] =
+    G.map(
+      F.traverse(run)(lv => G.product(G.pure(lv._1), f(lv._2)))
+    )(WriterT.apply)
 }
 
 object WriterT extends WriterTInstances with WriterTFunctions {

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -108,7 +108,7 @@ private[data] sealed abstract class WriterTInstances extends WriterTInstances0 {
     }
 
   implicit def catsDataTraverseForWriterTId[L](implicit F: Traverse[Id]): Traverse[WriterT[Id, L, ?]] =
-    catsDataTraverseForWriterT[Id, L]
+    catsDataTraverseForWriterT[Id, L](F)
 }
 
 private[data] sealed abstract class WriterTInstances0 extends WriterTInstances1 {
@@ -119,7 +119,7 @@ private[data] sealed abstract class WriterTInstances0 extends WriterTInstances1 
     }
 
   implicit def catsDataFoldableForWriterTId[L](implicit F: Foldable[Id]): Foldable[WriterT[Id, L, ?]] =
-    catsDataFoldableForWriterT[Id, L]
+    catsDataFoldableForWriterT[Id, L](F)
 }
 
 private[data] sealed abstract class WriterTInstances1 extends WriterTInstances2 {
@@ -177,7 +177,7 @@ private[data] sealed abstract class WriterTInstances2 extends WriterTInstances3 
     catsDataSemigroupForWriterT[Id, L, V]
 
   implicit def catsDataComonadForWriterTId[L](implicit F: Comonad[Id]): Comonad[WriterT[Id, L, ?]] =
-    catsDataComonadForWriterT[Id, L]
+    catsDataComonadForWriterT[Id, L](F)
 }
 
 private[data] sealed abstract class WriterTInstances3 extends WriterTInstances4 {

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -253,7 +253,6 @@ private[data] sealed abstract class WriterTInstances9 extends WriterTInstances10
       implicit val F0: Applicative[F] = F
       implicit val L0: Monoid[L] = L
     }
-
 }
 
 private[data] sealed abstract class WriterTInstances10 extends WriterTInstances11 {
@@ -264,7 +263,14 @@ private[data] sealed abstract class WriterTInstances10 extends WriterTInstances1
     }
 }
 
-private[data] sealed abstract class WriterTInstances11 {
+private[data] sealed abstract class WriterTInstances11 extends WriterTInstances12 {
+  implicit def catsDataComonadForWriterT[F[_], L](implicit F: Comonad[F]): Comonad[WriterT[F, L, ?]] =
+    new WriterTComonad[F, L] {
+      implicit val F0: Comonad[F] = F
+    }
+}
+
+private[data] sealed abstract class WriterTInstances12 {
   implicit def catsDataCoflatMapForWriterT[F[_], L](implicit F: Functor[F]): CoflatMap[WriterT[F, L, ?]] =
     new WriterTCoflatMap[F, L] {
       implicit val F0: Functor[F] = F
@@ -433,6 +439,13 @@ private[data] sealed trait WriterTCoflatMap[F[_], L] extends CoflatMap[WriterT[F
   def coflatMap[A, B](fa: WriterT[F, L, A])(f: WriterT[F, L, A] => B): WriterT[F, L, B] = fa.map(_ => f(fa))
 }
 
+private[data] sealed trait WriterTComonad[F[_], L] extends Comonad[WriterT[F, L, ?]] with WriterTCoflatMap[F, L] {
+
+  override implicit def F0: Comonad[F]
+
+  def extract[A](fa: WriterT[F, L, A]): A = F0.extract(fa.value)
+}
+
 private[data] sealed trait WriterTFoldable[F[_], L] extends Foldable[WriterT[F, L, ?]] {
 
   implicit def F0: Foldable[F]
@@ -443,7 +456,7 @@ private[data] sealed trait WriterTFoldable[F[_], L] extends Foldable[WriterT[F, 
 
 private[data] sealed trait WriterTTraverse[F[_], L] extends Traverse[WriterT[F, L, ?]] with WriterTFoldable[F, L] {
 
-  implicit def F0: Traverse[F]
+  override implicit def F0: Traverse[F]
 
   def traverse[G[_]: Applicative, A, B](fa: WriterT[F, L, A])(f: A => G[B]): G[WriterT[F, L, B]] = fa.traverse(f)
 }

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -69,6 +69,8 @@ final case class WriterT[F[_], L, V](run: F[(L, V)]) {
 
   def foldRight[C](lc: Eval[C])(f: (V, Eval[C]) => Eval[C])(implicit F: Foldable[F]): Eval[C] =
     F.foldRight(run, lc)((v, z) => f(v._2, z))
+
+  def traverse[G[_], V1](f: V => G[V1])(implicit F: Traverse[F], G: Applicative[G]): G[WriterT[F, L, V1]] = ???
 }
 
 object WriterT extends WriterTInstances with WriterTFunctions {
@@ -101,9 +103,21 @@ private[data] sealed abstract class WriterTInstances extends WriterTInstances0 {
       implicit val F0: Monad[F] = F
       implicit val L0: Monoid[L] = L
     }
+
+  implicit def catsDataFoldableForWriterT[F[_], L, V](implicit F: Foldable[F]): Foldable[WriterT[F, L, ?]] =
+    new WriterTFoldable[F, L]{
+      val F0: Foldable[F] = F
+    }
 }
 
 private[data] sealed abstract class WriterTInstances0 extends WriterTInstances1 {
+  implicit def catsDataTraverseForWriterT[F[_], L, V](implicit F: Traverse[F]): Traverse[WriterT[F, L, ?]] =
+    new WriterTTraverse[F, L] {
+      val F0: Traverse[F] = F
+    }
+}
+
+private[data] sealed abstract class WriterTInstances1 extends WriterTInstances2 {
   implicit def catsDataMonadErrorForWriterT[F[_], L, E](implicit F: MonadError[F, E], L: Monoid[L]): MonadError[WriterT[F, L, ?], E] =
     new WriterTMonadError[F, L, E] {
       implicit val F0: MonadError[F, E] = F
@@ -140,14 +154,9 @@ private[data] sealed abstract class WriterTInstances0 extends WriterTInstances1 
 
   implicit def catsDataMonoidForWriterTId[L:Monoid, V:Monoid]: Monoid[WriterT[Id, L, V]] =
     catsDataMonoidForWriterT[Id, L, V]
-
-  implicit def catsDataFoldableForWriterT[F[_], L, V](implicit F: Foldable[F]): Foldable[WriterT[F, L, ?]] =
-    new WriterTFoldable[F, L]{
-      val F0: Foldable[F] = F
-    }
 }
 
-private[data] sealed abstract class WriterTInstances1 extends WriterTInstances2 {
+private[data] sealed abstract class WriterTInstances2 extends WriterTInstances3 {
   implicit def catsDataMonadForWriterTId[L:Monoid]: Monad[WriterT[Id, L, ?]] =
     catsDataMonadForWriterT[Id, L]
 
@@ -158,7 +167,7 @@ private[data] sealed abstract class WriterTInstances1 extends WriterTInstances2 
     catsDataSemigroupForWriterT[Id, L, V]
 }
 
-private[data] sealed abstract class WriterTInstances2 extends WriterTInstances3 {
+private[data] sealed abstract class WriterTInstances3 extends WriterTInstances4 {
   implicit def catsDataMonadForWriterT[F[_], L](implicit F: Monad[F], L: Monoid[L]): Monad[WriterT[F, L, ?]] =
     new WriterTMonad[F, L] {
       implicit val F0: Monad[F] = F
@@ -174,12 +183,12 @@ private[data] sealed abstract class WriterTInstances2 extends WriterTInstances3 
     catsDataCoflatMapForWriterT[Id, L]
 }
 
-private[data] sealed abstract class WriterTInstances3 extends WriterTInstances4 {
+private[data] sealed abstract class WriterTInstances4 extends WriterTInstances5 {
   implicit def catsDataFlatMapForWriterTId[L:Semigroup]: FlatMap[WriterT[Id, L, ?]] =
     catsDataFlatMapForWriterT2[Id, L]
 }
 
-private[data] sealed abstract class WriterTInstances4 extends WriterTInstances5 {
+private[data] sealed abstract class WriterTInstances5 extends WriterTInstances6 {
   implicit def catsDataFlatMapForWriterT1[F[_], L](implicit F: FlatMap[F], L: Monoid[L]): FlatMap[WriterT[F, L, ?]] =
     new WriterTFlatMap1[F, L] {
       implicit val F0: FlatMap[F] = F
@@ -192,7 +201,7 @@ private[data] sealed abstract class WriterTInstances4 extends WriterTInstances5 
     }
 }
 
-private[data] sealed abstract class WriterTInstances5 extends WriterTInstances6 {
+private[data] sealed abstract class WriterTInstances6 extends WriterTInstances7 {
   implicit def catsDataApplicativeErrorForWriterT[F[_], L, E](implicit F: ApplicativeError[F, E], L: Monoid[L]): ApplicativeError[WriterT[F, L, ?], E] =
     new WriterTApplicativeError[F, L, E] {
       implicit val F0: ApplicativeError[F, E] = F
@@ -200,7 +209,7 @@ private[data] sealed abstract class WriterTInstances5 extends WriterTInstances6 
     }
 }
 
-private[data] sealed abstract class WriterTInstances6 extends WriterTInstances7 {
+private[data] sealed abstract class WriterTInstances7 extends WriterTInstances8 {
   implicit def catsDataAlternativeForWriterT[F[_], L](implicit F: Alternative[F], L: Monoid[L]): Alternative[WriterT[F, L, ?]] =
     new WriterTAlternative[F, L] {
       implicit val F0: Alternative[F] = F
@@ -213,7 +222,7 @@ private[data] sealed abstract class WriterTInstances6 extends WriterTInstances7 
     }
 }
 
-private[data] sealed abstract class WriterTInstances7 extends WriterTInstances8 {
+private[data] sealed abstract class WriterTInstances8 extends WriterTInstances9 {
   implicit def catsDataMonoidKForWriterT[F[_], L](implicit F: MonoidK[F]): MonoidK[WriterT[F, L, ?]] =
     new WriterTMonoidK[F, L] {
       implicit val F0: MonoidK[F] = F
@@ -230,7 +239,7 @@ private[data] sealed abstract class WriterTInstances7 extends WriterTInstances8 
   }
 }
 
-private[data] sealed abstract class WriterTInstances8 extends WriterTInstances9 {
+private[data] sealed abstract class WriterTInstances9 extends WriterTInstances10 {
   implicit def catsDataSemigroupKForWriterT[F[_], L](implicit F: SemigroupK[F]): SemigroupK[WriterT[F, L, ?]] =
     new WriterTSemigroupK[F, L] {
       implicit val F0: SemigroupK[F] = F
@@ -244,7 +253,7 @@ private[data] sealed abstract class WriterTInstances8 extends WriterTInstances9 
 
 }
 
-private[data] sealed abstract class WriterTInstances9 extends WriterTInstances10 {
+private[data] sealed abstract class WriterTInstances10 extends WriterTInstances11 {
   implicit def catsDataApplyForWriterT[F[_], L](implicit F: Apply[F], L: Semigroup[L]): Apply[WriterT[F, L, ?]] =
     new WriterTApply[F, L] {
       implicit val F0: Apply[F] = F
@@ -252,7 +261,7 @@ private[data] sealed abstract class WriterTInstances9 extends WriterTInstances10
     }
 }
 
-private[data] sealed abstract class WriterTInstances10 {
+private[data] sealed abstract class WriterTInstances11 {
   implicit def catsDataCoflatMapForWriterT[F[_], L](implicit F: Functor[F]): CoflatMap[WriterT[F, L, ?]] =
     new WriterTCoflatMap[F, L] {
       implicit val F0: Functor[F] = F
@@ -427,6 +436,13 @@ private[data] sealed trait WriterTFoldable[F[_], L] extends Foldable[WriterT[F, 
 
   def foldLeft[A, B](fa: WriterT[F, L, A], b: B)(f: (B, A) => B): B = fa.foldLeft(b)(f)
   def foldRight[A, B](fa: WriterT[F, L, A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] = fa.foldRight(lb)(f)
+}
+
+private[data] sealed trait WriterTTraverse[F[_], L] extends Traverse[WriterT[F, L, ?]] with WriterTFoldable[F, L] {
+
+  implicit def F0: Traverse[F]
+
+  def traverse[G[_]: Applicative, A, B](fa: WriterT[F, L, A])(f: A => G[B]): G[WriterT[F, L, B]] = fa.traverse(f)
 }
 
 private[data] trait WriterTFunctions {

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -106,11 +106,6 @@ private[data] sealed abstract class WriterTInstances extends WriterTInstances0 {
       implicit val F0: Monad[F] = F
       implicit val L0: Monoid[L] = L
     }
-
-  implicit def catsDataFoldableForWriterT[F[_], L, V](implicit F: Foldable[F]): Foldable[WriterT[F, L, ?]] =
-    new WriterTFoldable[F, L]{
-      val F0: Foldable[F] = F
-    }
 }
 
 private[data] sealed abstract class WriterTInstances0 extends WriterTInstances1 {
@@ -157,6 +152,11 @@ private[data] sealed abstract class WriterTInstances1 extends WriterTInstances2 
 
   implicit def catsDataMonoidForWriterTId[L:Monoid, V:Monoid]: Monoid[WriterT[Id, L, V]] =
     catsDataMonoidForWriterT[Id, L, V]
+
+  implicit def catsDataFoldableForWriterT[F[_], L, V](implicit F: Foldable[F]): Foldable[WriterT[F, L, ?]] =
+    new WriterTFoldable[F, L]{
+      val F0: Foldable[F] = F
+    }
 }
 
 private[data] sealed abstract class WriterTInstances2 extends WriterTInstances3 {

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -439,13 +439,6 @@ private[data] sealed trait WriterTCoflatMap[F[_], L] extends CoflatMap[WriterT[F
   def coflatMap[A, B](fa: WriterT[F, L, A])(f: WriterT[F, L, A] => B): WriterT[F, L, B] = fa.map(_ => f(fa))
 }
 
-private[data] sealed trait WriterTComonad[F[_], L] extends Comonad[WriterT[F, L, ?]] with WriterTCoflatMap[F, L] {
-
-  override implicit def F0: Comonad[F]
-
-  def extract[A](fa: WriterT[F, L, A]): A = F0.extract(fa.value)
-}
-
 private[data] sealed trait WriterTFoldable[F[_], L] extends Foldable[WriterT[F, L, ?]] {
 
   implicit def F0: Foldable[F]
@@ -459,6 +452,13 @@ private[data] sealed trait WriterTTraverse[F[_], L] extends Traverse[WriterT[F, 
   override implicit def F0: Traverse[F]
 
   def traverse[G[_]: Applicative, A, B](fa: WriterT[F, L, A])(f: A => G[B]): G[WriterT[F, L, B]] = fa.traverse(f)
+}
+
+private[data] sealed trait WriterTComonad[F[_], L] extends Comonad[WriterT[F, L, ?]] with WriterTCoflatMap[F, L] {
+
+  override implicit def F0: Comonad[F]
+
+  def extract[A](fa: WriterT[F, L, A]): A = F0.extract(F0.map(fa.run)(_._2))
 }
 
 private[data] trait WriterTFunctions {

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -290,7 +290,7 @@ private[data] sealed abstract class WriterTInstances12 {
 private[data] sealed trait WriterTFunctor[F[_], L] extends Functor[WriterT[F, L, ?]] {
   implicit def F0: Functor[F]
 
-  def map[A, B](fa: WriterT[F, L, A])(f: A => B): WriterT[F, L, B] =
+  override def map[A, B](fa: WriterT[F, L, A])(f: A => B): WriterT[F, L, B] =
     fa.map(f)
 }
 
@@ -461,7 +461,6 @@ private[data] sealed trait WriterTTraverse[F[_], L] extends Traverse[WriterT[F, 
 
   override implicit def F0: Traverse[F]
 
-  override def map[A, B](fa: WriterT[F, L, A])(f: A => B): WriterT[F, L, B] = super[WriterTFunctor].map(fa)(f)
   def traverse[G[_]: Applicative, A, B](fa: WriterT[F, L, A])(f: A => G[B]): G[WriterT[F, L, B]] = fa.traverse(f)
 }
 

--- a/tests/src/test/scala/cats/tests/WriterTSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterTSuite.scala
@@ -373,28 +373,43 @@ class WriterTSuite extends CatsSuite {
   {
     // F has a Foldable and L has a Monoid
     implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
+    Foldable[Const[String, ?]]
     Foldable[WriterT[Const[String, ?], ListWrapper[Int], ?]]
 
     checkAll("WriterT[Const[String, ?], ListWrapper[Int], ?]", FoldableTests[WriterT[Const[String, ?], ListWrapper[Int], ?]].foldable[Int, Int])
     checkAll("Foldable[WriterT[Const[String, ?], ListWrapper[Int], ?]]", SerializableTests.serializable(Foldable[WriterT[Const[String, ?], ListWrapper[Int], ?]]))
+
+    Foldable[Id]
+    Foldable[WriterT[Id, ListWrapper[Int], ?]]
+    Foldable[Writer[ListWrapper[Int], ?]]
   }
 
   {
     // F has a Traverse and L has a Monoid
     implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
+    Traverse[Const[String, ?]]
     Traverse[WriterT[Const[String, ?], ListWrapper[Int], ?]]
 
     checkAll("WriterT[Const[String, ?], ListWrapper[Int], ?]", TraverseTests[WriterT[Const[String, ?], ListWrapper[Int], ?]].traverse[Int, Int, Int, Int, Option, Option])
     checkAll("Traverse[WriterT[Const[String, ?], ListWrapper[Int], ?]]", SerializableTests.serializable(Traverse[WriterT[Const[String, ?], ListWrapper[Int], ?]]))
+
+    Traverse[Id]
+    Traverse[WriterT[Id, ListWrapper[Int], ?]]
+    Traverse[Writer[ListWrapper[Int], ?]]
   }
 
   {
     // F has a Comonad and L has a Monoid
     implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
+    Comonad[(String, ?)]
     Comonad[WriterT[(String, ?), ListWrapper[Int], ?]]
 
     checkAll("WriterT[(String, ?), ListWrapper[Int], ?]", ComonadTests[WriterT[(String, ?), ListWrapper[Int], ?]].comonad[Int, Int, Int])
     checkAll("Comonad[WriterT[(String, ?), ListWrapper[Int], ?]]", SerializableTests.serializable(Comonad[WriterT[(String, ?), ListWrapper[Int], ?]]))
+
+    Comonad[Id]
+    Comonad[WriterT[Id, ListWrapper[Int], ?]]
+    Comonad[Writer[ListWrapper[Int], ?]]
   }
 
   checkAll("WriterT[Option, Int, ?]", CommutativeMonadTests[WriterT[Option, Int, ?]].commutativeMonad[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/WriterTSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterTSuite.scala
@@ -370,6 +370,15 @@ class WriterTSuite extends CatsSuite {
     checkAll("ContravariantMonoidal[WriterT[Const[String, ?], Int, ?]]", SerializableTests.serializable(ContravariantMonoidal[WriterT[Const[String, ?], Int, ?]]))
   }
 
+  {
+    // F has a Foldable and L has a Monoid
+    implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
+    Foldable[WriterT[Const[String, ?], Int, ?]]
+
+    checkAll("WriterT[Const[String, ?], ListWrapper[Int], ?]", FoldableTests[WriterT[Const[String, ?], ListWrapper[Int], ?]].foldable[Int, Int])
+    checkAll("Foldable[WriterT[Const[String, ?], ListWrapper[Int], ?]]", SerializableTests.serializable(Foldable[WriterT[Const[String, ?], ListWrapper[Int], ?]]))
+  }
+
   checkAll("WriterT[Option, Int, ?]", CommutativeMonadTests[WriterT[Option, Int, ?]].commutativeMonad[Int, Int, Int])
   checkAll("CommutativeMonad[WriterT[Option, Int, ?]]",SerializableTests.serializable(CommutativeMonad[WriterT[Option, Int, ?]]))
 }

--- a/tests/src/test/scala/cats/tests/WriterTSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterTSuite.scala
@@ -391,10 +391,10 @@ class WriterTSuite extends CatsSuite {
   {
     // F has a Comonad and L has a Monoid
     implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
-    Comonad[WriterT[Const[String, ?], ListWrapper[Int], ?]]
+    Comonad[WriterT[(String, ?), ListWrapper[Int], ?]]
 
-    checkAll("WriterT[Const[String, ?], ListWrapper[Int], ?]", ComonadTests[WriterT[Const[String, ?], ListWrapper[Int], ?]].comonad[Int, Int, Int])
-    checkAll("Comonad[WriterT[Const[String, ?], ListWrapper[Int], ?]]", SerializableTests.serializable(Comonad[WriterT[Const[String, ?], ListWrapper[Int], ?]]))
+    checkAll("WriterT[(String, ?), ListWrapper[Int], ?]", ComonadTests[WriterT[(String, ?), ListWrapper[Int], ?]].comonad[Int, Int, Int])
+    checkAll("Comonad[WriterT[(String, ?), ListWrapper[Int], ?]]", SerializableTests.serializable(Comonad[WriterT[(String, ?), ListWrapper[Int], ?]]))
   }
 
   checkAll("WriterT[Option, Int, ?]", CommutativeMonadTests[WriterT[Option, Int, ?]].commutativeMonad[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/WriterTSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterTSuite.scala
@@ -382,6 +382,9 @@ class WriterTSuite extends CatsSuite {
     Foldable[Id]
     Foldable[WriterT[Id, ListWrapper[Int], ?]]
     Foldable[Writer[ListWrapper[Int], ?]]
+
+    checkAll("WriterT[Id, ListWrapper[Int], ?]", FoldableTests[WriterT[Id, ListWrapper[Int], ?]].foldable[Int, Int])
+    checkAll("Foldable[WriterT[Id, ListWrapper[Int], ?]]", SerializableTests.serializable(Foldable[WriterT[Id, ListWrapper[Int], ?]]))
   }
 
   {
@@ -396,6 +399,9 @@ class WriterTSuite extends CatsSuite {
     Traverse[Id]
     Traverse[WriterT[Id, ListWrapper[Int], ?]]
     Traverse[Writer[ListWrapper[Int], ?]]
+
+    checkAll("WriterT[Id, ListWrapper[Int], ?]", TraverseTests[WriterT[Id, ListWrapper[Int], ?]].traverse[Int, Int, Int, Int, Option, Option])
+    checkAll("Traverse[WriterT[Id, ListWrapper[Int], ?]]", SerializableTests.serializable(Traverse[WriterT[Id, ListWrapper[Int], ?]]))
   }
 
   {
@@ -410,6 +416,9 @@ class WriterTSuite extends CatsSuite {
     Comonad[Id]
     Comonad[WriterT[Id, ListWrapper[Int], ?]]
     Comonad[Writer[ListWrapper[Int], ?]]
+
+    checkAll("WriterT[Id, ListWrapper[Int], ?]", ComonadTests[WriterT[Id, ListWrapper[Int], ?]].comonad[Int, Int, Int])
+    checkAll("Comonad[WriterT[Id, ListWrapper[Int], ?]]", SerializableTests.serializable(Comonad[WriterT[Id, ListWrapper[Int], ?]]))
   }
 
   checkAll("WriterT[Option, Int, ?]", CommutativeMonadTests[WriterT[Option, Int, ?]].commutativeMonad[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/WriterTSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterTSuite.scala
@@ -388,6 +388,15 @@ class WriterTSuite extends CatsSuite {
     checkAll("Traverse[WriterT[Const[String, ?], ListWrapper[Int], ?]]", SerializableTests.serializable(Traverse[WriterT[Const[String, ?], ListWrapper[Int], ?]]))
   }
 
+  {
+    // F has a Comonad and L has a Monoid
+    implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
+    Comonad[WriterT[Const[String, ?], ListWrapper[Int], ?]]
+
+    checkAll("WriterT[Const[String, ?], ListWrapper[Int], ?]", ComonadTests[WriterT[Const[String, ?], ListWrapper[Int], ?]].comonad[Int, Int, Int])
+    checkAll("Comonad[WriterT[Const[String, ?], ListWrapper[Int], ?]]", SerializableTests.serializable(Comonad[WriterT[Const[String, ?], ListWrapper[Int], ?]]))
+  }
+
   checkAll("WriterT[Option, Int, ?]", CommutativeMonadTests[WriterT[Option, Int, ?]].commutativeMonad[Int, Int, Int])
   checkAll("CommutativeMonad[WriterT[Option, Int, ?]]",SerializableTests.serializable(CommutativeMonad[WriterT[Option, Int, ?]]))
 }

--- a/tests/src/test/scala/cats/tests/WriterTSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterTSuite.scala
@@ -384,7 +384,6 @@ class WriterTSuite extends CatsSuite {
     Foldable[Writer[ListWrapper[Int], ?]]
 
     checkAll("WriterT[Id, ListWrapper[Int], ?]", FoldableTests[WriterT[Id, ListWrapper[Int], ?]].foldable[Int, Int])
-    checkAll("Foldable[WriterT[Id, ListWrapper[Int], ?]]", SerializableTests.serializable(Foldable[WriterT[Id, ListWrapper[Int], ?]]))
   }
 
   {
@@ -401,7 +400,6 @@ class WriterTSuite extends CatsSuite {
     Traverse[Writer[ListWrapper[Int], ?]]
 
     checkAll("WriterT[Id, ListWrapper[Int], ?]", TraverseTests[WriterT[Id, ListWrapper[Int], ?]].traverse[Int, Int, Int, Int, Option, Option])
-    checkAll("Traverse[WriterT[Id, ListWrapper[Int], ?]]", SerializableTests.serializable(Traverse[WriterT[Id, ListWrapper[Int], ?]]))
   }
 
   {
@@ -418,7 +416,6 @@ class WriterTSuite extends CatsSuite {
     Comonad[Writer[ListWrapper[Int], ?]]
 
     checkAll("WriterT[Id, ListWrapper[Int], ?]", ComonadTests[WriterT[Id, ListWrapper[Int], ?]].comonad[Int, Int, Int])
-    checkAll("Comonad[WriterT[Id, ListWrapper[Int], ?]]", SerializableTests.serializable(Comonad[WriterT[Id, ListWrapper[Int], ?]]))
   }
 
   checkAll("WriterT[Option, Int, ?]", CommutativeMonadTests[WriterT[Option, Int, ?]].commutativeMonad[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/WriterTSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterTSuite.scala
@@ -373,10 +373,19 @@ class WriterTSuite extends CatsSuite {
   {
     // F has a Foldable and L has a Monoid
     implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
-    Foldable[WriterT[Const[String, ?], Int, ?]]
+    Foldable[WriterT[Const[String, ?], ListWrapper[Int], ?]]
 
     checkAll("WriterT[Const[String, ?], ListWrapper[Int], ?]", FoldableTests[WriterT[Const[String, ?], ListWrapper[Int], ?]].foldable[Int, Int])
     checkAll("Foldable[WriterT[Const[String, ?], ListWrapper[Int], ?]]", SerializableTests.serializable(Foldable[WriterT[Const[String, ?], ListWrapper[Int], ?]]))
+  }
+
+  {
+    // F has a Traverse and L has a Monoid
+    implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
+    Traverse[WriterT[Const[String, ?], ListWrapper[Int], ?]]
+
+    checkAll("WriterT[Const[String, ?], ListWrapper[Int], ?]", TraverseTests[WriterT[Const[String, ?], ListWrapper[Int], ?]].traverse[Int, Int, Int, Int, Option, Option])
+    checkAll("Traverse[WriterT[Const[String, ?], ListWrapper[Int], ?]]", SerializableTests.serializable(Traverse[WriterT[Const[String, ?], ListWrapper[Int], ?]]))
   }
 
   checkAll("WriterT[Option, Int, ?]", CommutativeMonadTests[WriterT[Option, Int, ?]].commutativeMonad[Int, Int, Int])


### PR DESCRIPTION
This adds `Foldable`, `Traverse` and `Comonad` instances for WriterT. The relevant issue is https://github.com/typelevel/cats/issues/620