### PR TITLE
Fix #1733: make Kleisli.flatMap stack safe

### DIFF
--- a/tests/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/KleisliSuite.scala
@@ -256,6 +256,14 @@ class KleisliSuite extends CatsSuite {
     kconfig1.run(config) should === (kconfig2.run(config))
   }
 
+  test("flatMap is stack safe for left associative binds when F is") {
+    val unit = Kleisli.pure[Eval, Unit, Unit](())
+    val result = (0 until 10000).foldLeft(unit) { (acc, _) =>
+      acc.flatMap(_ => unit)
+    }
+    result.run(()).value should === ()
+  }
+
   /**
    * Testing that implicit resolution works. If it compiles, the "test" passes.
    */

--- a/tests/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/KleisliSuite.scala
@@ -9,8 +9,9 @@ import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
 import org.scalacheck.Arbitrary
 import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
-import cats.laws.discipline.{SemigroupKTests, MonoidKTests}
+import cats.laws.discipline.{MonoidKTests, SemigroupKTests}
 import Helpers.CSemi
+import catalysts.Platform
 
 class KleisliSuite extends CatsSuite {
   implicit def kleisliEq[F[_], A, B](implicit A: Arbitrary[A], FB: Eq[F[B]]): Eq[Kleisli[F, A, B]] =
@@ -258,7 +259,8 @@ class KleisliSuite extends CatsSuite {
 
   test("flatMap is stack safe on repeated left binds when F is") {
     val unit = Kleisli.pure[Eval, Unit, Unit](())
-    val result = (0 until 10000).foldLeft(unit) { (acc, _) =>
+    val count = if (Platform.isJvm) 10000 else 100
+    val result = (0 until count).foldLeft(unit) { (acc, _) =>
       acc.flatMap(_ => unit)
     }
     result.run(()).value
@@ -266,7 +268,8 @@ class KleisliSuite extends CatsSuite {
 
   test("flatMap is stack safe on repeated right binds when F is") {
     val unit = Kleisli.pure[Eval, Unit, Unit](())
-    val result = (0 until 10000).foldLeft(unit) { (acc, _) =>
+    val count = if (Platform.isJvm) 10000 else 100
+    val result = (0 until count).foldLeft(unit) { (acc, _) =>
       unit.flatMap(_ => acc)
     }
     result.run(()).value

--- a/tests/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/KleisliSuite.scala
@@ -256,12 +256,20 @@ class KleisliSuite extends CatsSuite {
     kconfig1.run(config) should === (kconfig2.run(config))
   }
 
-  test("flatMap is stack safe for left associative binds when F is") {
+  test("flatMap is stack safe on repeated left binds when F is") {
     val unit = Kleisli.pure[Eval, Unit, Unit](())
     val result = (0 until 10000).foldLeft(unit) { (acc, _) =>
       acc.flatMap(_ => unit)
     }
-    result.run(()).value should === ()
+    result.run(()).value
+  }
+
+  test("flatMap is stack safe on repeated right binds when F is") {
+    val unit = Kleisli.pure[Eval, Unit, Unit](())
+    val result = (0 until 10000).foldLeft(unit) { (acc, _) =>
+      unit.flatMap(_ => acc)
+    }
+    result.run(()).value
   }
 
   /**


### PR DESCRIPTION
Close #1733.

This is badly needed in `cats-effect` in order to define a `Sync[Kleisli[F, R, ?]]` implementation.

I'm already pushing one right now, but with a patched `flatMap` implementation that would no longer preserve _coherence_ with the official `flatMap` of Kleisli. So it would be nice if both these PRs happen, see: https://github.com/typelevel/cats-effect/pull/144

The way to fix it is to define a `flatMap` implementation that triggers the `F[_]` context _earlier_. Like this:

```scala
def flatMap[C](f: B => Kleisli[F, A, C])(implicit F: Monad[F]): Kleisli[F, A, C] =
  Kleisli(a => F.pure(a).flatMap(a => F.flatMap[B, C](run(a))((b: B) => f(b).run(a))))
  //                     ^^^^^^^                      ^^^^^^
  //              Suspended execution in F[_], no longer increases the stack size
```

Unfortunately this solution doesn't work directly because we have a `FlatMap` restriction on that operation, not `Monad`. And so the trick is to discriminate between plain `FlatMap` and `Monad` via inheritance and the subtyping encoding that we're all doing, this being a subtitute for `Kleisli.apply`:

```scala
private[data] def shift[F[_], A, B](run: A => F[B])
  (implicit F: FlatMap[F]): Kleisli[F, A, B] = {

  F match {
    case ap: Applicative[F] @unchecked =>
      Kleisli(r => F.flatMap(ap.pure(r))(run))
    case _ =>
      Kleisli(run)
  }
}
```

And now the `flatMap` definition can be:

```scala
def flatMap[C](f: B => Kleisli[F, A, C])(implicit F: FlatMap[F]): Kleisli[F, A, C] =
  Kleisli.shift(a => F.flatMap[B, C](run(a))((b: B) => f(b).run(a)))
```

As proven by the tests with `Eval`, this works. And it will work splendidly with `cats-effect`.

---

## FAQ

In preparation for the upcoming discussions, I can think of the following ...

### Is there any other solution possible?

No, this is the only fix possible for Cats version 1.x, given the `A => F[B]` encoding.

We could end up with a different internal encoding, say `F[A => F[B]]`, but note that such an encoding doesn't guarantee a fix either. In spite of popular belief note that `StateT` isn't currently stack safe for left binds either, see: https://github.com/typelevel/cats-effect/issues/139

### Doesn't this assume that a stack safe `F.pure(a).flatMap(f)` is lazy?

Yes, however it is my firm belief that no stack safe `flatMap` can be defined with strict evaluation, not even when the source is `F.pure`. This is because you can always define a recursive structure that's already evaluated (in memory) and that triggers stack overflows.

In other words if `F[_]` really has a stack safe `flatMap` (that could pass the laws of `Sync` in `cats-effect` for example, or that could describe `tailRecM`), then the behavior of `F.pure(a).flatMap(f)` is necessarily lazy.

For details and a working example: https://github.com/typelevel/cats-effect/issues/92

### Isn't usage of isInstanceOf a hack?

A much more elaborate signature would do something like the [Priority](https://github.com/typelevel/algebra/blob/master/core/src/main/scala/algebra/Priority.scala) pattern in Algebra.

However consider that:

1. we cannot break compatibility
2. this is cleaner, lets not forget the scary `CanBuildFrom` signatures
3. the cases where this will yield problems (i.e. those cases where the `Monad` definition comes from a different place than `FlatMap`) are totally uninteresting; the Scala compiler will pick `Monad` if in scope because it has a preference for sub-types or in case they happen to have the same "score", it yields a conflict anyway

Most importantly is that this PR solves a problem and without it we cannot solve that problem.

Perfect is the enemy of good 😉