### PR TITLE
Fix #2186: make IndexedStateT stack safe

### DIFF
--- a/bench/src/main/scala/cats/bench/StateTBench.scala
+++ b/bench/src/main/scala/cats/bench/StateTBench.scala
@@ -1,0 +1,63 @@
+package cats.bench
+
+import cats.Eval
+import cats.data.StateT
+import org.openjdk.jmh.annotations._
+
+/**
+ * To run:
+ *
+ *     bench/jmh:run -i 10 -wi 10 -f 2 -t 1 cats.bench.StateTBench
+ */
+@State(Scope.Thread)
+@BenchmarkMode(Array(Mode.Throughput))
+class StateTBench {
+  @Param(Array("10"))
+  var count: Int = _
+
+  @Benchmark
+  def single(): Long = {
+    randLong.run(32311).value._2
+  }
+
+  @Benchmark
+  def repeatedLeftBinds(): Int = {
+    var state = randInt
+    var i = 0
+    while (i < count) {
+      state = state.flatMap(int => randInt.map(_ + int))
+      i += 1
+    }
+    state.run(32312).value._2
+  }
+
+  @Benchmark
+  def repeatedRightBinds(): Int = {
+    var state = randInt
+    var i = 0
+    while (i < count) {
+      val oldS = state
+      state = randInt.flatMap(int => oldS.map(_ + int))
+      i += 1
+    }
+    state.run(32313).value._2
+  }
+
+  def fn(seed: Long): Eval[(Long, Int)] =
+    Eval.now {
+      val newSeed = (seed * 0x5DEECE66DL + 0xBL) & 0xFFFFFFFFFFFFL
+      val n = (newSeed >>> 16).toInt
+      (newSeed, n)
+    }
+
+  val randInt: StateT[Eval, Long, Int] =
+    StateT(fn)
+
+  val randLong: StateT[Eval, Long, Long] =
+    for {
+      int1 <- randInt
+      int2 <- randInt
+    } yield {
+      (int1.toLong << 32) | int2
+    }
+}

--- a/core/src/main/scala/cats/data/AndThen.scala
+++ b/core/src/main/scala/cats/data/AndThen.scala
@@ -97,7 +97,7 @@ private[cats] sealed abstract class AndThen[-T, +R]
     self.asInstanceOf[AndThen[T, E]]
   }
 
-  override def toString =
+  override def toString: String =
     "AndThen$" + System.identityHashCode(this)
 }
 

--- a/core/src/main/scala/cats/data/AndThen.scala
+++ b/core/src/main/scala/cats/data/AndThen.scala
@@ -36,7 +36,7 @@ private[cats] sealed abstract class AndThen[-T, +R]
       case Single(f, index) if index != 127 =>
         Single(f.andThen(g), index + 1)
       case _ =>
-        andThenF(Single(g, 0))
+        andThenF(AndThen(g))
     }
   }
 
@@ -47,7 +47,7 @@ private[cats] sealed abstract class AndThen[-T, +R]
       case Single(f, index) if index != 127 =>
         Single(f.compose(g), index + 1)
       case _ =>
-        composeF(Single(g, 0))
+        composeF(AndThen(g))
     }
   }
 
@@ -103,11 +103,15 @@ private[cats] sealed abstract class AndThen[-T, +R]
 
 private[cats] object AndThen {
   /** Builds simple [[AndThen]] reference by wrapping a function. */
-  def apply[A, B](f: A => B): (A => B) =
+  def apply[A, B](f: A => B): AndThen[A, B] =
     f match {
       case ref: AndThen[A, B] @unchecked => ref
       case _ => Single(f, 0)
     }
+
+  /** Alias for `apply` that returns a `Function1` type. */
+  def wrap[A, B](f: A => B): (A => B) =
+    apply(f)
 
   private final case class Single[-A, +B](f: A => B, index: Int)
     extends AndThen[A, B]

--- a/core/src/main/scala/cats/data/AndThen.scala
+++ b/core/src/main/scala/cats/data/AndThen.scala
@@ -110,14 +110,14 @@ private[cats] object AndThen {
   private final case class Concat[-A, E, +B](left: AndThen[A, E], right: AndThen[E, B])
     extends AndThen[A, B]
 
-  /** 
-   * Establishes the maximum stack depth when fusing `andThen` or 
+  /**
+   * Establishes the maximum stack depth when fusing `andThen` or
    * `compose` calls.
    *
    * The default is `128`, from which we substract one as an optimization,
    * a "!=" comparisson being slightly more efficient than a "<".
    *
-   * This value was reached by taking into account the default stack 
+   * This value was reached by taking into account the default stack
    * size as set on 32 bits or 64 bits, Linux or Windows systems,
    * being enough to notice performance gains, but not big enough
    * to be in danger of triggering a stack-overflow error.

--- a/core/src/main/scala/cats/data/AndThen.scala
+++ b/core/src/main/scala/cats/data/AndThen.scala
@@ -1,0 +1,100 @@
+package cats.data
+
+import java.io.Serializable
+
+/**
+ * Internal API (Cats) — A type-aligned seq for representing
+ * function composition in constant stack space with amortized
+ * linear time application (in the number of constituent functions).
+ *
+ * A variation of this implementation was first introduced in the
+ * `cats-effect` project. Implementation is enormously uglier than
+ * it should be since `@tailrec` doesn't work properly on functions
+ * with existential types.
+ *
+ * Example:
+ *
+ * {{{
+ *   val seed = AndThen((x: Int) => x + 1))
+ *   val f = (0 until 10000).foldLeft(seed)((acc, _) => acc.andThen(_ + 1))
+ *   // This should not trigger stack overflow ;-)
+ *   f(0)
+ * }}}
+ */
+private[cats] sealed abstract class AndThen[-T, +R]
+  extends (T => R) with Product with Serializable {
+
+  import AndThen._
+
+  final def apply(a: T): R =
+    runLoop(a)
+
+  override def compose[A](g: A => T): A => R =
+    composeF(AndThen(g))
+
+  override def andThen[A](g: R => A): T => A =
+    andThenF(AndThen(g))
+
+  private def runLoop(start: T): R = {
+    var self: AndThen[Any, Any] = this.asInstanceOf[AndThen[Any, Any]]
+    var current: Any = start.asInstanceOf[Any]
+    var continue = true
+
+    while (continue) {
+      self match {
+        case Single(f) =>
+          current = f(current)
+          continue = false
+
+        case Concat(Single(f), right) =>
+          current = f(current)
+          self = right.asInstanceOf[AndThen[Any, Any]]
+
+        case Concat(left @ Concat(_, _), right) =>
+          self = left.rotateAccum(right)
+      }
+    }
+    current.asInstanceOf[R]
+  }
+
+  final def andThenF[X](right: AndThen[R, X]): AndThen[T, X] =
+    Concat(this, right)
+  final def composeF[X](right: AndThen[X, T]): AndThen[X, R] =
+    Concat(right, this)
+
+  // converts left-leaning to right-leaning
+  protected final def rotateAccum[E](_right: AndThen[R, E]): AndThen[T, E] = {
+    var self: AndThen[Any, Any] = this.asInstanceOf[AndThen[Any, Any]]
+    var right: AndThen[Any, Any] = _right.asInstanceOf[AndThen[Any, Any]]
+    var continue = true
+    while (continue) {
+      self match {
+        case Concat(left, inner) =>
+          self = left.asInstanceOf[AndThen[Any, Any]]
+          right = inner.andThenF(right)
+
+        case _ => // Single
+          self = self.andThenF(right)
+          continue = false
+      }
+    }
+    self.asInstanceOf[AndThen[T, E]]
+  }
+
+  override def toString =
+    "AndThen$" + System.identityHashCode(this)
+}
+
+private[cats] object AndThen {
+  /** Builds simple [[AndThen]] reference by wrapping a function. */
+  def apply[A, B](f: A => B): AndThen[A, B] =
+    f match {
+      case ref: AndThen[A, B] @unchecked => ref
+      case _ => Single(f)
+    }
+
+  final case class Single[-A, +B](f: A => B)
+    extends AndThen[A, B]
+  final case class Concat[-A, E, +B](left: AndThen[A, E], right: AndThen[E, B])
+    extends AndThen[A, B]
+}

--- a/core/src/main/scala/cats/data/AndThen.scala
+++ b/core/src/main/scala/cats/data/AndThen.scala
@@ -110,7 +110,7 @@ private[cats] object AndThen {
     }
 
   /** Alias for `apply` that returns a `Function1` type. */
-  def wrap[A, B](f: A => B): (A => B) =
+  def of[A, B](f: A => B): (A => B) =
     apply(f)
 
   private final case class Single[-A, +B](f: A => B, index: Int)

--- a/core/src/main/scala/cats/data/IndexedStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedStateT.scala
@@ -19,11 +19,12 @@ import cats.syntax.either._
  * Given `IndexedStateT[F, S, S, A]`, this yields the `StateT[F, S, A]` monad.
  */
 final class IndexedStateT[F[_], SA, SB, A](val runF: F[SA => F[(SB, A)]]) extends Serializable {
+  import IndexedStateT.shift
 
   def flatMap[B, SC](fas: A => IndexedStateT[F, SB, SC, B])(implicit F: FlatMap[F]): IndexedStateT[F, SA, SC, B] =
     IndexedStateT.applyF(F.map(runF) { safsba =>
-      safsba.andThen { fsba =>
-        F.flatMap(fsba) { case (sb, a) =>
+      shift { sa =>
+        F.flatMap(safsba(sa)) { case (sb, a) =>
           fas(a).run(sb)
         }
       }
@@ -31,8 +32,8 @@ final class IndexedStateT[F[_], SA, SB, A](val runF: F[SA => F[(SB, A)]]) extend
 
   def flatMapF[B](faf: A => F[B])(implicit F: FlatMap[F]): IndexedStateT[F, SA, SB, B] =
     IndexedStateT.applyF(F.map(runF) { sfsa =>
-      sfsa.andThen { fsa =>
-        F.flatMap(fsa) { case (s, a) => F.map(faf(a))((s, _)) }
+      shift { sa =>
+        F.flatMap(sfsa(sa)) { case (s, a) => F.map(faf(a))((s, _)) }
       }
     })
 
@@ -221,6 +222,35 @@ object IndexedStateT extends IndexedStateTInstances with CommonStateTConstructor
 
   def setF[F[_], SA, SB](fsb: F[SB])(implicit F: Applicative[F]): IndexedStateT[F, SA, SB, Unit] =
     IndexedStateT(_ => F.map(fsb)(s => (s, ())))
+
+  /**
+   * Internal API — shifts the execution of `f` in the `F` context.
+   *
+   * Used to build `IndexedStateT` values for `F[_]` data types that
+   * implement `Monad`, in which case it is safer to trigger the `F[_]`
+   * context earlier.
+   *
+   * The requirement is for `FlatMap` as this will get used in operations
+   * that invoke `F.flatMap` (e.g. in `IndexedStateT#flatMap`). However we are
+   * doing discrimination based on inheritance and if we detect an
+   * `Applicative`, then we use it to trigger the `F[_]` context earlier.
+   *
+   * Triggering the `F[_]` context earlier is important to avoid stack
+   * safety issues for `F` monads that have a stack safe `flatMap`
+   * implementation. For example `Eval` or `IO`. Without this the `Monad`
+   * instance is stack unsafe, even if the underlying `F` is stack safe
+   * in `flatMap`.
+   */
+  private def shift[F[_], SA, SB, A](f: SA => F[(SB, A)])
+    (implicit F: FlatMap[F]): (SA => F[(SB, A)]) = {
+
+    F match {
+      case ap: Applicative[F] @unchecked =>
+        sa => F.flatMap(ap.pure(sa))(f)
+      case _ =>
+        f
+    }
+  }
 }
 
 private[data] abstract class StateTFunctions extends CommonStateTConstructors {

--- a/tests/src/test/scala/cats/tests/AndThenSuite.scala
+++ b/tests/src/test/scala/cats/tests/AndThenSuite.scala
@@ -6,7 +6,7 @@ import cats.data._
 class AndThenSuite extends CatsSuite {
   test("compose a chain of functions with andThen") {
     check { (i: Int, fs: List[Int => Int]) =>
-      val result = fs.map(AndThen.wrap(_)).reduceOption(_.andThen(_)).map(_(i))
+      val result = fs.map(AndThen.of(_)).reduceOption(_.andThen(_)).map(_(i))
       val expect = fs.reduceOption(_.andThen(_)).map(_(i))
 
       result == expect
@@ -15,7 +15,7 @@ class AndThenSuite extends CatsSuite {
 
   test("compose a chain of functions with compose") {
     check { (i: Int, fs: List[Int => Int]) =>
-      val result = fs.map(AndThen.wrap(_)).reduceOption(_.compose(_)).map(_(i))
+      val result = fs.map(AndThen.of(_)).reduceOption(_.compose(_)).map(_(i))
       val expect = fs.reduceOption(_.compose(_)).map(_(i))
 
       result == expect
@@ -25,7 +25,7 @@ class AndThenSuite extends CatsSuite {
   test("andThen is stack safe") {
     val count = if (Platform.isJvm) 500000 else 1000
     val fs = (0 until count).map(_ => { i: Int => i + 1 })
-    val result = fs.foldLeft(AndThen.wrap((x: Int) => x))(_.andThen(_))(42)
+    val result = fs.foldLeft(AndThen.of((x: Int) => x))(_.andThen(_))(42)
 
     result shouldEqual (count + 42)
   }
@@ -33,7 +33,7 @@ class AndThenSuite extends CatsSuite {
   test("compose is stack safe") {
     val count = if (Platform.isJvm) 500000 else 1000
     val fs = (0 until count).map(_ => { i: Int => i + 1 })
-    val result = fs.foldLeft(AndThen.wrap((x: Int) => x))(_.compose(_))(42)
+    val result = fs.foldLeft(AndThen.of((x: Int) => x))(_.compose(_))(42)
 
     result shouldEqual (count + 42)
   }

--- a/tests/src/test/scala/cats/tests/AndThenSuite.scala
+++ b/tests/src/test/scala/cats/tests/AndThenSuite.scala
@@ -6,7 +6,7 @@ import cats.data._
 class AndThenSuite extends CatsSuite {
   test("compose a chain of functions with andThen") {
     check { (i: Int, fs: List[Int => Int]) =>
-      val result = fs.map(AndThen(_)).reduceOption(_.andThen(_)).map(_(i))
+      val result = fs.map(AndThen.wrap(_)).reduceOption(_.andThen(_)).map(_(i))
       val expect = fs.reduceOption(_.andThen(_)).map(_(i))
 
       result == expect
@@ -15,7 +15,7 @@ class AndThenSuite extends CatsSuite {
 
   test("compose a chain of functions with compose") {
     check { (i: Int, fs: List[Int => Int]) =>
-      val result = fs.map(AndThen(_)).reduceOption(_.compose(_)).map(_(i))
+      val result = fs.map(AndThen.wrap(_)).reduceOption(_.compose(_)).map(_(i))
       val expect = fs.reduceOption(_.compose(_)).map(_(i))
 
       result == expect
@@ -25,7 +25,7 @@ class AndThenSuite extends CatsSuite {
   test("andThen is stack safe") {
     val count = if (Platform.isJvm) 500000 else 1000
     val fs = (0 until count).map(_ => { i: Int => i + 1 })
-    val result = fs.map(AndThen(_)).reduceLeft(_.andThen(_))(42)
+    val result = fs.foldLeft(AndThen.wrap((x: Int) => x))(_.andThen(_))(42)
 
     result shouldEqual (count + 42)
   }
@@ -33,7 +33,7 @@ class AndThenSuite extends CatsSuite {
   test("compose is stack safe") {
     val count = if (Platform.isJvm) 500000 else 1000
     val fs = (0 until count).map(_ => { i: Int => i + 1 })
-    val result = fs.map(AndThen(_)).reduceLeft(_.compose(_))(42)
+    val result = fs.foldLeft(AndThen.wrap((x: Int) => x))(_.compose(_))(42)
 
     result shouldEqual (count + 42)
   }
@@ -50,7 +50,4 @@ class AndThenSuite extends CatsSuite {
   test("toString") {
     AndThen((x: Int) => x).toString should startWith("AndThen$")
   }
-
-  // Utils
-  val id = AndThen((x: Int) => x)
 }

--- a/tests/src/test/scala/cats/tests/AndThenSuite.scala
+++ b/tests/src/test/scala/cats/tests/AndThenSuite.scala
@@ -6,7 +6,7 @@ import cats.data._
 class AndThenSuite extends CatsSuite {
   test("compose a chain of functions with andThen") {
     check { (i: Int, fs: List[Int => Int]) =>
-      val result = fs.map(AndThen(_)).reduceOption(_.andThenF(_)).map(_(i))
+      val result = fs.map(AndThen(_)).reduceOption(_.andThen(_)).map(_(i))
       val expect = fs.reduceOption(_.andThen(_)).map(_(i))
 
       result == expect
@@ -15,7 +15,7 @@ class AndThenSuite extends CatsSuite {
 
   test("compose a chain of functions with compose") {
     check { (i: Int, fs: List[Int => Int]) =>
-      val result = fs.map(AndThen(_)).reduceOption(_.composeF(_)).map(_(i))
+      val result = fs.map(AndThen(_)).reduceOption(_.compose(_)).map(_(i))
       val expect = fs.reduceOption(_.compose(_)).map(_(i))
 
       result == expect
@@ -23,9 +23,17 @@ class AndThenSuite extends CatsSuite {
   }
 
   test("andThen is stack safe") {
-    val count = if (Platform.isJvm) 50000 else 1000
+    val count = if (Platform.isJvm) 500000 else 1000
     val fs = (0 until count).map(_ => { i: Int => i + 1 })
-    val result = fs.map(AndThen(_)).reduceLeft(_.andThenF(_))(42)
+    val result = fs.map(AndThen(_)).reduceLeft(_.andThen(_))(42)
+
+    result shouldEqual (count + 42)
+  }
+
+  test("compose is stack safe") {
+    val count = if (Platform.isJvm) 500000 else 1000
+    val fs = (0 until count).map(_ => { i: Int => i + 1 })
+    val result = fs.map(AndThen(_)).reduceLeft(_.compose(_))(42)
 
     result shouldEqual (count + 42)
   }

--- a/tests/src/test/scala/cats/tests/AndThenSuite.scala
+++ b/tests/src/test/scala/cats/tests/AndThenSuite.scala
@@ -6,7 +6,7 @@ import cats.data._
 class AndThenSuite extends CatsSuite {
   test("compose a chain of functions with andThen") {
     check { (i: Int, fs: List[Int => Int]) =>
-      val result = fs.map(AndThen.of(_)).reduceOption(_.andThen(_)).map(_(i))
+      val result = fs.map(AndThen(_)).reduceOption(_.andThen(_)).map(_(i))
       val expect = fs.reduceOption(_.andThen(_)).map(_(i))
 
       result == expect
@@ -15,7 +15,7 @@ class AndThenSuite extends CatsSuite {
 
   test("compose a chain of functions with compose") {
     check { (i: Int, fs: List[Int => Int]) =>
-      val result = fs.map(AndThen.of(_)).reduceOption(_.compose(_)).map(_(i))
+      val result = fs.map(AndThen(_)).reduceOption(_.compose(_)).map(_(i))
       val expect = fs.reduceOption(_.compose(_)).map(_(i))
 
       result == expect
@@ -25,7 +25,7 @@ class AndThenSuite extends CatsSuite {
   test("andThen is stack safe") {
     val count = if (Platform.isJvm) 500000 else 1000
     val fs = (0 until count).map(_ => { i: Int => i + 1 })
-    val result = fs.foldLeft(AndThen.of((x: Int) => x))(_.andThen(_))(42)
+    val result = fs.foldLeft(AndThen((x: Int) => x))(_.andThen(_))(42)
 
     result shouldEqual (count + 42)
   }
@@ -33,7 +33,7 @@ class AndThenSuite extends CatsSuite {
   test("compose is stack safe") {
     val count = if (Platform.isJvm) 500000 else 1000
     val fs = (0 until count).map(_ => { i: Int => i + 1 })
-    val result = fs.foldLeft(AndThen.of((x: Int) => x))(_.compose(_))(42)
+    val result = fs.foldLeft(AndThen((x: Int) => x))(_.compose(_))(42)
 
     result shouldEqual (count + 42)
   }

--- a/tests/src/test/scala/cats/tests/AndThenSuite.scala
+++ b/tests/src/test/scala/cats/tests/AndThenSuite.scala
@@ -1,0 +1,48 @@
+package cats.tests
+
+import catalysts.Platform
+import cats.data._
+
+class AndThenSuite extends CatsSuite {
+  test("compose a chain of functions with andThen") {
+    check { (i: Int, fs: List[Int => Int]) =>
+      val result = fs.map(AndThen(_)).reduceOption(_.andThenF(_)).map(_(i))
+      val expect = fs.reduceOption(_.andThen(_)).map(_(i))
+
+      result == expect
+    }
+  }
+
+  test("compose a chain of functions with compose") {
+    check { (i: Int, fs: List[Int => Int]) =>
+      val result = fs.map(AndThen(_)).reduceOption(_.composeF(_)).map(_(i))
+      val expect = fs.reduceOption(_.compose(_)).map(_(i))
+
+      result == expect
+    }
+  }
+
+  test("andThen is stack safe") {
+    val count = if (Platform.isJvm) 50000 else 1000
+    val fs = (0 until count).map(_ => { i: Int => i + 1 })
+    val result = fs.map(AndThen(_)).reduceLeft(_.andThenF(_))(42)
+
+    result shouldEqual (count + 42)
+  }
+
+  test("Function1 andThen is stack safe") {
+    val count = if (Platform.isJvm) 50000 else 1000
+    val start: (Int => Int) = AndThen((x: Int) => x)
+    val fs = (0 until count).foldLeft(start) { (acc, _) =>
+      acc.andThen(_ + 1)
+    }
+    fs(0) shouldEqual count
+  }
+
+  test("toString") {
+    AndThen((x: Int) => x).toString should startWith("AndThen$")
+  }
+
+  // Utils
+  val id = AndThen((x: Int) => x)
+}


### PR DESCRIPTION
Close #2186.

This is very similar in spirit with the PR #2185 that fixes `Kleisli`, but this one is for `IndexedStateT` and with a different solution.

For `IndexedStateT` instead of piggybacking on an `F: Monad` for the stack safety of repeated left binds, this time we are introducing an `AndThen` implementation.

`AndThen` was first introduced in `cats-effect` for describing functions that are stack safe in `andThen` and `compose`, the original `cats.effect.IO` implementation being based on it.

Introduced as an internal helper (thus not exposed to the public), this is now used to provide stack safety for `IndexedStateT`.

Note that an implementation similar to that of PR #2185 is also possible, deferring this responsibility to `F[_]`, except that this version proposed here works for any `F[_]` when it comes to the stack safety of left associative binds.

---

## Benchmarks

I've added a benchmark (see [StateTBench](https://github.com/typelevel/cats/pull/2187/files#diff-cdb9115fe31f9ee2cf733f49d63749fc)) that I used to compare the new implementation with `master`. The results are:

| Benchmark |   Master |   This PR |  Units |
|-------------|----------:|----------:|------:|
| single flatMap | 3924997 | 3832845 | ops/s |
| repeated left binds | 353197 | 343995 | ops/s |
| repeated right binds | 346440 | 337696 | ops/s |

There is a difference but is imo insignificant.

## FAQ

In preparation for the upcoming discussion:

### Could this solution be used for Kleisli?

I do not see a solution, because `andThen` swallows the input and you need it a second time for triggering the instance returned by the mapping function:

```scala
def flatMap[C](f: B => Kleisli[F, A, C])(implicit F: FlatMap[F]): Kleisli[F, A, C] =
  Kleisli(AndThen(run).andThen { b =>
    f(b).run(a)
    //   ^^^^^^
    // We've lost `A` here, so this won't work :-(
  })
```

Unless I'm missing something, the answer is no — but it would have been awesome 😞

### Is `AndThen` reusable?

Yes, we might end up using it for fixing the stack safety of other data types too.

### Should we expose `AndThen`?

It's a pretty useful data type, maybe. Currently it's `private[cats]`.