### PR TITLE
Remove calls to PartialFunction.apply, deprecated in 2.12.5

### DIFF
--- a/laws/src/main/scala/cats/laws/ApplicativeErrorLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplicativeErrorLaws.scala
@@ -26,10 +26,10 @@ trait ApplicativeErrorLaws[F[_], E] extends ApplicativeLaws[F] {
     F.attempt(F.pure(a)) <-> F.pure(Right(a))
 
   def handleErrorWithConsistentWithRecoverWith[A](fa: F[A], f: E => F[A]): IsEq[F[A]] =
-    F.handleErrorWith(fa)(f) <-> F.recoverWith(fa)(PartialFunction(f))
+    F.handleErrorWith(fa)(f) <-> F.recoverWith(fa) { case x => f(x) }
 
   def handleErrorConsistentWithRecover[A](fa: F[A], f: E => A): IsEq[F[A]] =
-    F.handleError(fa)(f) <-> F.recover(fa)(PartialFunction(f))
+    F.handleError(fa)(f) <-> F.recover(fa) { case x => f(x) }
 
   def recoverConsistentWithRecoverWith[A](fa: F[A], pf: PartialFunction[E, A]): IsEq[F[A]] =
     F.recover(fa)(pf) <-> F.recoverWith(fa)(pf andThen F.pure)
@@ -41,7 +41,7 @@ trait ApplicativeErrorLaws[F[_], E] extends ApplicativeLaws[F] {
     F.attempt(F.fromEither(eab)) <-> F.pure(eab)
 
   def onErrorPure[A](a: A, f: E => F[Unit]): IsEq[F[A]] =
-    F.onError(F.pure(a))(PartialFunction(f)) <-> F.pure(a)
+    F.onError(F.pure(a)) { case x => f(x) } <-> F.pure(a)
 
   def onErrorRaise[A](fa: F[A], e: E, fb: F[Unit]): IsEq[F[A]] =
     F.onError(F.raiseError[A](e)){case err => fb} <-> F.map2(fb, F.raiseError[A](e))((_, b) => b)

--- a/laws/src/main/scala/cats/laws/MonadErrorLaws.scala
+++ b/laws/src/main/scala/cats/laws/MonadErrorLaws.scala
@@ -15,10 +15,10 @@ trait MonadErrorLaws[F[_], E] extends ApplicativeErrorLaws[F, E] with MonadLaws[
     F.ensureOr(fa)(e)(p) <-> F.flatMap(fa)(a => if (p(a)) F.pure(a) else F.raiseError(e(a)))
 
   def adaptErrorPure[A](a: A, f: E => E): IsEq[F[A]] =
-    F.adaptError(F.pure(a))(PartialFunction(f)) <-> F.pure(a)
+    F.adaptError(F.pure(a)) { case x => f(x) } <-> F.pure(a)
 
   def adaptErrorRaise[A](e: E, f: E => E): IsEq[F[A]] =
-    F.adaptError(F.raiseError[A](e))(PartialFunction(f)) <-> F.raiseError(f(e))
+    F.adaptError(F.raiseError[A](e)) { case x => f(x) } <-> F.raiseError(f(e))
 
   def rethrowAttempt[A](fa: F[A]): IsEq[F[A]] =
     F.rethrow(F.attempt(fa)) <-> fa


### PR DESCRIPTION
`PartialFunction.apply` is deprecated in 2.12.5, removed in 2.13.0. So this PR is advance work for the 2.13 build. Error message in 2.13.0-M3 build:

> method apply in object PartialFunction is deprecated (since 2.12.5): For converting an ordinary function f to a partial function pf, use `val pf: PartialFunction[A, B] = { case x => f(x) }`. For creating a new PartialFunction, use an explicit type annotation instead, like in `val pf: PartialFunction[Int, String] = { case 1 => "one" }`.

Required for https://github.com/typelevel/cats/pull/2173