### PR TITLE
Extend Functor implementation in the Traverse instance of EitherT, OptionT and Tuple2K

### DIFF
--- a/core/src/main/scala/cats/data/EitherK.scala
+++ b/core/src/main/scala/cats/data/EitherK.scala
@@ -140,7 +140,7 @@ private[data] sealed abstract class EitherKInstances2 extends EitherKInstances3 
 
 private[data] sealed abstract class EitherKInstances1 extends EitherKInstances2 {
   implicit def catsDataCoflatMapForEitherK[F[_], G[_]](implicit F0: CoflatMap[F], G0: CoflatMap[G]): CoflatMap[EitherK[F, G, ?]] =
-    new EitherKCoflatMap[F, G] {
+    new EitherKCoflatMap[F, G] with EitherKFunctor[F, G] {
       implicit def F: CoflatMap[F] = F0
 
       implicit def G: CoflatMap[G] = G0
@@ -149,7 +149,7 @@ private[data] sealed abstract class EitherKInstances1 extends EitherKInstances2 
 
 private[data] sealed abstract class EitherKInstances0 extends EitherKInstances1 {
   implicit def catsDataTraverseForEitherK[F[_], G[_]](implicit F0: Traverse[F], G0: Traverse[G]): Traverse[EitherK[F, G, ?]] =
-    new EitherKTraverse[F, G] {
+    new EitherKTraverse[F, G] with EitherKFunctor[F, G] {
       implicit def F: Traverse[F] = F0
 
       implicit def G: Traverse[G] = G0
@@ -159,7 +159,7 @@ private[data] sealed abstract class EitherKInstances0 extends EitherKInstances1 
 private[data] sealed abstract class EitherKInstances extends EitherKInstances0 {
 
   implicit def catsDataComonadForEitherK[F[_], G[_]](implicit F0: Comonad[F], G0: Comonad[G]): Comonad[EitherK[F, G, ?]] =
-    new EitherKComonad[F, G] {
+    new EitherKComonad[F, G] with EitherKFunctor[F, G] {
       implicit def F: Comonad[F] = F0
 
       implicit def G: Comonad[G] = G0
@@ -171,7 +171,7 @@ private[data] trait EitherKFunctor[F[_], G[_]] extends Functor[EitherK[F, G, ?]]
 
   implicit def G: Functor[G]
 
-  def map[A, B](a: EitherK[F, G, A])(f: A => B): EitherK[F, G, B] =
+  override def map[A, B](a: EitherK[F, G, A])(f: A => B): EitherK[F, G, B] =
     a map f
 }
 

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -462,8 +462,8 @@ private[data] abstract class EitherTInstances extends EitherTInstances1 {
     Contravariant[Show].contramap(sh)(_.value)
 
   implicit def catsDataBifunctorForEitherT[F[_]](implicit F: Functor[F]): Bifunctor[EitherT[F, ?, ?]] =
-    new Bifunctor[EitherT[F, ?, ?]] {
-      override def bimap[A, B, C, D](fab: EitherT[F, A, B])(f: A => C, g: B => D): EitherT[F, C, D] = fab.bimap(f, g)
+    new EitherTBifunctor[F] {
+      val F0: Functor[F] = F
     }
 
   implicit def catsDataTraverseForEitherT[F[_], L](implicit FF: Traverse[F]): Traverse[EitherT[F, L, ?]] =
@@ -493,7 +493,7 @@ private[data] abstract class EitherTInstances1 extends EitherTInstances2 {
     }
 
   implicit def catsDataBitraverseForEitherT[F[_]](implicit F: Traverse[F]): Bitraverse[EitherT[F, ?, ?]] =
-    new EitherTBitraverse[F] {
+    new EitherTBitraverse[F] with EitherTBifunctor[F] {
       val F0: Traverse[F] = F
     }
 
@@ -639,6 +639,12 @@ private[data] sealed trait EitherTBitraverse[F[_]] extends Bitraverse[EitherT[F,
 
   override def bitraverse[G[_], A, B, C, D](fab: EitherT[F, A, B])(f: A => G[C], g: B => G[D])(implicit G: Applicative[G]): G[EitherT[F, C, D]] =
     fab.bitraverse(f, g)
+}
+
+private[data] sealed trait EitherTBifunctor[F[_]] extends Bifunctor[EitherT[F, ?, ?]] {
+  implicit def F0: Functor[F]
+
+  override def bimap[A, B, C, D](fab: EitherT[F, A, B])(f: A => C, g: B => D): EitherT[F, C, D] = fab.bimap(f, g)
 }
 
 private[data] sealed trait EitherTEq[F[_], L, A] extends Eq[EitherT[F, L, A]] {

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -496,14 +496,14 @@ private[data] abstract class EitherTInstances1 extends EitherTInstances2 {
       val F0: Traverse[F] = F
     }
 
-  implicit def catsDataMonadErrorForEitherT[F[_], L](implicit F0: Monad[F]): MonadError[EitherT[F, L, ?], L] =
+  implicit def catsDataMonadErrorForEitherT[F[_], L](implicit F: Monad[F]): MonadError[EitherT[F, L, ?], L] =
     new EitherTMonadError[F, L] {
-      implicit val F = F0
+      val F0: Monad[F] = F
       override def ensure[A](fa: EitherT[F, L, A])(error: => L)(predicate: (A) => Boolean): EitherT[F, L, A] =
-        fa.ensure(error)(predicate)(F)
+        fa.ensure(error)(predicate)(F0)
 
       override def ensureOr[A](fa: EitherT[F, L, A])(error: (A) => L)(predicate: (A) => Boolean): EitherT[F, L, A] =
-        fa.ensureOr(error)(predicate)(F)
+        fa.ensureOr(error)(predicate)(F0)
     }
 }
 
@@ -523,11 +523,11 @@ private[data] abstract class EitherTInstances2 extends EitherTInstances3 {
    * }}}
    */
   implicit def catsDataMonadErrorFForEitherT[F[_], E, L](implicit FE0: MonadError[F, E]): MonadError[EitherT[F, L, ?], E] =
-    new EitherTMonadErrorF[F, E, L] { implicit val F = FE0 }
+    new EitherTMonadErrorF[F, E, L] { val F0: MonadError[F, E] = FE0 }
 
 
-  implicit def catsDataSemigroupKForEitherT[F[_], L](implicit F0: Monad[F]): SemigroupK[EitherT[F, L, ?]] =
-    new EitherTSemigroupK[F, L] { implicit val F = F0 }
+  implicit def catsDataSemigroupKForEitherT[F[_], L](implicit F: Monad[F]): SemigroupK[EitherT[F, L, ?]] =
+    new EitherTSemigroupK[F, L] { val F0: Monad[F] = F }
 
   implicit def catsDataEqForEitherT[F[_], L, R](implicit F: Eq[F[Either[L, R]]]): Eq[EitherT[F, L, R]] =
     new EitherTEq[F, L, R] {
@@ -536,8 +536,8 @@ private[data] abstract class EitherTInstances2 extends EitherTInstances3 {
 }
 
 private[data] abstract class EitherTInstances3 {
-  implicit def catsDataFunctorForEitherT[F[_], L](implicit F0: Functor[F]): Functor[EitherT[F, L, ?]] =
-    new EitherTFunctor[F, L] { implicit val F = F0 }
+  implicit def catsDataFunctorForEitherT[F[_], L](implicit F: Functor[F]): Functor[EitherT[F, L, ?]] =
+    new EitherTFunctor[F, L] { val F0: Functor[F] = F }
 }
 
 private[data] trait EitherTSemigroup[F[_], L, A] extends Semigroup[EitherT[F, L, A]] {
@@ -552,26 +552,26 @@ private[data] trait EitherTMonoid[F[_], L, A] extends Monoid[EitherT[F, L, A]] w
 }
 
 private[data] trait EitherTSemigroupK[F[_], L] extends SemigroupK[EitherT[F, L, ?]] {
-  implicit val F: Monad[F]
+  implicit val F0: Monad[F]
   def combineK[A](x: EitherT[F, L, A], y: EitherT[F, L, A]): EitherT[F, L, A] =
-    EitherT(F.flatMap(x.value) {
+    EitherT(F0.flatMap(x.value) {
       case l @ Left(_) => y.value
-      case r @ Right(_) => F.pure(r)
+      case r @ Right(_) => F0.pure(r)
     })
 }
 
 private[data] trait EitherTFunctor[F[_], L] extends Functor[EitherT[F, L, ?]] {
-  implicit val F: Functor[F]
+  implicit def F0: Functor[F]
   override def map[A, B](fa: EitherT[F, L, A])(f: A => B): EitherT[F, L, B] = fa map f
 }
 
 private[data] trait EitherTMonad[F[_], L] extends Monad[EitherT[F, L, ?]] with EitherTFunctor[F, L] {
-  implicit val F: Monad[F]
+  implicit def F0: Monad[F]
   def pure[A](a: A): EitherT[F, L, A] = EitherT.pure(a)
 
   def flatMap[A, B](fa: EitherT[F, L, A])(f: A => EitherT[F, L, B]): EitherT[F, L, B] = fa flatMap f
   def tailRecM[A, B](a: A)(f: A => EitherT[F, L, Either[A, B]]): EitherT[F, L, B] =
-    EitherT(F.tailRecM(a)(a0 => F.map(f(a0).value) {
+    EitherT(F0.tailRecM(a)(a0 => F0.map(f(a0).value) {
       case Left(l)         => Right(Left(l))
       case Right(Left(a1)) => Left(a1)
       case Right(Right(b)) => Right(Right(b))
@@ -579,26 +579,26 @@ private[data] trait EitherTMonad[F[_], L] extends Monad[EitherT[F, L, ?]] with E
 }
 
 private[data] trait EitherTMonadErrorF[F[_], E, L] extends MonadError[EitherT[F, L, ?], E] with EitherTMonad[F, L] {
-  implicit val F: MonadError[F, E]
+  implicit def F0: MonadError[F, E]
 
   def handleErrorWith[A](fea: EitherT[F, L, A])(f: E => EitherT[F, L, A]): EitherT[F, L, A] =
-    EitherT(F.handleErrorWith(fea.value)(f(_).value))
+    EitherT(F0.handleErrorWith(fea.value)(f(_).value))
 
-  def raiseError[A](e: E): EitherT[F, L, A] = EitherT(F.raiseError(e))
+  def raiseError[A](e: E): EitherT[F, L, A] = EitherT(F0.raiseError(e))
 }
 
 private[data] trait EitherTMonadError[F[_], L] extends MonadError[EitherT[F, L, ?], L] with EitherTMonad[F, L] {
   def handleErrorWith[A](fea: EitherT[F, L, A])(f: L => EitherT[F, L, A]): EitherT[F, L, A] =
-    EitherT(F.flatMap(fea.value) {
+    EitherT(F0.flatMap(fea.value) {
       case Left(e) => f(e).value
-      case r @ Right(_) => F.pure(r)
+      case r @ Right(_) => F0.pure(r)
     })
   override def handleError[A](fea: EitherT[F, L, A])(f: L => A): EitherT[F, L, A] =
-    EitherT(F.flatMap(fea.value) {
-      case Left(e) => F.pure(Right(f(e)))
-      case r @ Right(_) => F.pure(r)
+    EitherT(F0.flatMap(fea.value) {
+      case Left(e) => F0.pure(Right(f(e)))
+      case r @ Right(_) => F0.pure(r)
     })
-  def raiseError[A](e: L): EitherT[F, L, A] = EitherT.left(F.pure(e))
+  def raiseError[A](e: L): EitherT[F, L, A] = EitherT.left(F0.pure(e))
   override def attempt[A](fla: EitherT[F, L, A]): EitherT[F, L, Either[L, A]] = EitherT.right(fla.value)
   override def recover[A](fla: EitherT[F, L, A])(pf: PartialFunction[L, A]): EitherT[F, L, A] =
     fla.recover(pf)
@@ -616,7 +616,7 @@ private[data] sealed trait EitherTFoldable[F[_], L] extends Foldable[EitherT[F, 
     fa.foldRight(lb)(f)
 }
 
-private[data] sealed trait EitherTTraverse[F[_], L] extends Traverse[EitherT[F, L, ?]] with EitherTFoldable[F, L] {
+private[data] sealed trait EitherTTraverse[F[_], L] extends Traverse[EitherT[F, L, ?]] with EitherTFoldable[F, L] with EitherTFunctor[F, L] {
   override implicit def F0: Traverse[F]
 
   override def traverse[G[_]: Applicative, A, B](fa: EitherT[F, L, A])(f: A => G[B]): G[EitherT[F, L, B]] =

--- a/core/src/main/scala/cats/data/IorT.scala
+++ b/core/src/main/scala/cats/data/IorT.scala
@@ -410,7 +410,7 @@ private[data] abstract class IorTInstances extends IorTInstances1 {
     }
 
   implicit def catsDataTraverseForIorT[F[_], A](implicit F: Traverse[F]): Traverse[IorT[F, A, ?]] =
-    new IorTTraverse[F, A] { val F0: Traverse[F] = F }
+    new IorTTraverse[F, A] with IorTFunctor[F, A] { val F0: Traverse[F] = F }
 
   implicit def catsDataMonoidForIorT[F[_], A, B](implicit F: Monoid[F[Ior[A, B]]]): Monoid[IorT[F, A, B]] =
     new IorTMonoid[F, A, B] { val F0: Monoid[F[Ior[A, B]]] = F }

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -238,7 +238,7 @@ private[data] sealed abstract class KleisliInstances6 extends KleisliInstances7 
 
 private[data] sealed abstract class KleisliInstances7 extends KleisliInstances8 {
   implicit def catsDataDistributiveForKleisli[F[_], R](implicit F0: Distributive[F]): Distributive[Kleisli[F, R, ?]] =
-    new KleisliDistributive[F, R] { implicit def F: Distributive[F] = F0 }
+    new KleisliDistributive[F, R] with KleisliFunctor[F, R] { implicit def F: Distributive[F] = F0 }
 }
 
 private[data] sealed abstract class KleisliInstances8 {

--- a/core/src/main/scala/cats/data/Nested.scala
+++ b/core/src/main/scala/cats/data/Nested.scala
@@ -45,7 +45,7 @@ private[data] sealed abstract class NestedInstances extends NestedInstances0 {
     }
 
   implicit def catsDataContravariantMonoidalForApplicativeForNested[F[_]: Applicative, G[_]: ContravariantMonoidal]: ContravariantMonoidal[Nested[F, G, ?]] =
-    new NestedContravariantMonoidal[F, G] {
+    new NestedContravariantMonoidal[F, G] with NestedContravariant[F, G] {
       val FG: ContravariantMonoidal[λ[α => F[G[α]]]] = Applicative[F].composeContravariantMonoidal[G]
     }
 }
@@ -284,7 +284,7 @@ private[data] trait NestedNonEmptyTraverse[F[_], G[_]] extends NonEmptyTraverse[
 private[data] trait NestedContravariant[F[_], G[_]] extends Contravariant[Nested[F, G, ?]] {
   def FG: Contravariant[λ[α => F[G[α]]]]
 
-  def contramap[A, B](fga: Nested[F, G, A])(f: B => A): Nested[F, G, B] =
+  override def contramap[A, B](fga: Nested[F, G, A])(f: B => A): Nested[F, G, B] =
     Nested(FG.contramap(fga.value)(f))
 }
 

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -258,7 +258,7 @@ private[data] sealed abstract class OptionTInstances1 extends OptionTInstances2 
 
 private[data] sealed abstract class OptionTInstances2 extends OptionTInstances3 {
   implicit def catsDataTraverseForOptionT[F[_]](implicit F0: Traverse[F]): Traverse[OptionT[F, ?]] =
-    new OptionTTraverse[F] { implicit val F = F0 }
+    new OptionTTraverse[F] with OptionTFunctor[F] { implicit val F = F0 }
 }
 
 private[data] sealed abstract class OptionTInstances3 {
@@ -324,7 +324,7 @@ private[data] trait OptionTFoldable[F[_]] extends Foldable[OptionT[F, ?]] {
     fa.foldRight(lb)(f)
 }
 
-private[data] sealed trait OptionTTraverse[F[_]] extends Traverse[OptionT[F, ?]] with OptionTFoldable[F] with OptionTFunctor[F] {
+private[data] sealed trait OptionTTraverse[F[_]] extends Traverse[OptionT[F, ?]] with OptionTFoldable[F] {
   implicit def F: Traverse[F]
 
   def traverse[G[_]: Applicative, A, B](fa: OptionT[F, A])(f: A => G[B]): G[OptionT[F, B]] =

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -324,7 +324,7 @@ private[data] trait OptionTFoldable[F[_]] extends Foldable[OptionT[F, ?]] {
     fa.foldRight(lb)(f)
 }
 
-private[data] sealed trait OptionTTraverse[F[_]] extends Traverse[OptionT[F, ?]] with OptionTFoldable[F] {
+private[data] sealed trait OptionTTraverse[F[_]] extends Traverse[OptionT[F, ?]] with OptionTFoldable[F] with OptionTFunctor[F] {
   implicit def F: Traverse[F]
 
   def traverse[G[_]: Applicative, A, B](fa: OptionT[F, A])(f: A => G[B]): G[OptionT[F, B]] =

--- a/core/src/main/scala/cats/data/Tuple2K.scala
+++ b/core/src/main/scala/cats/data/Tuple2K.scala
@@ -30,7 +30,7 @@ private[data] sealed abstract class Tuple2KInstances extends Tuple2KInstances0 {
     def G: Show[G[A]] = GF
   }
   implicit def catsDataContravariantMonoidalForTuple2k[F[_], G[_]](implicit FD: ContravariantMonoidal[F], GD: ContravariantMonoidal[G]): ContravariantMonoidal[λ[α => Tuple2K[F, G, α]]] =
-    new Tuple2KContravariantMonoidal[F, G] {
+    new Tuple2KContravariantMonoidal[F, G] with Tuple2KContravariant[F, G] {
       def F: ContravariantMonoidal[F] = FD
       def G: ContravariantMonoidal[G] = GD
     }
@@ -110,10 +110,11 @@ private[data] sealed abstract class Tuple2KInstances6 extends Tuple2KInstances7 
 }
 
 private[data] sealed abstract class Tuple2KInstances7 extends Tuple2KInstances8 {
-  implicit def catsDataDistributiveForTuple2K[F[_], G[_]](implicit FF: Distributive[F], GG: Distributive[G]): Distributive[λ[α => Tuple2K[F, G, α]]] = new Tuple2KDistributive[F, G] {
-    def F: Distributive[F] = FF
-    def G: Distributive[G] = GG
-  }
+  implicit def catsDataDistributiveForTuple2K[F[_], G[_]](implicit FF: Distributive[F], GG: Distributive[G]): Distributive[λ[α => Tuple2K[F, G, α]]] =
+    new Tuple2KDistributive[F, G] with Tuple2KFunctor[F, G] {
+      def F: Distributive[F] = FF
+      def G: Distributive[G] = GG
+    }
 }
 
 private[data] sealed abstract class Tuple2KInstances8 {
@@ -133,14 +134,19 @@ private[data] sealed trait Tuple2KFunctor[F[_], G[_]] extends Functor[λ[α => T
 private[data] sealed trait Tuple2KDistributive[F[_], G[_]] extends Distributive[λ[α => Tuple2K[F, G, α]]] {
   def F: Distributive[F]
   def G: Distributive[G]
-  override def distribute[H[_]: Functor, A, B](ha: H[A])(f: A => Tuple2K[F, G, B]): Tuple2K[F, G, H[B]] = Tuple2K(F.distribute(ha){a => f(a).first}, G.distribute(ha){a => f(a).second})
-  override def map[A, B](fa: Tuple2K[F, G, A])(f: A => B): Tuple2K[F, G, B] = Tuple2K(F.map(fa.first)(f), G.map(fa.second)(f))
+
+  override def distribute[H[_]: Functor, A, B](ha: H[A])(f: A => Tuple2K[F, G, B]): Tuple2K[F, G, H[B]] =
+    Tuple2K(F.distribute(ha){a => f(a).first}, G.distribute(ha){a => f(a).second})
+
+  override def map[A, B](fa: Tuple2K[F, G, A])(f: A => B): Tuple2K[F, G, B] =
+    Tuple2K(F.map(fa.first)(f), G.map(fa.second)(f))
 }
 
 private[data] sealed trait Tuple2KContravariant[F[_], G[_]] extends Contravariant[λ[α => Tuple2K[F, G, α]]] {
   def F: Contravariant[F]
   def G: Contravariant[G]
-  def contramap[A, B](fa: Tuple2K[F, G, A])(f: B => A): Tuple2K[F, G, B] = Tuple2K(F.contramap(fa.first)(f), G.contramap(fa.second)(f))
+  override def contramap[A, B](fa: Tuple2K[F, G, A])(f: B => A): Tuple2K[F, G, B] =
+    Tuple2K(F.contramap(fa.first)(f), G.contramap(fa.second)(f))
 }
 
 private[data] sealed trait Tuple2KContravariantMonoidal[F[_], G[_]] extends ContravariantMonoidal[λ[α => Tuple2K[F, G, α]]] {

--- a/core/src/main/scala/cats/data/Tuple2K.scala
+++ b/core/src/main/scala/cats/data/Tuple2K.scala
@@ -37,10 +37,11 @@ private[data] sealed abstract class Tuple2KInstances extends Tuple2KInstances0 {
 }
 
 private[data] sealed abstract class Tuple2KInstances0 extends Tuple2KInstances1 {
-  implicit def catsDataTraverseForTuple2K[F[_], G[_]](implicit FF: Traverse[F], GF: Traverse[G]): Traverse[λ[α => Tuple2K[F, G, α]]] = new Tuple2KTraverse[F, G] {
-    def F: Traverse[F] = FF
-    def G: Traverse[G] = GF
-  }
+  implicit def catsDataTraverseForTuple2K[F[_], G[_]](implicit FF: Traverse[F], GF: Traverse[G]): Traverse[λ[α => Tuple2K[F, G, α]]] =
+    new Tuple2KTraverse[F, G] with Tuple2KFunctor[F, G] {
+      def F: Traverse[F] = FF
+      def G: Traverse[G] = GF
+    }
   implicit def catsDataContravariantForTuple2K[F[_], G[_]](implicit FC: Contravariant[F], GC: Contravariant[G]): Contravariant[λ[α => Tuple2K[F, G, α]]] = new Tuple2KContravariant[F, G] {
     def F: Contravariant[F] = FC
     def G: Contravariant[G] = GC
@@ -218,7 +219,7 @@ private[data] sealed trait Tuple2KFoldable[F[_], G[_]] extends Foldable[λ[α =>
     F.foldRight(fa.first, G.foldRight(fa.second, lb)(f))(f)
 }
 
-private[data] sealed trait Tuple2KTraverse[F[_], G[_]] extends Traverse[λ[α => Tuple2K[F, G, α]]] with Tuple2KFoldable[F, G] with Tuple2KFunctor[F, G] {
+private[data] sealed trait Tuple2KTraverse[F[_], G[_]] extends Traverse[λ[α => Tuple2K[F, G, α]]] with Tuple2KFoldable[F, G] {
   def F: Traverse[F]
   def G: Traverse[G]
 

--- a/core/src/main/scala/cats/data/Tuple2K.scala
+++ b/core/src/main/scala/cats/data/Tuple2K.scala
@@ -218,7 +218,7 @@ private[data] sealed trait Tuple2KFoldable[F[_], G[_]] extends Foldable[λ[α =>
     F.foldRight(fa.first, G.foldRight(fa.second, lb)(f))(f)
 }
 
-private[data] sealed trait Tuple2KTraverse[F[_], G[_]] extends Traverse[λ[α => Tuple2K[F, G, α]]] with Tuple2KFoldable[F, G] {
+private[data] sealed trait Tuple2KTraverse[F[_], G[_]] extends Traverse[λ[α => Tuple2K[F, G, α]]] with Tuple2KFoldable[F, G] with Tuple2KFunctor[F, G] {
   def F: Traverse[F]
   def G: Traverse[G]
 

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -297,7 +297,7 @@ private[data] sealed trait WriterTFunctor[F[_], L] extends Functor[WriterT[F, L,
 private[data] sealed trait WriterTContravariant[F[_], L] extends Contravariant[WriterT[F, L, ?]] {
   implicit def F0: Contravariant[F]
 
-  def contramap[A, B](fa: WriterT[F, L, A])(f: B => A): WriterT[F, L, B] =
+  override def contramap[A, B](fa: WriterT[F, L, A])(f: B => A): WriterT[F, L, B] =
     fa.contramap(f)
 }
 
@@ -414,13 +414,13 @@ private[data] sealed trait WriterTAlternative[F[_], L] extends Alternative[Write
   override implicit def F0: Alternative[F]
 }
 
-private[data] sealed trait WriterTContravariantMonoidal[F[_], L] extends ContravariantMonoidal[WriterT[F, L, ?]] {
-  implicit def F0: ContravariantMonoidal[F]
+private[data] sealed trait WriterTContravariantMonoidal[F[_], L] extends ContravariantMonoidal[WriterT[F, L, ?]] with WriterTContravariant[F, L] {
+  override implicit def F0: ContravariantMonoidal[F]
 
   override def unit: WriterT[F, L, Unit] = WriterT(F0.trivial[(L, Unit)])
 
   override def contramap[A, B](fa: WriterT[F, L, A])(f: B => A): WriterT[F, L, B] =
-    WriterT(F0.contramap(fa.run)((d: (L, B)) => (d._1, f(d._2))))
+    super[WriterTContravariant].contramap(fa)(f)
 
   override def product[A, B](fa: WriterT[F, L, A], fb: WriterT[F, L, B]): WriterT[F, L, (A, B)] =
     WriterT(

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -414,13 +414,13 @@ private[data] sealed trait WriterTAlternative[F[_], L] extends Alternative[Write
   override implicit def F0: Alternative[F]
 }
 
-private[data] sealed trait WriterTContravariantMonoidal[F[_], L] extends ContravariantMonoidal[WriterT[F, L, ?]] with WriterTContravariant[F, L] {
-  override implicit def F0: ContravariantMonoidal[F]
+private[data] sealed trait WriterTContravariantMonoidal[F[_], L] extends ContravariantMonoidal[WriterT[F, L, ?]] {
+  implicit def F0: ContravariantMonoidal[F]
 
   override def unit: WriterT[F, L, Unit] = WriterT(F0.trivial[(L, Unit)])
 
   override def contramap[A, B](fa: WriterT[F, L, A])(f: B => A): WriterT[F, L, B] =
-    super[WriterTContravariant].contramap(fa)(f)
+    fa.contramap(f)
 
   override def product[A, B](fa: WriterT[F, L, A], fb: WriterT[F, L, B]): WriterT[F, L, (A, B)] =
     WriterT(

--- a/tests/src/test/scala/cats/tests/NestedSuite.scala
+++ b/tests/src/test/scala/cats/tests/NestedSuite.scala
@@ -89,6 +89,8 @@ class NestedSuite extends CatsSuite {
 
   {
     // CommutativeApply composition
+    implicit val optionApply = Apply[Option]
+    implicit val validatedApply = Apply[Validated[Int, ?]]
     checkAll("Nested[Option, Validated[Int, ?], ?]", CommutativeApplyTests[Nested[Option, Validated[Int, ?], ?]].commutativeApply[Int, Int, Int])
     checkAll("CommutativeApply[Nested[List, ListWrapper, ?]]", SerializableTests.serializable(CommutativeApply[Nested[Option, Validated[Int, ?], ?]]))
   }

--- a/tests/src/test/scala/cats/tests/NestedSuite.scala
+++ b/tests/src/test/scala/cats/tests/NestedSuite.scala
@@ -92,7 +92,7 @@ class NestedSuite extends CatsSuite {
     implicit val optionApply = Apply[Option]
     implicit val validatedApply = Apply[Validated[Int, ?]]
     checkAll("Nested[Option, Validated[Int, ?], ?]", CommutativeApplyTests[Nested[Option, Validated[Int, ?], ?]].commutativeApply[Int, Int, Int])
-    checkAll("CommutativeApply[Nested[List, ListWrapper, ?]]", SerializableTests.serializable(CommutativeApply[Nested[Option, Validated[Int, ?], ?]]))
+    checkAll("CommutativeApply[Nested[Option, Validated[Int, ?], ?], ?]]", SerializableTests.serializable(CommutativeApply[Nested[Option, Validated[Int, ?], ?]]))
   }
 
   {

--- a/tests/src/test/scala/cats/tests/Tuple2KSuite.scala
+++ b/tests/src/test/scala/cats/tests/Tuple2KSuite.scala
@@ -47,6 +47,8 @@ class Tuple2KSuite extends CatsSuite {
   }
 
   {
+    implicit val optionApply = Apply[Option]
+    implicit val validatedApply = Apply[Validated[Int, ?]]
     checkAll("Tuple2K[Option, Validated[Int, ?], ?]", CommutativeApplyTests[Tuple2K[Option, Validated[Int, ?], ?]].commutativeApply[Int, Int, Int])
     checkAll("Apply[Tuple2K[Option, Validated[Int, ?], ?]]", SerializableTests.serializable(CommutativeApply[Tuple2K[Option, Validated[Int, ?], ?]]))
   }

--- a/tests/src/test/scala/cats/tests/WriterTSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterTSuite.scala
@@ -404,8 +404,6 @@ class WriterTSuite extends CatsSuite {
 
   {
     // F has a Comonad and L has a Monoid
-    implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
-    Comonad[(String, ?)]
     Comonad[WriterT[(String, ?), ListWrapper[Int], ?]]
 
     checkAll("WriterT[(String, ?), ListWrapper[Int], ?]", ComonadTests[WriterT[(String, ?), ListWrapper[Int], ?]].comonad[Int, Int, Int])


### PR DESCRIPTION
This is about using the Functor instance in Traverse for the monad transformers `EitherT` and `OptionT` and in `Tuple2K` so to use its `map` implementation. This follows @peterneyens 's comment https://github.com/typelevel/cats/pull/2182#discussion_r173720529 related to `WriterT`.