### PR TITLE
Add "Law Testing" to side menu to increase visiblity.

### DIFF
--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -116,6 +116,10 @@ options:
     url: typeclasses/arrow.html
     menu_type: typeclasses
 
+  - title: Law Testing
+    url: typeclasses/lawtesting.html
+    menu_type: typeclasses
+
   ###########################
   # Data Types Menu Options #
   ###########################


### PR DESCRIPTION
Laws are important and the link to the Law Testing page is quite hidden (in a hyperlink all the way down the bottom of the Typeclasses page). I suspect making it more visible might encourage more people to learn how to test typeclass laws.

Here's a screenshot on how it would look:

<img width="955" alt="law-testing-screen" src="https://user-images.githubusercontent.com/368630/37501003-8f40873a-2889-11e8-99c4-c5bd58cbd8ca.png">
