### PR TITLE
Added Magma, and alter Semigroup so it's based on Magma.

### DIFF
--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -84,6 +84,7 @@ package object cats {
   type Comparison = cats.kernel.Comparison
   type Order[A] = cats.kernel.Order[A]
   type Hash[A] = cats.kernel.Hash[A]
+  type Magma[A] = cats.kernel.Magma[A]
   type Semigroup[A] = cats.kernel.Semigroup[A]
   type Monoid[A] = cats.kernel.Monoid[A]
   type Group[A] = cats.kernel.Group[A]
@@ -93,6 +94,7 @@ package object cats {
   val Order = cats.kernel.Order
   val Comparison = cats.kernel.Comparison
   val Hash = cats.kernel.Hash
+  val Magma = cats.kernel.Magma
   val Semigroup = cats.kernel.Semigroup
   val Monoid = cats.kernel.Monoid
   val Group = cats.kernel.Group

--- a/kernel/src/main/scala/cats/kernel/Magma.scala
+++ b/kernel/src/main/scala/cats/kernel/Magma.scala
@@ -1,0 +1,88 @@
+package cats.kernel
+
+import scala.{ specialized => sp }
+import scala.annotation.tailrec
+
+/**
+  * A magma is any set `A` with a binary operation (`combine`).
+  */
+trait Magma[@sp(Int, Long, Float, Double) A] extends Any with Serializable {
+
+  /**
+    * Binary operation which combines two values.
+    */
+  def combine(x: A, y: A): A
+  
+  /**
+    * Return `a` combined with itself `n` times.
+    */
+  def combineN(a: A, n: Int): A =
+    if (n <= 0) throw new IllegalArgumentException("Repeated combining for magmas must have n > 0")
+    else repeatedCombineN(a, n)
+
+  /**
+    * Return `a` combined with itself more than once.
+    */
+  protected[this] def repeatedCombineN(a: A, n: Int): A = {
+    @tailrec def loop(b: A, k: Int, extra: A): A =
+      if (k == 1) combine(b, extra) else {
+        val x = if ((k & 1) == 1) combine(b, extra) else extra
+        loop(combine(b, b), k >>> 1, x)
+      }
+    if (n == 1) a else loop(a, n - 1, a)
+  }
+
+  /**
+    * Given a sequence of `as`, combine them and return the total.
+    *
+    * If the sequence is empty, returns None. Otherwise, returns Some(total).
+    */
+  def combineAllOption(as: TraversableOnce[A]): Option[A] =
+    as.reduceOption(combine)
+}
+
+abstract class MagmaFunctions[M[T] <: Magma[T]] {
+
+  def combine[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: M[A]): A =
+    ev.combine(x, y)
+
+  def maybeCombine[@sp(Int, Long, Float, Double) A](ox: Option[A], y: A)(implicit ev: M[A]): A =
+    ox match {
+      case Some(x) => ev.combine(x, y)
+      case None => y
+    }
+
+  def maybeCombine[@sp(Int, Long, Float, Double) A](x: A, oy: Option[A])(implicit ev: M[A]): A =
+    oy match {
+      case Some(y) => ev.combine(x, y)
+      case None => x
+    }
+
+  def isCommutative[A](implicit ev: M[A]): Boolean =
+  ev.isInstanceOf[CommutativeSemigroup[_]]
+
+  def isIdempotent[A](implicit ev: M[A]): Boolean =
+  ev.isInstanceOf[Band[_]]
+
+  def combineN[@sp(Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: M[A]): A =
+  ev.combineN(a, n)
+
+  def combineAllOption[A](as: TraversableOnce[A])(implicit ev: M[A]): Option[A] =
+  ev.combineAllOption(as)
+
+}
+
+object Magma extends MagmaFunctions[Magma] {
+
+  /**
+    * Access an implicit `Magma[A]`.
+    */
+  @inline final def apply[A](implicit ev: Magma[A]): Magma[A] = ev
+
+  /**
+    * Create a `Magma` instance from the given function.
+    */
+  @inline def instance[A](cmb: (A, A) => A): Magma[A] = new Magma[A] {
+    override def combine(x: A, y: A): A = cmb(x, y)
+  }
+}

--- a/kernel/src/main/scala/cats/kernel/Semigroup.scala
+++ b/kernel/src/main/scala/cats/kernel/Semigroup.scala
@@ -1,74 +1,17 @@
 package cats.kernel
 
-import scala.{ specialized => sp }
-import scala.annotation.tailrec
+import scala.{specialized => sp}
 
 /**
  * A semigroup is any set `A` with an associative operation (`combine`).
  */
-trait Semigroup[@sp(Int, Long, Float, Double) A] extends Any with Serializable {
+trait Semigroup[@sp(Int, Long, Float, Double) A] extends Any with Magma[A] {
 
-  /**
-   * Associative operation which combines two values.
-   */
-  def combine(x: A, y: A): A
+  // In a semigroup the combine operation is associate
 
-  /**
-   * Return `a` combined with itself `n` times.
-   */
-  def combineN(a: A, n: Int): A =
-    if (n <= 0) throw new IllegalArgumentException("Repeated combining for semigroups must have n > 0")
-    else repeatedCombineN(a, n)
-
-  /**
-   * Return `a` combined with itself more than once.
-   */
-  protected[this] def repeatedCombineN(a: A, n: Int): A = {
-    @tailrec def loop(b: A, k: Int, extra: A): A =
-      if (k == 1) combine(b, extra) else {
-        val x = if ((k & 1) == 1) combine(b, extra) else extra
-        loop(combine(b, b), k >>> 1, x)
-      }
-    if (n == 1) a else loop(a, n - 1, a)
-  }
-
-  /**
-   * Given a sequence of `as`, combine them and return the total.
-   *
-   * If the sequence is empty, returns None. Otherwise, returns Some(total).
-   */
-  def combineAllOption(as: TraversableOnce[A]): Option[A] =
-    as.reduceOption(combine)
 }
 
-abstract class SemigroupFunctions[S[T] <: Semigroup[T]] {
-  def combine[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: S[A]): A =
-    ev.combine(x, y)
-
-  def maybeCombine[@sp(Int, Long, Float, Double) A](ox: Option[A], y: A)(implicit ev: S[A]): A =
-    ox match {
-      case Some(x) => ev.combine(x, y)
-      case None => y
-    }
-
-  def maybeCombine[@sp(Int, Long, Float, Double) A](x: A, oy: Option[A])(implicit ev: S[A]): A =
-    oy match {
-      case Some(y) => ev.combine(x, y)
-      case None => x
-    }
-
-  def isCommutative[A](implicit ev: S[A]): Boolean =
-    ev.isInstanceOf[CommutativeSemigroup[_]]
-
-  def isIdempotent[A](implicit ev: S[A]): Boolean =
-    ev.isInstanceOf[Band[_]]
-
-  def combineN[@sp(Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: S[A]): A =
-    ev.combineN(a, n)
-
-  def combineAllOption[A](as: TraversableOnce[A])(implicit ev: S[A]): Option[A] =
-    ev.combineAllOption(as)
-}
+abstract class SemigroupFunctions[S[T] <: Semigroup[T]] extends MagmaFunctions[S]
 
 object Semigroup extends SemigroupFunctions[Semigroup] {
 


### PR DESCRIPTION
I'm using cats in a project where I'm building abstract syntax trees (ASTs).  I've run into an issue where it would be nice to be able to differentiate between associative operators and non-associative operators, so you could know if you could rearrange the AST.  Currently with Semigroup being the top of the Group-like structure hierarchy, this is not possible as far as I can tell.

This change will break binary compatibility, but I'm putting it forward in response to the [Code review cats-kernel](https://github.com/typelevel/cats/issues/2093) issue.  We might also want to think about adding Quasi-groups and loops into the mix while we're at it, but I do think since Magma is the most abstract Group-like algebraic structure, we should at least add that.

I'm not super familiar with the entire cats codebase so this is more of a work in progress and will probably need a few more things before be able to be merged.  The good thing is for Magma, there aren't any laws since the only thing about it (having a closed binary operation) can be checked by the type system.