### PR TITLE
Feature/add EitherT sequence

### DIFF
--- a/tests/src/test/scala/cats/tests/EitherTSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherTSuite.scala
@@ -471,4 +471,19 @@ class EitherTSuite extends CatsSuite {
     }
   }
 
+  test("sequence a list of eitherT") {
+    forAll { (ls: List[EitherT[Id, String, Int]]) =>
+      val t = Traverse[List]
+      EitherT.sequence(ls) shouldBe t.sequence(ls)
+    }
+  }
+
+  test("sequence in a list the eithert.right of a list") {
+    forAll { (ls: List[EitherT[Id, String, Int]]) =>
+      val rights = ls.filter(e => e.isRight)
+      val t = Traverse[List]
+      EitherT.sequenceRight(ls) shouldBe t.sequence(rights)
+    }
+  }
+
 }

--- a/tests/src/test/scala/cats/tests/EitherTSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherTSuite.scala
@@ -478,12 +478,4 @@ class EitherTSuite extends CatsSuite {
     }
   }
 
-  test("sequence in a list the eithert.right of a list") {
-    forAll { (ls: List[EitherT[Id, String, Int]]) =>
-      val rights = ls.filter(e => e.isRight)
-      val t = Traverse[List]
-      EitherT.sequenceRight(ls) shouldBe t.sequence(rights)
-    }
-  }
-
 }


### PR DESCRIPTION
This refers to https://github.com/typelevel/cats/issues/2208 adds a sequence method to build an `EitherT[_, _, F[_]` from a `Foldable[EitherT]`