### PR TITLE
Don't override neqv in Order

### DIFF
--- a/kernel/src/main/scala/cats/kernel/Order.scala
+++ b/kernel/src/main/scala/cats/kernel/Order.scala
@@ -55,12 +55,6 @@ trait Order[@sp A] extends Any with PartialOrder[A] { self =>
     compare(x, y) == 0
 
   /**
-   * Returns true if `x` != `y`, false otherwise.
-   */
-  override def neqv(x: A, y: A): Boolean =
-    compare(x, y) != 0
-
-  /**
    * Returns true if `x` <= `y`, false otherwise.
    */
   override def lteqv(x: A, y: A): Boolean =


### PR DESCRIPTION
Eq provides a reasonable default implementation of `neqv`:

```scala
def neqv(x: A, y: A): Boolean = !eqv(x, y)
```

Before this change, `Order` overrides this default implementation as:

```scala
compare(x, y) != 0
```

I think that this override is questionable for a few reasons:

- The negation of `eqv` seems like the most straightforward implementation of
`neqv` to me
- It seems like an oversight that `Order` overrides `neqv` but `PartialOrder`
does not.
- If someone is overriding `eqv` on an `Order` instance, presumably they are
doing it because their `eqv` implelentation can be faster than doing a full
`compare`. If this is the case and they don't override `neqv`, it would be
better for them to inherit a `!eqv` implementation.

As a sidenote, the current implementation leads to a lack of symmetry
between `===` and `=!=` in the presence of `null`. `"foo" === null`
returns `false` while `"foo" =!= null` throws an NPE. I generally agree
with the decision in Cats to not perform special-handling of `null`.
However, the way that I ran into this was when adding a linting rule
that forbids non type-safe equality (== and !=), and it is kind of a
bummer that if you are working with a third-party library that might
return `null` and you want to safeguard against that you can't just
check for `x =!= null` instead of `x != null` to satisfy the linting
rule. You can do something like `Option(x).isDefined`, but that
introduces an extra allocation and seems a little roundabout to me.