### PR TITLE
Add some FlatMap loops useful for State and Effects

### DIFF
--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -137,14 +137,6 @@ final case class OptionT[F[_], A](value: F[Option[A]]) {
    * }}}
    */
   def toNested: Nested[F, Option, A] = Nested(value)
-
-  /**
-   * This repeats an F until we get defined values. This can be useful
-   * for polling type operations on State (or RNG) Monads, or in effect
-   * monads.
-   */
-  def untilDefined(implicit F: FlatMap[F]): F[A] =
-    (new syntax.FlatMapOptionOps(value)).untilDefinedM
 }
 
 object OptionT extends OptionTInstances {

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -137,6 +137,14 @@ final case class OptionT[F[_], A](value: F[Option[A]]) {
    * }}}
    */
   def toNested: Nested[F, Option, A] = Nested(value)
+
+  /**
+   * This repeats an F until we get defined values. This can be useful
+   * for polling type operations on State (or RNG) Monads, or in effect
+   * monads.
+   */
+  def untilDefined(implicit F: FlatMap[F]): F[A] =
+    (new syntax.FlatMapOptionOps(value)).untilDefinedM
 }
 
 object OptionT extends OptionTInstances {

--- a/core/src/main/scala/cats/implicits.scala
+++ b/core/src/main/scala/cats/implicits.scala
@@ -3,4 +3,5 @@ package cats
 object implicits
     extends syntax.AllSyntax
     with syntax.AllSyntaxBinCompat0
+    with syntax.AllSyntaxBinCompat1
     with instances.AllInstances

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -4,6 +4,7 @@ package syntax
 abstract class AllSyntaxBinCompat
     extends AllSyntax
     with AllSyntaxBinCompat0
+    with AllSyntaxBinCompat1
 
 trait AllSyntax
     extends AlternativeSyntax
@@ -57,3 +58,5 @@ trait AllSyntaxBinCompat0
     extends UnorderedTraverseSyntax
     with ApplicativeErrorExtension
     with TrySyntax
+
+trait AllSyntaxBinCompat1 extends FlatMapOptionSyntax

--- a/core/src/main/scala/cats/syntax/flatMap.scala
+++ b/core/src/main/scala/cats/syntax/flatMap.scala
@@ -57,8 +57,10 @@ final class FlatMapOps[F[_], A](val fa: F[A]) extends AnyVal {
    * exponentially increasing memory and very quickly OOM.
    */
   def foreverM[B](implicit F: FlatMap[F]): F[B] = {
+    // allocate two things once for efficiency.
     val leftUnit = Left(())
-    F.tailRecM(()) { _ => F.map(fa)(_ => leftUnit) }
+    val stepResult: F[Either[Unit, B]] = F.map(fa)(_ => leftUnit)
+    F.tailRecM(())(_ => stepResult)
   }
 
 }

--- a/core/src/main/scala/cats/syntax/flatMap.scala
+++ b/core/src/main/scala/cats/syntax/flatMap.scala
@@ -43,6 +43,24 @@ final class FlatMapOps[F[_], A](val fa: F[A]) extends AnyVal {
   @deprecated("Use productLEval instead.", "1.0.0-RC2")
   def forEffectEval[B](fb: Eval[F[B]])(implicit F: FlatMap[F]): F[A] =
     F.productLEval(fa)(fb)
+
+  /**
+   * Like an infinite loop of >> calls. This is most useful effect loops
+   * that you want to run forever in for instance a server.
+   *
+   * This will be an infinite loop, or it will return an F[Nothing].
+   *
+   * Be careful using this.
+   * For instance, a List of length k will produce a list of length k^n at iteration
+   * n. This means if k = 0, we return an empty list, if k = 1, we loop forever
+   * allocating single element lists, but if we have a k > 1, we will allocate
+   * exponentially increasing memory and very quickly OOM.
+   */
+  def foreverM[B](implicit F: FlatMap[F]): F[B] = {
+    val leftUnit = Left(())
+    F.tailRecM(()) { _ => F.map(fa)(_ => leftUnit) }
+  }
+
 }
 
 final class FlattenOps[F[_], A](val ffa: F[F[A]]) extends AnyVal {
@@ -101,4 +119,33 @@ final class FlatMapIdOps[A](val a: A) extends AnyVal {
    *}}}
    */
   def tailRecM[F[_], B](f: A => F[Either[A, B]])(implicit F: FlatMap[F]): F[B] = F.tailRecM(a)(f)
+
+  /**
+   * iterateForeverM is almost exclusively useful for effect types. For instance,
+   * A may be some state, we may take the current state, run some effect to get
+   * a new state and repeat.
+   */
+  def iterateForeverM[F[_], B](f: A => F[A])(implicit F: FlatMap[F]): F[B] =
+    tailRecM[F, B](f.andThen { fa => F.map(fa)(Left(_): Either[A, B]) })
+}
+
+trait FlatMapOptionSyntax {
+  implicit final def catsSyntaxFlatMapOptionOps[F[_]: FlatMap, A](foa: F[Option[A]]): FlatMapOptionOps[F, A] =
+    new FlatMapOptionOps[F, A](foa)
+}
+
+final class FlatMapOptionOps[F[_], A](val fopta: F[Option[A]]) extends AnyVal {
+  /**
+   * This repeats an F until we get defined values. This can be useful
+   * for polling type operations on State (or RNG) Monads, or in effect
+   * monads.
+   */
+  def untilDefinedM(implicit F: FlatMap[F]): F[A] = {
+    val leftUnit: Either[Unit, A] = Left(())
+    val feither: F[Either[Unit, A]] = F.map(fopta) {
+      case None => leftUnit
+      case Some(a) => Right(a)
+    }
+    F.tailRecM(())(_ => feither)
+  }
 }

--- a/testkit/src/main/scala/cats/tests/CatsSuite.scala
+++ b/testkit/src/main/scala/cats/tests/CatsSuite.scala
@@ -4,7 +4,7 @@ package tests
 import catalysts.Platform
 
 import cats.instances.AllInstances
-import cats.syntax.{AllSyntax, AllSyntaxBinCompat0, EqOps}
+import cats.syntax.{AllSyntax, AllSyntaxBinCompat0, AllSyntaxBinCompat1, EqOps}
 
 import org.scalactic.anyvals.{PosZDouble, PosInt, PosZInt}
 import org.scalatest.{FunSuite, FunSuiteLike, Matchers}
@@ -36,7 +36,7 @@ trait CatsSuite extends FunSuite
     with Discipline
     with TestSettings
     with AllInstances
-    with AllSyntax with AllSyntaxBinCompat0
+    with AllSyntax with AllSyntaxBinCompat0 with AllSyntaxBinCompat1
     with StrictCatsEquality { self: FunSuiteLike =>
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =

--- a/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
@@ -3,7 +3,7 @@ package tests
 
 import catalysts.Platform
 import cats.arrow.{Profunctor, Strong}
-import cats.data.{EitherT, IndexedStateT, OptionT, State, StateT}
+import cats.data.{EitherT, IndexedStateT, State, StateT}
 import cats.arrow.Profunctor
 import cats.kernel.instances.tuple._
 import cats.laws.discipline._
@@ -280,8 +280,6 @@ class IndexedStateTSuite extends CatsSuite {
     }
 
     counter.untilDefinedM.run(0).value should === ((stackSafeTestSize + 2, stackSafeTestSize + 1))
-
-    OptionT(counter).untilDefined.run(0).value should === ((stackSafeTestSize + 2, stackSafeTestSize + 1))
   }
 
   test("foreverM works") {


### PR DESCRIPTION
Three cases I have wanted:

1. taking a scalacheck `Gen[Option[A]] => Gen[A]`
2. writing a server that has a single step as `IO[Unit]` then repeating that forever.
3. a server that has some state: `S => IO[S]` that each call updates the state and repeat forever.

This has to be done with syntax backwards compatibility hacks, but we can repair that at cats 2.0
