### PR TITLE
Add `.nested` syntax.

### DIFF
--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -38,6 +38,7 @@ trait AllSyntax
     with MonadErrorSyntax
     with MonadSyntax
     with MonoidSyntax
+    with NestedSyntax
     with OptionSyntax
     with OrderSyntax
     with ParallelSyntax

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -38,7 +38,6 @@ trait AllSyntax
     with MonadErrorSyntax
     with MonadSyntax
     with MonoidSyntax
-    with NestedSyntax
     with OptionSyntax
     with OrderSyntax
     with ParallelSyntax
@@ -60,4 +59,6 @@ trait AllSyntaxBinCompat0
     with ApplicativeErrorExtension
     with TrySyntax
 
-trait AllSyntaxBinCompat1 extends FlatMapOptionSyntax
+trait AllSyntaxBinCompat1
+    extends FlatMapOptionSyntax
+    with NestedSyntax

--- a/core/src/main/scala/cats/syntax/nested.scala
+++ b/core/src/main/scala/cats/syntax/nested.scala
@@ -1,0 +1,27 @@
+package cats
+package syntax
+
+import cats.data.Nested
+
+trait NestedSyntax {
+  implicit final def catsSyntaxNestedId[F[_], G[_], A](value: F[G[A]]): NestedIdOps[F, G, A] =
+    new NestedIdOps[F, G, A](value)
+}
+
+final class NestedIdOps[F[_], G[_], A](val value: F[G[A]]) extends AnyVal {
+  /**
+    * Wrap a value in `Nested`.
+    *
+    * `x.nested` is equivalent to `Nested(x)`.
+    *
+    * Example:
+    * {{{
+    * scala> import cats.implicits._
+    * scala> List(Some(3), None).nested.map(_+1).value
+    * res0: List[Option[Int]] = List(Some(4), None)
+    * }}}
+    */
+  def nested: Nested[F, G, A] = Nested[F, G, A](value)
+}
+
+

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -33,6 +33,7 @@ package object syntax {
   object monad extends MonadSyntax
   object monadError extends MonadErrorSyntax
   object monoid extends MonoidSyntax
+  object nested extends NestedSyntax
   object option extends OptionSyntax
   object order extends OrderSyntax
   object parallel extends ParallelSyntax

--- a/tests/src/test/scala/cats/tests/SyntaxSuite.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxSuite.scala
@@ -4,7 +4,7 @@ package tests
 import cats.arrow.Compose
 import cats.data.Nested
 import cats.instances.AllInstances
-import cats.syntax.{AllSyntax, NestedSyntax}
+import cats.syntax.{AllSyntax, AllSyntaxBinCompat1}
 
 
 /**
@@ -25,7 +25,7 @@ import cats.syntax.{AllSyntax, NestedSyntax}
  *
  * None of these tests should ever run, or do any runtime checks.
  */
-object SyntaxSuite extends AllInstances with AllSyntax with NestedSyntax {
+object SyntaxSuite extends AllInstances with AllSyntax with AllSyntaxBinCompat1 {
 
   // pretend we have a value of type A
   def mock[A]: A = ???

--- a/tests/src/test/scala/cats/tests/SyntaxSuite.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxSuite.scala
@@ -4,7 +4,7 @@ package tests
 import cats.arrow.Compose
 import cats.data.Nested
 import cats.instances.AllInstances
-import cats.syntax.AllSyntax
+import cats.syntax.{AllSyntax, NestedSyntax}
 
 
 /**
@@ -25,7 +25,7 @@ import cats.syntax.AllSyntax
  *
  * None of these tests should ever run, or do any runtime checks.
  */
-object SyntaxSuite extends AllInstances with AllSyntax {
+object SyntaxSuite extends AllInstances with AllSyntax with NestedSyntax {
 
   // pretend we have a value of type A
   def mock[A]: A = ???

--- a/tests/src/test/scala/cats/tests/SyntaxSuite.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxSuite.scala
@@ -2,6 +2,7 @@ package cats
 package tests
 
 import cats.arrow.Compose
+import cats.data.Nested
 import cats.instances.AllInstances
 import cats.syntax.AllSyntax
 
@@ -336,6 +337,12 @@ object SyntaxSuite extends AllInstances with AllSyntax {
 
     val pfegea = mock[PartialFunction[E, G[A]]]
     val gea4 = ga.recoverWith(pfegea)
+  }
+
+  def testNested[F[_], G[_], A]: Unit = {
+    val fga: F[G[A]] = mock[F[G[A]]]
+
+    val nested: Nested[F, G, A] = fga.nested
   }
 
 }


### PR DESCRIPTION
I attended @iravid's talk at the typelevel summit and was surprised that I hadn't known about `Nested` yet. 
Also, I found the syntax a bit clunky. I would propose to add a `.nested` extension method so that
```scala
listOfOption.nested
```
is equivalent to 
```scala
Nested(listOfOption)
```

Since many people `import cats.implicits._` this change would also make it easier to discover `.nested` through an IDE's syntax completion. 
  