### PR TITLE
added `liftTo` syntax to `Validated`

### DIFF
--- a/core/src/main/scala/cats/ApplicativeError.scala
+++ b/core/src/main/scala/cats/ApplicativeError.scala
@@ -175,7 +175,12 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
    * }}}
    */
   def fromEither[A](x: E Either A): F[A] =
-    x.fold(raiseError, pure)
+    x match {
+      case Right(a) => pure(a)
+      case Left(e)  => raiseError(e)
+    }
+
+
 }
 
 object ApplicativeError {

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -64,3 +64,4 @@ trait AllSyntaxBinCompat1
     with NestedSyntax
     with BinestedSyntax
     with ParallelFlatSyntax
+    with ValidatedExtensionSyntax

--- a/core/src/main/scala/cats/syntax/applicativeError.scala
+++ b/core/src/main/scala/cats/syntax/applicativeError.scala
@@ -1,7 +1,8 @@
 package cats
 package syntax
 
-import cats.data.EitherT
+import cats.data.Validated.{Invalid, Valid}
+import cats.data.{EitherT, Validated}
 
 trait ApplicativeErrorSyntax {
   implicit final def catsSyntaxApplicativeErrorId[E](e: E): ApplicativeErrorIdOps[E] =
@@ -41,6 +42,27 @@ final class ApplicativeErrorExtensionOps[F[_], E](F: ApplicativeError[F, E]) {
     */
   def fromOption[A](oa: Option[A], ifEmpty: => E): F[A] =
     ApplicativeError.liftFromOption(oa, ifEmpty)(F)
+
+  /**
+   * Convert from cats.data.Validated
+   *
+   * Example:
+   * {{{
+   * scala> import cats.implicits._
+   * scala> import cats.ApplicativeError
+   *
+   * scala> ApplicativeError[Option, Unit].fromValidated(1.valid[Unit])
+   * res0: scala.Option[Int] = Some(1)
+   *
+   * scala> ApplicativeError[Option, Unit].fromValidated(().invalid[Int])
+   * res1: scala.Option[Int] = None
+   * }}}
+   */
+  def fromValidated[A](x: Validated[E, A]): F[A] =
+    x match {
+      case Invalid(e) => F.raiseError(e)
+      case Valid(a) => F.pure(a)
+    }
 
 }
 

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -49,7 +49,7 @@ package object syntax {
   object traverse extends TraverseSyntax
   object nonEmptyTraverse extends NonEmptyTraverseSyntax
   object unorderedTraverse extends UnorderedTraverseSyntax
-  object validated extends ValidatedSyntax
+  object validated extends ValidatedSyntax with ValidatedExtensionSyntax
   object vector extends VectorSyntax
   object writer extends WriterSyntax
 }

--- a/core/src/main/scala/cats/syntax/validated.scala
+++ b/core/src/main/scala/cats/syntax/validated.scala
@@ -13,3 +13,13 @@ final class ValidatedIdSyntax[A](val a: A) extends AnyVal {
   def invalid[B]: Validated[A, B] = Validated.Invalid(a)
   def invalidNel[B]: ValidatedNel[A, B] = Validated.invalidNel(a)
 }
+
+trait ValidatedExtensionSyntax {
+  implicit final def catsSyntaxValidatedExtension[E, A](v: Validated[E, A]): ValidatedExtension[E, A] =
+    new ValidatedExtension(v)
+}
+
+final class ValidatedExtension[E, A](val self: Validated[E, A]) extends AnyVal {
+  def liftTo[F[_]](implicit F: ApplicativeError[F, E]): F[A] =
+    new ApplicativeErrorExtensionOps(F).fromValidated(self)
+}

--- a/tests/src/test/scala/cats/tests/ValidatedSuite.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedSuite.scala
@@ -279,4 +279,10 @@ class ValidatedSuite extends CatsSuite {
       Validated.condNel(cond, s, i) should === (Either.cond(cond, s, i).toValidatedNel)
     }
   }
+
+  test("liftTo consistent with direct to Option") {
+    forAll { (v: Validated[Unit, Int]) =>
+      v.liftTo[Option] shouldBe v.toOption
+    }
+  }
 }


### PR DESCRIPTION
so that you can lift a `Validated[E, A]` to any `F[A]` that has an `Applicative[F, E]`. 

Note that I placed the syntax in a `ValidatedOps` value class mainly work around the variance requirement.  (If the method is inside `Validated` you wouldn't be able to use `E` and `A` in invariant/contravariant position, so you would have to introduce an EE >: E and AA >: A but that requires extra type parameters to be passed in, which beat the purpose of this thing which is mostly ergonomic.