### PR TITLE
Add empty to State and StateT objects

### DIFF
--- a/core/src/main/scala/cats/data/IndexedStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedStateT.scala
@@ -173,6 +173,9 @@ private[data] trait CommonStateTConstructors {
   def pure[F[_], S, A](a: A)(implicit F: Applicative[F]): IndexedStateT[F, S, S, A] =
     IndexedStateT(s => F.pure((s, a)))
 
+  def empty[F[_], S, A: Monoid](implicit F: Applicative[F]): IndexedStateT[F, S, S, A] =
+    pure(Monoid[A].empty)
+
   def liftF[F[_], S, A](fa: F[A])(implicit F: Applicative[F]): IndexedStateT[F, S, S, A] =
     IndexedStateT(s => F.map(fa)(a => (s, a)))
 
@@ -292,6 +295,11 @@ private[data] abstract class StateFunctions {
    * Return `a` and maintain the input state.
    */
   def pure[S, A](a: A): State[S, A] = State(s => (s, a))
+
+  /**
+    * Return `A`'s empty monoid value and maintain the input state.
+    */
+  def empty[S, A: Monoid]: State[S, A] = pure(Monoid[A].empty)
 
   /**
    * Modify the input state and return Unit.

--- a/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
@@ -55,6 +55,17 @@ class IndexedStateTSuite extends CatsSuite {
     }
   }
 
+  test("State.empty, StateT.empty and IndexedStateT.empty are consistent"){
+    forAll { (s: String) =>
+      val state: State[String, Int] = State.empty
+      val stateT: State[String, Int] = StateT.empty
+      val indexedStateT: State[String, Int] = IndexedStateT.empty
+
+      state.run(s) should === (stateT.run(s))
+      state.run(s) should === (indexedStateT.run(s))
+    }
+  }
+
   test("State.get, StateT.get and IndexedStateT.get are consistent") {
     forAll{ (s: String) =>
       val state: State[String, String] = State.get


### PR DESCRIPTION
Hi,

I had some `State`s where I needed to deal with empty values, such as:

```scala
def orEmpty[F[_]: MonadError[?[_], Unit]: SemigroupK, A: Monoid](s: Parser[F, A]) =
    s <+> StateT.pure(Monoid[A].empty)
```
In order to be explicit, why not add a `empty` constructor using a `Monoid[A]` that calls `pure` behind the scene? Note that `IndexedStateT` has `runEmpty` variants with the same `Monoid[A]` logic.

If you think it's an API overhead, feel free to discard and close the PR, no worry.
