### PR TITLE
Replace to new jvm flag

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,7 +1,7 @@
 -Dfile.encoding=UTF8
 -Xms1G
 -Xmx6G
--XX:MaxPermSize=512M
+-XX:MaxMetaspaceSize=512M
 -XX:ReservedCodeCacheSize=250M
 -XX:+TieredCompilation
 -XX:-UseGCOverheadLimit


### PR DESCRIPTION
`MaxPermSize` was deprecated.