### PR TITLE
Add Rainier to the cats library list

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ By sharing the same set of type classes, instances and data types provided by Ca
  * [monadic-html](https://github.com/OlivierBlanvillain/monadic-html): Tiny DOM binding library for Scala.js
  * [Monix](https://github.com/monix/monix): high-performance library for composing asynchronous and event-based programs
  * [pureconfig](https://github.com/pureconfig/pureconfig): A boilerplate-free library for loading configuration files
+ * [rainier](https://github.com/stripe/rainier): Bayesian inference in Scala
  * [scanamo](https://github.com/guardian/scanamo): simpler DynamoDB access for Scala
  * [seals](https://github.com/durban/seals): tools for schema evolution and language-integrated schemata
  * [tsec](https://github.com/jmcardon/tsec/): Typesafe, functional, general purpose cryptography and security library.


### PR DESCRIPTION
Interoperability provided in Rainier since the recent addition of a Cats module

Addresses https://github.com/stripe/rainier/issues/167 in Rainier. cc @kailuowang 