### PR TITLE
Add choice syntax

### DIFF
--- a/core/src/main/scala/cats/arrow/Choice.scala
+++ b/core/src/main/scala/cats/arrow/Choice.scala
@@ -14,7 +14,7 @@ import simulacrum.typeclass
    * scala> import cats.implicits._
    * scala> val b: Boolean => String = _ + " is a boolean"
    * scala> val i: Int => String =  _ + " is an integer"
-   * scala> val f: (Either[Boolean, Int]) => String = Choice[Function1].choice(b, i)
+   * scala> val f: (Either[Boolean, Int]) => String = b ||| i
    *
    * scala> f(Right(3))
    * res0: String = 3 is an integer

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -17,7 +17,6 @@ trait AllSyntax
     with BifoldableSyntax
     with BitraverseSyntax
     with SemigroupalSyntax
-    with ChoiceSyntax
     with CoflatMapSyntax
     with ComonadSyntax
     with ComposeSyntax
@@ -62,6 +61,7 @@ trait AllSyntaxBinCompat0
 
 trait AllSyntaxBinCompat1
   extends FlatMapOptionSyntax
+    with ChoiceSyntax
     with NestedSyntax
     with BinestedSyntax
     with ParallelFlatSyntax

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -17,6 +17,7 @@ trait AllSyntax
     with BifoldableSyntax
     with BitraverseSyntax
     with SemigroupalSyntax
+    with ChoiceSyntax
     with CoflatMapSyntax
     with ComonadSyntax
     with ComposeSyntax

--- a/core/src/main/scala/cats/syntax/choice.scala
+++ b/core/src/main/scala/cats/syntax/choice.scala
@@ -1,0 +1,6 @@
+package cats
+package syntax
+
+import cats.arrow.Choice
+
+trait ChoiceSyntax extends Choice.ToChoiceOps

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -14,6 +14,7 @@ package object syntax {
   object bitraverse extends BitraverseSyntax
   @deprecated("use cats.syntax.semigroupal instead", "1.0.0-RC1")
   object cartesian extends SemigroupalSyntax
+  object choice extends ChoiceSyntax
   object coflatMap extends CoflatMapSyntax
   object distributive extends DistributiveSyntax
   object eitherK extends EitherKSyntax

--- a/laws/src/main/scala/cats/laws/ChoiceLaws.scala
+++ b/laws/src/main/scala/cats/laws/ChoiceLaws.scala
@@ -2,6 +2,7 @@ package cats
 package laws
 
 import cats.arrow.Choice
+import cats.syntax.choice._
 import cats.syntax.compose._
 
 /**
@@ -11,7 +12,7 @@ trait ChoiceLaws[F[_, _]] extends CategoryLaws[F] {
   implicit override def F: Choice[F]
 
   def choiceCompositionDistributivity[A, B, C, D](fac: F[A, C], fbc: F[B, C], fcd: F[C, D]): IsEq[F[Either[A, B], D]] =
-    (F.choice(fac, fbc) andThen fcd) <-> F.choice(fac andThen fcd, fbc andThen fcd)
+    ((fac ||| fbc) >>> fcd) <-> ((fac >>> fcd) ||| (fbc >>> fcd))
 }
 
 object ChoiceLaws {


### PR DESCRIPTION
[Choice ](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/arrow/Choice.scala) doesn't have a separate syntax object in `cats.syntax` package and its syntax (`choice`, `|||`) is not accessible via `import cats.implicits._`