### PR TITLE
POC of Delay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ TAGS
 *.sublime-project
 *.sublime-workspace
 tests.iml
+**/.bloop
 # Auto-copied by sbt-microsites
 docs/src/main/tut/contributing.md
 docs/src/main/tut/index.md

--- a/free/src/main/scala/cats/free/Cofree.scala
+++ b/free/src/main/scala/cats/free/Cofree.scala
@@ -1,6 +1,8 @@
 package cats
 package free
 
+import cats.kernel.Delay
+
 /**
   * A free comonad for some branching functor `S`. Branching is done lazily using [[Eval]].
   * A tree with data at the branches, as opposed to [[Free]] which is a tree with data at the leaves.
@@ -100,6 +102,12 @@ sealed private[free] abstract class CofreeInstances1 extends CofreeInstances2 {
 sealed private[free] abstract class CofreeInstances extends CofreeInstances1 {
   implicit def catsFreeComonadForCofree[S[_] : Functor]: Comonad[Cofree[S, ?]] = new CofreeComonad[S] {
     def F = implicitly
+  }
+
+  implicit def catsFreeEqForCofree[A : Eq, S[_]](implicit D: Delay[Eq, S]): Eq[Cofree[S, A]] = new Eq[Cofree[S, A]] {
+    override def eqv(x: Cofree[S, A], y: Cofree[S, A]): Boolean = {
+      Eq[A].eqv(x.head, y.head) && D.apply(this).eqv(x.tailForced, y.tailForced)
+    }
   }
 }
 

--- a/free/src/test/scala/cats/free/CofreeSuite.scala
+++ b/free/src/test/scala/cats/free/CofreeSuite.scala
@@ -14,7 +14,7 @@ class CofreeSuite extends CatsSuite {
 
   implicit val iso = SemigroupalTests.Isomorphisms.invariant[Cofree[Option, ?]]
 
-  checkAll("Cofree[Option, ?]", EqTests[Cofree[List, ?]].eqv)
+  checkAll("Cofree[Option, ?]", EqTests[Cofree[Option, Int]].eqv)
   checkAll("Cofree[Option, ?]", ComonadTests[Cofree[Option, ?]].comonad[Int, Int, Int])
   locally {
     implicit val instance = Cofree.catsTraverseForCofree[Option]

--- a/free/src/test/scala/cats/free/CofreeSuite.scala
+++ b/free/src/test/scala/cats/free/CofreeSuite.scala
@@ -2,7 +2,8 @@ package cats
 package free
 
 import cats.data.{NonEmptyList, OptionT}
-import cats.laws.discipline.{SemigroupalTests, ComonadTests, ReducibleTests, SerializableTests, TraverseTests}
+import cats.kernel.laws.discipline.EqTests
+import cats.laws.discipline.{ComonadTests, ReducibleTests, SemigroupalTests, SerializableTests, TraverseTests}
 import cats.syntax.list._
 import cats.tests.{CatsSuite, Spooky}
 import org.scalacheck.{Arbitrary, Cogen, Gen}
@@ -13,6 +14,7 @@ class CofreeSuite extends CatsSuite {
 
   implicit val iso = SemigroupalTests.Isomorphisms.invariant[Cofree[Option, ?]]
 
+  checkAll("Cofree[Option, ?]", EqTests[Cofree[List, ?]].eqv)
   checkAll("Cofree[Option, ?]", ComonadTests[Cofree[Option, ?]].comonad[Int, Int, Int])
   locally {
     implicit val instance = Cofree.catsTraverseForCofree[Option]
@@ -118,19 +120,6 @@ sealed trait CofreeSuiteInstances {
 
   type CofreeNel[A] = Cofree[Option, A]
   type CofreeRoseTree[A] = Cofree[List, A]
-
-  implicit def cofNelEq[A](implicit e: Eq[A]): Eq[CofreeNel[A]] = new Eq[CofreeNel[A]] {
-    override def eqv(a: CofreeNel[A], b: CofreeNel[A]): Boolean = {
-      def tr(a: CofreeNel[A], b: CofreeNel[A]): Boolean =
-        (a.tailForced, b.tailForced) match {
-          case (Some(at), Some(bt)) if e.eqv(a.head, b.head) => tr(at, bt)
-          case (None, None) if e.eqv(a.head, b.head) => true
-          case _ => false
-        }
-      tr(a, b)
-    }
-  }
-
 
   implicit def CofreeOptionCogen[A: Cogen]: Cogen[CofreeNel[A]] =
     implicitly[Cogen[List[A]]].contramap[CofreeNel[A]](cofNelToNel(_).toList)

--- a/kernel/src/main/scala/cats/kernel/Delay.scala
+++ b/kernel/src/main/scala/cats/kernel/Delay.scala
@@ -1,0 +1,9 @@
+package cats.kernel
+
+trait Delay[F[_], G[_]] {
+  def apply[A](fa: F[A]): F[G[A]]
+}
+
+object Delay {
+  def apply[F[_], G[_]](implicit D: Delay[F, G]): Delay[F, G] = D
+}

--- a/kernel/src/main/scala/cats/kernel/Eq.scala
+++ b/kernel/src/main/scala/cats/kernel/Eq.scala
@@ -43,6 +43,7 @@ trait EqToEquivConversion {
 }
 
 object Eq extends EqFunctions[Eq] with EqToEquivConversion {
+  implicit def delayedToEq[F[_], A : Eq](implicit del: Delay[Eq, F]): Eq[F[A]] = del.apply(Eq[A])
 
   /**
    * Access an implicit `Eq[A]`.

--- a/kernel/src/main/scala/cats/kernel/instances/list.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/list.scala
@@ -21,8 +21,10 @@ trait ListInstances1 extends ListInstances2 {
 }
 
 trait ListInstances2 {
-  implicit def catsKernelStdEqForList[A: Eq]: Eq[List[A]] =
-    new ListEq[A]
+  implicit def catsKernelStdEqForList: Delay[Eq, List] =
+    new Delay[Eq, List] {
+      override def apply[A](fa: Eq[A]): Eq[List[A]] = new ListEq[A]()(fa)
+    }
 }
 
 class ListOrder[A](implicit ev: Order[A]) extends Order[List[A]] {

--- a/kernel/src/main/scala/cats/kernel/instances/option.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/option.scala
@@ -21,8 +21,9 @@ trait OptionInstances1 extends OptionInstances2 {
 }
 
 trait OptionInstances2 {
-  implicit def catsKernelStdEqForOption[A: Eq]: Eq[Option[A]] =
-    new OptionEq[A]
+  implicit def catsKernelStdEqForOption: Delay[Eq, Option] = new Delay[Eq, Option] {
+    override def apply[A](fa: Eq[A]): Eq[Option[A]] = new OptionEq[A]()(fa)
+  }
 }
 
 class OptionOrder[A](implicit A: Order[A]) extends Order[Option[A]] {


### PR DESCRIPTION
This introduces a quickly written `Delay` as seen in Matryoshka.

Motivation: #2308, #2300 

So far I only added instances for `Eq` for `Option` and `List`, and an `Eq` instance for `Cofree` to see if the solution helps. One problem that I already see is that a generic implicit that'll summon the underlying instance didn't get picked up when I placed it in the companion object of `Delay`:

```scala
implicit def applied[F[_], G[_], A](implicit D: Delay[F, G], A: F[A]): F[G[A]] = D.apply(A)
```

but if an instance for a specific `F` is created, it works. For example, `Eq`:
```scala
implicit def delayedToEq[F[_], A : Eq](implicit D: Delay[Eq, F]): Eq[F[A]] = D.apply(Eq[A])
```

The instance for `Cofree` works (as in, passes the tests), but isn't stack safe:

```scala
implicit def catsFreeEqForCofree[A : Eq, S[_]](implicit D: Delay[Eq, S]): Eq[Cofree[S, A]] = new Eq[Cofree[S, A]] {
  override def eqv(x: Cofree[S, A], y: Cofree[S, A]): Boolean = {
    Eq[A].eqv(x.head, y.head) && D.apply(this).eqv(x.tailForced, y.tailForced)
  }
}
```

There was one for `Cofree[Option, ?]` in the tests that was stack safe:

```scala
implicit def cofNelEq[A](implicit e: Eq[A]): Eq[CofreeNel[A]] = new Eq[CofreeNel[A]] {
  override def eqv(a: CofreeNel[A], b: CofreeNel[A]): Boolean = {
    def tr(a: CofreeNel[A], b: CofreeNel[A]): Boolean =
      (a.tailForced, b.tailForced) match {
        case (Some(at), Some(bt)) if e.eqv(a.head, b.head) => tr(at, bt)
        case (None, None) if e.eqv(a.head, b.head) => true
        case _ => false
      }
    tr(a, b)
  }
}
```

but I don't know if and how it'd be possible to write something similar in an arbitrary way. Even if we only define `Delay[Eq, Cofree[S, ?]]`.

Maybe it would be possible to define it with tail recursion if we had `EqK` as a typeclass itself, but I'm not sure.

What do you guys think? 