### PR TITLE
Remove useless Order constraint in NonEmptyMap constructors

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -31,15 +31,15 @@ private[data] object NonEmptyMapImpl extends NonEmptyMapInstances with Newtype2 
   private[cats] def unwrap[K, A](m: Type[K, A]): SortedMap[K, A] =
     m.asInstanceOf[SortedMap[K, A]]
 
-  def fromMap[K: Order, A](as: SortedMap[K, A]): Option[NonEmptyMap[K, A]] =
+  def fromMap[K, A](as: SortedMap[K, A]): Option[NonEmptyMap[K, A]] =
     if (as.nonEmpty) Option(create(as)) else None
 
-  def fromMapUnsafe[K: Order, A](m: SortedMap[K, A]): NonEmptyMap[K, A] =
+  def fromMapUnsafe[K, A](m: SortedMap[K, A]): NonEmptyMap[K, A] =
     if (m.nonEmpty) create(m)
     else throw new IllegalArgumentException("Cannot create NonEmptyMap from empty map")
 
-  def apply[K, A](head: (K, A), tail: SortedMap[K, A])(implicit K: Order[K]): NonEmptyMap[K, A] =
-    create(SortedMap(head)(K.toOrdering) ++ tail)
+  def apply[K, A](head: (K, A), tail: SortedMap[K, A]): NonEmptyMap[K, A] =
+    create(tail + head)
 
 
   def of[K, A](a: (K, A), as: (K, A)*)(implicit K: Order[K]): NonEmptyMap[K, A] =


### PR DESCRIPTION
Constructors which take `SortedMap` as a parameter don't need to take extra `Order` implicit as it is already there.