### PR TITLE
Add one off object for importing lawless Map instances

### DIFF
--- a/alleycats-core/src/main/scala/alleycats/std/map.scala
+++ b/alleycats-core/src/main/scala/alleycats/std/map.scala
@@ -3,6 +3,8 @@ package std
 
 import cats._
 
+object map extends MapInstances
+
 trait MapInstances {
 
   // toList is inconsistent. See https://github.com/typelevel/cats/issues/1831


### PR DESCRIPTION
Adds the ability to import just the lawless instances for Map.


Some context:
Right now the most sane way to import lawless map instances is via `import alleycats.std.all._`. However, this is problematic due to conflicting ambiguous instances between lawless Try and regular Try:

```
[error] SomeFile.scala:38: ambiguous implicit values:                                                                
[error]  both method catsStdInstancesForTry in trait TryInstances of type => cats.MonadError[scala.util.Try,Throwable] with cats.CoflatMap[scala.util.Try] with cats.Traverse[scala.util.Try] with cats.Monad[scala.util.Try]                                                                                             
[error]  and method legacyTryBimonad in trait LegacyTryInstances of type (implicit e: export.ExportOrphan[cats.Bimonad[scala.util.Try]])cats.Bimonad[scala.util.Try]                                             
```