### PR TITLE
Remove unnecessary context bound in NonEmptyMap

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -31,10 +31,10 @@ private[data] object NonEmptyMapImpl extends NonEmptyMapInstances with Newtype2 
   private[cats] def unwrap[K, A](m: Type[K, A]): SortedMap[K, A] =
     m.asInstanceOf[SortedMap[K, A]]
 
-  def fromMap[K: Order, A](as: SortedMap[K, A]): Option[NonEmptyMap[K, A]] =
+  def fromMap[K, A](as: SortedMap[K, A]): Option[NonEmptyMap[K, A]] =
     if (as.nonEmpty) Option(create(as)) else None
 
-  def fromMapUnsafe[K: Order, A](m: SortedMap[K, A]): NonEmptyMap[K, A] =
+  def fromMapUnsafe[K, A](m: SortedMap[K, A]): NonEmptyMap[K, A] =
     if (m.nonEmpty) create(m)
     else throw new IllegalArgumentException("Cannot create NonEmptyMap from empty map")
 


### PR DESCRIPTION
Hello,

I was trying to construct a NonEmptyMap with fromMap, but it is context bound on Order[K]. This looks unnecessary unless I'm missing something. It is also inconsistent with https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/data/NonEmptySet.scala#L35 for example.

Thanks.