### PR TITLE
 temporarily disable scaladoc on 2.13

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,9 +44,13 @@ lazy val commonSettings = Seq(
   doctestGenTests := {
     val unchanged = doctestGenTests.value
     if(priorTo2_13(scalaVersion.value)) unchanged else Nil
+  },
+  //todo: re-enable disable scaladoc on 2.13 due to https://github.com/scala/bug/issues/11045
+  sources in (Compile, doc) := {
+    val docSource = (sources in (Compile, doc)).value
+    if (priorTo2_13(scalaVersion.value)) docSource else Nil
   }
 ) ++ warnUnusedImport ++ update2_12 ++ xlint
-
 
 
 def macroDependencies(scalaVersion: String) =
@@ -191,7 +195,7 @@ lazy val docSettings = Seq(
     "gray-lighter" -> "#F4F3F4",
     "white-color" -> "#FFFFFF"),
   autoAPIMappings := true,
-  unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(kernelJVM, coreJVM, freeJVM),
+  unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(kernelJVM, coreJVM, freeJVM, alleycatsCoreJVM),
   docsMappingsAPIDir := "api",
   addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), docsMappingsAPIDir),
   ghpagesNoJekyll := false,

--- a/build.sbt
+++ b/build.sbt
@@ -203,7 +203,11 @@ lazy val docSettings = Seq(
     "-doc-source-url", scmInfo.value.get.browseUrl + "/tree/master€{FILE_PATH}.scala",
     "-sourcepath", baseDirectory.in(LocalRootProject).value.getAbsolutePath,
     "-diagrams"
-  ),
+  ) ++ (if(priorTo2_13(scalaVersion.value)) Seq(
+    "-Yno-adapted-args",
+  ) else Seq(
+    "-Ymacro-annotations"
+  )),
   scalacOptions in Tut ~= (_.filterNot(Set("-Ywarn-unused-import", "-Ywarn-dead-code"))),
   git.remoteRepo := "git@github.com:typelevel/cats.git",
   includeFilter in makeSite := "*.html" | "*.css" | "*.png" | "*.jpg" | "*.gif" | "*.js" | "*.swf" | "*.yml" | "*.md" | "*.svg",

--- a/build.sbt
+++ b/build.sbt
@@ -195,7 +195,7 @@ lazy val docSettings = Seq(
     "gray-lighter" -> "#F4F3F4",
     "white-color" -> "#FFFFFF"),
   autoAPIMappings := true,
-  unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(kernelJVM, coreJVM, freeJVM, alleycatsCoreJVM),
+  unidocProjectFilter in (ScalaUnidoc, unidoc) := inProjects(kernelJVM, coreJVM, freeJVM),
   docsMappingsAPIDir := "api",
   addMappingsToSiteDir(mappings in (ScalaUnidoc, packageDoc), docsMappingsAPIDir),
   ghpagesNoJekyll := false,

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -20,10 +20,10 @@
 
 sbt_cmd="sbt ++$TRAVIS_SCALA_VERSION"
 
-export publish_cmd=""
+export publish_cmd="publishLocal"
 
 if [[ $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "master" && $(cat version.sbt) =~ "-SNAPSHOT" ]]; then
-  export publish_cmd="&& $sbt_cmd publish gitSnapshots publish"
+  export publish_cmd="publish gitSnapshots publish"
   # temporarily disable to stabilize travis
   #if [[ $TRAVIS_SCALA_VERSION =~ ^2\.11\. ]]; then
   #  export publish_cmd="publishMicrosite"
@@ -57,7 +57,7 @@ fi
 if [[ $JS_BUILD == "true" ]]; then
 run_cmd="$js"
 else
-run_cmd="$scalafix $jvm $publish_cmd"
+run_cmd="$scalafix $jvm && $sbt_cmd $publish_cmd"
 fi
 
 eval $run_cmd


### PR DESCRIPTION
simulacrum companion expansion doesn't work when scaladoc compile on 2.13. 
It is probably a bug on the scala macro side, reported at https://github.com/scala/bug/issues/11045