### PR TITLE
Make kittens officially a Cats module (still separate repo)

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ functionality, you can pick-and-choose from amongst these modules
  * [`cats-effect`](https://github.com/typelevel/cats-effect): standard `IO` type together with `Sync`, `Async` and `Effect` type classes 
  * [`cats-mtl`](https://github.com/typelevel/cats-mtl): transformer typeclasses for Cats' Monads, Applicatives and Functors.
  * [`mouse`](https://github.com/typelevel/mouse): a small companion to Cats that provides convenient syntax (aka extension methods) 
-
+ * [`kittens`](https://github.com/typelevel/kittens): automatic type class instance derivation for Cats and generic utility functions
 
 Release notes for Cats are available in [CHANGES.md](https://github.com/typelevel/cats/blob/master/CHANGES.md).
 


### PR DESCRIPTION
I had a discussion with @milessabin see (https://github.com/typelevel/kittens/issues/96). We think that making kittens an official cats module (still in its own separate repo) would be a good idea. @milessabin moved it to under github typelevel.  I'm proposing this to the Cats community through this PR.

Update: I updated the title to further clarify the intention. 