### PR TITLE
Updates 47 Degrees homepage URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Here's a (non-exhaustive) list of companies that use Cats in production. Don't s
 - [Spotahome](https://spotahome.com)
 - [Stripe](https://stripe.com)
 - [Zalando](https://zalando.com)
-- [47 degrees](https://47deg.com)
+- [47 Degrees](https://www.47deg.com)
 
 ### Maintainers
 


### PR DESCRIPTION
In the _Adopters_ section given that https://47deg.com is not working.