### PR TITLE
Fix typos detected by github.com/client9/misspell

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -803,7 +803,7 @@ Additions:
  * [#1319](https://github.com/typelevel/cats/pull/1347): add missing `BigDecimal` instances.
  * [#1324](https://github.com/typelevel/cats/pull/1324): add missing function and `BitSet` instances.
 
-Note that 0.7.2 was preceeded by a botched 0.7.1. release. Please
+Note that 0.7.2 was preceded by a botched 0.7.1. release. Please
 avoid using this version of Cats -- it has major incompatibilities
 with 0.7.0 and is not documented here.
 

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -87,7 +87,7 @@ to be updated:
 You can get a list of changes between release tags `v0.1.2` and
 `v0.2.0` via `git log v0.1.2..v0.2.0`. Scanning this list of commit
 messages is a good way to get a summary of what happened, although it
-does not account for conversations that occured on Github.
+does not account for conversations that occurred on Github.
 
 Once the relevant documentation changes have been committed, new
 [release notes](https://github.com/typelevel/cats/releases) should be

--- a/core/src/main/scala/cats/Reducible.scala
+++ b/core/src/main/scala/cats/Reducible.scala
@@ -92,7 +92,7 @@ import simulacrum.typeclass
     reduceLeftM(fa)(f)((b, a) => G.map(f(a))(B.combine(b, _)))
 
   /**
-   * Overriden from [[Foldable]] for efficiency.
+   * Overridden from [[Foldable]] for efficiency.
    */
   override def reduceLeftToOption[A, B](fa: F[A])(f: A => B)(g: (B, A) => B): Option[B] =
     Some(reduceLeftTo(fa)(f)(g))
@@ -104,7 +104,7 @@ import simulacrum.typeclass
   def reduceRightTo[A, B](fa: F[A])(f: A => B)(g: (A, Eval[B]) => Eval[B]): Eval[B]
 
   /**
-   * Overriden from [[Foldable]] for efficiency.
+   * Overridden from [[Foldable]] for efficiency.
    */
   override def reduceRightToOption[A, B](fa: F[A])(f: A => B)(g: (A, Eval[B]) => Eval[B]): Eval[Option[B]] =
     reduceRightTo(fa)(f)(g).map(Some(_))

--- a/core/src/main/scala/cats/UnorderedFoldable.scala
+++ b/core/src/main/scala/cats/UnorderedFoldable.scala
@@ -44,7 +44,7 @@ import cats.instances.long._
   /**
     * The size of this UnorderedFoldable.
     *
-    * This is overriden in structures that have more efficient size implementations
+    * This is overridden in structures that have more efficient size implementations
     * (e.g. Vector, Set, Map).
     *
     * Note: will not terminate for infinite-sized collections.

--- a/core/src/main/scala/cats/data/AndThen.scala
+++ b/core/src/main/scala/cats/data/AndThen.scala
@@ -157,8 +157,8 @@ object AndThen extends AndThenInstances0 {
    * Establishes the maximum stack depth when fusing `andThen` or
    * `compose` calls.
    *
-   * The default is `128`, from which we substract one as an optimization,
-   * a "!=" comparisson being slightly more efficient than a "<".
+   * The default is `128`, from which we subtract one as an optimization,
+   * a "!=" comparison being slightly more efficient than a "<".
    *
    * This value was reached by taking into account the default stack
    * size as set on 32 bits or 64 bits, Linux or Windows systems,

--- a/core/src/main/scala/cats/evidence/package.scala
+++ b/core/src/main/scala/cats/evidence/package.scala
@@ -28,7 +28,7 @@ package object evidence {
 
   /**
    * The property that a value of type A can be used in a context
-   * expecting a B if A <~< B is refered to as the "Liskov
+   * expecting a B if A <~< B is referred to as the "Liskov
    * Substitution Principal", which is named for Barbara Liskov:
    * https://en.wikipedia.org/wiki/Barbara_Liskov
    */

--- a/docs/src/main/tut/datatypes/eithert.md
+++ b/docs/src/main/tut/datatypes/eithert.md
@@ -104,7 +104,7 @@ val error: EitherT[Option, String, Int] = EitherT.leftT("Not a number")
 
 ## From `F[A]` or `F[B]` to `EitherT[F, A, B]`
 
-Similary, use `EitherT.left` and `EitherT.right` to convert an `F[A]` or an `F[B]`
+Similarly, use `EitherT.left` and `EitherT.right` to convert an `F[A]` or an `F[B]`
 into an `EitherT`. It is also possible to use `EitherT.liftF` as an alias for
 `EitherT.right`.
 

--- a/kernel-laws/src/main/scala/cats/kernel/laws/SerializableLaws.scala
+++ b/kernel-laws/src/main/scala/cats/kernel/laws/SerializableLaws.scala
@@ -23,7 +23,7 @@ object SerializableLaws {
   // compile time, so we rely on scalac to prune away the "other"
   // branch. Thus, when scala.js look at this method it won't "see"
   // the branch which was removed, and will avoid an error trying to
-  // suport java.io.*.
+  // support java.io.*.
   //
   // This ends up being a lot nicer than having to split the entire
   // laws project.

--- a/tests/src/test/scala/cats/tests/EvalSuite.scala
+++ b/tests/src/test/scala/cats/tests/EvalSuite.scala
@@ -20,7 +20,7 @@ class EvalSuite extends CatsSuite {
    *
    * It will then proceed to call `value` 0-or-more times, verifying
    * that the result is equal to `value`, and also that the
-   * appropriate number of evaluations are occuring using the
+   * appropriate number of evaluations are occurring using the
    * `numCalls` function.
    *
    * In other words, each invocation of run says:
@@ -148,7 +148,7 @@ class EvalSuite extends CatsSuite {
     }
   }
 
-  // the following machinery is all to faciliate testing deeply-nested
+  // the following machinery is all to facilitate testing deeply-nested
   // eval values for stack safety. the idea is that we want to
   // randomly generate deep chains of eval operations.
   //


### PR DESCRIPTION
Fixing typos is sometimes very hard. It's not so easy to visually review them. Recently, I discovered a very useful tool for it, [misspell](https://github.com/client9/misspell). 

This pull request fixes minor typos detected by [misspell](https://github.com/client9/misspell) except for the false positives. If you would like me to work on other files as well, let me know. 

## before

```
$ misspell . | grep -v '/target/'
PROCESS.md:90:40: "occured" is a misspelling of "occurred"
CHANGES.md:806:20: "preceeded" is a misspelling of "preceded"
core/src/main/scala/cats/Reducible.scala:95:5: "Overriden" is a misspelling of "Overridden"
core/src/main/scala/cats/Reducible.scala:107:5: "Overriden" is a misspelling of "Overridden"
core/src/main/scala/cats/UnorderedFoldable.scala:47:14: "overriden" is a misspelling of "overridden"
core/src/main/scala/cats/data/AndThen.scala:160:41: "substract" is a misspelling of "subtract"
core/src/main/scala/cats/data/AndThen.scala:161:12: "comparisson" is a misspelling of "comparisons"
core/src/main/scala/cats/evidence/package.scala:31:33: "refered" is a misspelling of "referred"
docs/src/main/tut/datatypes/eithert.md:107:0: "Similary" is a misspelling of "Similarly"
kernel-laws/src/main/scala/cats/kernel/laws/SerializableLaws.scala:26:5: "suport" is a misspelling of "support"
tests/src/test/scala/cats/tests/EvalSuite.scala:23:43: "occuring" is a misspelling of "occurring"
tests/src/test/scala/cats/tests/EvalSuite.scala:151:39: "faciliate" is a misspelling of "facilitate"
```

## after

```
$ misspell . | grep -v '/target/'
$
```
