### PR TITLE
Fix NestedIdOps.value leaking to types of shapes `F[G[A]]`

### DIFF
--- a/core/src/main/scala/cats/syntax/nested.scala
+++ b/core/src/main/scala/cats/syntax/nested.scala
@@ -8,7 +8,7 @@ trait NestedSyntax {
     new NestedIdOps[F, G, A](value)
 }
 
-final class NestedIdOps[F[_], G[_], A](val value: F[G[A]]) extends AnyVal {
+final class NestedIdOps[F[_], G[_], A](private val value: F[G[A]]) extends AnyVal {
   /**
     * Wrap a value in `Nested`.
     *

--- a/core/src/main/scala/cats/syntax/nested.scala
+++ b/core/src/main/scala/cats/syntax/nested.scala
@@ -8,7 +8,7 @@ trait NestedSyntax {
     new NestedIdOps[F, G, A](value)
 }
 
-final class NestedIdOps[F[_], G[_], A](private val value: F[G[A]]) extends AnyVal {
+final class NestedIdOps[F[_], G[_], A](private[syntax] val value: F[G[A]]) extends AnyVal {
   /**
     * Wrap a value in `Nested`.
     *


### PR DESCRIPTION
Made 'value'  private in `NestedIdOps`
This prevents 'value' from leaking into types with shape `F[G[A]]`.  

I encountered this issue while using Scalatests `OptionValues` on things with a `G[A]` shape, so I had a `Option[G[A]]` and tried to use `.value`.  It caused an ambiguous implicit match with `NestedIdOps`.


I didn't add a test, because I didn't know where it should go.  Would `SyntaxSuite.testNested` be an appropriate place?