### PR TITLE
Fixes #2434 Rename NonEmptySet to NonEmptySortedSet

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -97,7 +97,7 @@ sealed class NonEmptyMapOps[K, A](val value: NonEmptyMap[K, A]) {
   /**
     * Returns a `SortedSet` containing all the keys of this map.
     */
-  def keys: NonEmptySet[K] = NonEmptySet.fromSetUnsafe(toSortedMap.keySet)
+  def keys: NonEmptySortedSet[K] = NonEmptySortedSet.fromSetUnsafe(toSortedMap.keySet)
 
   /**
     * Returns the first key-value pair of this map.
@@ -238,7 +238,7 @@ sealed class NonEmptyMapOps[K, A](val value: NonEmptyMap[K, A]) {
     * Typesafe equality operator.
     *
     * This method is similar to == except that it only allows two
-    * NonEmptySet[A] values to be compared to each other, and uses
+    * NonEmptySortedSet[A] values to be compared to each other, and uses
     * equality provided by Eq[_] instances, rather than using the
     * universal equality provided by .equals.
     */

--- a/core/src/main/scala/cats/data/NonEmptySortedSet.scala
+++ b/core/src/main/scala/cats/data/NonEmptySortedSet.scala
@@ -32,26 +32,26 @@ private[data] object NonEmptySetImpl extends NonEmptySetInstances with Newtype {
     s.asInstanceOf[SortedSet[A]]
 
 
-  def fromSet[A](as: SortedSet[A]): Option[NonEmptySet[A]] =
+  def fromSet[A](as: SortedSet[A]): Option[NonEmptySortedSet[A]] =
     if (as.nonEmpty) Option(create(as)) else None
 
-  def fromSetUnsafe[A](set: SortedSet[A]): NonEmptySet[A] =
+  def fromSetUnsafe[A](set: SortedSet[A]): NonEmptySortedSet[A] =
     if (set.nonEmpty) create(set)
-    else throw new IllegalArgumentException("Cannot create NonEmptySet from empty set")
+    else throw new IllegalArgumentException("Cannot create NonEmptySortedSet from empty set")
 
 
-  def of[A](a: A, as: A*)(implicit A: Order[A]): NonEmptySet[A] =
+  def of[A](a: A, as: A*)(implicit A: Order[A]): NonEmptySortedSet[A] =
     create(SortedSet(a +: as: _*)(A.toOrdering))
-  def apply[A](head: A, tail: SortedSet[A])(implicit A: Order[A]): NonEmptySet[A] =
+  def apply[A](head: A, tail: SortedSet[A])(implicit A: Order[A]): NonEmptySortedSet[A] =
     create(SortedSet(head)(A.toOrdering) ++ tail)
-  def one[A](a: A)(implicit A: Order[A]): NonEmptySet[A] = create(SortedSet(a)(A.toOrdering))
+  def one[A](a: A)(implicit A: Order[A]): NonEmptySortedSet[A] = create(SortedSet(a)(A.toOrdering))
 
-  implicit def catsNonEmptySetOps[A](value: NonEmptySet[A]): NonEmptySetOps[A] =
+  implicit def catsNonEmptySetOps[A](value: NonEmptySortedSet[A]): NonEmptySetOps[A] =
     new NonEmptySetOps(value)
 }
 
 
-sealed class NonEmptySetOps[A](val value: NonEmptySet[A]) {
+sealed class NonEmptySetOps[A](val value: NonEmptySortedSet[A]) {
 
   private implicit val ordering: Ordering[A] = toSortedSet.ordering
   private implicit val order: Order[A] = Order.fromOrdering
@@ -63,69 +63,69 @@ sealed class NonEmptySetOps[A](val value: NonEmptySet[A]) {
 
 
   /**
-    * Adds an element to this set, returning a new `NonEmptySet`
+    * Adds an element to this set, returning a new `NonEmptySortedSet`
     */
-  def add(a: A): NonEmptySet[A] = NonEmptySet.create(toSortedSet + a)
+  def add(a: A): NonEmptySortedSet[A] = NonEmptySortedSet.create(toSortedSet + a)
 
   /**
     * Alias for [[union]]
     * {{{
-    * scala> import cats.data.NonEmptySet
+    * scala> import cats.data.NonEmptySortedSet
     * scala> import cats.implicits._
-    * scala> val nes = NonEmptySet.of(1, 2, 4, 5)
-    * scala> nes ++ NonEmptySet.of(1, 2, 7)
-    * res0: cats.data.NonEmptySet[Int] = TreeSet(1, 2, 4, 5, 7)
+    * scala> val nes = NonEmptySortedSet.of(1, 2, 4, 5)
+    * scala> nes ++ NonEmptySortedSet.of(1, 2, 7)
+    * res0: cats.data.NonEmptySortedSet[Int] = TreeSet(1, 2, 4, 5, 7)
     * }}}
     */
-  def ++(as: NonEmptySet[A]): NonEmptySet[A] = union(as)
+  def ++(as: NonEmptySortedSet[A]): NonEmptySortedSet[A] = union(as)
 
   /**
     * Alias for [[union]]
     * {{{
-    * scala> import cats.data.NonEmptySet
+    * scala> import cats.data.NonEmptySortedSet
     * scala> import cats.implicits._
-    * scala> val nes = NonEmptySet.of(1, 2, 4, 5)
-    * scala> nes | NonEmptySet.of(1, 2, 7)
-    * res0: cats.data.NonEmptySet[Int] = TreeSet(1, 2, 4, 5, 7)
+    * scala> val nes = NonEmptySortedSet.of(1, 2, 4, 5)
+    * scala> nes | NonEmptySortedSet.of(1, 2, 7)
+    * res0: cats.data.NonEmptySortedSet[Int] = TreeSet(1, 2, 4, 5, 7)
     * }}}
     */
-  def | (as: NonEmptySet[A]): NonEmptySet[A] = union(as)
+  def | (as: NonEmptySortedSet[A]): NonEmptySortedSet[A] = union(as)
 
   /**
     * Alias for [[diff]]
     * {{{
-    * scala> import cats.data.NonEmptySet
+    * scala> import cats.data.NonEmptySortedSet
     * scala> import cats.implicits._
-    * scala> val nes = NonEmptySet.of(1, 2, 4, 5)
-    * scala> nes -- NonEmptySet.of(1, 2, 7)
+    * scala> val nes = NonEmptySortedSet.of(1, 2, 4, 5)
+    * scala> nes -- NonEmptySortedSet.of(1, 2, 7)
     * res0: scala.collection.immutable.SortedSet[Int] = TreeSet(4, 5)
     * }}}
     */
-  def --(as: NonEmptySet[A]): SortedSet[A] = diff(as)
+  def --(as: NonEmptySortedSet[A]): SortedSet[A] = diff(as)
 
   /**
     * Alias for [[diff]]
     * {{{
-    * scala> import cats.data.NonEmptySet
+    * scala> import cats.data.NonEmptySortedSet
     * scala> import cats.implicits._
-    * scala> val nes = NonEmptySet.of(1, 2, 4, 5)
-    * scala> nes &~ NonEmptySet.of(1, 2, 7)
+    * scala> val nes = NonEmptySortedSet.of(1, 2, 4, 5)
+    * scala> nes &~ NonEmptySortedSet.of(1, 2, 7)
     * res0: scala.collection.immutable.SortedSet[Int] = TreeSet(4, 5)
     * }}}
     */
-  def &~(as: NonEmptySet[A]): SortedSet[A] = diff(as)
+  def &~(as: NonEmptySortedSet[A]): SortedSet[A] = diff(as)
 
   /**
     * Alias for [[intersect]]
     * {{{
-    * scala> import cats.data.NonEmptySet
+    * scala> import cats.data.NonEmptySortedSet
     * scala> import cats.implicits._
-    * scala> val nes = NonEmptySet.of(1, 2, 4, 5)
-    * scala> nes & NonEmptySet.of(1, 2, 7)
+    * scala> val nes = NonEmptySortedSet.of(1, 2, 4, 5)
+    * scala> nes & NonEmptySortedSet.of(1, 2, 7)
     * res0: scala.collection.immutable.SortedSet[Int] = TreeSet(1, 2)
     * }}}
     */
-  def &(as: NonEmptySet[A]): SortedSet[A] = intersect(as)
+  def &(as: NonEmptySortedSet[A]): SortedSet[A] = intersect(as)
 
 
   /**
@@ -136,7 +136,7 @@ sealed class NonEmptySetOps[A](val value: NonEmptySet[A]) {
   /**
     * Applies f to all the elements
     */
-  def map[B](f: A => B)(implicit B: Order[B]): NonEmptySet[B] = {
+  def map[B](f: A => B)(implicit B: Order[B]): NonEmptySortedSet[B] = {
     implicit val bOrdering = B.toOrdering
     NonEmptySetImpl.create(toSortedSet.map(f))
   }
@@ -145,9 +145,9 @@ sealed class NonEmptySetOps[A](val value: NonEmptySet[A]) {
   /**
     * Converts this set to a `NonEmptyList`.
     * {{{
-    * scala> import cats.data.NonEmptySet
+    * scala> import cats.data.NonEmptySortedSet
     * scala> import cats.implicits._
-    * scala> val nes = NonEmptySet.of(1, 2, 3, 4, 5)
+    * scala> val nes = NonEmptySortedSet.of(1, 2, 3, 4, 5)
     * scala> nes.toNonEmptyList
     * res0: cats.data.NonEmptyList[Int] = NonEmptyList(1, 2, 3, 4, 5)
     * }}}
@@ -172,9 +172,9 @@ sealed class NonEmptySetOps[A](val value: NonEmptySet[A]) {
   /**
     * Alias for [[contains]]
     * {{{
-    * scala> import cats.data.NonEmptySet
+    * scala> import cats.data.NonEmptySortedSet
     * scala> import cats.implicits._
-    * scala> val nes = NonEmptySet.of(1, 2, 3, 4, 5)
+    * scala> val nes = NonEmptySortedSet.of(1, 2, 3, 4, 5)
     * scala> nes(3)
     * res0: Boolean = true
     * scala> nes(7)
@@ -191,17 +191,17 @@ sealed class NonEmptySetOps[A](val value: NonEmptySet[A]) {
   /**
     * Computes the difference of this set and another set.
     */
-  def diff(as: NonEmptySet[A]): SortedSet[A] = toSortedSet -- as.toSortedSet
+  def diff(as: NonEmptySortedSet[A]): SortedSet[A] = toSortedSet -- as.toSortedSet
 
   /**
     * Computes the union between this NES and another NES.
     */
-  def union(as: NonEmptySet[A]): NonEmptySet[A] = NonEmptySetImpl.create(toSortedSet ++ as.toSortedSet)
+  def union(as: NonEmptySortedSet[A]): NonEmptySortedSet[A] = NonEmptySetImpl.create(toSortedSet ++ as.toSortedSet)
 
   /**
     * Computes the intersection between this set and another set.
     */
-  def intersect(as: NonEmptySet[A]): SortedSet[A] = toSortedSet.filter(as.apply)
+  def intersect(as: NonEmptySortedSet[A]): SortedSet[A] = toSortedSet.filter(as.apply)
 
   /**
     * Tests whether a predicate holds for all elements of this set.
@@ -290,14 +290,14 @@ sealed class NonEmptySetOps[A](val value: NonEmptySet[A]) {
   /**
     * Map a function over all the elements of this set and concatenate the resulting sets into one.
     * {{{
-    * scala> import cats.data.NonEmptySet
+    * scala> import cats.data.NonEmptySortedSet
     * scala> import cats.implicits._
-    * scala> val nes = NonEmptySet.of(1, 2, 3)
-    * scala> nes.concatMap(n => NonEmptySet.of(n, n * 4, n * 5))
-    * res0: cats.data.NonEmptySet[Int] = TreeSet(1, 2, 3, 4, 5, 8, 10, 12, 15)
+    * scala> val nes = NonEmptySortedSet.of(1, 2, 3)
+    * scala> nes.concatMap(n => NonEmptySortedSet.of(n, n * 4, n * 5))
+    * res0: cats.data.NonEmptySortedSet[Int] = TreeSet(1, 2, 3, 4, 5, 8, 10, 12, 15)
     * }}}
     */
-  def concatMap[B](f: A => NonEmptySet[B])(implicit B: Order[B]): NonEmptySet[B] = {
+  def concatMap[B](f: A => NonEmptySortedSet[B])(implicit B: Order[B]): NonEmptySortedSet[B] = {
     implicit val ordering = B.toOrdering
     NonEmptySetImpl.create(toSortedSet.flatMap(f andThen (_.toSortedSet)))
   }
@@ -317,11 +317,11 @@ sealed class NonEmptySetOps[A](val value: NonEmptySet[A]) {
     * Typesafe equality operator.
     *
     * This method is similar to == except that it only allows two
-    * NonEmptySet[A] values to be compared to each other, and uses
+    * NonEmptySortedSet[A] values to be compared to each other, and uses
     * equality provided by Eq[_] instances, rather than using the
     * universal equality provided by .equals.
     */
-  def ===(that: NonEmptySet[A]): Boolean =
+  def ===(that: NonEmptySortedSet[A]): Boolean =
     Eq[SortedSet[A]].eqv(toSortedSet, that.toSortedSet)
 
   /**
@@ -330,39 +330,39 @@ sealed class NonEmptySetOps[A](val value: NonEmptySet[A]) {
   def length: Int = toSortedSet.size
 
   /**
-    * Zips this `NonEmptySet` with another `NonEmptySet` and applies a function for each pair of elements.
+    * Zips this `NonEmptySortedSet` with another `NonEmptySortedSet` and applies a function for each pair of elements.
     *
     * {{{
-    * scala> import cats.data.NonEmptySet
+    * scala> import cats.data.NonEmptySortedSet
     * scala> import cats.implicits._
-    * scala> val as = NonEmptySet.of(1, 2, 3)
-    * scala> val bs = NonEmptySet.of("A", "B", "C")
+    * scala> val as = NonEmptySortedSet.of(1, 2, 3)
+    * scala> val bs = NonEmptySortedSet.of("A", "B", "C")
     * scala> as.zipWith(bs)(_ + _)
-    * res0: cats.data.NonEmptySet[String] = TreeSet(1A, 2B, 3C)
+    * res0: cats.data.NonEmptySortedSet[String] = TreeSet(1A, 2B, 3C)
     * }}}
     */
-  def zipWith[B, C](b: NonEmptySet[B])(f: (A, B) => C)(implicit C: Order[C]): NonEmptySet[C] = {
+  def zipWith[B, C](b: NonEmptySortedSet[B])(f: (A, B) => C)(implicit C: Order[C]): NonEmptySortedSet[C] = {
     implicit val cOrdering = C.toOrdering
     NonEmptySetImpl.create((toSortedSet, b.toSortedSet).zipped.map(f))
   }
 
   /**
-    * Zips this `NonEmptySet` with its index.
+    * Zips this `NonEmptySortedSet` with its index.
     */
-  def zipWithIndex: NonEmptySet[(A, Int)] = {
+  def zipWithIndex: NonEmptySortedSet[(A, Int)] = {
     NonEmptySetImpl.create(cats.compat.SortedSet.zipWithIndex(toSortedSet))
   }
 
   /**
-    * Groups elements inside this `NonEmptySet` according to the `Order`
+    * Groups elements inside this `NonEmptySortedSet` according to the `Order`
     * of the keys produced by the given mapping function.
     */
-  def groupBy[B](f: A => B)(implicit B: Order[B]): NonEmptyMap[B, NonEmptySet[A]] = {
-     reduceLeftTo(a => NonEmptyMap.one(f(a), NonEmptySet.one(a))) { (acc, a) =>
+  def groupBy[B](f: A => B)(implicit B: Order[B]): NonEmptyMap[B, NonEmptySortedSet[A]] = {
+     reduceLeftTo(a => NonEmptyMap.one(f(a), NonEmptySortedSet.one(a))) { (acc, a) =>
        val key = f(a)
        val result = acc.lookup(key) match {
          case Some(nes) => nes.add(a)
-         case _ => NonEmptySet.one(a)
+         case _ => NonEmptySortedSet.one(a)
        }
        acc.add((key, result))
      }
@@ -370,62 +370,62 @@ sealed class NonEmptySetOps[A](val value: NonEmptySet[A]) {
 }
 
 private[data] sealed abstract class NonEmptySetInstances {
-  implicit val catsDataInstancesForNonEmptySet: SemigroupK[NonEmptySet] with Reducible[NonEmptySet] =
-    new SemigroupK[NonEmptySet] with Reducible[NonEmptySet] {
+  implicit val catsDataInstancesForNonEmptySet: SemigroupK[NonEmptySortedSet] with Reducible[NonEmptySortedSet] =
+    new SemigroupK[NonEmptySortedSet] with Reducible[NonEmptySortedSet] {
 
-      def combineK[A](a: NonEmptySet[A], b: NonEmptySet[A]): NonEmptySet[A] =
+      def combineK[A](a: NonEmptySortedSet[A], b: NonEmptySortedSet[A]): NonEmptySortedSet[A] =
         a | b
 
-      override def size[A](fa: NonEmptySet[A]): Long = fa.length.toLong
+      override def size[A](fa: NonEmptySortedSet[A]): Long = fa.length.toLong
 
-      override def reduceLeft[A](fa: NonEmptySet[A])(f: (A, A) => A): A =
+      override def reduceLeft[A](fa: NonEmptySortedSet[A])(f: (A, A) => A): A =
         fa.reduceLeft(f)
 
-      override def reduce[A](fa: NonEmptySet[A])(implicit A: Semigroup[A]): A =
+      override def reduce[A](fa: NonEmptySortedSet[A])(implicit A: Semigroup[A]): A =
         fa.reduce
 
-      def reduceLeftTo[A, B](fa: NonEmptySet[A])(f: A => B)(g: (B, A) => B): B = fa.reduceLeftTo(f)(g)
+      def reduceLeftTo[A, B](fa: NonEmptySortedSet[A])(f: A => B)(g: (B, A) => B): B = fa.reduceLeftTo(f)(g)
 
-      def reduceRightTo[A, B](fa: NonEmptySet[A])(f: A => B)(g: (A, Eval[B]) => Eval[B]): Eval[B] =
+      def reduceRightTo[A, B](fa: NonEmptySortedSet[A])(f: A => B)(g: (A, Eval[B]) => Eval[B]): Eval[B] =
         fa.reduceRightTo(f)(g)
 
-      override def foldLeft[A, B](fa: NonEmptySet[A], b: B)(f: (B, A) => B): B =
+      override def foldLeft[A, B](fa: NonEmptySortedSet[A], b: B)(f: (B, A) => B): B =
         fa.foldLeft(b)(f)
 
-      override def foldRight[A, B](fa: NonEmptySet[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
+      override def foldRight[A, B](fa: NonEmptySortedSet[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
         fa.foldRight(lb)(f)
 
-      override def foldMap[A, B](fa: NonEmptySet[A])(f: A => B)(implicit B: Monoid[B]): B =
+      override def foldMap[A, B](fa: NonEmptySortedSet[A])(f: A => B)(implicit B: Monoid[B]): B =
         B.combineAll(fa.toSortedSet.iterator.map(f))
 
-      override def fold[A](fa: NonEmptySet[A])(implicit A: Monoid[A]): A =
+      override def fold[A](fa: NonEmptySortedSet[A])(implicit A: Monoid[A]): A =
         fa.reduce
 
-      override def find[A](fa: NonEmptySet[A])(f: A => Boolean): Option[A] =
+      override def find[A](fa: NonEmptySortedSet[A])(f: A => Boolean): Option[A] =
         fa.find(f)
 
-      override def forall[A](fa: NonEmptySet[A])(p: A => Boolean): Boolean =
+      override def forall[A](fa: NonEmptySortedSet[A])(p: A => Boolean): Boolean =
         fa.forall(p)
 
-      override def exists[A](fa: NonEmptySet[A])(p: A => Boolean): Boolean =
+      override def exists[A](fa: NonEmptySortedSet[A])(p: A => Boolean): Boolean =
         fa.exists(p)
 
-      override def toList[A](fa: NonEmptySet[A]): List[A] = fa.toSortedSet.toList
+      override def toList[A](fa: NonEmptySortedSet[A]): List[A] = fa.toSortedSet.toList
 
-      override def toNonEmptyList[A](fa: NonEmptySet[A]): NonEmptyList[A] =
+      override def toNonEmptyList[A](fa: NonEmptySortedSet[A]): NonEmptyList[A] =
         fa.toNonEmptyList
     }
 
-  implicit def catsDataEqForNonEmptySet[A: Order]: Eq[NonEmptySet[A]] =
-    new Eq[NonEmptySet[A]]{
-      def eqv(x: NonEmptySet[A], y: NonEmptySet[A]): Boolean = x === y
+  implicit def catsDataEqForNonEmptySet[A: Order]: Eq[NonEmptySortedSet[A]] =
+    new Eq[NonEmptySortedSet[A]]{
+      def eqv(x: NonEmptySortedSet[A], y: NonEmptySortedSet[A]): Boolean = x === y
     }
 
-  implicit def catsDataShowForNonEmptySet[A](implicit A: Show[A]): Show[NonEmptySet[A]] =
-    Show.show[NonEmptySet[A]](_.show)
+  implicit def catsDataShowForNonEmptySet[A](implicit A: Show[A]): Show[NonEmptySortedSet[A]] =
+    Show.show[NonEmptySortedSet[A]](_.show)
 
-  implicit def catsDataSemilatticeForNonEmptySet[A]: Semilattice[NonEmptySet[A]] = new Semilattice[NonEmptySet[A]] {
-    def combine(x: NonEmptySet[A], y: NonEmptySet[A]): NonEmptySet[A] = x | y
+  implicit def catsDataSemilatticeForNonEmptySet[A]: Semilattice[NonEmptySortedSet[A]] = new Semilattice[NonEmptySortedSet[A]] {
+    def combine(x: NonEmptySortedSet[A], y: NonEmptySortedSet[A]): NonEmptySortedSet[A] = x | y
   }
 }
 

--- a/core/src/main/scala/cats/data/package.scala
+++ b/core/src/main/scala/cats/data/package.scala
@@ -18,8 +18,13 @@ package object data {
   type NonEmptyMap[K, +A] = NonEmptyMapImpl.Type[K, A]
   val NonEmptyMap = NonEmptyMapImpl
 
-  type NonEmptySet[A] = NonEmptySetImpl.Type[A]
-  val NonEmptySet = NonEmptySetImpl
+  type NonEmptySortedSet[A] = NonEmptySetImpl.Type[A]
+  val NonEmptySortedSet = NonEmptySetImpl
+
+  @deprecated("Use NonEmptySortedSet", "1.2.1")
+  type NonEmptySet[A] = NonEmptySortedSet[A]
+  @deprecated("Use NonEmptySortedSet", "1.2.1")
+  val NonEmptySet = NonEmptySortedSet
 
   type NonEmptyChain[+A] = NonEmptyChainImpl.Type[A]
   val NonEmptyChain = NonEmptyChainImpl

--- a/core/src/main/scala/cats/syntax/set.scala
+++ b/core/src/main/scala/cats/syntax/set.scala
@@ -1,7 +1,7 @@
 package cats.syntax
 
 import scala.collection.immutable.{SortedSet, SortedMap}
-import cats.data.NonEmptySet
+import cats.data.NonEmptySortedSet
 import cats.Order
 
 trait SetSyntax {
@@ -11,42 +11,42 @@ trait SetSyntax {
 final class SetOps[A](val se: SortedSet[A]) extends AnyVal {
 
   /**
-    * Returns an Option of NonEmptySet from a SortedSet
+    * Returns an Option of NonEmptySortedSet from a SortedSet
     *
     * Example:
     * {{{
     * scala> import scala.collection.immutable.SortedSet
-    * scala> import cats.data.NonEmptySet
+    * scala> import cats.data.NonEmptySortedSet
     * scala> import cats.implicits._
     *
     * scala> val result1: SortedSet[Int] = SortedSet(1, 2)
     * scala> result1.toNes
-    * res0: Option[NonEmptySet[Int]] = Some(TreeSet(1, 2))
+    * res0: Option[NonEmptySortedSet[Int]] = Some(TreeSet(1, 2))
     *
     * scala> val result2: SortedSet[Int] = SortedSet.empty[Int]
     * scala> result2.toNes
-    * res1: Option[NonEmptySet[Int]] = None
+    * res1: Option[NonEmptySortedSet[Int]] = None
     * }}}
     */
-  def toNes: Option[NonEmptySet[A]] = NonEmptySet.fromSet(se)
+  def toNes: Option[NonEmptySortedSet[A]] = NonEmptySortedSet.fromSet(se)
 
   /**
     * Groups elements inside this `SortedSet` according to the `Order` of the keys
     * produced by the given mapping function.
     *
     * {{{
-    * scala> import cats.data.NonEmptySet
+    * scala> import cats.data.NonEmptySortedSet
     * scala> import scala.collection.immutable.{SortedMap, SortedSet}
     * scala> import cats.implicits._
     *
     * scala> val sortedSet = SortedSet(12, -2, 3, -5)
     *
     * scala> sortedSet.groupByNes(_ >= 0)
-    * res0: SortedMap[Boolean, NonEmptySet[Int]] = Map(false -> TreeSet(-5, -2), true -> TreeSet(3, 12))
+    * res0: SortedMap[Boolean, NonEmptySortedSet[Int]] = Map(false -> TreeSet(-5, -2), true -> TreeSet(3, 12))
     * }}}
     */
-  def groupByNes[B](f: A => B)(implicit B: Order[B]): SortedMap[B, NonEmptySet[A]] = {
+  def groupByNes[B](f: A => B)(implicit B: Order[B]): SortedMap[B, NonEmptySortedSet[A]] = {
     implicit val ordering = B.toOrdering
-    toNes.fold(SortedMap.empty[B, NonEmptySet[A]])(_.groupBy(f).toSortedMap)
+    toNes.fold(SortedMap.empty[B, NonEmptySortedSet[A]])(_.groupBy(f).toSortedMap)
   }
 }

--- a/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
@@ -51,11 +51,11 @@ object arbitrary extends ArbitraryInstances0 {
   implicit def catsLawsCogenForNonEmptyVector[A](implicit A: Cogen[A]): Cogen[NonEmptyVector[A]] =
     Cogen[Vector[A]].contramap(_.toVector)
 
-  implicit def catsLawsArbitraryForNonEmptySet[A: Order](implicit A: Arbitrary[A]): Arbitrary[NonEmptySet[A]] =
+  implicit def catsLawsArbitraryForNonEmptySortedSet[A: Order](implicit A: Arbitrary[A]): Arbitrary[NonEmptySortedSet[A]] =
     Arbitrary(implicitly[Arbitrary[SortedSet[A]]].arbitrary.flatMap(fa =>
-      A.arbitrary.map(a => NonEmptySet(a, fa))))
+      A.arbitrary.map(a => NonEmptySortedSet(a, fa))))
 
-  implicit def catsLawsCogenForNonEmptySet[A: Order: Cogen]: Cogen[NonEmptySet[A]] =
+  implicit def catsLawsCogenForNonEmptySortedSet[A: Order: Cogen]: Cogen[NonEmptySortedSet[A]] =
     Cogen[SortedSet[A]].contramap(_.toSortedSet)
 
   implicit def catsLawsArbitraryForZipVector[A](implicit A: Arbitrary[A]): Arbitrary[ZipVector[A]] =

--- a/tests/src/test/scala/cats/tests/NonEmptySetSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptySetSuite.scala
@@ -19,104 +19,104 @@ package tests
 
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
-import cats.data.NonEmptySet
+import cats.data.NonEmptySortedSet
 import cats.kernel.laws.discipline.{SemilatticeTests, EqTests}
 
 import scala.collection.immutable.SortedSet
 
-class NonEmptySetSuite extends CatsSuite {
+class NonEmptySortedSetSuite extends CatsSuite {
 
-  checkAll("NonEmptySet[Int]", SemigroupKTests[NonEmptySet].semigroupK[Int])
-  checkAll("NonEmptySet[Int]", ReducibleTests[NonEmptySet].reducible[Option, Int, Int])
-  checkAll("NonEmptySet[String]", SemilatticeTests[NonEmptySet[String]].band)
-  checkAll("NonEmptySet[String]", EqTests[NonEmptySet[String]].eqv)
+  checkAll("NonEmptySortedSet[Int]", SemigroupKTests[NonEmptySortedSet].semigroupK[Int])
+  checkAll("NonEmptySortedSet[Int]", ReducibleTests[NonEmptySortedSet].reducible[Option, Int, Int])
+  checkAll("NonEmptySortedSet[String]", SemilatticeTests[NonEmptySortedSet[String]].band)
+  checkAll("NonEmptySortedSet[String]", EqTests[NonEmptySortedSet[String]].eqv)
 
   test("First element is always the smallest") {
-    forAll { (nes: NonEmptySet[Int]) =>
+    forAll { (nes: NonEmptySortedSet[Int]) =>
       nes.forall { v => Order[Int].lteqv(nes.head, v) } should === (true)
 
     }
   }
 
   test("Show is not empty and is formatted as expected") {
-    forAll { (nes: NonEmptySet[Int]) =>
+    forAll { (nes: NonEmptySortedSet[Int]) =>
       nes.show.nonEmpty should === (true)
       nes.show.startsWith("NonEmptySortedSet(") should === (true)
-      nes.show should === (implicitly[Show[NonEmptySet[Int]]].show(nes))
+      nes.show should === (implicitly[Show[NonEmptySortedSet[Int]]].show(nes))
       nes.show.contains(nes.head.show) should === (true)
     }
   }
 
   test("Show is formatted correctly") {
-    val nonEmptySet = NonEmptySet("Test", SortedSet.empty[String])
+    val nonEmptySet = NonEmptySortedSet("Test", SortedSet.empty[String])
     nonEmptySet.show should === ("NonEmptySortedSet(Test)")
   }
 
-  test("Creating NonEmptySet + toSet is identity") {
+  test("Creating NonEmptySortedSet + toSet is identity") {
     forAll { (i: Int, tail: SortedSet[Int]) =>
       val set = tail + i
-      val nonEmptySet = NonEmptySet(i, tail)
+      val nonEmptySet = NonEmptySortedSet(i, tail)
       set should === (nonEmptySet.toSortedSet)
     }
   }
 
-  test("NonEmptySet#filter is consistent with Set#filter") {
-    forAll { (nes: NonEmptySet[Int], p: Int => Boolean) =>
+  test("NonEmptySortedSet#filter is consistent with Set#filter") {
+    forAll { (nes: NonEmptySortedSet[Int], p: Int => Boolean) =>
       val set = nes.toSortedSet
       nes.filter(p) should === (set.filter(p))
     }
   }
 
-  test("NonEmptySet#filterNot is consistent with Set#filterNot") {
-    forAll { (nes: NonEmptySet[Int], p: Int => Boolean) =>
+  test("NonEmptySortedSet#filterNot is consistent with Set#filterNot") {
+    forAll { (nes: NonEmptySortedSet[Int], p: Int => Boolean) =>
       val set = nes.toSortedSet
       nes.filterNot(p) should === (set.filterNot(p))
     }
   }
 
-  test("NonEmptySet#collect is consistent with Set#collect") {
-    forAll { (nes: NonEmptySet[Int], pf: PartialFunction[Int, String]) =>
+  test("NonEmptySortedSet#collect is consistent with Set#collect") {
+    forAll { (nes: NonEmptySortedSet[Int], pf: PartialFunction[Int, String]) =>
       val set = nes.toSortedSet
       nes.collect(pf) should === (set.collect(pf))
     }
   }
 
-  test("NonEmptySet#find is consistent with Set#find") {
-    forAll { (nes: NonEmptySet[Int], p: Int => Boolean) =>
+  test("NonEmptySortedSet#find is consistent with Set#find") {
+    forAll { (nes: NonEmptySortedSet[Int], p: Int => Boolean) =>
       val set = nes.toSortedSet
       nes.find(p) should === (set.find(p))
     }
   }
 
-  test("NonEmptySet#exists is consistent with Set#exists") {
-    forAll { (nes: NonEmptySet[Int], p: Int => Boolean) =>
+  test("NonEmptySortedSet#exists is consistent with Set#exists") {
+    forAll { (nes: NonEmptySortedSet[Int], p: Int => Boolean) =>
       val set = nes.toSortedSet
       nes.exists(p) should === (set.exists(p))
     }
   }
 
-  test("NonEmptySet#forall is consistent with Set#forall") {
-    forAll { (nes: NonEmptySet[Int], p: Int => Boolean) =>
+  test("NonEmptySortedSet#forall is consistent with Set#forall") {
+    forAll { (nes: NonEmptySortedSet[Int], p: Int => Boolean) =>
       val set = nes.toSortedSet
       nes.forall(p) should === (set.forall(p))
     }
   }
 
-  test("NonEmptySet#map is consistent with Set#map") {
-    forAll { (nes: NonEmptySet[Int], p: Int => String) =>
+  test("NonEmptySortedSet#map is consistent with Set#map") {
+    forAll { (nes: NonEmptySortedSet[Int], p: Int => String) =>
       val set = nes.toSortedSet
       nes.map(p).toSortedSet should === (set.map(p))
     }
   }
 
   test("reduceLeft consistent with foldLeft") {
-    forAll { (nes: NonEmptySet[Int], f: (Int, Int) => Int) =>
+    forAll { (nes: NonEmptySortedSet[Int], f: (Int, Int) => Int) =>
       nes.reduceLeft(f) should === (nes.tail.foldLeft(nes.head)(f))
     }
   }
 
   test("reduceRight consistent with foldRight") {
-    forAll { (nes: NonEmptySet[Int], f: (Int, Eval[Int]) => Eval[Int]) =>
+    forAll { (nes: NonEmptySortedSet[Int], f: (Int, Eval[Int]) => Eval[Int]) =>
       val got = nes.reduceRight(f).value
       val last = nes.last
       val rev = nes - last
@@ -126,20 +126,20 @@ class NonEmptySetSuite extends CatsSuite {
   }
 
   test("reduce consistent with fold") {
-    forAll { (nes: NonEmptySet[Int]) =>
+    forAll { (nes: NonEmptySortedSet[Int]) =>
       nes.reduce should === (nes.fold)
     }
   }
 
 
   test("reduce consistent with reduceK") {
-    forAll { (nes: NonEmptySet[Option[Int]]) =>
+    forAll { (nes: NonEmptySortedSet[Option[Int]]) =>
       nes.reduce(SemigroupK[Option].algebra[Int]) should === (nes.reduceK)
     }
   }
 
   test("reduceLeftToOption consistent with foldLeft + Option") {
-    forAll { (nes: NonEmptySet[Int], f: Int => String, g: (String, Int) => String) =>
+    forAll { (nes: NonEmptySortedSet[Int], f: Int => String, g: (String, Int) => String) =>
       val expected = nes.tail.foldLeft(Option(f(nes.head))) { (opt, i) =>
         opt.map(s => g(s, i))
       }
@@ -148,7 +148,7 @@ class NonEmptySetSuite extends CatsSuite {
   }
 
   test("reduceRightToOption consistent with foldRight + Option") {
-    forAll { (nes: NonEmptySet[Int], f: Int => String, g: (Int, Eval[String]) => Eval[String]) =>
+    forAll { (nes: NonEmptySortedSet[Int], f: Int => String, g: (Int, Eval[String]) => Eval[String]) =>
       val got = nes.reduceRightToOption(f)(g).value
       val last = nes.last
       val rev = nes - last
@@ -160,7 +160,7 @@ class NonEmptySetSuite extends CatsSuite {
   }
 
   test("reduceLeftM consistent with foldM") {
-    forAll { (nes: NonEmptySet[Int], f: Int => Option[Int]) =>
+    forAll { (nes: NonEmptySortedSet[Int], f: Int => Option[Int]) =>
       val got = nes.reduceLeftM(f)((acc, i) => f(i).map(acc + _))
       val expected = f(nes.head).flatMap { hd =>
         nes.tail.foldM(hd)((acc, i) => f(i).map(acc + _))
@@ -170,71 +170,71 @@ class NonEmptySetSuite extends CatsSuite {
   }
 
   test("reduceMapM consistent with foldMapM") {
-    forAll { (nes: NonEmptySet[Int], f: Int => Option[Int]) =>
+    forAll { (nes: NonEmptySortedSet[Int], f: Int => Option[Int]) =>
       nes.reduceMapM(f) should === (nes.foldMapM(f))
     }
   }
 
   test("fromSet round trip") {
     forAll { l: SortedSet[Int] =>
-      NonEmptySet.fromSet(l).map(_.toSortedSet).getOrElse(SortedSet.empty[Int]) should === (l)
+      NonEmptySortedSet.fromSet(l).map(_.toSortedSet).getOrElse(SortedSet.empty[Int]) should === (l)
     }
 
-    forAll { nes: NonEmptySet[Int] =>
-      NonEmptySet.fromSet(nes.toSortedSet) should === (Some(nes))
+    forAll { nes: NonEmptySortedSet[Int] =>
+      NonEmptySortedSet.fromSet(nes.toSortedSet) should === (Some(nes))
     }
   }
 
   test("fromSetUnsafe/fromSet consistency") {
-    forAll { nes: NonEmptySet[Int] =>
-      NonEmptySet.fromSet(nes.toSortedSet) should === (Some(NonEmptySet.fromSetUnsafe(nes.toSortedSet)))
+    forAll { nes: NonEmptySortedSet[Int] =>
+      NonEmptySortedSet.fromSet(nes.toSortedSet) should === (Some(NonEmptySortedSet.fromSetUnsafe(nes.toSortedSet)))
     }
   }
 
   test("fromSetUnsafe empty set") {
     val _ = intercept[IllegalArgumentException] {
-      NonEmptySet.fromSetUnsafe(SortedSet.empty[Int])
+      NonEmptySortedSet.fromSetUnsafe(SortedSet.empty[Int])
     }
   }
 
   test("+ consistent with Set") {
-    forAll { (nes: NonEmptySet[Int], i: Int) =>
+    forAll { (nes: NonEmptySortedSet[Int], i: Int) =>
       (nes add i).toSortedSet should === (nes.toSortedSet + i)
     }
   }
 
-  test("NonEmptySet#zipWithIndex is consistent with Set#zipWithIndex") {
-    forAll { nes: NonEmptySet[Int] =>
+  test("NonEmptySortedSet#zipWithIndex is consistent with Set#zipWithIndex") {
+    forAll { nes: NonEmptySortedSet[Int] =>
       nes.zipWithIndex.toSortedSet should === (nes.toSortedSet.zipWithIndex)
     }
   }
 
-  test("NonEmptySet#length is consistent with Set#size") {
-    forAll { nes: NonEmptySet[Int] =>
+  test("NonEmptySortedSet#length is consistent with Set#size") {
+    forAll { nes: NonEmptySortedSet[Int] =>
       nes.length should === (nes.toSortedSet.size)
     }
   }
 
-  test("NonEmptySet#concat is consistent with Set#++") {
-    forAll { (nes: NonEmptySet[Int], l: SortedSet[Int], n: Int) =>
-      nes.union(NonEmptySet(n, l)).toSortedSet should === (nes.toSortedSet ++ (l + n))
+  test("NonEmptySortedSet#concat is consistent with Set#++") {
+    forAll { (nes: NonEmptySortedSet[Int], l: SortedSet[Int], n: Int) =>
+      nes.union(NonEmptySortedSet(n, l)).toSortedSet should === (nes.toSortedSet ++ (l + n))
     }
   }
 
-  test("NonEmptySet#zipWith is consistent with Set#zip and then Set#map") {
-    forAll { (a: NonEmptySet[Int], b: NonEmptySet[Int], f: (Int, Int) => Int) =>
+  test("NonEmptySortedSet#zipWith is consistent with Set#zip and then Set#map") {
+    forAll { (a: NonEmptySortedSet[Int], b: NonEmptySortedSet[Int], f: (Int, Int) => Int) =>
       a.zipWith(b)(f).toSortedSet should ===(a.toSortedSet.zip(b.toSortedSet).map { case (x, y) => f(x, y) })
     }
   }
 
-  test("NonEmptySet.of is consistent with removal") {
+  test("NonEmptySortedSet.of is consistent with removal") {
     forAll { (is: SortedSet[Int], i: Int) =>
-      NonEmptySet.of(i, is.toList: _*) - i should ===(is - i)
+      NonEmptySortedSet.of(i, is.toList: _*) - i should ===(is - i)
     }
   }
 
-  test("NonEmptySet#groupBy is consistent with Set#groupBy") {
-    forAll { (nes: NonEmptySet[Int], f: Int => Int) =>
+  test("NonEmptySortedSet#groupBy is consistent with Set#groupBy") {
+    forAll { (nes: NonEmptySortedSet[Int], f: Int => Int) =>
       nes.groupBy(f).map(_.toSortedSet).toSortedMap should === (nes.toSortedSet.groupBy(f))
     }
   }

--- a/tests/src/test/scala/cats/tests/SyntaxSuite.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxSuite.scala
@@ -4,7 +4,7 @@ package tests
 import scala.collection.immutable.SortedSet
 import scala.collection.immutable.SortedMap
 import cats.arrow.Compose
-import cats.data.{Binested, Nested, NonEmptyChain, NonEmptyList, NonEmptySet}
+import cats.data.{Binested, Nested, NonEmptyChain, NonEmptyList, NonEmptySortedSet}
 import cats.instances.AllInstances
 import cats.syntax.{AllSyntax, AllSyntaxBinCompat}
 
@@ -361,12 +361,12 @@ object SyntaxSuite extends AllSyntaxBinCompat with AllInstances with AllSyntax {
     val binested: Binested[F, G, H, A, B] = fgahb.binested
   }
 
-  def testNonEmptySet[A, B: Order] : Unit = {
+  def testNonEmptySortedSet[A, B: Order] : Unit = {
     val f = mock[A => B]
     val set = mock[SortedSet[A]]
 
-    val nes: Option[NonEmptySet[A]] = set.toNes
-    val grouped: SortedMap[B, NonEmptySet[A]] = set.groupByNes(f)
+    val nes: Option[NonEmptySortedSet[A]] = set.toNes
+    val grouped: SortedMap[B, NonEmptySortedSet[A]] = set.groupByNes(f)
   }
 
   def testNonEmptyList[A, B: Order] : Unit = {


### PR DESCRIPTION
Fixes #2434

I renamed `NonEmptySet` to the `NonEmptySortedSet`. To keep backward compatibility I created an alias from `NonEmptySet` to `NonEmptySortedSet`. This alias marked as deprecated.

To save binary compatibility I had to preserve names for:
  * `NonEmptySetImpl`
  * `NonEmptySetImpl.catsNonEmptySetOps`
  * `NonEmptySetOps`
  * `NonEmptySetInstances`
  * `NonEmptySetInstances.catsDataInstancesForNonEmptySet`
  * `NonEmptySetInstances.catsDataEqForNonEmptySet`
  * `NonEmptySetInstances.catsDataShowForNonEmptySet`
  * `NonEmptySetInstances.catsDataSemilatticeForNonEmptySet`

I'm not happy with this, but I don't know another way to save binary compatibility.