### PR TITLE
#2429 Replace all usage of the list Monoid in the docs with the chain Monoid

### DIFF
--- a/docs/src/main/tut/datatypes/ior.md
+++ b/docs/src/main/tut/datatypes/ior.md
@@ -49,9 +49,9 @@ Here's an example of how we might be able to do that:
 
 ```tut:silent
 import cats.implicits._
-import cats.data.{ NonEmptyList => Nel }
+import cats.data.{ NonEmptyChain => Nec }
 
-type Failures = Nel[String]
+type Failures = Nec[String]
 
 case class Username(value: String) extends AnyVal
 case class Password(value: String) extends AnyVal
@@ -60,18 +60,18 @@ case class User(name: Username, pw: Password)
 
 def validateUsername(u: String): Failures Ior Username = {
   if (u.isEmpty)
-    Nel.one("Can't be empty").leftIor
+    Nec.one("Can't be empty").leftIor
   else if (u.contains("."))
-    Ior.both(Nel.one("Dot in name is deprecated"), Username(u))
+    Ior.both(Nec.one("Dot in name is deprecated"), Username(u))
   else
     Username(u).rightIor
 }
 
 def validatePassword(p: String): Failures Ior Password = {
   if (p.length < 8)
-    Nel.one("Password too short").leftIor
+    Nec.one("Password too short").leftIor
   else if (p.length < 10)
-    Ior.both(Nel.one("Password should be longer"), Password(p))
+    Ior.both(Nec.one("Password should be longer"), Password(p))
   else
     Password(p).rightIor
 }
@@ -98,22 +98,23 @@ To extract the values, we can use the `fold` method, which expects a function fo
 ```tut
 
 validateUser("john.doe", "password").fold(
-  errorNel => s"Error: ${errorNel.head}",
+  errorNec => s"Error: ${errorNec.head}",
   user => s"Success: $user",
   (warnings, user) => s"Warning: ${user.name.value}; The following warnings occurred: ${warnings.show}"
 )
 
 ```
-Similar to [Validated](validated.html), there is also a type alias for using a `NonEmptyList` on the left side.
+Similar to [Validated](validated.html), there is also a type alias for using a `NonEmptyChain` on the left side.
 
 ```tut:silent
-type IorNel[B, A] = Ior[NonEmptyList[B], A]
+type IorNec[B, A] = Ior[NonEmptyChain[B], A]
 ```
 
 
 ```tut
+import cats.implicits._, cats.data.NonEmptyChain
 
-val left: IorNel[String, Int] = Ior.leftNel("Error")
+val left: IorNec[String, Int] = Ior.fromEither("Error".leftNec[Int])
 
 ```
 

--- a/docs/src/main/tut/datatypes/iort.md
+++ b/docs/src/main/tut/datatypes/iort.md
@@ -19,22 +19,22 @@ validating an address:
 
 ```tut:silent
 import cats.data.Ior
-import cats.data.{ NonEmptyList => Nel }
+import cats.data.{ NonEmptyChain => Nec }
 import cats.implicits._
 import scala.util.{Success, Try}
 
-type Logs = Nel[String]
+type Logs = Nec[String]
 
 def parseNumber(input: String): Ior[Logs, Option[Int]] =
   Try(input.trim.toInt) match {
     case Success(number) if number > 0 => Ior.Right(Some(number))
-    case Success(_) => Ior.Both(Nel.one(s"'$input' is non-positive number"), None)
-    case _ => Ior.Both(Nel.one(s"'$input' is not a number"), None)
+    case Success(_) => Ior.Both(Nec.one(s"'$input' is non-positive number"), None)
+    case _ => Ior.Both(Nec.one(s"'$input' is not a number"), None)
   }
 
 def parseStreet(input: String): Ior[Logs, String] = {
   if (input.trim.isEmpty)
-    Ior.Left(Nel.one(s"'$input' is not a street"))
+    Ior.Left(Nec.one(s"'$input' is not a street"))
   else
     Ior.Right(input)
 }
@@ -42,7 +42,7 @@ def parseStreet(input: String): Ior[Logs, String] = {
 def numberToString(number: Option[Int]): Ior[Logs, String] =
   number match {
     case Some(n) => Ior.Right(n.toString)
-    case None => Ior.Both(Nel.one("used default address number"), "n/a")
+    case None => Ior.Both(Nec.one("used default address number"), "n/a")
   }
 
 def addressProgram(numberInput: String, streetInput: String): Ior[Logs, String] =


### PR DESCRIPTION
* replace `NonEmptyList` with `NonEmptyChain` in `Ior` and `IorT` docs

* fixes #2429 
