### PR TITLE
Add Order#fromLessThan

### DIFF
--- a/kernel-laws/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -142,6 +142,7 @@ class Tests extends FunSuite with Discipline {
   checkAll("fromOrdering[Int]", OrderTests(Order.fromOrdering[Int]).order)
   checkAll("Order.reverse(Order[Int])", OrderTests(Order.reverse(Order[Int])).order)
   checkAll("Order.reverse(Order.reverse(Order[Int]))", OrderTests(Order.reverse(Order.reverse(Order[Int]))).order)
+  checkAll("Order.fromLessThan[Int](_ < _)", OrderTests(Order.fromLessThan[Int](_ < _)).order)
 
   checkAll("Monoid[String]", MonoidTests[String].monoid)
   checkAll("Monoid[String]", SerializableTests.serializable(Monoid[String]))

--- a/kernel/src/main/scala/cats/kernel/Order.scala
+++ b/kernel/src/main/scala/cats/kernel/Order.scala
@@ -170,6 +170,23 @@ object Order extends OrderFunctions[Order] with OrderToOrderingConversion {
     }
 
   /**
+   * Define an `Order[A]` using the given 'less than' function `f`.
+   */
+  def fromLessThan[@sp A](f: (A, A) => Boolean): Order[A] =
+    new Order[A] {
+      override def compare(x: A, y: A): Int =
+        if (f(x, y)) -1 else if (f(y, x)) 1 else 0
+
+      // Overridden for performance (avoids multiple comparisons)
+      override def eqv(x: A, y: A): Boolean = !(f(x, y) || f(y, x))
+      override def neqv(x: A, y: A): Boolean = f(x, y) || f(y, x)
+      override def lteqv(x: A, y: A): Boolean = !f(y, x)
+      override def lt(x: A, y: A): Boolean = f(x, y)
+      override def gteqv(x: A, y: A): Boolean = !f(x, y)
+      override def gt(x: A, y: A): Boolean = f(y, x)
+    }
+
+  /**
    * An `Order` instance that considers all `A` instances to be equal.
    */
   def allEqual[A]: Order[A] =


### PR DESCRIPTION
I sometimes find myself writing `Order` instances using a 'less than' function. There is no such helper function for `Order`, but there is one for `Ordering`, which means that you currently have to rely on the `fromOrdering` function as follows.

```scala
import cats.Order
import java.time.Instant

implicit val orderInstant: Order[Instant] =
  Order.fromOrdering(Ordering.fromLessThan(_ isBefore _))
```

This pull request adds a `fromLessThan` function to `Order`, so we don't have to use `Ordering`.

```scala
implicit val orderInstant: Order[Instant] =
  Order.fromLessThan(_ isBefore _)
```