### PR TITLE
improve interaction with subtyping in OptionOps#liftTo

### DIFF
--- a/core/src/main/scala/cats/ApplicativeError.scala
+++ b/core/src/main/scala/cats/ApplicativeError.scala
@@ -187,7 +187,7 @@ object ApplicativeError {
   def apply[F[_], E](implicit F: ApplicativeError[F, E]): ApplicativeError[F, E] = F
 
   private[cats] final class LiftFromOptionPartially[F[_]](val dummy: Boolean = true) extends AnyVal {
-    def apply[E, A](oa: Option[A], ifEmpty: => E)(implicit F: ApplicativeError[F, E]): F[A] =
+    def apply[E, A](oa: Option[A], ifEmpty: => E)(implicit F: ApplicativeError[F, _ >: E]): F[A] =
       oa match {
         case Some(a) => F.pure(a)
         case None => F.raiseError(ifEmpty)

--- a/core/src/main/scala/cats/syntax/either.scala
+++ b/core/src/main/scala/cats/syntax/either.scala
@@ -277,8 +277,8 @@ final class EitherOps[A, B](val eab: Either[A, B]) extends AnyVal {
     * scala> import cats.implicits._
     * scala> import cats.data.EitherT
     * scala> val e: Either[String, Int] = Right(3)
-    * scala> e.liftTo[EitherT[Option, String, ?]]
-    * res0: cats.data.EitherT[Option, String, Int] = EitherT(Some(Right(3)))
+    * scala> e.liftTo[EitherT[Option, CharSequence, ?]]
+    * res0: cats.data.EitherT[Option, CharSequence, Int] = EitherT(Some(Right(3)))
     * }}}
     */
   def liftTo[F[_]](implicit F: ApplicativeError[F, _ >: A]): F[B] = F.fromEither(eab)

--- a/core/src/main/scala/cats/syntax/either.scala
+++ b/core/src/main/scala/cats/syntax/either.scala
@@ -281,7 +281,7 @@ final class EitherOps[A, B](val eab: Either[A, B]) extends AnyVal {
     * res0: cats.data.EitherT[Option, String, Int] = EitherT(Some(Right(3)))
     * }}}
     */
-  def liftTo[F[_]](implicit F: ApplicativeError[F, A]): F[B] = F.fromEither(eab)
+  def liftTo[F[_]](implicit F: ApplicativeError[F, _ >: A]): F[B] = F.fromEither(eab)
 }
 
 

--- a/core/src/main/scala/cats/syntax/option.scala
+++ b/core/src/main/scala/cats/syntax/option.scala
@@ -203,7 +203,7 @@ final class OptionOps[A](val oa: Option[A]) extends AnyVal {
 
 object OptionOps {
   private[syntax] final class LiftToPartiallyApplied[F[_], A](oa: Option[A]) {
-    def apply[E](ifEmpty: => E)(implicit F: ApplicativeError[F, E]): F[A] =
+    def apply[E](ifEmpty: => E)(implicit F: ApplicativeError[F, _ >: E]): F[A] =
       ApplicativeError.liftFromOption(oa, ifEmpty)
   }
 }

--- a/core/src/main/scala/cats/syntax/option.scala
+++ b/core/src/main/scala/cats/syntax/option.scala
@@ -178,14 +178,11 @@ final class OptionOps[A](val oa: Option[A]) extends AnyVal {
     * Example:
     * {{{
     * scala> import cats.implicits._
-    * scala> import cats.data.EitherT
-    * scala> Some(1).liftTo[Either[String, ?]]("Empty")
-    * res0: scala.Either[String, Int] = Right(1)
+    * scala> Some(1).liftTo[Either[CharSequence, ?]]("Empty")
+    * res0: scala.Either[CharSequence, Int] = Right(1)
     *
-    * scala> Option.empty[Int].liftTo[Either[String, ?]]("Empty")
-    * res1: scala.Either[String, Int] = Left(Empty)
-    * scala> 42.some.liftTo[EitherT[Option, CharSequence, ?]]("Empty")
-    * res2: EitherT[Option, CharSequence, Int] = EitherT(Some(Right(42)))
+    * scala> Option.empty[Int].liftTo[Either[CharSequence, ?]]("Empty")
+    * res1: scala.Either[CharSequence, Int] = Left(Empty)
     * }}}
     */
   def liftTo[F[_]]: LiftToPartiallyApplied[F, A] = new LiftToPartiallyApplied(oa)

--- a/core/src/main/scala/cats/syntax/option.scala
+++ b/core/src/main/scala/cats/syntax/option.scala
@@ -178,12 +178,14 @@ final class OptionOps[A](val oa: Option[A]) extends AnyVal {
     * Example:
     * {{{
     * scala> import cats.implicits._
-    *
+    * scala> import cats.data.EitherT
     * scala> Some(1).liftTo[Either[String, ?]]("Empty")
     * res0: scala.Either[String, Int] = Right(1)
     *
     * scala> Option.empty[Int].liftTo[Either[String, ?]]("Empty")
     * res1: scala.Either[String, Int] = Left(Empty)
+    * scala> 42.some.liftTo[EitherT[Option, CharSequence, ?]]("Empty")
+    * res2: EitherT[Option, CharSequence, Int] = EitherT(Some(Right(42)))
     * }}}
     */
   def liftTo[F[_]]: LiftToPartiallyApplied[F, A] = new LiftToPartiallyApplied(oa)


### PR DESCRIPTION
Currently OptionOps#liftTo interacts badly with subtyping. Something like this won't compile:
```scala
42.some.liftTo[IO](new Exception("foo"))
```
One needs to write this instead: 
```scala
42.some.liftTo[IO](new Exception("foo"): Throwable)
```
This patch fixes this. 
