### PR TITLE
Update applicative.md

### DIFF
--- a/docs/src/main/tut/typeclasses/applicative.md
+++ b/docs/src/main/tut/typeclasses/applicative.md
@@ -66,6 +66,12 @@ Such an `Applicative` must obey three laws:
     * `fa.product(pure(())) ~ fa`
     * As an equality: `fa.product(pure(())).map(_._1) = fa`
 
+Note also that, although similar, `product` does not always yield the same results as the `combine` operations that you can find in `Semigroup`. For example for `Option` we have that:
+```tut:book:silent
+Semigroup[Option[Int]].combine(Some(1), None) == Some(1)
+Applicative[Option].product(Some(1), None) == None
+```
+
 ## Applicatives for effect management
 
 If we view `Functor` as the ability to work with a single effect, `Applicative` encodes working with


### PR DESCRIPTION
Added observation wrt `Semigroup[A].combine` versus `Applicative[F[_]].product`.

I'm not sure whether you want to add this information (which might be obvious) and if this is the right place to add it but to me discovering that combining via applicative and combining via semigroup was different was quite surprising.