### PR TITLE
Proposal - add cats-tagless as an external module

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ functionality, you can pick-and-choose from amongst these modules
  * [`cats-mtl`](https://github.com/typelevel/cats-mtl): transformer typeclasses for Cats' Monads, Applicatives and Functors.
  * [`mouse`](https://github.com/typelevel/mouse): a small companion to Cats that provides convenient syntax (aka extension methods) 
  * [`kittens`](https://github.com/typelevel/kittens): automatic type class instance derivation for Cats and generic utility functions
+ * [`cats-tagless`](https://github.com/typelevel/cats-tagless): Utilities for tagless final encoded algebras
 
 Release notes for Cats are available in [CHANGES.md](https://github.com/typelevel/cats/blob/master/CHANGES.md).
 


### PR DESCRIPTION
 Not a module inside Cats repo, it's still in its own repo with its own release cycle just like the other 4 "outside" modules cats-mtl, cats-effect, mouse and kittens. 
Nothing really special about being an official cats external module other than some sort of commitment that Cats maintainers are going to help its maintenance. As of now, the majority of the code of cats-tagless came from two projects from two Cats maintainer @LukaJCB and myself. I plan to remain a maintainer of the project. (how about you @LukaJCB ?)