### PR TITLE
Kill scala-collection-compat

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -36,8 +36,6 @@ lazy val commonSettings = Seq(
     Resolver.sonatypeRepo("releases"),
     Resolver.sonatypeRepo("snapshots")),
   fork in test := true,
-  libraryDependencies ++= Seq(
-    "org.scala-lang.modules" %% "scala-collection-compat" % "0.1.1"),
   parallelExecution in Test := false,
   scalacOptions in (Compile, doc) := (scalacOptions in (Compile, doc)).value.filter(_ != "-Xfatal-warnings"),
   //todo: reenable doctests on 2.13 once it's officially released. it's disabled for now due to changes to the `toString` impl of collections


### PR DESCRIPTION
Are we sure we even need this? I just ran `buildJVM` on my laptop for 2.13.0-M4 and it worked just fine.