### PR TITLE
Add Pure instance for Future

### DIFF
--- a/alleycats-core/src/main/scala/alleycats/std/all.scala
+++ b/alleycats-core/src/main/scala/alleycats/std/all.scala
@@ -9,5 +9,6 @@ import export._
   OptionInstances,
   SetInstances,
   TryInstances,
-  IterableInstances
+  IterableInstances,
+  FutureInstances
 ) object all extends LegacySetInstances with LegacyTryInstances with LegacyIterableInstances with MapInstances

--- a/alleycats-core/src/main/scala/alleycats/std/future.scala
+++ b/alleycats-core/src/main/scala/alleycats/std/future.scala
@@ -1,0 +1,17 @@
+package alleycats
+package std
+
+import export._
+
+import scala.concurrent.Future
+
+@reexports(FutureInstances)
+object future
+
+object FutureInstances {
+  @export(Orphan)
+  implicit val exportFuturePure: Pure[Future] =
+    new Pure[Future] {
+      override def pure[A](a: A): Future[A] = Future.successful(a)
+    }
+}


### PR DESCRIPTION
The big advantage of doing this is that doing `pure` does not require an ExecutionContext, as catsStdInstancesForFuture does