### PR TITLE
.raiseError syntax allows an error subtype

### DIFF
--- a/core/src/main/scala/cats/syntax/applicativeError.scala
+++ b/core/src/main/scala/cats/syntax/applicativeError.scala
@@ -67,7 +67,7 @@ final class ApplicativeErrorExtensionOps[F[_], E](F: ApplicativeError[F, E]) {
 }
 
 final class ApplicativeErrorIdOps[E](val e: E) extends AnyVal {
-  def raiseError[F[_], A](implicit F: ApplicativeError[F, E]): F[A] =
+  def raiseError[F[_], A](implicit F: ApplicativeError[F, _ >: E]): F[A] =
     F.raiseError(e)
 }
 

--- a/tests/src/test/scala/cats/tests/SyntaxSuite.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxSuite.scala
@@ -349,6 +349,10 @@ object SyntaxSuite extends AllSyntaxBinCompat with AllInstances with AllSyntax {
     val gea4 = ga.recoverWith(pfegea)
   }
 
+  def testApplicativeErrorSubtype[F[_], A](implicit F: ApplicativeError[F, CharSequence]): Unit = {
+    val fea = "meow".raiseError[F, A]
+  }
+
   def testNested[F[_], G[_], A]: Unit = {
     val fga: F[G[A]] = mock[F[G[A]]]
 


### PR DESCRIPTION
Inspired by #2480, applying the same trick to `.raiseError` so that I can write `MyException(...).raiseError[IO, Unit]`, instead of `(MyException(...): Throwable).raiseError[IO, Unit]`.