### PR TITLE
improved support for subtyping in applicativeError syntax

### DIFF
--- a/core/src/main/scala/cats/syntax/applicativeError.scala
+++ b/core/src/main/scala/cats/syntax/applicativeError.scala
@@ -67,7 +67,7 @@ final class ApplicativeErrorExtensionOps[F[_], E](F: ApplicativeError[F, E]) {
 }
 
 final class ApplicativeErrorIdOps[E](val e: E) extends AnyVal {
-  def raiseError[F[_], A](implicit F: ApplicativeError[F, E]): F[A] =
+  def raiseError[F[_], A](implicit F: ApplicativeError[F, _ >: E]): F[A] =
     F.raiseError(e)
 }
 


### PR DESCRIPTION
This is a case that I missed in my last pull request.
`new Exception("foo").raiseError[Either[Throwable, ?], Nothing]` now compiles; without this patch, you need to write `(new Exception("foo"): Throwable).raiseError[Either[Throwable, ?], Nothing]`

@LukaJCB , @kailuowang since you merged my last PR, you might want to take a look at this too.