### PR TITLE
Use the Foldable, Luka!

### DIFF
--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -70,8 +70,7 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
         B.combineAll(fa.iterator.map(f))
 
       def traverse[G[_], A, B](fa: List[A])(f: A => G[B])(implicit G: Applicative[G]): G[List[B]] =
-        foldRight[A, G[List[B]]](fa, Always(G.pure(List.empty))) { (a, lglb) =>
-          G.map2Eval(f(a), lglb)(_ :: _)
+        foldRight[A, G[List[B]]](fa, Always(G.pure(List.empty))) { (a, lglb) => G.map2Eval(f(a), lglb)(_ :: _)
         }.value
 
       override def mapWithIndex[A, B](fa: List[A])(f: (A, Int) => B): List[B] =
@@ -113,8 +112,7 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
         def step(in: (List[A], B)): G[Either[(List[A], B), B]] = in match {
           case (Nil, b) => G.pure(Right(b))
           case (a :: tail, b) =>
-            G.map(f(b, a)) { bnext =>
-              Left((tail, bnext))
+            G.map(f(b, a)) { bnext => Left((tail, bnext))
             }
         }
 
@@ -165,13 +163,15 @@ trait ListInstancesBinCompat0 {
     override def flattenOption[A](fa: List[Option[A]]): List[A] = fa.flatten
 
     def traverseFilter[G[_], A, B](fa: List[A])(f: (A) => G[Option[B]])(implicit G: Applicative[G]): G[List[B]] =
-      fa.foldRight(Eval.now(G.pure(List.empty[B])))(
+      traverse
+        .foldRight(fa, Eval.now(G.pure(List.empty[B])))(
           (x, xse) => G.map2Eval(f(x), xse)((i, o) => i.fold(o)(_ :: o))
         )
         .value
 
     override def filterA[G[_], A](fa: List[A])(f: (A) => G[Boolean])(implicit G: Applicative[G]): G[List[A]] =
-      fa.foldRight(Eval.now(G.pure(List.empty[A])))(
+      traverse
+        .foldRight(fa, Eval.now(G.pure(List.empty[A])))(
           (x, xse) => G.map2Eval(f(x), xse)((b, list) => if (b) x :: list else list)
         )
         .value


### PR DESCRIPTION
This PR makes sure that in instances for List we don't use the standard library's `foldRight` (which reverses the list and then folds left) but the faster `Foldable[List].foldRight` implementation.