### PR TITLE
Add `allOf` to Eq

### DIFF
--- a/kernel/src/main/scala/cats/kernel/Eq.scala
+++ b/kernel/src/main/scala/cats/kernel/Eq.scala
@@ -76,6 +76,14 @@ object Eq extends EqFunctions[Eq] with EqToEquivConversion {
       def eqv(x: A, y: A) = eq1.eqv(x, y) || eq2.eqv(x, y)
     }
 
+  /**
+    * Return an Eq that gives the result of conjunction of all arguments
+    * Note this is idempotent
+    */
+  def compose[@sp A](eqs: Eq[A]*): Eq[A] =
+    new Eq[A] {
+      def eqv(x: A, y: A) = eqs.forall(_.eqv(x, y))
+    }
 
   /**
    * Create an `Eq` instance from an `eqv` implementation.

--- a/kernel/src/main/scala/cats/kernel/Eq.scala
+++ b/kernel/src/main/scala/cats/kernel/Eq.scala
@@ -80,7 +80,7 @@ object Eq extends EqFunctions[Eq] with EqToEquivConversion {
     * Return an Eq that gives the result of conjunction of all arguments
     * Note this is idempotent
     */
-  def compose[@sp A](eqs: Eq[A]*): Eq[A] =
+  def allOf[@sp A](eqs: Eq[A]*): Eq[A] =
     new Eq[A] {
       def eqv(x: A, y: A) = eqs.forall(_.eqv(x, y))
     }

--- a/tests/src/test/scala/cats/tests/EqSuite.scala
+++ b/tests/src/test/scala/cats/tests/EqSuite.scala
@@ -17,4 +17,27 @@ class EqSuite extends CatsSuite {
     checkAll("Eq[Int]", ContravariantMonoidalTests[Eq].contravariantMonoidal[Int, Int, Int])
     checkAll("ContravariantMonoidal[Eq]", SerializableTests.serializable(ContravariantMonoidal[Eq]))
 
+    case class Something(a: Int, b: Int, c: Int)
+
+    test("Eq returned by Eq.compose yields true on all underlying Eq's true") {
+        val somethingEq = Eq.compose[Something](
+            Eq.by(_.a), Eq.by(_.b), Eq.by(_.c)
+        )
+
+        val sut = Something(1, 2, 3)
+
+        somethingEq.eqv(sut, sut) shouldBe true
+    }
+
+    test("Eq returned by Eq.compose yields false if some of underlying Eq's false") {
+        val somethingEq = Eq.compose[Something](
+            Eq.by(_.a), Eq.by(_.b), Eq.by(_.c)
+        )
+
+        val sut = Something(1, 2, 3)
+
+        somethingEq.eqv(sut, sut.copy(a = 4)) shouldBe false
+        somethingEq.eqv(sut, sut.copy(b = 4)) shouldBe false
+        somethingEq.eqv(sut, sut.copy(c = 4)) shouldBe false
+    }
 }

--- a/tests/src/test/scala/cats/tests/EqSuite.scala
+++ b/tests/src/test/scala/cats/tests/EqSuite.scala
@@ -19,8 +19,8 @@ class EqSuite extends CatsSuite {
 
     case class Something(a: Int, b: Int, c: Int)
 
-    test("Eq returned by Eq.compose yields true on all underlying Eq's true") {
-        val somethingEq = Eq.compose[Something](
+    test("Eq returned by Eq.allOf yields true on all underlying Eq's true") {
+        val somethingEq = Eq.allOf[Something](
             Eq.by(_.a), Eq.by(_.b), Eq.by(_.c)
         )
 
@@ -29,8 +29,8 @@ class EqSuite extends CatsSuite {
         somethingEq.eqv(sut, sut) shouldBe true
     }
 
-    test("Eq returned by Eq.compose yields false if some of underlying Eq's false") {
-        val somethingEq = Eq.compose[Something](
+    test("Eq returned by Eq.allOf yields false if some of underlying Eq's false") {
+        val somethingEq = Eq.allOf[Something](
             Eq.by(_.a), Eq.by(_.b), Eq.by(_.c)
         )
 


### PR DESCRIPTION
Motivation:
Composing of multiple Eq's with `and` quickly becomes awkward, Eq.allOf makes it more convenient.