### PR TITLE
Add empty to State and StateT objects

### DIFF
--- a/core/src/main/scala/cats/data/IndexedStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedStateT.scala
@@ -203,7 +203,7 @@ private[data] trait CommonStateTConstructors {
     IndexedStateT(s => F.pure((s, s)))
 }
 
-object IndexedStateT extends IndexedStateTInstances with CommonStateTConstructors {
+object IndexedStateT extends IndexedStateTInstances with CommonStateTConstructors0 {
   def apply[F[_], SA, SB, A](f: SA => F[(SB, A)])(implicit F: Applicative[F]): IndexedStateT[F, SA, SB, A] =
     new IndexedStateT(F.pure(f))
 
@@ -221,6 +221,11 @@ object IndexedStateT extends IndexedStateTInstances with CommonStateTConstructor
 
   def setF[F[_], SA, SB](fsb: F[SB])(implicit F: Applicative[F]): IndexedStateT[F, SA, SB, Unit] =
     IndexedStateT(_ => F.map(fsb)(s => (s, ())))
+}
+
+private[data] trait CommonStateTConstructors0 extends CommonStateTConstructors {
+  def empty[F[_], S, A](implicit A: Monoid[A], F: Applicative[F]): IndexedStateT[F, S, S, A] =
+    pure(A.empty)
 }
 
 private[data] abstract class StateTFunctions extends CommonStateTConstructors {
@@ -298,6 +303,11 @@ private[data] abstract class StateFunctions {
    * Return `a` and maintain the input state.
    */
   def pure[S, A](a: A): State[S, A] = State(s => (s, a))
+
+  /**
+    * Return `A`'s empty monoid value and maintain the input state.
+    */
+  def empty[S, A](implicit A: Monoid[A]): State[S, A] = pure(A.empty)
 
   /**
    * Modify the input state and return Unit.

--- a/core/src/main/scala/cats/data/package.scala
+++ b/core/src/main/scala/cats/data/package.scala
@@ -49,7 +49,7 @@ package object data {
    * context along with the `A` value.
    */
   type StateT[F[_], S, A] = IndexedStateT[F, S, S, A]
-  object StateT extends StateTFunctions
+  object StateT extends StateTFunctions with CommonStateTConstructors0
 
   type State[S, A] = StateT[Eval, S, A]
   object State extends StateFunctions

--- a/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
@@ -55,6 +55,17 @@ class IndexedStateTSuite extends CatsSuite {
     }
   }
 
+  test("State.empty, StateT.empty and IndexedStateT.empty are consistent"){
+    forAll { (s: String) =>
+      val state: State[String, Int] = State.empty
+      val stateT: State[String, Int] = StateT.empty
+      val indexedStateT: State[String, Int] = IndexedStateT.empty
+
+      state.run(s) should === (stateT.run(s))
+      state.run(s) should === (indexedStateT.run(s))
+    }
+  }
+
   test("State.get, StateT.get and IndexedStateT.get are consistent") {
     forAll{ (s: String) =>
       val state: State[String, String] = State.get


### PR DESCRIPTION
Work by @sderosiaux in #2294. Rebased to current master. For some reason, the bincompat error also went away (at least locally).