### PR TITLE
Introduce `OrElse` type class

### DIFF
--- a/alleycats-core/src/main/scala/alleycats/OrElse.scala
+++ b/alleycats-core/src/main/scala/alleycats/OrElse.scala
@@ -1,0 +1,8 @@
+package alleycats
+
+import simulacrum.op
+import simulacrum.typeclass
+
+@typeclass trait OrElse[F[_]] {
+  @op("orElse") def orElse[A](fa: F[A], alternative: => F[A]): F[A]
+}

--- a/alleycats-core/src/main/scala/alleycats/std/future.scala
+++ b/alleycats-core/src/main/scala/alleycats/std/future.scala
@@ -3,7 +3,7 @@ package std
 
 import export._
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 @reexports(FutureInstances)
 object future
@@ -13,5 +13,12 @@ object FutureInstances {
   implicit val exportFuturePure: Pure[Future] =
     new Pure[Future] {
       override def pure[A](a: A): Future[A] = Future.successful(a)
+    }
+
+  @export(Orphan)
+  implicit def exportFutureOrElse(implicit ec: ExecutionContext): OrElse[Future] =
+    new OrElse[Future] {
+      override def orElse[A](fa: Future[A], alternative: => Future[A]): Future[A] =
+        fa.recoverWith { case _: NoSuchElementException => alternative }
     }
 }

--- a/alleycats-core/src/main/scala/alleycats/std/option.scala
+++ b/alleycats-core/src/main/scala/alleycats/std/option.scala
@@ -13,4 +13,11 @@ object OptionInstances {
     new EmptyK[Option] {
       def empty[A]: Option[A] = None
     }
+
+  @export(Orphan)
+  implicit val exportOptionOrElse: OrElse[Option] =
+    new OrElse[Option] {
+      override def orElse[A](fa: Option[A], alternative: => Option[A]): Option[A] =
+        fa.orElse(alternative)
+    }
 }

--- a/alleycats-core/src/main/scala/alleycats/std/try.scala
+++ b/alleycats-core/src/main/scala/alleycats/std/try.scala
@@ -44,6 +44,13 @@ object TryInstances {
 
       def tailRecM[A, B](a: A)(f: (A) => Try[Either[A, B]]): Try[B] = cats.instances.try_.catsStdInstancesForTry.tailRecM(a)(f)
     }
+
+  @export(Orphan)
+  implicit val tryOrEls: OrElse[Try] =
+    new OrElse[Try] {
+      override def orElse[A](fa: Try[A], alternative: => Try[A]): Try[A] =
+        fa.orElse(alternative)
+    }
 }
 
 // TODO: remove when cats.{ Monad, Comonad, Bimonad } support export-hook


### PR DESCRIPTION
This PR introduces `OrElse` typeclass into alleycats. `OrElse` is a generalization of the idea of getting of "alternative" value instead of inappropriate contents of a container. The original problem was abstracting from throwing `NoSuchElementException` by the `filter` method of `Future` when I worked on my https://github.com/danslapman/asyncstreams library