### PR TITLE
Missing Contravariant instance for OptionT

### DIFF
--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -66,14 +66,6 @@ private[data] sealed abstract class ConstInstances extends ConstInstances0 {
     def show(f: Const[A, B]): String = f.show
   }
 
-  implicit def catsDataContravariantMonoidalForConst[D: Monoid]: ContravariantMonoidal[Const[D, ?]] = new ContravariantMonoidal[Const[D, ?]] {
-    override def unit = Const.empty[D, Unit]
-    override def contramap[A, B](fa: Const[D, A])(f: B => A): Const[D, B] =
-      fa.retag[B]
-    override def product[A, B](fa: Const[D, A], fb: Const[D, B]): Const[D, (A, B)] =
-      fa.retag[(A, B)] combine fb.retag[(A, B)]
-  }
-
   implicit def catsDataTraverseForConst[C]: Traverse[Const[C, ?]] = new Traverse[Const[C, ?]] {
     def foldLeft[A, B](fa: Const[C, A], b: B)(f: (B, A) => B): B = b
 
@@ -126,6 +118,15 @@ private[data] sealed abstract class ConstInstances extends ConstInstances0 {
 
 private[data] sealed abstract class ConstInstances0 extends ConstInstances1 {
 
+  implicit def catsDataContravariantMonoidalForConst[D: Monoid]: ContravariantMonoidal[Const[D, ?]] =
+    new ContravariantMonoidal[Const[D, ?]] {
+      override def unit = Const.empty[D, Unit]
+      override def contramap[A, B](fa: Const[D, A])(f: B => A): Const[D, B] =
+        fa.retag[B]
+      override def product[A, B](fa: Const[D, A], fb: Const[D, B]): Const[D, (A, B)] =
+        fa.retag[(A, B)] combine fb.retag[(A, B)]
+    }
+
   implicit def catsDataCommutativeApplicativeForConst[C](implicit C: CommutativeMonoid[C]): CommutativeApplicative[Const[C, ?]] =
     new ConstApplicative[C] with CommutativeApplicative[Const[C, ?]] { val C0: CommutativeMonoid[C] = C }
 }
@@ -140,11 +141,6 @@ private[data] sealed abstract class ConstInstances2 extends ConstInstances3 {
 
   implicit def catsDataSemigroupForConst[A: Semigroup, B]: Semigroup[Const[A, B]] = new Semigroup[Const[A, B]] {
     def combine(x: Const[A, B], y: Const[A, B]): Const[A, B] = x combine y
-  }
-
-  implicit def catsDataContravariantForConst[C]: Contravariant[Const[C, ?]] = new Contravariant[Const[C, ?]] {
-    override def contramap[A, B](fa: Const[C, A])(f: (B) => A): Const[C, B] =
-      fa.retag[B]
   }
 
   implicit def catsDataPartialOrderForConst[A: PartialOrder, B]: PartialOrder[Const[A, B]] = new PartialOrder[Const[A, B]]{
@@ -171,10 +167,18 @@ private[data] sealed abstract class ConstInstances4 {
 
   implicit def catsDataFunctorForConst[C]: Functor[Const[C, ?]] =
     new ConstFunctor[C]{}
+
+  implicit def catsDataContravariantForConst[C]: Contravariant[Const[C, ?]] =
+    new ConstContravariant[C] {}
 }
 
 private[data] sealed trait ConstFunctor[C] extends Functor[Const[C, ?]] {
   def map[A, B](fa: Const[C, A])(f: A => B): Const[C, B] =
+    fa.retag[B]
+}
+
+private[data] sealed trait ConstContravariant[C] extends Contravariant[Const[C, ?]] {
+  override def contramap[A, B](fa: Const[C, A])(f: B => A): Const[C, B] =
     fa.retag[B]
 }
 

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -28,11 +28,6 @@ final case class OptionT[F[_], A](value: F[Option[A]]) {
   def map[B](f: A => B)(implicit F: Functor[F]): OptionT[F, B] =
     OptionT(F.map(value)(_.map(f)))
 
-  def imap[B](f: A => B)(g: B => A)(implicit F: Invariant[F]): OptionT[F, B] =
-    OptionT {
-      F.imap(value)(_ map f)(_ map g)
-    }
-
   def contramap[B](f: B => A)(implicit F: Contravariant[F]): OptionT[F, B] =
     OptionT {
       F.contramap(value)(_ map f)

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -289,8 +289,8 @@ private[data] sealed abstract class OptionTInstances0 extends OptionTInstances1 
   implicit def catsDateFunctorFilterForOptionT[F[_]](implicit F0: Functor[F]): FunctorFilter[OptionT[F, ?]] =
     new OptionTFunctorFilter[F] { implicit val F = F0 }
 
-  implicit def catsDataInvariantForOptionT[F[_]](implicit F0: Invariant[F]): Invariant[OptionT[F, ?]] =
-    new OptionTInvariant[F] { implicit val F = F0 }
+  implicit def catsDataContravariantForOptionT[F[_]](implicit F0: Contravariant[F]): Contravariant[OptionT[F, ?]] =
+    new OptionTContravariant[F] { implicit val F = F0 }
 }
 
 private[data] sealed abstract class OptionTInstances1 extends OptionTInstances2 {
@@ -308,8 +308,8 @@ private[data] sealed abstract class OptionTInstances2 extends OptionTInstances3 
   implicit def catsDataFoldableForOptionT[F[_]](implicit F0: Foldable[F]): Foldable[OptionT[F, ?]] =
     new OptionTFoldable[F] { implicit val F = F0 }
 
-  implicit def catsDataContravariantForOptionT[F[_]](implicit F0: Contravariant[F]): Contravariant[OptionT[F, ?]] =
-    new OptionTContravariant[F] { implicit val F = F0 }
+  implicit def catsDataInvariantForOptionT[F[_]](implicit F0: Invariant[F]): Invariant[OptionT[F, ?]] =
+    new OptionTInvariant[F] { implicit val F = F0 }
 }
 
 private[data] sealed abstract class OptionTInstances3 {

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -300,13 +300,13 @@ private[data] sealed abstract class OptionTInstances2 extends OptionTInstances3 
   implicit def catsDataFoldableForOptionT[F[_]](implicit F0: Foldable[F]): Foldable[OptionT[F, ?]] =
     new OptionTFoldable[F] { implicit val F = F0 }
 
-  implicit def catsDataFunctorForOptionT[F[_]](implicit F0: Functor[F]): Functor[OptionT[F, ?]] =
-    new OptionTFunctor[F] { implicit val F = F0 }
+  implicit def catsDataContravariantForOptionT[F[_]](implicit F0: Contravariant[F]): Contravariant[OptionT[F, ?]] =
+    new OptionTContravariant[F] { implicit val F = F0 }
 }
 
 private[data] sealed abstract class OptionTInstances3 {
-  implicit def catsDataContravariantForOptionT[F[_]](implicit F0: Contravariant[F]): Contravariant[OptionT[F, ?]] =
-    new OptionTContravariant[F] { implicit val F = F0 }
+  implicit def catsDataFunctorForOptionT[F[_]](implicit F0: Functor[F]): Functor[OptionT[F, ?]] =
+    new OptionTFunctor[F] { implicit val F = F0 }
 }
 
 private[data] trait OptionTFunctor[F[_]] extends Functor[OptionT[F, ?]] {

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -28,6 +28,11 @@ final case class OptionT[F[_], A](value: F[Option[A]]) {
   def map[B](f: A => B)(implicit F: Functor[F]): OptionT[F, B] =
     OptionT(F.map(value)(_.map(f)))
 
+  def imap[B](f: A => B)(g: B => A)(implicit F: Invariant[F]): OptionT[F, B] =
+    OptionT {
+      F.imap(value)(_ map f)(_ map g)
+    }
+
   def contramap[B](f: B => A)(implicit F: Contravariant[F]): OptionT[F, B] =
     OptionT {
       F.contramap(value)(_ map f)
@@ -302,6 +307,9 @@ private[data] sealed abstract class OptionTInstances1 extends OptionTInstances2 
 private[data] sealed abstract class OptionTInstances2 extends OptionTInstances3 {
   implicit def catsDataFoldableForOptionT[F[_]](implicit F0: Foldable[F]): Foldable[OptionT[F, ?]] =
     new OptionTFoldable[F] { implicit val F = F0 }
+
+  implicit def catsDataInvariantForOptionT[F[_]](implicit F0: Invariant[F]): Invariant[OptionT[F, ?]] =
+    new OptionTInvariant[F] { implicit val F = F0 }
 }
 
 private[data] sealed abstract class OptionTInstances3 {
@@ -313,6 +321,13 @@ private[data] trait OptionTFunctor[F[_]] extends Functor[OptionT[F, ?]] {
   implicit def F: Functor[F]
 
   override def map[A, B](fa: OptionT[F, A])(f: A => B): OptionT[F, B] = fa.map(f)
+}
+
+private[data] sealed trait OptionTInvariant[F[_]] extends Invariant[OptionT[F, ?]] {
+  implicit def F: Invariant[F]
+
+  override def imap[A, B](fa: OptionT[F, A])(f: A => B)(g: B => A): OptionT[F, B] =
+    fa.imap(f)(g)
 }
 
 private[data] sealed trait OptionTContravariant[F[_]] extends Contravariant[OptionT[F, ?]] {

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -307,9 +307,6 @@ private[data] sealed abstract class OptionTInstances1 extends OptionTInstances2 
 private[data] sealed abstract class OptionTInstances2 extends OptionTInstances3 {
   implicit def catsDataFoldableForOptionT[F[_]](implicit F0: Foldable[F]): Foldable[OptionT[F, ?]] =
     new OptionTFoldable[F] { implicit val F = F0 }
-
-  implicit def catsDataInvariantForOptionT[F[_]](implicit F0: Invariant[F]): Invariant[OptionT[F, ?]] =
-    new OptionTInvariant[F] { implicit val F = F0 }
 }
 
 private[data] sealed abstract class OptionTInstances3 {
@@ -321,13 +318,6 @@ private[data] trait OptionTFunctor[F[_]] extends Functor[OptionT[F, ?]] {
   implicit def F: Functor[F]
 
   override def map[A, B](fa: OptionT[F, A])(f: A => B): OptionT[F, B] = fa.map(f)
-}
-
-private[data] sealed trait OptionTInvariant[F[_]] extends Invariant[OptionT[F, ?]] {
-  implicit def F: Invariant[F]
-
-  override def imap[A, B](fa: OptionT[F, A])(f: A => B)(g: B => A): OptionT[F, B] =
-    fa.imap(f)(g)
 }
 
 private[data] sealed trait OptionTContravariant[F[_]] extends Contravariant[OptionT[F, ?]] {

--- a/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
@@ -4,11 +4,9 @@ package discipline
 
 import cats.data.NonEmptyList.ZipNonEmptyList
 import cats.data.NonEmptyVector.ZipNonEmptyVector
-
 import scala.util.{Failure, Success, Try}
 import scala.collection.immutable.{SortedMap, SortedSet}
 import cats.data._
-import cats.kernel.Semigroup
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import org.scalacheck.Arbitrary.{arbitrary => getArbitrary}
 
@@ -321,7 +319,7 @@ object arbitrary extends ArbitraryInstances0 {
 
 }
 
-private[discipline] sealed trait ArbitraryInstances0 extends ArbitraryInstances1 {
+private[discipline] sealed trait ArbitraryInstances0 {
 
   implicit def catsLawArbitraryForIndexedStateT[F[_], SA, SB, A](implicit F: Arbitrary[F[SA => F[(SB, A)]]]): Arbitrary[IndexedStateT[F, SA, SB, A]] =
     Arbitrary(F.arbitrary.map(IndexedStateT.applyF))
@@ -337,30 +335,4 @@ private[discipline] sealed trait ArbitraryInstances0 extends ArbitraryInstances1
 
   implicit def catsLawsArbitraryForCokleisli[F[_], A, B](implicit AFA: Arbitrary[F[A]], CFA: Cogen[F[A]], B: Arbitrary[B]): Arbitrary[Cokleisli[F, A, B]] =
     Arbitrary(Arbitrary.arbitrary[F[A] => B].map(Cokleisli(_)))
-}
-
-private[discipline] sealed trait ArbitraryInstances1 {
-
-  implicit def catsLawsArbitraryForSemigroupOfOption[A](implicit ev: Semigroup[A]): Arbitrary[Semigroup[Option[A]]] =
-    Arbitrary {
-      Gen.const(
-        new Semigroup[Option[A]] {
-          def combine(x: Option[A], y: Option[A]): Option[A] =
-            (x, y) match {
-              case (Some(a1), Some(a2)) => Some(ev.combine(a1, a2))
-              case _ => None
-            }
-        }
-      )
-    }
-
-  implicit def catsLawsArbitraryForSemigroupOfTuple[L, V](implicit ev1: Semigroup[L], ev2: Semigroup[V]): Arbitrary[Semigroup[(L, V)]] =
-    Arbitrary {
-      Gen.const(
-        new Semigroup[(L, V)] {
-          def combine(x: (L, V), y: (L, V)): (L, V) =
-            ev1.combine(x._1, y._1) -> ev2.combine(x._2, y._2)
-        }
-      )
-    }
 }

--- a/tests/src/test/scala/cats/tests/ConstSuite.scala
+++ b/tests/src/test/scala/cats/tests/ConstSuite.scala
@@ -45,6 +45,14 @@ class ConstSuite extends CatsSuite {
   checkAll("PartialOrder[Const[Set[Int], String]]", PartialOrderTests[Const[Set[Int], String]].partialOrder)
   checkAll("Order[Const[Int, String]]", OrderTests[Const[Int, String]].order)
 
+  {
+    implicitly[Invariant[Const[String, ?]]]
+    Invariant[Const[String, ?]]
+
+    checkAll("Const[String, Int]", InvariantTests[Const[String, ?]].invariant[Int, Int, Int])
+    checkAll("Invariant[Const[String, ?]]", SerializableTests.serializable(Invariant[Const[String, ?]]))
+  }
+
   checkAll("Const[String, Int]", ContravariantTests[Const[String, ?]].contravariant[Int, Int, Int])
   checkAll("Contravariant[Const[String, ?]]", SerializableTests.serializable(Contravariant[Const[String, ?]]))
 

--- a/tests/src/test/scala/cats/tests/OptionTSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionTSuite.scala
@@ -70,6 +70,16 @@ class OptionTSuite extends CatsSuite {
     checkAll("Functor[OptionT[ListWrapper, ?]]", SerializableTests.serializable(Functor[OptionT[ListWrapper, ?]]))
   }
 
+  {
+    // F has a Contravariant
+    Contravariant[OptionT[Const[String, ?], ?]]
+
+    checkAll("OptionT[Const[String, ?], ?]", ContravariantTests[OptionT[Const[String, ?], ?]].contravariant[Int, Int, Int])
+    checkAll("Contravariant[OptionT[Const[String, ?], ?]]", SerializableTests.serializable(Contravariant[OptionT[Const[String, ?], ?]]))
+
+    Contravariant[OptionT[Show, ?]]
+  }
+
 
   {
     // F has a ContravariantMonoidal

--- a/tests/src/test/scala/cats/tests/OptionTSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionTSuite.scala
@@ -2,7 +2,8 @@ package cats
 package tests
 
 import cats.data.{Const, OptionT}
-import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests, OrderTests, PartialOrderTests, EqTests}
+import cats.kernel.{Monoid, Semigroup}
+import cats.kernel.laws.discipline.{EqTests, MonoidTests, OrderTests, PartialOrderTests, SemigroupTests}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
@@ -73,11 +74,11 @@ class OptionTSuite extends CatsSuite {
 
   {
     // F has an Invariant
-    Invariant[Show]
-    Invariant[OptionT[Show, ?]]
+    Invariant[Semigroup]
+    Invariant[OptionT[Semigroup, ?]]
 
-    checkAll("OptionT[Show, ?]", InvariantTests[OptionT[Show, ?]].invariant[Int, Int, Int])
-    checkAll("Invariant[OptionT[Show, ?]]", SerializableTests.serializable(Invariant[OptionT[Show, ?]]))
+    checkAll("OptionT[Semigroup, ?]", InvariantTests[OptionT[Semigroup, ?]].invariant[Int, Int, Int])
+    checkAll("Invariant[OptionT[Semigroup, ?]]", SerializableTests.serializable(Invariant[OptionT[Semigroup, ?]]))
   }
 
   {

--- a/tests/src/test/scala/cats/tests/OptionTSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionTSuite.scala
@@ -5,6 +5,7 @@ import cats.data.{Const, OptionT}
 import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests, OrderTests, PartialOrderTests, EqTests}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.eq._
 
 class OptionTSuite extends CatsSuite {
   implicit val iso = SemigroupalTests.Isomorphisms.invariant[OptionT[ListWrapper, ?]](OptionT.catsDataFunctorForOptionT(ListWrapper.functor))
@@ -72,25 +73,21 @@ class OptionTSuite extends CatsSuite {
 
   {
     // F has an Invariant
-    implicitly[Invariant[OptionT[Const[String, ?], ?]]]
-    Invariant[OptionT[Const[String, ?], ?]]
+    Invariant[Show]
+    Invariant[OptionT[Show, ?]]
 
-    checkAll("OptionT[Const[String, ?], ?]", InvariantTests[OptionT[Const[String, ?], ?]].invariant[Int, Int, Int])
-    checkAll("Invariant[OptionT[Const[String, ?], ?]]", SerializableTests.serializable(Invariant[OptionT[Const[String, ?], ?]]))
+    checkAll("OptionT[Show, ?]", InvariantTests[OptionT[Show, ?]].invariant[Int, Int, Int])
+    checkAll("Invariant[OptionT[Show, ?]]", SerializableTests.serializable(Invariant[OptionT[Show, ?]]))
   }
 
   {
     // F has a Contravariant
-    implicitly[Contravariant[OptionT[Const[String, ?], ?]]]
-    Contravariant[OptionT[Const[String, ?], ?]]
-
-    checkAll("OptionT[Const[String, ?], ?]", ContravariantTests[OptionT[Const[String, ?], ?]].contravariant[Int, Int, Int])
-    checkAll("Contravariant[OptionT[Const[String, ?], ?]]", SerializableTests.serializable(Contravariant[OptionT[Const[String, ?], ?]]))
-
-    implicitly[Contravariant[OptionT[Show, ?]]]
+    Contravariant[Show]
     Contravariant[OptionT[Show, ?]]
-  }
 
+    checkAll("OptionT[Show, ?]", ContravariantTests[OptionT[Show, ?]].contravariant[Int, Int, Int])
+    checkAll("Contravariant[OptionT[Show, ?]]", SerializableTests.serializable(Contravariant[OptionT[Show, ?]]))
+  }
 
   {
     // F has a ContravariantMonoidal

--- a/tests/src/test/scala/cats/tests/OptionTSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionTSuite.scala
@@ -71,12 +71,23 @@ class OptionTSuite extends CatsSuite {
   }
 
   {
+    // F has an Invariant
+    implicitly[Invariant[OptionT[Const[String, ?], ?]]]
+    Invariant[OptionT[Const[String, ?], ?]]
+
+    checkAll("OptionT[Const[String, ?], ?]", InvariantTests[OptionT[Const[String, ?], ?]].invariant[Int, Int, Int])
+    checkAll("Invariant[OptionT[Const[String, ?], ?]]", SerializableTests.serializable(Invariant[OptionT[Const[String, ?], ?]]))
+  }
+
+  {
     // F has a Contravariant
+    implicitly[Contravariant[OptionT[Const[String, ?], ?]]]
     Contravariant[OptionT[Const[String, ?], ?]]
 
     checkAll("OptionT[Const[String, ?], ?]", ContravariantTests[OptionT[Const[String, ?], ?]].contravariant[Int, Int, Int])
     checkAll("Contravariant[OptionT[Const[String, ?], ?]]", SerializableTests.serializable(Contravariant[OptionT[Const[String, ?], ?]]))
 
+    implicitly[Contravariant[OptionT[Show, ?]]]
     Contravariant[OptionT[Show, ?]]
   }
 

--- a/tests/src/test/scala/cats/tests/OptionTSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionTSuite.scala
@@ -74,11 +74,12 @@ class OptionTSuite extends CatsSuite {
 
   {
     // F has an Invariant
-    Invariant[Semigroup]
-    Invariant[OptionT[Semigroup, ?]]
+    implicit val evidence = ListWrapper.invariant
+    Invariant[ListWrapper]
+    Invariant[OptionT[ListWrapper, ?]]
 
-    checkAll("OptionT[Semigroup, ?]", InvariantTests[OptionT[Semigroup, ?]].invariant[Int, Int, Int])
-    checkAll("Invariant[OptionT[Semigroup, ?]]", SerializableTests.serializable(Invariant[OptionT[Semigroup, ?]]))
+    checkAll("OptionT[ListWrapper, ?]", InvariantTests[OptionT[ListWrapper, ?]].invariant[Int, Int, Int])
+    checkAll("Invariant[OptionT[ListWrapper, ?]]", SerializableTests.serializable(Invariant[OptionT[ListWrapper, ?]]))
   }
 
   {

--- a/tests/src/test/scala/cats/tests/WriterTSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterTSuite.scala
@@ -372,6 +372,14 @@ class WriterTSuite extends CatsSuite {
   }
 
   {
+    // F has an Invariant
+    Invariant[WriterT[Const[String, ?], Int, ?]]
+
+    checkAll("WriterT[Const[String, ?], Int, ?]", InvariantTests[WriterT[Const[String, ?], Int, ?]].invariant[Int, Int, Int])
+    checkAll("Invariant[WriterT[Const[String, ?], Int, ?]]", SerializableTests.serializable(Invariant[WriterT[Const[String, ?], Int, ?]]))
+  }
+
+  {
     // F has a Foldable and L has a Monoid
     implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
     Foldable[Const[String, ?]]

--- a/tests/src/test/scala/cats/tests/WriterTSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterTSuite.scala
@@ -372,11 +372,12 @@ class WriterTSuite extends CatsSuite {
 
   {
     // F has an Invariant
-    Invariant[Semigroup]
-    Invariant[WriterT[Semigroup, Int, ?]]
+    implicit val evidence = ListWrapper.invariant
+    Invariant[ListWrapper]
+    Invariant[WriterT[ListWrapper, Int, ?]]
 
-    checkAll("WriterT[Semigroup, Int, ?]", InvariantTests[WriterT[Semigroup, Int, ?]].invariant[Int, Int, Int])
-    checkAll("Invariant[WriterT[Semigroup, Int, ?]]", SerializableTests.serializable(Invariant[WriterT[Semigroup, Int, ?]]))
+    checkAll("WriterT[ListWrapper, Int, ?]", InvariantTests[WriterT[ListWrapper, Int, ?]].invariant[Int, Int, Int])
+    checkAll("Invariant[WriterT[ListWrapper, Int, ?]]", SerializableTests.serializable(Invariant[WriterT[ListWrapper, Int, ?]]))
   }
 
   {

--- a/tests/src/test/scala/cats/tests/WriterTSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterTSuite.scala
@@ -373,10 +373,11 @@ class WriterTSuite extends CatsSuite {
 
   {
     // F has an Invariant
-    Invariant[WriterT[Const[String, ?], Int, ?]]
+    Invariant[Show]
+    Invariant[WriterT[Show, Int, ?]]
 
-    checkAll("WriterT[Const[String, ?], Int, ?]", InvariantTests[WriterT[Const[String, ?], Int, ?]].invariant[Int, Int, Int])
-    checkAll("Invariant[WriterT[Const[String, ?], Int, ?]]", SerializableTests.serializable(Invariant[WriterT[Const[String, ?], Int, ?]]))
+    checkAll("WriterT[Show, Int, ?]", InvariantTests[WriterT[Show, Int, ?]].invariant[Int, Int, Int])
+    checkAll("Invariant[WriterT[Show, Int, ?]]", SerializableTests.serializable(Invariant[WriterT[Show, Int, ?]]))
   }
 
   {

--- a/tests/src/test/scala/cats/tests/WriterTSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterTSuite.scala
@@ -2,12 +2,11 @@ package cats
 package tests
 
 import cats.data.{Const, EitherT, Validated, Writer, WriterT}
-
+import cats.kernel.Semigroup
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
-
-import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests, EqTests}
+import cats.kernel.laws.discipline.{EqTests, MonoidTests, SemigroupTests}
 
 class WriterTSuite extends CatsSuite {
   type Logged[A] = Writer[ListWrapper[Int], A]
@@ -373,11 +372,11 @@ class WriterTSuite extends CatsSuite {
 
   {
     // F has an Invariant
-    Invariant[Show]
-    Invariant[WriterT[Show, Int, ?]]
+    Invariant[Semigroup]
+    Invariant[WriterT[Semigroup, Int, ?]]
 
-    checkAll("WriterT[Show, Int, ?]", InvariantTests[WriterT[Show, Int, ?]].invariant[Int, Int, Int])
-    checkAll("Invariant[WriterT[Show, Int, ?]]", SerializableTests.serializable(Invariant[WriterT[Show, Int, ?]]))
+    checkAll("WriterT[Semigroup, Int, ?]", InvariantTests[WriterT[Semigroup, Int, ?]].invariant[Int, Int, Int])
+    checkAll("Invariant[WriterT[Semigroup, Int, ?]]", SerializableTests.serializable(Invariant[WriterT[Semigroup, Int, ?]]))
   }
 
   {


### PR DESCRIPTION
It should close https://github.com/typelevel/cats/issues/2545

While checking the Invariant I noticed that there is an issue with the priority of ContravariantMonoidal and Traverse in Const so I fixed it and added tests. Can be reproduced with
```scala
scala> import cats._, cats.implicits._, cats.data._
import cats._
import cats.implicits._
import cats.data._

scala> Invariant[Const[String, ?]]
<console>:21: error: ambiguous implicit values:
 both method catsDataContravariantMonoidalForConst in class ConstInstances of type [D](implicit evidence$3: cats.Monoid[D])cats.ContravariantMonoidal[[β$0$]cats.data.Const[D,β$0$]]
 and method catsDataTraverseForConst in class ConstInstances of type [C]=> cats.Traverse[[β$2$]cats.data.Const[C,β$2$]]
 match expected type cats.Invariant[[β$0$]cats.data.Const[String,β$0$]]
       Invariant[Const[String, ?]]
```