### PR TITLE
Proposal: add `cats-collections` as an external cats module

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ functionality, you can pick-and-choose from amongst these modules
  * [`mouse`](https://github.com/typelevel/mouse): a small companion to Cats that provides convenient syntax (aka extension methods) 
  * [`kittens`](https://github.com/typelevel/kittens): automatic type class instance derivation for Cats and generic utility functions
  * [`cats-tagless`](https://github.com/typelevel/cats-tagless): Utilities for tagless final encoded algebras
+ * [`cats-collections`](https://github.com/typelevel/cats-collections): Data structures which facilitate pure functional programming
 
 Release notes for Cats are available in [CHANGES.md](https://github.com/typelevel/cats/blob/master/CHANGES.md).
 


### PR DESCRIPTION
@stew generously [donated dogs to become typelevel/cats-collections](https://github.com/typelevel/cats-collections/issues/104). @larsrh completed the migration and started actively maintaining it. @LukaJCB, @ChristopherDavenport and I also signed up for help maintaining it. 
We'd like to propose to the Cats community to make cats-collections an external Cats module (separate repo and release cycle). 
The main implication for being a Cats external module is that at least some Cats maintainers will help maintaining it, which is the case now.