### PR TITLE
Optimize the foldM implementation for Vector

### DIFF
--- a/bench/src/main/scala/cats/bench/FoldBench.scala
+++ b/bench/src/main/scala/cats/bench/FoldBench.scala
@@ -3,6 +3,8 @@ package cats.bench
 import cats.data.Const
 import cats.instances.string._
 import cats.instances.list._
+import cats.instances.vector._
+import cats.instances.option._
 import cats.{Foldable, Traverse}
 import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
 
@@ -10,6 +12,8 @@ import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
 class FoldBench {
 
   val chars: List[String] = ('a' to 'z').map(_.toString).toList
+  val charsVector: Vector[String] = chars.toVector
+  val combineStringsSome: (String, String) => Option[String] = (s1, s2) => Some(s1 + s2)
 
   /** Benchmark fold of Foldable[List] */
   @Benchmark
@@ -20,5 +24,13 @@ class FoldBench {
   @Benchmark
   def traverseConst(): String =
     Traverse[List].traverse[Const[String, ?], String, String](chars)(Const(_)).getConst
+
+  @Benchmark
+  def vectorToListFoldM(): Option[String] =
+    Foldable[List].foldM(charsVector.toList, "")(combineStringsSome)
+
+  @Benchmark
+  def vectorIndexFoldM(): Option[String] =
+    Foldable[Vector].foldM(charsVector, "")(combineStringsSome)
 
 }


### PR DESCRIPTION
I've also added a benchmark to compare the new implementation with the
old. Here are the results that I got on my computer when running
`bench/jmh:run -i 10 -wi 10 -f1 -t1 .*FoldBench\.vector.*`:

```
Benchmark                     Mode  Cnt        Score       Error  Units
FoldBench.vectorIndexFoldM   thrpt   10  1185138.829 ± 45633.259  ops/s
FoldBench.vectorToListFoldM  thrpt   10   817330.438 ± 21998.851  ops/s
```