### PR TITLE
give test more memory

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -34,6 +34,7 @@ lazy val commonSettings = Seq(
   },
   resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.sonatypeRepo("snapshots")),
   fork in test := true,
+  test / javaOptions := Seq("-Xmx6G"),
   parallelExecution in Test := false,
   scalacOptions in (Compile, doc) := (scalacOptions in (Compile, doc)).value.filter(_ != "-Xfatal-warnings"),
   //todo: reenable doctests on 2.13 once it's officially released. it's disabled for now due to changes to the `toString` impl of collections


### PR DESCRIPTION
I noticed that the test is running in fork and was using the default java options. 
This setting change shall boost it's max memory to 6GB, according to travis, we have 7.5 G on the machine. 