### PR TITLE
Remove duplicate menu item in docs

### DIFF
--- a/docs/src/main/resources/microsite/data/menu.yml
+++ b/docs/src/main/resources/microsite/data/menu.yml
@@ -40,22 +40,9 @@ options:
        menu_section: applicative
 
   - title: Monads
-    url: typeclasses/functor.html
+    url: typeclasses/monad.html
     menu_type: typeclasses
     menu_section: monads
-
-    nested_options:
-     - title: Functor
-       url: typeclasses/functor.html
-       menu_section: monads
-       menu_section: monads
-     - title: Applicative
-       url: typeclasses/applicative.html
-       menu_section: monads
-     - title: Monad
-       url: typeclasses/monad.html
-       menu_type: typeclasses
-       menu_section: monads
 
   - title: Variance and Functors
     url: typeclasses/functor.html


### PR DESCRIPTION
I've noticed that in the documentation, there seems to be duplicate sub-menu items for Functors and Applicatives, under both `Traversable Functors` and `Monads`.
When you click on either sub-menu items, they show the exact same page and highlight both items on the side menu. It seems to make more sense to remove `Functors` and `Applicatives` from the Monads menu, since Monads appear right after `Traversable Functors` anyways. 

Let me know if this is something that has already been raised before, or it is this way for a reason. I was just initially confused because I noticed that 2 menu items would be lit up when I visited these pages. 