### PR TITLE
Contributing guidelines link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -131,7 +131,7 @@ builds:
 
 ### Write code
 
-[See guidelines](/cats/guidelines.html).
+[See guidelines](https://typelevel.org/cats/guidelines.html).
 
 ### Attributions
 


### PR DESCRIPTION
Made the link to the code guidelines in `CONTRIBUTING.md` absolute so that it works in both the github markdown viewer and form the website as discussed here https://gitter.im/typelevel/cats?at=5bccdbb8bbdc0b25057a0716.

Consistent with the references to [laws](https://github.com/typelevel/cats/blob/master/CONTRIBUTING.md#L165) [lawtesting](https://github.com/typelevel/cats/blob/master/CONTRIBUTING.md#L165).