### PR TITLE
Add flap function to Apply

### DIFF
--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -40,6 +40,28 @@ trait Apply[F[_]] extends Functor[F] with InvariantSemigroupal[F] with ApplyArit
   def ap[A, B](ff: F[A => B])(fa: F[A]): F[B]
 
   /**
+   * Given a function in the Apply context and a plain value, supplies the
+   * value to the function.
+   *
+   * Example:
+   * {{{
+   * scala> import cats.implicits._
+   *
+   * scala> val someF: Option[Int => Long] = Some(_.toLong + 1L)
+   * scala> val noneF: Option[Int => Long] = None
+   * scala> val anInt: Int = 3
+   *
+   * scala> Apply[Option].flap(someF)(anInt)
+   * res0: Option[Long] = Some(4)
+   *
+   * scala> Apply[Option].flap(noneF)(anInt)
+   * res1: Option[Long] = None
+   *
+   * }}}
+   */
+  def flap[A, B](ff: F[A => B])(a: A): F[B] = map(ff)(_(a))
+
+  /**
    * Compose two actions, discarding any value produced by the first.
    *
    * @see [[productL]] to discard the value of the second instead.

--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -40,28 +40,6 @@ trait Apply[F[_]] extends Functor[F] with InvariantSemigroupal[F] with ApplyArit
   def ap[A, B](ff: F[A => B])(fa: F[A]): F[B]
 
   /**
-   * Given a function in the Apply context and a plain value, supplies the
-   * value to the function.
-   *
-   * Example:
-   * {{{
-   * scala> import cats.implicits._
-   *
-   * scala> val someF: Option[Int => Long] = Some(_.toLong + 1L)
-   * scala> val noneF: Option[Int => Long] = None
-   * scala> val anInt: Int = 3
-   *
-   * scala> Apply[Option].flap(someF)(anInt)
-   * res0: Option[Long] = Some(4)
-   *
-   * scala> Apply[Option].flap(noneF)(anInt)
-   * res1: Option[Long] = None
-   *
-   * }}}
-   */
-  def flap[A, B](ff: F[A => B])(a: A): F[B] = map(ff)(_(a))
-
-  /**
    * Compose two actions, discarding any value produced by the first.
    *
    * @see [[productL]] to discard the value of the second instead.

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -31,6 +31,7 @@ trait AllSyntax
     with EqSyntax
     with FlatMapSyntax
     with FoldableSyntax
+    with Function1Syntax
     with FunctorSyntax
     with GroupSyntax
     with HashSyntax

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -31,7 +31,6 @@ trait AllSyntax
     with EqSyntax
     with FlatMapSyntax
     with FoldableSyntax
-    with Function1Syntax
     with FunctorSyntax
     with GroupSyntax
     with HashSyntax
@@ -77,4 +76,4 @@ trait AllSyntaxBinCompat2
     with ListSyntaxBinCompat0
     with ValidatedSyntaxBincompat0
 
-trait AllSyntaxBinCompat3 extends UnorderedFoldableSyntax
+trait AllSyntaxBinCompat3 extends UnorderedFoldableSyntax with Function1Syntax

--- a/core/src/main/scala/cats/syntax/function1.scala
+++ b/core/src/main/scala/cats/syntax/function1.scala
@@ -7,6 +7,7 @@ trait Function1Syntax {
     new Function1Ops[F, A, B](fab)
 
   final class Function1Ops[F[_]: Functor, A, B](fab: F[Function1[A, B]]) {
+
     /**
      * Given a function in the Functor context and a plain value, supplies the
      * value to the function.

--- a/core/src/main/scala/cats/syntax/function1.scala
+++ b/core/src/main/scala/cats/syntax/function1.scala
@@ -1,0 +1,32 @@
+package cats
+package syntax
+
+trait Function1Syntax {
+
+  implicit def catsSyntaxFunction1[F[_]: Functor, A, B](fab: F[Function1[A, B]]) =
+    new Function1Ops[F, A, B](fab)
+
+  final class Function1Ops[F[_]: Functor, A, B](fab: F[Function1[A, B]]) {
+    /**
+     * Given a function in the Functor context and a plain value, supplies the
+     * value to the function.
+     *
+     * Example:
+     * {{{
+     * scala> import cats.implicits._
+     *
+     * scala> val someF: Option[Int => Long] = Some(_.toLong + 1L)
+     * scala> val noneF: Option[Int => Long] = None
+     * scala> val anInt: Int = 3
+     *
+     * scala> someF.mapApply(anInt)
+     * res0: Option[Long] = Some(4)
+     *
+     * scala> noneF.mapApply(anInt)
+     * res1: Option[Long] = None
+     *
+     * }}}
+     */
+    def mapApply(a: A): F[B] = Functor[F].map(fab)(_(a))
+  }
+}

--- a/core/src/main/scala/cats/syntax/function1.scala
+++ b/core/src/main/scala/cats/syntax/function1.scala
@@ -3,7 +3,7 @@ package syntax
 
 trait Function1Syntax {
 
-  implicit def catsSyntaxFunction1[F[_]: Functor, A, B](fab: F[Function1[A, B]]) =
+  implicit def catsSyntaxFunction1[F[_]: Functor, A, B](fab: F[Function1[A, B]]): Function1Ops[F, A, B] =
     new Function1Ops[F, A, B](fab)
 
   final class Function1Ops[F[_]: Functor, A, B](fab: F[Function1[A, B]]) {


### PR DESCRIPTION
Add the `flap` function to `Apply` to facilitate combining a function in an
`Apply` context with a value which is not.

This is similar to `ap`:

```
def ap[A, B](ff: F[A => B])(fa: F[A]): F[B]
```

with the minor change of the value not being in a context:

```
def flap[A, B](ff: F[A => B])(a: A): F[B]
                              ^^^^
```

Thank you for contributing to Cats!

This is a kind reminder to run `sbt prePR` and commit the changed files before submitting. 


