### PR TITLE
Add `updateWith` method to NonEmptyMap

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -94,6 +94,11 @@ sealed class NonEmptyMapOps[K, A](val value: NonEmptyMap[K, A]) {
   def lookup(k: K): Option[A] = toSortedMap.get(k)
 
   /**
+   * Applies f to the value stored at k. If lookup misses, does nothing.
+   */
+  def updateWith(k: K, f: A => A): NonEmptyMap[K, A] = lookup(k).fold(value)(v => add((k, f(v))))
+
+  /**
    * Returns a `SortedSet` containing all the keys of this map.
    */
   def keys: NonEmptySet[K] = NonEmptySet.fromSetUnsafe(toSortedMap.keySet)

--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -96,7 +96,11 @@ sealed class NonEmptyMapOps[K, A](val value: NonEmptyMap[K, A]) {
   /**
    * Applies f to the value stored at k. If lookup misses, does nothing.
    */
-  def updateWith(k: K)(f: A => A): NonEmptyMap[K, A] = lookup(k).fold(value)(v => add((k, f(v))))
+  def updateWith(k: K)(f: A => A): NonEmptyMap[K, A] =
+    lookup(k) match {
+      case Some(v) => add((k, f(v)))
+      case None    => value
+    }
 
   /**
    * Returns a `SortedSet` containing all the keys of this map.

--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -96,7 +96,7 @@ sealed class NonEmptyMapOps[K, A](val value: NonEmptyMap[K, A]) {
   /**
    * Applies f to the value stored at k. If lookup misses, does nothing.
    */
-  def updateWith(k: K, f: A => A): NonEmptyMap[K, A] = lookup(k).fold(value)(v => add((k, f(v))))
+  def updateWith(k: K)(f: A => A): NonEmptyMap[K, A] = lookup(k).fold(value)(v => add((k, f(v))))
 
   /**
    * Returns a `SortedSet` containing all the keys of this map.

--- a/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
@@ -212,9 +212,9 @@ class NonEmptyMapSuite extends CatsSuite {
 
   test("NonEmptyMap#updateWith consistent with equivalent operations") {
     forAll { (nem: NonEmptyMap[String, Int], i: (String, Int)) =>
-      nem.add(i) should ===(nem.add(i).updateWith(i._1, identity))
-      nem.add(i).lookup(i._1).map(_ + 1) should ===(nem.add(i).updateWith(i._1, _ + 1).lookup(i._1))
-      nem.lookup(i._1) should ===(nem.updateWith(i._1, _ => i._2).lookup(i._1))
+      nem.add(i) should ===(nem.add(i).updateWith(i._1)(identity))
+      nem.add(i).lookup(i._1).map(_ + 1) should ===(nem.add(i).updateWith(i._1)(_ + 1).lookup(i._1))
+      nem.lookup(i._1) should ===(nem.updateWith(i._1)(_ => i._2).lookup(i._1))
     }
   }
 }

--- a/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
@@ -214,6 +214,7 @@ class NonEmptyMapSuite extends CatsSuite {
     forAll { (nem: NonEmptyMap[String, Int], i: (String, Int)) =>
       nem.add(i) should ===(nem.add(i).updateWith(i._1, identity))
       nem.add(i).lookup(i._1).map(_ + 1) should ===(nem.add(i).updateWith(i._1, _ + 1).lookup(i._1))
+      nem.lookup(i._1) should ===(nem.updateWith(i._1, _ => i._2).lookup(i._1))
     }
   }
 }

--- a/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
@@ -210,9 +210,14 @@ class NonEmptyMapSuite extends CatsSuite {
     }
   }
 
-  test("NonEmptyMap#updateWith consistent with equivalent operations") {
+  test("NonEmptyMap#updateWith identity should be a no-op") {
     forAll { (nem: NonEmptyMap[String, Int], i: (String, Int)) =>
       nem.add(i) should ===(nem.add(i).updateWith(i._1)(identity))
+    }
+  }
+
+  test("NonEmptyMap#updateWith on existing value should behave like Option#map on the same value") {
+    forAll { (nem: NonEmptyMap[String, Int], i: (String, Int)) =>
       nem.add(i).lookup(i._1).map(_ + 1) should ===(nem.add(i).updateWith(i._1)(_ + 1).lookup(i._1))
     }
   }

--- a/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
@@ -214,7 +214,12 @@ class NonEmptyMapSuite extends CatsSuite {
     forAll { (nem: NonEmptyMap[String, Int], i: (String, Int)) =>
       nem.add(i) should ===(nem.add(i).updateWith(i._1)(identity))
       nem.add(i).lookup(i._1).map(_ + 1) should ===(nem.add(i).updateWith(i._1)(_ + 1).lookup(i._1))
-      nem.lookup(i._1) should ===(nem.updateWith(i._1)(_ => i._2).lookup(i._1))
     }
   }
+
+  test("NonEmptyMap#updateWith should not act when key is missing") {
+    val single = NonEmptyMap[String, Int](("here", 1), SortedMap())
+    single.lookup("notHere") should ===(single.updateWith("notHere")(_ => 1).lookup("notHere"))
+  }
+
 }

--- a/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
@@ -209,4 +209,11 @@ class NonEmptyMapSuite extends CatsSuite {
       nem.toNel should ===(NonEmptyList.fromListUnsafe(nem.toSortedMap.toList))
     }
   }
+
+  test("NonEmptyMap#updateWith consistent with equivalent operations") {
+    forAll { (nem: NonEmptyMap[String, Int], i: (String, Int)) =>
+      nem.add(i) should ===(nem.add(i).updateWith(i._1, identity))
+      nem.add(i).lookup(i._1).map(_ + 1) should ===(nem.add(i).updateWith(i._1, _ + 1).lookup(i._1))
+    }
+  }
 }


### PR DESCRIPTION
- Named `updateWith` since `updated` would imply a simple setting of k -> v
- Added a couple small tests

Closes https://github.com/typelevel/cats/issues/2288


