### PR TITLE
Get FunctorFilter on par with the other MTL typeclasses

### DIFF
--- a/core/src/main/scala/cats/data/IndexedStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedStateT.scala
@@ -262,6 +262,15 @@ sealed abstract private[data] class IndexedStateTInstances extends IndexedStateT
       def defer[A](fa: => IndexedStateT[F, SA, SB, A]): IndexedStateT[F, SA, SB, A] =
         IndexedStateT.applyF(F.defer(fa.runF))
     }
+
+  implicit def catsDataFunctorFilterForIndexedStateT[F[_], SA, SB](
+    implicit
+      ev1: Monad[F],
+      ev2: FunctorFilter[F]): FunctorFilter[IndexedStateT[F, SA, SB, ?]] =
+    new IndexedStateTFunctorFilter[F, SA, SB] {
+      val F0 = ev1
+      val FF = ev2
+    }
 }
 
 sealed abstract private[data] class IndexedStateTInstances1 extends IndexedStateTInstances2 {
@@ -474,4 +483,16 @@ sealed abstract private[data] class IndexedStateTMonadError[F[_], S, E]
 
   def handleErrorWith[A](fa: IndexedStateT[F, S, S, A])(f: E => IndexedStateT[F, S, S, A]): IndexedStateT[F, S, S, A] =
     IndexedStateT(s => F.handleErrorWith(fa.run(s))(e => f(e).run(s)))
+}
+
+private[this] trait IndexedStateTFunctorFilter[F[_], SA, SB] extends FunctorFilter[IndexedStateT[F, SA, SB, ?]] {
+
+  implicit def F0: Monad[F]
+  def FF: FunctorFilter[F]
+
+  def functor: Functor[IndexedStateT[F, SA, SB, ?]] =
+    IndexedStateT.catsDataFunctorForIndexedStateT(FF.functor)
+
+  def mapFilter[A, B](fa: IndexedStateT[F, SA, SB, A])(f: A => Option[B]): IndexedStateT[F, SA, SB, B] =
+    fa.flatMapF(a => FF.mapFilter(F0.pure(a))(f))
 }

--- a/core/src/main/scala/cats/data/IndexedStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedStateT.scala
@@ -265,8 +265,9 @@ sealed abstract private[data] class IndexedStateTInstances extends IndexedStateT
 
   implicit def catsDataFunctorFilterForIndexedStateT[F[_], SA, SB](
     implicit
-      ev1: Monad[F],
-      ev2: FunctorFilter[F]): FunctorFilter[IndexedStateT[F, SA, SB, ?]] =
+    ev1: Monad[F],
+    ev2: FunctorFilter[F]
+  ): FunctorFilter[IndexedStateT[F, SA, SB, ?]] =
     new IndexedStateTFunctorFilter[F, SA, SB] {
       val F0 = ev1
       val FF = ev2

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -168,6 +168,9 @@ sealed abstract private[data] class KleisliInstances extends KleisliInstances0 {
         }
       }
     }
+
+  implicit def catsDataFunctorFilterForKleisli[F[_], A](implicit ev: FunctorFilter[F]): FunctorFilter[Kleisli[F, A, ?]] =
+    new KleisliFunctorFilter[F, A] { val FF = ev }
 }
 
 sealed abstract private[data] class KleisliInstances0 extends KleisliInstances0_5 {
@@ -502,4 +505,14 @@ private trait KleisliDistributive[F[_], R] extends Distributive[Kleisli[F, R, ?]
     Kleisli(r => F.distribute(a)(f(_).run(r)))
 
   def map[A, B](fa: Kleisli[F, R, A])(f: A => B): Kleisli[F, R, B] = fa.map(f)
+}
+
+private[this] trait KleisliFunctorFilter[F[_], R] extends FunctorFilter[Kleisli[F, R, ?]] {
+
+  def FF: FunctorFilter[F]
+
+  def functor: Functor[Kleisli[F, R, ?]] = Kleisli.catsDataFunctorForKleisli(FF.functor)
+
+  def mapFilter[A, B](fa: Kleisli[F, R, A])(f: A => Option[B]): Kleisli[F, R, B] =
+    Kleisli[F, R, B] { r => FF.mapFilter(fa.run(r))(f) }
 }

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -169,7 +169,9 @@ sealed abstract private[data] class KleisliInstances extends KleisliInstances0 {
       }
     }
 
-  implicit def catsDataFunctorFilterForKleisli[F[_], A](implicit ev: FunctorFilter[F]): FunctorFilter[Kleisli[F, A, ?]] =
+  implicit def catsDataFunctorFilterForKleisli[F[_], A](
+    implicit ev: FunctorFilter[F]
+  ): FunctorFilter[Kleisli[F, A, ?]] =
     new KleisliFunctorFilter[F, A] { val FF = ev }
 }
 
@@ -514,5 +516,7 @@ private[this] trait KleisliFunctorFilter[F[_], R] extends FunctorFilter[Kleisli[
   def functor: Functor[Kleisli[F, R, ?]] = Kleisli.catsDataFunctorForKleisli(FF.functor)
 
   def mapFilter[A, B](fa: Kleisli[F, R, A])(f: A => Option[B]): Kleisli[F, R, B] =
-    Kleisli[F, R, B] { r => FF.mapFilter(fa.run(r))(f) }
+    Kleisli[F, R, B] { r =>
+      FF.mapFilter(fa.run(r))(f)
+    }
 }

--- a/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
@@ -358,6 +358,16 @@ class IndexedStateTSuite extends CatsSuite {
   }
 
   {
+    implicit val F0 = ListWrapper.monad
+    implicit val FF = ListWrapper.functorFilter
+
+    checkAll("IndexedStateT[ListWrapper, String, Int, ?]", FunctorFilterTests[IndexedStateT[ListWrapper, String, Int, ?]].functorFilter[Int, Int, Int])
+    checkAll("FunctorFilter[IndexedStateT[ListWrapper, String, Int, ?]]", SerializableTests.serializable(FunctorFilter[IndexedStateT[ListWrapper, String, Int, ?]]))
+
+    FunctorFilter[IndexedStateT[ListWrapper, String, Int, ?]]
+  }
+
+  {
     implicit val F: Monad[ListWrapper] = ListWrapper.monad
     implicit val FS: Contravariant[IndexedStateT[ListWrapper, ?, Int, Int]] =
       IndexedStateT.catsDataContravariantForIndexedStateT

--- a/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
@@ -361,8 +361,10 @@ class IndexedStateTSuite extends CatsSuite {
     implicit val F0 = ListWrapper.monad
     implicit val FF = ListWrapper.functorFilter
 
-    checkAll("IndexedStateT[ListWrapper, String, Int, ?]", FunctorFilterTests[IndexedStateT[ListWrapper, String, Int, ?]].functorFilter[Int, Int, Int])
-    checkAll("FunctorFilter[IndexedStateT[ListWrapper, String, Int, ?]]", SerializableTests.serializable(FunctorFilter[IndexedStateT[ListWrapper, String, Int, ?]]))
+    checkAll("IndexedStateT[ListWrapper, String, Int, ?]",
+             FunctorFilterTests[IndexedStateT[ListWrapper, String, Int, ?]].functorFilter[Int, Int, Int])
+    checkAll("FunctorFilter[IndexedStateT[ListWrapper, String, Int, ?]]",
+             SerializableTests.serializable(FunctorFilter[IndexedStateT[ListWrapper, String, Int, ?]]))
 
     FunctorFilter[IndexedStateT[ListWrapper, String, Int, ?]]
   }

--- a/tests/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/KleisliSuite.scala
@@ -3,7 +3,7 @@ package tests
 
 import cats.Contravariant
 import cats.arrow._
-import cats.data.{Const, EitherT, Kleisli, Reader}
+import cats.data.{Const, EitherT, Kleisli, Reader, ReaderT}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
@@ -139,6 +139,15 @@ class KleisliSuite extends CatsSuite {
     implicit val catsDataFunctorForKleisli = Kleisli.catsDataFunctorForKleisli[Option, Int]
     checkAll("Kleisli[Option, Int, Int]", FunctorTests[Kleisli[Option, Int, ?]].functor[Int, Int, Int])
     checkAll("Functor[Kleisli[Option, Int, ?]]", SerializableTests.serializable(Functor[Kleisli[Option, Int, ?]]))
+  }
+
+  {
+    implicit val FF = ListWrapper.functorFilter
+
+    checkAll("Kleisli[ListWrapper, Int, ?]", FunctorFilterTests[Kleisli[ListWrapper, Int, ?]].functorFilter[Int, Int, Int])
+    checkAll("FunctorFilter[Kleisli[ListWrapper, Int, ?]]", SerializableTests.serializable(FunctorFilter[Kleisli[ListWrapper, Int, ?]]))
+
+    FunctorFilter[ReaderT[ListWrapper, Int, ?]]
   }
 
   {

--- a/tests/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/KleisliSuite.scala
@@ -144,8 +144,10 @@ class KleisliSuite extends CatsSuite {
   {
     implicit val FF = ListWrapper.functorFilter
 
-    checkAll("Kleisli[ListWrapper, Int, ?]", FunctorFilterTests[Kleisli[ListWrapper, Int, ?]].functorFilter[Int, Int, Int])
-    checkAll("FunctorFilter[Kleisli[ListWrapper, Int, ?]]", SerializableTests.serializable(FunctorFilter[Kleisli[ListWrapper, Int, ?]]))
+    checkAll("Kleisli[ListWrapper, Int, ?]",
+             FunctorFilterTests[Kleisli[ListWrapper, Int, ?]].functorFilter[Int, Int, Int])
+    checkAll("FunctorFilter[Kleisli[ListWrapper, Int, ?]]",
+             SerializableTests.serializable(FunctorFilter[Kleisli[ListWrapper, Int, ?]]))
 
     FunctorFilter[ReaderT[ListWrapper, Int, ?]]
   }


### PR DESCRIPTION
This adds `FunctorFilter` to `Kleisli` and `IndexedStateT` as from the issue https://github.com/typelevel/cats/issues/2556 . As a side note I tried to reduce the requirements for the `IndexedStateT` instance but I couldn't come up with anything that need less than `Applicative` and `FlatMap`, so I kept the implementation in the issue that requires `Monad` (see below as an example)
```scala
def mapFilter[A, B](fa: IndexedStateT[F, SA, SB, A])(f: A => Option[B]): IndexedStateT[F, SA, SB, B] =
  IndexedStateT[F, SA, SB, B] { sa =>
    FF.mapFilter(fa.run(sa)){ case (sb, a) => f(a) map (sb -> _) }
  }
```
I'm happy to change it though if there's something less restrictive.
There is still some work to do about the comments at the bottom of the ticket that I'm still investigating. I need more details there.

Also I'm planning to open some follow up PRs to add instances of `TraverseFilter` as well to `Kleisli` and `IndexedStateT`, and to add both to other transformers where they are still missing. Is it something that's needed ? Happy to stop if they are not a priority.
