### PR TITLE
Optimize `Apply` methods in `FlatMap`

### DIFF
--- a/core/src/main/scala/cats/FlatMap.scala
+++ b/core/src/main/scala/cats/FlatMap.scala
@@ -22,12 +22,6 @@ import simulacrum.noop
   def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B]
 
 
-  override def productR[A, B](fa: F[A])(fb: F[B]): F[B] =
-    flatMap(fa)(_ => fb)
-
-  override def productL[A, B](fa: F[A])(fb: F[B]): F[A] =
-    flatMap(fa)(a => map(fb)(_ => a))
-
   /**
    * "flatten" a nested `F` of `F` structure into a single-layer `F` structure.
    *
@@ -102,6 +96,11 @@ import simulacrum.noop
   override def map2[A, B, Z](fa: F[A], fb: F[B])(f: (A, B) => Z): F[Z] =
     flatMap(fa)(a => map(fb)(b => f(a, b)))
 
+  override def productR[A, B](fa: F[A])(fb: F[B]): F[B] =
+    flatMap(fa)(_ => fb)
+
+  override def productL[A, B](fa: F[A])(fb: F[B]): F[A] =
+    map2(fa, fb)((a, _) => a)
 
   /**
    * Pair `A` with the result of function application.

--- a/core/src/main/scala/cats/FlatMap.scala
+++ b/core/src/main/scala/cats/FlatMap.scala
@@ -96,6 +96,13 @@ import simulacrum.noop
   override def product[A, B](fa: F[A], fb: F[B]): F[(A, B)] =
     flatMap(fa)(a => map(fb)(b => (a, b)))
 
+  override def ap2[A, B, Z](ff: F[(A, B) => Z])(fa: F[A], fb: F[B]): F[Z] =
+    flatMap(fa)(a => flatMap(fb)(b => map(ff)(_(a, b))))
+
+  override def map2[A, B, Z](fa: F[A], fb: F[B])(f: (A, B) => Z): F[Z] =
+    flatMap(fa)(a => map(fb)(b => f(a, b)))
+
+
   /**
    * Pair `A` with the result of function application.
    *

--- a/core/src/main/scala/cats/FlatMap.scala
+++ b/core/src/main/scala/cats/FlatMap.scala
@@ -21,6 +21,13 @@ import simulacrum.noop
 @typeclass trait FlatMap[F[_]] extends Apply[F] {
   def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B]
 
+
+  override def productR[A, B](fa: F[A])(fb: F[B]): F[B] =
+    flatMap(fa)(_ => fb)
+
+  override def productL[A, B](fa: F[A])(fb: F[B]): F[A] =
+    flatMap(fa)(a => map(fb)(_ => a))
+
   /**
    * "flatten" a nested `F` of `F` structure into a single-layer `F` structure.
    *

--- a/core/src/main/scala/cats/FlatMap.scala
+++ b/core/src/main/scala/cats/FlatMap.scala
@@ -21,7 +21,6 @@ import simulacrum.noop
 @typeclass trait FlatMap[F[_]] extends Apply[F] {
   def flatMap[A, B](fa: F[A])(f: A => F[B]): F[B]
 
-
   /**
    * "flatten" a nested `F` of `F` structure into a single-layer `F` structure.
    *


### PR DESCRIPTION
I noticed that these implementations can be slightly improved. Given their common usages I think it would worth it. 
related issue https://github.com/typelevel/cats-effect/issues/401