### PR TITLE
Rename EitherT.biflatMap

### DIFF
--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -77,7 +77,7 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
                                                          applicativeG: Applicative[G]): G[EitherT[F, C, D]] =
     applicativeG.map(traverseF.traverse(value)(axb => Bitraverse[Either].bitraverse(axb)(f, g)))(EitherT.apply)
 
-  def biFlatMap[AA >: A, BB >: B](fa: A => EitherT[F, AA, BB],
+  def biflatMap[AA >: A, BB >: B](fa: A => EitherT[F, AA, BB],
                                   fb: B => EitherT[F, AA, BB])(implicit F: FlatMap[F]): EitherT[F, AA, BB] =
     EitherT(F.flatMap(value) {
       case Left(a)  => fa(a).value

--- a/tests/src/test/scala/cats/tests/EitherTSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherTSuite.scala
@@ -523,28 +523,28 @@ class EitherTSuite extends CatsSuite {
     }
   }
 
-  test("biFlatMap consistent with flatMap") {
+  test("biflatMap consistent with flatMap") {
     forAll { (eithert: EitherT[List, String, Int], fb: Int => EitherT[List, String, Int]) =>
       val noChangeLeft = (s: String) => EitherT.left[Int](List(s))
 
-      eithert.biFlatMap(noChangeLeft, fb) should ===(eithert.flatMap(fb))
+      eithert.biflatMap(noChangeLeft, fb) should ===(eithert.flatMap(fb))
     }
   }
 
-  test("biFlatMap consistent with leftFlatMap") {
+  test("biflatMap consistent with leftFlatMap") {
     forAll { (eithert: EitherT[List, String, Int], fa: String => EitherT[List, String, Int]) =>
       val noChangeRight = (i: Int) => EitherT.right[String](List(i))
 
-      eithert.biFlatMap(fa, noChangeRight) should ===(eithert.leftFlatMap(fa))
+      eithert.biflatMap(fa, noChangeRight) should ===(eithert.leftFlatMap(fa))
     }
   }
 
-  test("biFlatMap with Left and Right consistent with leftFlatMap and then flatMap") {
+  test("biflatMap with Left and Right consistent with leftFlatMap and then flatMap") {
     forAll { (eithert: EitherT[List, String, Int], string: String, int: Int) =>
       val leftFun = (_: String) => EitherT.left[Int](List(string))
       val rightFun = (_: Int) => EitherT.right[String](List(int))
 
-      eithert.biFlatMap(leftFun, rightFun) should ===(eithert.leftFlatMap(leftFun).flatMap(rightFun))
+      eithert.biflatMap(leftFun, rightFun) should ===(eithert.leftFlatMap(leftFun).flatMap(rightFun))
     }
   }
 


### PR DESCRIPTION
Rename biFlatMap to biflatMap in EitherT to keep it consistent with bimap and bitraverse.
