### PR TITLE
Reduce Xmx in .jvmopts and build.sbt

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,4 +1,4 @@
--Dfile.encoding=UTF8
+-Dfile.encoding=UTF8
 -Xms1G
 -Xmx3G
 -XX:ReservedCodeCacheSize=250M

--- a/.jvmopts
+++ b/.jvmopts
@@ -1,7 +1,6 @@
--Dfile.encoding=UTF8
+-Dfile.encoding=UTF8
 -Xms1G
--Xmx6G
--XX:MaxMetaspaceSize=4G
+-Xmx3G
 -XX:ReservedCodeCacheSize=250M
 -XX:+TieredCompilation
 -XX:-UseGCOverheadLimit

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-import microsites._
+﻿import microsites._
 import ReleaseTransformations._
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 import sbtcrossproject.CrossProject
@@ -113,7 +113,7 @@ lazy val commonJvmSettings = Seq(
     Tests.Argument(TestFrameworks.ScalaTest, flag)
   },
   Test / fork := true,
-  Test / javaOptions := Seq("-Xmx6G")
+  Test / javaOptions := Seq("-Xmx3G")
 )
 
 lazy val commonNativeSettings = Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-﻿import microsites._
+import microsites._
 import ReleaseTransformations._
 import scala.xml.transform.{RewriteRule, RuleTransformer}
 import sbtcrossproject.CrossProject


### PR DESCRIPTION
Another attempt at fixing OOM's in build 

So the .jvmopts sets max memory to 6G AND the (one) forked jvm for tests also sets memory to 6G (which by default would receive the same settings anyway, btw). So if my maths is correct, that‘s 12G in total on a machine that IIRC is only 7.5G. 

So set .jvmopts to 3G and the forked JVM javaopts to also 3G

Supporting issue :
  https://github.com/scalatest/scalatest/issues/770, 

NB:
„...to cap the memory for the main process + the forked process to be < 3G at any point of time. That would mean:
main process + SBT forked process + debugger process in test (if you created)
should not be > 3G“

„...providing the memory caps on the main process, forked, process, and children worked.“

Note that, if you follow the links, the same issue is reported for specs2 and also on laptops - ie not just on travis.