### PR TITLE
Make the value of the class private

### DIFF
--- a/binCompatTest/src/main/scala/catsBC/MimaExceptions.scala
+++ b/binCompatTest/src/main/scala/catsBC/MimaExceptions.scala
@@ -18,7 +18,9 @@ object MimaExceptions {
       cats.data.Kleisli.catsDataCommutativeFlatMapForKleisli[Option, Int],
       cats.data.IRWST.catsDataStrongForIRWST[List, Int, Int, Int],
       cats.data.OptionT.catsDataMonadErrorMonadForOptionT[List],
-      FunctionK.lift(headOption)
+      FunctionK.lift(headOption),
+      "blah".leftNec[Int],
+      List(Some(4), None).nested
   )
 
 }

--- a/build.sbt
+++ b/build.sbt
@@ -280,7 +280,10 @@ def mimaSettings(moduleName: String) =
         exclude[DirectMissingMethodProblem]("cats.data.KleisliInstances1.catsDataCommutativeArrowForKleisli"),
         exclude[DirectMissingMethodProblem]("cats.data.KleisliInstances4.catsDataCommutativeFlatMapForKleisli"),
         exclude[DirectMissingMethodProblem]("cats.data.IRWSTInstances1.catsDataStrongForIRWST"),
-        exclude[DirectMissingMethodProblem]("cats.data.OptionTInstances1.catsDataMonadErrorMonadForOptionT")
+        exclude[DirectMissingMethodProblem]("cats.data.OptionTInstances1.catsDataMonadErrorMonadForOptionT"),
+        //These 2 things are `.value` on a Ops class (which shouldn't have ever been exposed) - See #2514 and #2613.
+        exclude[DirectMissingMethodProblem]("cats.syntax.EitherIdOpsBinCompat0.value"),
+        exclude[DirectMissingMethodProblem]("cats.syntax.NestedIdOps.value")
       ) ++ // Only compile-time abstractions (macros) allowed here
         Seq(
           exclude[IncompatibleMethTypeProblem]("cats.arrow.FunctionKMacros.lift"),

--- a/core/src/main/scala/cats/syntax/either.scala
+++ b/core/src/main/scala/cats/syntax/either.scala
@@ -404,7 +404,7 @@ trait EitherSyntaxBinCompat0 {
     new EitherIdOpsBinCompat0(a)
 }
 
-final class EitherIdOpsBinCompat0[A](val value: A) extends AnyVal {
+final class EitherIdOpsBinCompat0[A](private val value: A) extends AnyVal {
 
   /**
    * Wrap a value to a left EitherNec

--- a/core/src/main/scala/cats/syntax/nested.scala
+++ b/core/src/main/scala/cats/syntax/nested.scala
@@ -8,7 +8,7 @@ trait NestedSyntax {
     new NestedIdOps[F, G, A](value)
 }
 
-final class NestedIdOps[F[_], G[_], A](private[syntax] val value: F[G[A]]) extends AnyVal {
+final class NestedIdOps[F[_], G[_], A](private val value: F[G[A]]) extends AnyVal {
 
   /**
    * Wrap a value in `Nested`.


### PR DESCRIPTION
This makes the `.value` of two of the `Ops` classes private, since they shouldn't ever be referenced and they collide with Scalatest.

Fixes #2514 and #2613