### PR TITLE
Issue 2608 - Ambiguous implicit values for Functor[Kleisli[F, A, ?]]

### DIFF
--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -291,32 +291,35 @@ sealed abstract private[data] class KleisliInstances4 extends KleisliInstances5 
   implicit def catsDataSemigroupKForKleisli[F[_], A](implicit F0: SemigroupK[F]): SemigroupK[Kleisli[F, A, ?]] =
     new KleisliSemigroupK[F, A] { def F: SemigroupK[F] = F0 }
 
-  implicit def catsDataApplicativeErrorForKleisli[F[_], E, A](
-    implicit F0: ApplicativeError[F, E]
-  ): ApplicativeError[Kleisli[F, A, ?], E] =
-    new KleisliApplicativeError[F, A, E] { def F: ApplicativeError[F, E] = F0 }
-
   implicit def catsDataFlatMapForKleisli[F[_], A](implicit FM: FlatMap[F]): FlatMap[Kleisli[F, A, ?]] =
     new KleisliFlatMap[F, A] { def F: FlatMap[F] = FM }
 
 }
 
 sealed abstract private[data] class KleisliInstances5 extends KleisliInstances6 {
+
+  implicit def catsDataApplicativeErrorForKleisli[F[_], E, A](
+    implicit F0: ApplicativeError[F, E]
+  ): ApplicativeError[Kleisli[F, A, ?], E] =
+    new KleisliApplicativeError[F, A, E] { def F: ApplicativeError[F, E] = F0 }
+}
+
+sealed abstract private[data] class KleisliInstances6 extends KleisliInstances7 {
   implicit def catsDataApplicativeForKleisli[F[_], A](implicit A: Applicative[F]): Applicative[Kleisli[F, A, ?]] =
     new KleisliApplicative[F, A] { def F: Applicative[F] = A }
 }
 
-sealed abstract private[data] class KleisliInstances6 extends KleisliInstances7 {
+sealed abstract private[data] class KleisliInstances7 extends KleisliInstances8 {
   implicit def catsDataApplyForKleisli[F[_], A](implicit A: Apply[F]): Apply[Kleisli[F, A, ?]] =
     new KleisliApply[F, A] { def F: Apply[F] = A }
 }
 
-sealed abstract private[data] class KleisliInstances7 extends KleisliInstances8 {
+sealed abstract private[data] class KleisliInstances8 extends KleisliInstances9 {
   implicit def catsDataDistributiveForKleisli[F[_], R](implicit F0: Distributive[F]): Distributive[Kleisli[F, R, ?]] =
     new KleisliDistributive[F, R] with KleisliFunctor[F, R] { implicit def F: Distributive[F] = F0 }
 }
 
-sealed abstract private[data] class KleisliInstances8 {
+sealed abstract private[data] class KleisliInstances9 {
   implicit def catsDataFunctorForKleisli[F[_], A](implicit F0: Functor[F]): Functor[Kleisli[F, A, ?]] =
     new KleisliFunctor[F, A] { def F: Functor[F] = F0 }
 }

--- a/tests/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/KleisliSuite.scala
@@ -190,6 +190,11 @@ class KleisliSuite extends CatsSuite {
   checkAll("Contravariant[Kleisli[Option, ?, Int]]",
            SerializableTests.serializable(Contravariant[Kleisli[Option, ?, Int]]))
 
+  test("Functor[Kleisli[F, Int, ?]] is not ambiguous when an ApplicativeError and a FlatMap are in scope for F") {
+    def shouldCompile1[F[_]: ApplicativeError[?[_], E]: FlatMap, E]: Functor[Kleisli[F, Int, ?]] =
+      Functor[Kleisli[F, Int, ?]]
+  }
+
   test("local composes functions") {
     forAll { (f: Int => Option[String], g: Int => Int, i: Int) =>
       f(g(i)) should ===(Kleisli.local[Option, String, Int](g)(Kleisli(f)).run(i))


### PR DESCRIPTION
This should fix https://github.com/typelevel/cats/issues/2608 . @kailuowang I tried this other way to disambiguate the instance priority as Mima check passes on all the Scala versions (`+mimaReportBinaryIssues`) so I assume the BC is ok.
I'm happy to change it though, and do as you suggest if you think there will be problems.
