### PR TITLE
Add leftTraverse and leftSequence to Bitraverse typeclass

### DIFF
--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -76,4 +76,4 @@ trait AllSyntaxBinCompat2
     with ListSyntaxBinCompat0
     with ValidatedSyntaxBincompat0
 
-trait AllSyntaxBinCompat3 extends UnorderedFoldableSyntax with Function1Syntax
+trait AllSyntaxBinCompat3 extends UnorderedFoldableSyntax with Function1Syntax with BitraverseSyntaxBinCompat0

--- a/core/src/main/scala/cats/syntax/bitraverse.scala
+++ b/core/src/main/scala/cats/syntax/bitraverse.scala
@@ -22,3 +22,43 @@ final class NestedBitraverseOps[F[_, _], G[_], A, B](private val fgagb: F[G[A], 
   def bisequence(implicit F: Bitraverse[F], G: Applicative[G]): G[F[A, B]] =
     F.bisequence(fgagb)
 }
+
+trait BitraverseSyntaxBinCompat0 extends BisequenceSyntaxBinCompat0 {
+  implicit final def catsSyntaxBitraverseBinCompat0[F[_, _], A, B](fab: F[A, B]): BitraverseOpsBinCompat0[F, A, B] =
+    new BitraverseOpsBinCompat0(fab)
+}
+
+final class BitraverseOpsBinCompat0[F[_, _], A, B](private val value: F[A, B]) extends AnyVal {
+
+  /**
+   * Traverse the left side of the structure with the given function.
+   *
+   * Example:
+   * {{{
+   * scala> import cats.implicits._
+   *
+   * scala> def parseInt(s: String): Option[Int] = Either.catchOnly[NumberFormatException](s.toInt).toOption
+   *
+   * scala> ("1", "2").leftTraverse(parseInt)
+   * res0: Option[(Int, String)] = Some((1,2))
+   *
+   * scala> ("two", "2").leftTraverse(parseInt)
+   * res2: Option[(Int, String)] = None
+   *
+   * }}}
+   */
+  def leftTraverse[G[_], C](f: A => G[C])(implicit F: Bitraverse[F], G: Applicative[G]): G[F[C, B]] =
+    F.bitraverse(value)(f, G.pure)
+}
+
+trait BisequenceSyntaxBinCompat0 {
+  implicit final def catsSyntaxBisequenceBinCompat0[F[_, _], G[_], A, B](
+    fgab: F[G[A], B]
+  ): BisequenceOpsBinCompat0[F, G, A, B] =
+    new BisequenceOpsBinCompat0(fgab)
+}
+
+final class BisequenceOpsBinCompat0[F[_, _], G[_], A, B](private val value: F[G[A], B]) extends AnyVal {
+  def leftSequence(implicit F: Bitraverse[F], G: Applicative[G]): G[F[A, B]] =
+    new BitraverseOpsBinCompat0(value).leftTraverse(identity)
+}

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -11,7 +11,7 @@ package object syntax {
   object bifunctor extends BifunctorSyntax
   object bifoldable extends BifoldableSyntax
   object binested extends BinestedSyntax
-  object bitraverse extends BitraverseSyntax
+  object bitraverse extends BitraverseSyntax with BitraverseSyntaxBinCompat0
   @deprecated("use cats.syntax.semigroupal instead", "1.0.0-RC1")
   object cartesian extends SemigroupalSyntax
   object choice extends ChoiceSyntax

--- a/tests/src/test/scala/cats/tests/SyntaxSuite.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxSuite.scala
@@ -299,9 +299,14 @@ object SyntaxSuite extends AllSyntaxBinCompat with AllInstances with AllSyntax {
 
     val fab = mock[F[A, B]]
     val gfcd = fab.bitraverse(f, g)
+    val gfcb = fab.leftTraverse(f)
 
     val fgagb = mock[F[G[A], G[B]]]
     val gfab = fgagb.bisequence
+
+    val fgab = mock[F[G[A], B]]
+    val gfab2 = fgab.leftSequence
+
   }
 
   def testAlternativeMonad[F[_]: Alternative: Monad, G[_]: Foldable, H[_, _]: Bifoldable, A, B]: Unit = {


### PR DESCRIPTION
Bitraverse should offer "left" traversing functionality.
Right-traversal is already offered through Traverse typeclass, bi-traversal and left-traversal should both be offered by Bitraverse. This keeps it consistent with Bifunctor (which offers leftMap).

This resolves issue #2474