### PR TITLE
Throttle list size in ListWrapper

### DIFF
--- a/tests/src/test/scala/cats/tests/ListWrapper.scala
+++ b/tests/src/test/scala/cats/tests/ListWrapper.scala
@@ -32,7 +32,9 @@ import org.scalacheck.Arbitrary.arbitrary
  * }
  * }}}
  */
-final case class ListWrapper[A](list: List[A]) extends AnyVal
+final case class ListWrapper[A](listA: List[A]) extends AnyVal {
+  def list: List[A] = listA.take(100)
+}
 
 object ListWrapper {
   def order[A: Order]: Order[ListWrapper[A]] = Order.by(_.list)


### PR DESCRIPTION
Running the tests locally, and in particular `ApplicativeSuite`, I managed to occasionally, but nonetheless repeatedly, experience the same test timeouts we see on travis. Additionally, I observed some tests taking much longer than average, always coupled with the test JVM memory jumping up from about 1.2G to the max of 3G.

A few `println`'s later...the `List[A]`'s generated by `Arbitrary` in the custom `ListWrapper` are generally in the sub 100 element size, but I have seen them balloon to over 8 million in the slow tests; this would, I believe, explain the OOM's.

The real fix is to make sure scalacheck creates reasonable size lists for `List[A]`'s in the first place, but unfortunately, I could not _quickly_ achieve this. So the current fix is suboptimal, but works. 

So if you are happy with the investigation, I might suggest that the current "fix" is better than what we currently have - a new issue can be raised for a more elegant solution, that might also take into account other slow tests that might suffer from a similar issue.


