### PR TITLE
change prePR to run BC test on Scala 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -747,7 +747,7 @@ addCommandAlias("validateKernelJS", "kernelLawsJS/test")
 addCommandAlias("validateFreeJS", "freeJS/test") //separated due to memory constraint on travis
 addCommandAlias("validate", ";clean;validateJS;validateKernelJS;validateFreeJS;validateJVM")
 
-addCommandAlias("prePR", ";fmt;validateBC")
+addCommandAlias("prePR", ";fmt;++2.11.12;validateBC")
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Base Build Settings - Should not need to edit below this line.


### PR DESCRIPTION
Just realized that currently prePR is testing BC  on 2.12 which probably won't catch the majority of the BC breaking changes. 

