### PR TITLE
Fix broken link to Arrow.scala

### DIFF
--- a/docs/src/main/tut/faq.md
+++ b/docs/src/main/tut/faq.md
@@ -254,7 +254,7 @@ You can find more information [here](typeclasses/lawtesting.html).
 
 The cats community welcomes and encourages contributions, even if you are completely new to cats and functional programming. Here are a few ways to help out:
 
-- Find an undocumented method and write a ScalaDoc entry for it. See [Arrow.scala]({{ site.sources }}/core/src/main/scala/cats/arrow/Arrow.scala) for some examples of ScalaDoc entries that use [sbt-doctest](https://github.com/tkawachi/sbt-doctest).
+- Find an undocumented method and write a ScalaDoc entry for it. See [Arrow.scala](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/arrow/Arrow.scala) for some examples of ScalaDoc entries that use [sbt-doctest](https://github.com/tkawachi/sbt-doctest).
 - Look at the [code coverage report](https://codecov.io/github/typelevel/cats?branch=master), find some untested code, and write a test for it. Even simple helper methods and syntax enrichment should be tested.
 - Find an [open issue](https://github.com/typelevel/cats/issues?q=is%3Aopen+is%3Aissue+label%3Aready), leave a comment on it to let people know you are working on it, and submit a pull request. If you are new to cats, you may want to look for items with the [low-hanging-fruit](https://github.com/typelevel/cats/issues?q=is%3Aopen+is%3Aissue+label%3A%22low-hanging+fruit%22) label.
 


### PR DESCRIPTION
As stated by https://github.com/typelevel/cats/pull/1435#issuecomment-256284304 the `{{ site.sources }}` configuration item was lost. 

Already 6 occurrences exist in the docs that link directly to `https://github.com/typelevel/cats/blob/master`. 
In all documentation, this was the only place where `sources` was still used, so instead of adding a [custom yaml](https://47deg.github.io/sbt-microsites/docs/settings.html) and keep the tightly coupling with Jekyll, I've replaced this one instance with another hard-coded link to master.
