### PR TITLE
Add cats-retry library to ecosystem

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ By sharing the same set of type classes, instances and data types provided by Ca
 #### General purpose libraries to support pure functional programming
 
  * [cats-par](https://github.com/ChristopherDavenport/cats-par): Abstract type member Parallel instances
+ * [cats-retry](https://github.com/cb372/cats-retry): composable retry logic for Cats and Cats Effect
  * [droste](https://github.com/andyscott/droste): recursion schemes for Cats
  * [Dsl.scala](https://github.com/ThoughtWorksInc/Dsl.scala): The `!`-notation for creating Cats monadic expressions
  * [eff](https://github.com/atnos-org/eff): functional effects and effect handlers (alternative to monad transformers)
@@ -113,10 +114,10 @@ By sharing the same set of type classes, instances and data types provided by Ca
  * [hammock](https://github.com/pepegar/hammock): Purely functional HTTP client
  * [henkan](https://github.com/kailuowang/henkan): Type safe conversion between case class instances with similar fields
  * [http4s](https://github.com/http4s/http4s): A minimal, idiomatic Scala interface for HTTP
- * [monadic-html](https://github.com/OlivierBlanvillain/monadic-html): Tiny DOM binding library for Scala.js
- * [Monix](https://github.com/monix/monix): high-performance library for composing asynchronous and event-based programs
  * [linebacker](https://github.com/ChristopherDavenport/linebacker): functional thread pool management
  * [log4cats](https://github.com/ChristopherDavenport/log4cats): functional logging
+ * [monadic-html](https://github.com/OlivierBlanvillain/monadic-html): Tiny DOM binding library for Scala.js
+ * [Monix](https://github.com/monix/monix): high-performance library for composing asynchronous and event-based programs
  * [pureconfig](https://github.com/pureconfig/pureconfig): A boilerplate-free library for loading configuration files
  * [rainier](https://github.com/stripe/rainier): Bayesian inference in Scala
  * [scala-forex](https://github.com/snowplow/scala-forex): exchange rate lookups


### PR DESCRIPTION
Also fixed the alphabetical ordering in the list of libraries.

