### PR TITLE
add syntax <&> for parallel

### DIFF
--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -79,4 +79,4 @@ trait AllSyntaxBinCompat2
 
 trait AllSyntaxBinCompat3 extends UnorderedFoldableSyntax with Function1Syntax
 
-trait AllSyntaxBinCompat4 extends TraverseFilterSyntaxBinCompat0
+trait AllSyntaxBinCompat4 extends TraverseFilterSyntaxBinCompat0 with ParallelApplySyntax

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -39,7 +39,7 @@ package object syntax {
   object nested extends NestedSyntax
   object option extends OptionSyntax
   object order extends OrderSyntax
-  object parallel extends ParallelSyntax with ParallelTraverseSyntax
+  object parallel extends ParallelSyntax with ParallelTraverseSyntax with ParallelFlatSyntax with ParallelApplySyntax
   object partialOrder extends PartialOrderSyntax
   object profunctor extends ProfunctorSyntax
   object reducible extends ReducibleSyntax

--- a/core/src/main/scala/cats/syntax/parallel.scala
+++ b/core/src/main/scala/cats/syntax/parallel.scala
@@ -3,8 +3,6 @@ package cats.syntax
 import cats.{FlatMap, Foldable, Monad, Parallel, Traverse}
 
 trait ParallelSyntax extends TupleParallelSyntax {
-  implicit final def catsSyntaxParallelApply[F[_], A, B](fa: F[A => B]): ParallelApplyOps[F, A, B] =
-    new ParallelApplyOps[F, A, B](fa)
 
   implicit final def catsSyntaxParallelTraverse[T[_]: Traverse, A](ta: T[A]): ParallelTraversableOps[T, A] =
     new ParallelTraversableOps[T, A](ta)
@@ -16,6 +14,11 @@ trait ParallelSyntax extends TupleParallelSyntax {
   implicit final def catsSyntaxParallelAp[M[_]: FlatMap, A](ma: M[A]): ParallelApOps[M, A] =
     new ParallelApOps[M, A](ma)
 
+}
+
+trait ParallelApplySyntax {
+  implicit final def catsSyntaxParallelApply[F[_], A, B](fa: F[A => B]): ParallelApplyOps[F, A, B] =
+    new ParallelApplyOps[F, A, B](fa)
 }
 
 trait ParallelFlatSyntax {

--- a/core/src/main/scala/cats/syntax/parallel.scala
+++ b/core/src/main/scala/cats/syntax/parallel.scala
@@ -3,6 +3,9 @@ package cats.syntax
 import cats.{FlatMap, Foldable, Monad, Parallel, Traverse}
 
 trait ParallelSyntax extends TupleParallelSyntax {
+   implicit final def catsSyntaxParallelApply[F[_], A, B](fa: F[A => B]): ParallelApplyOps[F, A, B] =
+     new ParallelApplyOps[F, A, B](fa)
+
   implicit final def catsSyntaxParallelTraverse[T[_]: Traverse, A](ta: T[A]): ParallelTraversableOps[T, A] =
     new ParallelTraversableOps[T, A](ta)
 
@@ -74,4 +77,9 @@ final class ParallelApOps[M[_], A](private val ma: M[A]) extends AnyVal {
   def <&[F[_], B](mb: M[B])(implicit P: Parallel[M, F]): M[A] =
     P.parProductL(ma)(mb)
 
+}
+
+final class ParallelApplyOps[M[_], A, B](private val mab: M[A=>B]) extends AnyVal {
+  def <&>[F[_]](ma: M[A])(implicit P: Parallel[M,F]): M[B] =
+    Parallel.parAp(mab)(ma)
 }

--- a/core/src/main/scala/cats/syntax/parallel.scala
+++ b/core/src/main/scala/cats/syntax/parallel.scala
@@ -3,8 +3,8 @@ package cats.syntax
 import cats.{FlatMap, Foldable, Monad, Parallel, Traverse}
 
 trait ParallelSyntax extends TupleParallelSyntax {
-   implicit final def catsSyntaxParallelApply[F[_], A, B](fa: F[A => B]): ParallelApplyOps[F, A, B] =
-     new ParallelApplyOps[F, A, B](fa)
+  implicit final def catsSyntaxParallelApply[F[_], A, B](fa: F[A => B]): ParallelApplyOps[F, A, B] =
+    new ParallelApplyOps[F, A, B](fa)
 
   implicit final def catsSyntaxParallelTraverse[T[_]: Traverse, A](ta: T[A]): ParallelTraversableOps[T, A] =
     new ParallelTraversableOps[T, A](ta)
@@ -79,7 +79,7 @@ final class ParallelApOps[M[_], A](private val ma: M[A]) extends AnyVal {
 
 }
 
-final class ParallelApplyOps[M[_], A, B](private val mab: M[A=>B]) extends AnyVal {
-  def <&>[F[_]](ma: M[A])(implicit P: Parallel[M,F]): M[B] =
+final class ParallelApplyOps[M[_], A, B](private val mab: M[A => B]) extends AnyVal {
+  def <&>[F[_]](ma: M[A])(implicit P: Parallel[M, F]): M[B] =
     Parallel.parAp(mab)(ma)
 }

--- a/tests/src/test/scala/cats/tests/SyntaxSuite.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxSuite.scala
@@ -183,6 +183,9 @@ object SyntaxSuite
 
     val mb2: M[B] = ma &> mb
     val ma2: M[A] = ma <& mb
+
+    val mab = mock[M[A => B]]
+    val mb3: M[B] = mab <&> ma
   }
 
   def testParallelFlat[M[_]: Monad, F[_], T[_]: Traverse: FlatMap, A, B](implicit P: Parallel[M, F]): Unit = {


### PR DESCRIPTION
in #2038 introduced `&>` and `<&` syntax for parallel which are very helpful

why not have a `<&>` too, so  I can
```scala
mab <&> ma
```
instead of
```scala
Parallel.parAp(mab)(ma)
```

