### PR TITLE
Don't send Gitter notifications for fork builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ install:
 notifications:
   webhooks:
     urls:
-    - https://webhooks.gitter.im/e/2d5ea16a2f66f60a590b
+    - ${GITTER_WEBHOOK_URL}
     on_success: change
     on_failure: always
     on_start: false


### PR DESCRIPTION
At some point I set up Travis CI to build for my fork of Cats. An
unfortunate consequence of this is that pushing to a branch in my fork
triggers a Travis build that then sends a build notification to the Cats
Gitter channel. This is a little annoying and looks bad when I am doing
experimental changes that cause failed builds in my fork. Also it's a
little embarrassing when the 2000+ people in the Cats Gitter channel can
see that I'm breaking stuff.

I've configured an environment variable in the `typelevel/cats` Travis
build for the Gitter webhook URL. My understanding is that for forks
this environment variable won't be present and Travis will just silently
not send Gitter notifications. Admittedly, I'm not certain that this
will work, but I don't think that it causes any harm to give it a try.

Thank you for contributing to Cats!

This is a kind reminder to run `sbt prePR` and commit the changed files, if any, before submitting. 


