### PR TITLE
Private val in value classes (Resolve TODO since 2.10 is dropped)

### DIFF
--- a/binCompatTest/src/main/scala/catsBC/MimaExceptions.scala
+++ b/binCompatTest/src/main/scala/catsBC/MimaExceptions.scala
@@ -26,6 +26,6 @@ object MimaExceptions {
     cats.data.EitherT.left[Int](Option("err")),
     true.iterateUntilM(Option(_))(identity _),
     Either.catchOnly[NumberFormatException] { "foo".toInt },
-    (1.asRight[String], 2.asRight[String], 3.asRight[String]) mapN (_ + _ + _)
+    (1.validNel[String], 2.validNel[String], 3.validNel[String]) mapN (_ + _ + _)
   )
 }

--- a/binCompatTest/src/main/scala/catsBC/MimaExceptions.scala
+++ b/binCompatTest/src/main/scala/catsBC/MimaExceptions.scala
@@ -8,23 +8,24 @@ object MimaExceptions {
   import cats.arrow.FunctionK // needs to be imported because of a hygiene problem
 
   def isBinaryCompatible = (
-      cats.Monad[cats.data.OptionT[List, ?]],
-      cats.data.OptionT.catsDataTraverseForOptionT[List],
-      cats.data.Kleisli.catsDataCommutativeArrowForKleisliId,
-      cats.data.OptionT.catsDataMonoidKForOptionT[List],
-      cats.data.OptionT.catsDataMonoidForOptionT[List, Int],
-      cats.data.Kleisli.catsDataMonadForKleisliId[Int],
-      cats.data.Kleisli.catsDataCommutativeArrowForKleisli[Option],
-      cats.data.Kleisli.catsDataCommutativeFlatMapForKleisli[Option, Int],
-      cats.data.IRWST.catsDataStrongForIRWST[List, Int, Int, Int],
-      cats.data.OptionT.catsDataMonadErrorMonadForOptionT[List],
-      FunctionK.lift(headOption),
-      cats.data.OptionT.catsDataMonadErrorForOptionT[Either[String, ?], String],
-      cats.data.OptionT[Either[String, ?], Int](Right(Some(17))).ensure("error")(_ => true),
-      "blah".leftNec[Int],
-      List(Some(4), None).nested,
-      cats.data.EitherT.left[Int](Option("err")),
-      true.iterateUntilM(Option(_))(identity _),
-      Either.catchOnly[NumberFormatException] { "foo".toInt }
+    cats.Monad[cats.data.OptionT[List, ?]],
+    cats.data.OptionT.catsDataTraverseForOptionT[List],
+    cats.data.Kleisli.catsDataCommutativeArrowForKleisliId,
+    cats.data.OptionT.catsDataMonoidKForOptionT[List],
+    cats.data.OptionT.catsDataMonoidForOptionT[List, Int],
+    cats.data.Kleisli.catsDataMonadForKleisliId[Int],
+    cats.data.Kleisli.catsDataCommutativeArrowForKleisli[Option],
+    cats.data.Kleisli.catsDataCommutativeFlatMapForKleisli[Option, Int],
+    cats.data.IRWST.catsDataStrongForIRWST[List, Int, Int, Int],
+    cats.data.OptionT.catsDataMonadErrorMonadForOptionT[List],
+    FunctionK.lift(headOption),
+    cats.data.OptionT.catsDataMonadErrorForOptionT[Either[String, ?], String],
+    cats.data.OptionT[Either[String, ?], Int](Right(Some(17))).ensure("error")(_ => true),
+    "blah".leftNec[Int],
+    List(Some(4), None).nested,
+    cats.data.EitherT.left[Int](Option("err")),
+    true.iterateUntilM(Option(_))(identity _),
+    Either.catchOnly[NumberFormatException] { "foo".toInt },
+    (1.asRight[String], 2.asRight[String], 3.asRight[String]) mapN (_ + _ + _)
   )
 }

--- a/binCompatTest/src/main/scala/catsBC/MimaExceptions.scala
+++ b/binCompatTest/src/main/scala/catsBC/MimaExceptions.scala
@@ -24,6 +24,7 @@ object MimaExceptions {
       "blah".leftNec[Int],
       List(Some(4), None).nested,
       cats.data.EitherT.left[Int](Option("err")),
-      true.iterateUntilM(Option(_))(identity _)
+      true.iterateUntilM(Option(_))(identity _),
+      Either.catchOnly[NumberFormatException] { "foo".toInt }
   )
 }

--- a/build.sbt
+++ b/build.sbt
@@ -373,9 +373,28 @@ def mimaSettings(moduleName: String) =
           exclude[MissingTypesProblem]("cats.arrow.FunctionKMacros$"),
           exclude[IncompatibleMethTypeProblem]("cats.arrow.FunctionKMacros#Lifter.this"),
           exclude[IncompatibleResultTypeProblem]("cats.arrow.FunctionKMacros#Lifter.c")
-        )
+        ) ++ mimaBoilerplateSyntaxExclusions(scalaVersion.value)
     }
   )
+
+def mimaBoilerplateSyntaxExclusions(scalaVersion: String) = {
+  import com.typesafe.tools.mima.core._
+  import com.typesafe.tools.mima.core.ProblemFilters._
+
+  Seq(
+    exclude[IncompatibleResultTypeProblem]("cats.*.catsSyntaxTuple*Semigroupal"),
+    exclude[IncompatibleResultTypeProblem]("cats.*.catsSyntaxTuple*Parallel"),
+  ) ++ (CrossVersion.partialVersion(scalaVersion) match {
+    case Some((2, 11)) =>
+      Seq(
+        exclude[DirectMissingMethodProblem]("cats.syntax.TupleSemigroupalSyntax.catsSyntaxTuple*Semigroupal"),
+        exclude[DirectMissingMethodProblem]("cats.syntax.TupleParallelSyntax.catsSyntaxTuple*Parallel"),
+        exclude[ReversedMissingMethodProblem]("cats.syntax.TupleSemigroupalSyntax.catsSyntaxTuple*Semigroupal"),
+        exclude[ReversedMissingMethodProblem]("cats.syntax.TupleParallelSyntax.catsSyntaxTuple*Parallel")
+      )
+    case _ => Seq.empty
+  })
+}
 
 lazy val docs = project
   .enablePlugins(MicrositesPlugin)

--- a/build.sbt
+++ b/build.sbt
@@ -382,14 +382,11 @@ def mimaBoilerplateSyntaxExclusions(scalaVersion: String) = {
   import com.typesafe.tools.mima.core.ProblemFilters._
 
   Seq(
-    exclude[IncompatibleResultTypeProblem]("cats.*.catsSyntaxTuple*Semigroupal"),
-    exclude[IncompatibleResultTypeProblem]("cats.*.catsSyntaxTuple*Parallel"),
+    exclude[IncompatibleResultTypeProblem]("cats.*.catsSyntaxTuple*Parallel")
   ) ++ (CrossVersion.partialVersion(scalaVersion) match {
     case Some((2, 11)) =>
       Seq(
-        exclude[DirectMissingMethodProblem]("cats.syntax.TupleSemigroupalSyntax.catsSyntaxTuple*Semigroupal"),
         exclude[DirectMissingMethodProblem]("cats.syntax.TupleParallelSyntax.catsSyntaxTuple*Parallel"),
-        exclude[ReversedMissingMethodProblem]("cats.syntax.TupleSemigroupalSyntax.catsSyntaxTuple*Semigroupal"),
         exclude[ReversedMissingMethodProblem]("cats.syntax.TupleParallelSyntax.catsSyntaxTuple*Parallel")
       )
     case _ => Seq.empty

--- a/build.sbt
+++ b/build.sbt
@@ -321,6 +321,7 @@ def mimaSettings(moduleName: String) =
           exclude[DirectMissingMethodProblem]("cats.syntax.DistributiveOps.fa"),
           exclude[DirectMissingMethodProblem]("cats.syntax.EitherIdOps.obj"),
           exclude[DirectMissingMethodProblem]("cats.syntax.EitherIdOpsBinCompat0.value"),
+          exclude[DirectMissingMethodProblem]("cats.syntax.EitherSyntax#CatchOnlyPartiallyApplied.dummy"),
           exclude[DirectMissingMethodProblem]("cats.syntax.EitherKOps.fa"),
           exclude[DirectMissingMethodProblem]("cats.syntax.EitherObjectOps.either"),
           exclude[DirectMissingMethodProblem]("cats.syntax.EitherOps.eab"),

--- a/core/src/main/scala/cats/syntax/either.scala
+++ b/core/src/main/scala/cats/syntax/either.scala
@@ -25,7 +25,7 @@ object EitherSyntax {
   /**
    * Uses the [[http://typelevel.org/cats/guidelines.html#partially-applied-type-params Partially Applied Type Params technique]] for ergonomics.
    */
-  final private[syntax] class CatchOnlyPartiallyApplied[T](val dummy: Boolean = true) extends AnyVal {
+  final private[syntax] class CatchOnlyPartiallyApplied[T](private val dummy: Boolean = true) extends AnyVal {
     def apply[A](f: => A)(implicit CT: ClassTag[T], NT: NotNull[T]): Either[T, A] =
       try {
         Right(f)

--- a/core/src/main/scala/cats/syntax/foldable.scala
+++ b/core/src/main/scala/cats/syntax/foldable.scala
@@ -198,7 +198,7 @@ final class FoldableOps[F[_], A](private val fa: F[A]) extends AnyVal {
 
 }
 
-final class FoldableOps0[F[_], A](val fa: F[A]) extends AnyVal {
+final class FoldableOps0[F[_], A](private val fa: F[A]) extends AnyVal {
 
   /**
    * Fold implemented by mapping `A` values into `B` in a context `G` and then

--- a/core/src/main/scala/cats/syntax/reducible.scala
+++ b/core/src/main/scala/cats/syntax/reducible.scala
@@ -15,7 +15,7 @@ trait ReducibleSyntaxBinCompat0 {
     new ReducibleOps0[F, A](fa)
 }
 
-final class ReducibleOps0[F[_], A](val fa: F[A]) extends AnyVal {
+final class ReducibleOps0[F[_], A](private val fa: F[A]) extends AnyVal {
 
   /**
    * Apply `f` to each element of `fa` and combine them using the

--- a/core/src/main/scala/cats/syntax/traverseFilter.scala
+++ b/core/src/main/scala/cats/syntax/traverseFilter.scala
@@ -8,7 +8,7 @@ trait TraverseFilterSyntaxBinCompat0 {
     new SequenceFilterOps(fgoa)
 }
 
-final class SequenceFilterOps[F[_], G[_], A](val fgoa: F[G[Option[A]]]) extends AnyVal {
+final class SequenceFilterOps[F[_], G[_], A](private val fgoa: F[G[Option[A]]]) extends AnyVal {
 
   /**
    * {{{

--- a/kernel-laws/src/main/scala/cats/kernel/laws/package.scala
+++ b/kernel-laws/src/main/scala/cats/kernel/laws/package.scala
@@ -2,7 +2,7 @@ package cats.kernel
 
 package object laws {
 
-  implicit final class IsEqArrow[A](val lhs: A) extends AnyVal {
+  implicit final class IsEqArrow[A](private val lhs: A) extends AnyVal {
     def <->(rhs: A): IsEq[A] = IsEq(lhs, rhs)
   }
 }

--- a/laws/src/main/scala/cats/laws/package.scala
+++ b/laws/src/main/scala/cats/laws/package.scala
@@ -5,7 +5,7 @@ package object laws {
   type IsEq[A] = cats.kernel.laws.IsEq[A]
   val IsEq = cats.kernel.laws.IsEq
 
-  implicit final class IsEqArrow[A](val lhs: A) extends AnyVal {
+  implicit final class IsEqArrow[A](private val lhs: A) extends AnyVal {
     def <->(rhs: A): IsEq[A] = IsEq(lhs, rhs)
   }
 }

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -12,7 +12,7 @@ import sbt._
 object Boilerplate {
   import scala.StringContext._
 
-  implicit final class BlockHelper(val sc: StringContext) extends AnyVal {
+  implicit final class BlockHelper(private val sc: StringContext) extends AnyVal {
     def block(args: Any*): String = {
       val interpolated = sc.standardInterpolator(treatEscapes, args)
       val rawLines = interpolated.split('\n')

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -470,7 +470,7 @@ object Boilerplate {
         -  implicit def catsSyntaxTuple${arity}Semigroupal[F[_], ${`A..N`}]($tupleTpe): Tuple${arity}SemigroupalOps[F, ${`A..N`}] = new Tuple${arity}SemigroupalOps(t$arity)
       |}
       |
-        -private[syntax] final class Tuple${arity}SemigroupalOps[F[_], ${`A..N`}](private val $tupleTpe) extends AnyVal {
+        -private[syntax] final class Tuple${arity}SemigroupalOps[F[_], ${`A..N`}]($tupleTpe) {
         -  $map
         -  $contramap
         -  $imap

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -404,7 +404,7 @@ object Boilerplate {
          -  implicit def catsSyntaxTuple${arity}Parallel[M[_], ${`A..N`}]($tupleTpe): Tuple${arity}ParallelOps[M, ${`A..N`}] = new Tuple${arity}ParallelOps(t$arity)
       |}
       |
-         -private[syntax] final class Tuple${arity}ParallelOps[M[_], ${`A..N`}]($tupleTpe) {
+         -private[syntax] final class Tuple${arity}ParallelOps[M[_], ${`A..N`}](private val $tupleTpe) extends AnyVal {
          -  $parMap
          -  $parTupled
          -}
@@ -470,7 +470,7 @@ object Boilerplate {
         -  implicit def catsSyntaxTuple${arity}Semigroupal[F[_], ${`A..N`}]($tupleTpe): Tuple${arity}SemigroupalOps[F, ${`A..N`}] = new Tuple${arity}SemigroupalOps(t$arity)
       |}
       |
-        -private[syntax] final class Tuple${arity}SemigroupalOps[F[_], ${`A..N`}]($tupleTpe) {
+        -private[syntax] final class Tuple${arity}SemigroupalOps[F[_], ${`A..N`}](private val $tupleTpe) extends AnyVal {
         -  $map
         -  $contramap
         -  $imap

--- a/project/KernelBoiler.scala
+++ b/project/KernelBoiler.scala
@@ -13,7 +13,7 @@ import sbt._
 object KernelBoiler {
   import scala.StringContext._
 
-  implicit class BlockHelper(val sc: StringContext) extends AnyVal {
+  implicit class BlockHelper(private val sc: StringContext) extends AnyVal {
     def block(args: Any*): String = {
       val interpolated = sc.standardInterpolator(treatEscapes, args)
       val rawLines = interpolated.split('\n')


### PR DESCRIPTION
In relation to https://github.com/typelevel/cats/issues/2673 , this adds few more `private`s to constructor's parameters when extending `AnyVal`.
In the case of `Either`'s `CatchOnlyPartiallyApplied` I added an exception to MiMa as there are good chances no one is really using `dummy`.
