### PR TITLE
Add BabylonHealth to list of adopters

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Here's a (non-exhaustive) list of companies that use Cats in production. Don't s
 - [Apple Inc. (FEAR team)](https://news.ycombinator.com/item?id=16969118)
 - [AutoScout24](https://www.autoscout24.com) 
 - [Avast](https://avast.com)
+- [BabylonHealth](https://www.babylonhealth.com/)
 - [Banno Group inside of Jack Henry & Associates](https://banno.com/)
 - [Basefarm](https://basefarm.com/)
 - [buildo](https://buildo.io)


### PR DESCRIPTION
BabylonHealth is a London based healthcare and AI company with several teams using Scala and cats. I've added it to the list of adopters.

Thank you for contributing to Cats!

This is a kind reminder to run `sbt prePR` and commit the changed files, if any, before submitting. 


