### PR TITLE
Adds version of mkString_ with no prefix/suffix, matching the std lib.

### DIFF
--- a/core/src/main/scala/cats/syntax/foldable.scala
+++ b/core/src/main/scala/cats/syntax/foldable.scala
@@ -77,7 +77,9 @@ final class FoldableOps[F[_], A](private val fa: F[A]) extends AnyVal {
     A.combine(prefix, A.combine(F.intercalate(fa, delim), suffix))
 
   /**
-   * Make a string using `Show`, named as `mkString_` to avoid conflict
+   * Make a string using `Show`, prefix, delimiter, and suffix.
+   *
+   * Named as `mkString_` to avoid conflict.
    *
    * Example:
    * {{{
@@ -203,6 +205,26 @@ final class FoldableOps[F[_], A](private val fa: F[A]) extends AnyVal {
 }
 
 final class FoldableOps0[F[_], A](private val fa: F[A]) extends AnyVal {
+
+  /**
+   * Make a string using `Show` and delimiter.
+   *
+   * Named as `mkString_` to avoid conflict.
+   *
+   * Example:
+   * {{{
+   * scala> import cats.implicits._
+   *
+   * scala> val l: List[Int] = List(1, 2, 3)
+   * scala> l.mkString_(",")
+   * res0: String = 1,2,3
+   * scala> val el: List[Int] = List()
+   * scala> el.mkString_(",")
+   * res1: String =
+   * }}}
+   */
+  def mkString_(delim: String)(implicit A: Show[A], F: Foldable[F]): String =
+    new FoldableOps(fa).mkString_("", delim, "")
 
   /**
    * Fold implemented by mapping `A` values into `B` in a context `G` and then

--- a/testkit/src/main/scala/cats/tests/CatsSuite.scala
+++ b/testkit/src/main/scala/cats/tests/CatsSuite.scala
@@ -16,6 +16,7 @@ import cats.syntax.{
   AllSyntaxBinCompat1,
   AllSyntaxBinCompat2,
   AllSyntaxBinCompat3,
+  AllSyntaxBinCompat4
   EqOps
 }
 import org.scalactic.anyvals.{PosInt, PosZDouble, PosZInt}
@@ -59,6 +60,7 @@ trait CatsSuite
     with AllSyntaxBinCompat1
     with AllSyntaxBinCompat2
     with AllSyntaxBinCompat3
+    with AllSyntaxBinCompat4
     with StrictCatsEquality { self: FunSuiteLike =>
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =

--- a/testkit/src/main/scala/cats/tests/CatsSuite.scala
+++ b/testkit/src/main/scala/cats/tests/CatsSuite.scala
@@ -16,7 +16,7 @@ import cats.syntax.{
   AllSyntaxBinCompat1,
   AllSyntaxBinCompat2,
   AllSyntaxBinCompat3,
-  AllSyntaxBinCompat4
+  AllSyntaxBinCompat4,
   EqOps
 }
 import org.scalactic.anyvals.{PosInt, PosZDouble, PosZInt}

--- a/tests/src/test/scala/cats/tests/FoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/FoldableSuite.scala
@@ -79,7 +79,6 @@ abstract class FoldableSuite[F[_]: Foldable](name: String)(implicit ArbFInt: Arb
   }
 
   test("Foldable#partitionEitherM retains size") {
-    import cats.syntax.foldable._
     forAll { (fi: F[Int], f: Int => Either[String, String]) =>
       val vector = Foldable[F].toList(fi).toVector
       val result = Foldable[Vector].partitionEitherM(vector)(f.andThen(Option.apply)).map {
@@ -91,7 +90,6 @@ abstract class FoldableSuite[F[_]: Foldable](name: String)(implicit ArbFInt: Arb
   }
 
   test("Foldable#partitionEitherM consistent with List#partition") {
-    import cats.syntax.foldable._
     forAll { (fi: F[Int], f: Int => Either[String, String]) =>
       val list = Foldable[F].toList(fi)
       val partitioned = Foldable[List].partitionEitherM(list)(f.andThen(Option.apply))
@@ -108,7 +106,6 @@ abstract class FoldableSuite[F[_]: Foldable](name: String)(implicit ArbFInt: Arb
   }
 
   test("Foldable#partitionEitherM to one side is identity") {
-    import cats.syntax.foldable._
     forAll { (fi: F[Int], f: Int => String) =>
       val list = Foldable[F].toList(fi)
       val g: Int => Option[Either[Double, String]] = f.andThen(Right.apply).andThen(Option.apply)
@@ -123,7 +120,6 @@ abstract class FoldableSuite[F[_]: Foldable](name: String)(implicit ArbFInt: Arb
   }
 
   test("Foldable#partitionEitherM remains sorted") {
-    import cats.syntax.foldable._
     forAll { (fi: F[Int], f: Int => Either[String, String]) =>
       val list = Foldable[F].toList(fi)
 

--- a/tests/src/test/scala/cats/tests/FoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/FoldableSuite.scala
@@ -222,6 +222,12 @@ abstract class FoldableSuite[F[_]: Foldable](name: String)(implicit ArbFInt: Arb
     }
   }
 
+  test(s"Foldable[$name] mkString_ delimiter only") {
+    forAll { (fa: F[Int]) =>
+      fa.mkString_(",") should ===(fa.toList.mkString(","))
+    }
+  }
+
   test(s"Foldable[$name].collectFirstSomeM") {
     forAll { (fa: F[Int], n: Int) =>
       fa.collectFirstSomeM(x => (x > n).guard[Option].as(x).asRight[String]) should ===(


### PR DESCRIPTION
Thank you for contributing to Cats!

This is a kind reminder to run `sbt prePR` and commit the changed files, if any, before submitting. 


