### PR TITLE
Fixes #2631 Fix InvariantMonoidal Laws

### DIFF
--- a/laws/src/main/scala/cats/laws/InvariantMonoidalLaws.scala
+++ b/laws/src/main/scala/cats/laws/InvariantMonoidalLaws.scala
@@ -15,11 +15,6 @@ trait InvariantMonoidalLaws[F[_]] extends InvariantSemigroupalLaws[F] {
   def invariantMonoidalRightIdentity[A, B](fa: F[A]): IsEq[F[A]] =
     fa.product(F.unit).imap(_._1)(a => (a, ())) <-> fa
 
-  def invariantMonoidalAssociativity[A, B, C](fa: F[A], fb: F[B], fc: F[C]): IsEq[F[(A, (B, C))]] =
-    fa.product(fb.product(fc)) <-> fa
-      .product(fb)
-      .product(fc)
-      .imap { case ((a, b), c) => (a, (b, c)) } { case (a, (b, c)) => ((a, b), c) }
 }
 
 object InvariantMonoidalLaws {

--- a/laws/src/main/scala/cats/laws/InvariantSemigroupalLaws.scala
+++ b/laws/src/main/scala/cats/laws/InvariantSemigroupalLaws.scala
@@ -6,8 +6,16 @@ package laws
  */
 trait InvariantSemigroupalLaws[F[_]] extends InvariantLaws[F] with SemigroupalLaws[F] {
   implicit override def F: InvariantSemigroupal[F]
+  import cats.syntax.semigroupal._
+  import cats.syntax.invariant._
 
+  def invariantSemigroupalAssociativity[A, B, C](fa: F[A], fb: F[B], fc: F[C]): IsEq[F[(A, (B, C))]] =
+    fa.product(fb.product(fc)) <-> fa
+      .product(fb)
+      .product(fc)
+      .imap { case ((a, b), c) => (a, (b, c)) } { case (a, (b, c)) => ((a, b), c) }
 }
+
 object InvariantSemigroupalLaws {
   def apply[F[_]](implicit ev: InvariantSemigroupal[F]): InvariantSemigroupalLaws[F] =
     new InvariantSemigroupalLaws[F] { def F: InvariantSemigroupal[F] = ev }

--- a/laws/src/main/scala/cats/laws/discipline/InvariantMonoidalTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/InvariantMonoidalTests.scala
@@ -20,17 +20,15 @@ trait InvariantMonoidalTests[F[_]] extends InvariantSemigroupalTests[F] {
                                                                   EqFABC2: Eq[F[(A, B, C)]],
                                                                   iso: Isomorphisms[F],
                                                                   EqFA: Eq[F[A]],
+                                                                  EqFB: Eq[F[B]],
                                                                   EqFC: Eq[F[C]]): RuleSet =
     new RuleSet {
       val name = "invariantMonoidal"
-      val parents = Seq(invariant[A, B, C], semigroupal[A, B, C])
+      val parents = Seq(invariantSemigroupal[A, B, C])
       val bases = Seq.empty
       val props = Seq(
         "invariant monoidal left identity" -> forAll((fa: F[A]) => laws.invariantMonoidalLeftIdentity(fa)),
-        "invariant monoidal right identity" -> forAll((fa: F[A]) => laws.invariantMonoidalRightIdentity(fa)),
-        "invariant monoidal associativity" -> forAll(
-          (fa: F[A], fb: F[B], fc: F[C]) => laws.invariantMonoidalAssociativity(fa, fb, fc)
-        )
+        "invariant monoidal right identity" -> forAll((fa: F[A]) => laws.invariantMonoidalRightIdentity(fa))
       )
     }
 }

--- a/laws/src/main/scala/cats/laws/discipline/InvariantSemigroupalTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/InvariantSemigroupalTests.scala
@@ -2,8 +2,8 @@ package cats
 package laws
 package discipline
 
-import cats.InvariantSemigroupal
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
+import org.scalacheck.Prop.forAll
 import org.scalacheck.{Arbitrary, Cogen}
 
 trait InvariantSemigroupalTests[F[_]] extends InvariantTests[F] with SemigroupalTests[F] {
@@ -19,12 +19,17 @@ trait InvariantSemigroupalTests[F[_]] extends InvariantTests[F] with Semigroupal
                                                                      EqFA: Eq[F[A]],
                                                                      EqFB: Eq[F[B]],
                                                                      EqFC: Eq[F[C]],
-                                                                     EqFABC: Eq[F[(A, B, C)]],
+                                                                     EqFABC: Eq[F[(A, (B, C))]],
+                                                                     EqFABC2: Eq[F[(A, B, C)]],
                                                                      iso: Isomorphisms[F]): RuleSet = new RuleSet {
     val name = "invariantSemigroupal"
     val parents = Seq(invariant[A, B, C], semigroupal[A, B, C])
     val bases = Nil
-    val props = Nil
+    val props = Seq(
+      "invariant semigroupal associativity" -> forAll(
+        (fa: F[A], fb: F[B], fc: F[C]) => laws.invariantSemigroupalAssociativity(fa, fb, fc)
+      )
+    )
   }
 }
 


### PR DESCRIPTION
Changed the parents of InvariantMonoidalTests to invariantSemigroupal and moved the invariant associativity test from InvariantMonoidalTests to InvariantSemigroupalTests

