### PR TITLE
adding helper method `toFreeT` to `Free`

### DIFF
--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -183,12 +183,12 @@ sealed abstract class Free[S[_], A] extends Product with Serializable {
   final def inject[G[_]](implicit ev: InjectK[S, G]): Free[G, A] =
     mapK(λ[S ~> G](ev.inj(_)))
 
-  final def toFreeT: FreeT[S, Id, A] =
-    foldMap[FreeT[S, Id, ?]] { // this is safe because Free is stack safe
-      new (S ~> FreeT[S, Id, ?]) {
-        def apply[B](fa: S[B]): FreeT[S, Id, B] = FreeT.liftF((fa))
+  final def toFreeT[G[_]: Applicative]: FreeT[S, G, A] =
+    foldMap[FreeT[S, G, ?]] {
+      new (S ~> FreeT[S, G, ?]) {
+        def apply[B](fa: S[B]): FreeT[S, G, B] = FreeT.liftF(fa)
       }
-    }(FreeT.catsFreeMonadForFreeT[S,Id])
+    }(FreeT.catsFreeMonadForFreeT[S, G])
 
 
   override def toString: String =

--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -184,9 +184,7 @@ sealed abstract class Free[S[_], A] extends Product with Serializable {
     mapK(λ[S ~> G](ev.inj(_)))
 
   final def toFreeT[G[_]: Applicative]: FreeT[S, G, A] =
-    foldMap[FreeT[S, G, ?]](
-      λ[S ~> FreeT[S, G, ?]](FreeT.liftF(_))
-    )
+    foldMap[FreeT[S, G, ?]](λ[S ~> FreeT[S, G, ?]](FreeT.liftF(_)))
 
   override def toString: String =
     "Free(...)"

--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -184,11 +184,9 @@ sealed abstract class Free[S[_], A] extends Product with Serializable {
     mapK(λ[S ~> G](ev.inj(_)))
 
   final def toFreeT[G[_]: Applicative]: FreeT[S, G, A] =
-    foldMap[FreeT[S, G, ?]] {
-      new (S ~> FreeT[S, G, ?]) {
-        def apply[B](fa: S[B]): FreeT[S, G, B] = FreeT.liftF(fa)
-      }
-    }(FreeT.catsFreeMonadForFreeT[S, G])
+    foldMap[FreeT[S, G, ?]](
+      λ[S ~> FreeT[S, G, ?]](FreeT.liftF(_))
+    )(FreeT.catsFreeMonadForFreeT[S, G])
 
   override def toString: String =
     "Free(...)"

--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -30,7 +30,7 @@ sealed abstract class Free[S[_], A] extends Product with Serializable {
   final def mapK[T[_]](f: S ~> T): Free[T, A] =
     foldMap[Free[T, ?]] { // this is safe because Free is stack safe
       λ[FunctionK[S, Free[T, ?]]](fa => Suspend(f(fa)))
-    }(Free.catsFreeMonadForFree)
+    }
 
   /**
    * Bind the given continuation to the result of this computation.
@@ -186,7 +186,7 @@ sealed abstract class Free[S[_], A] extends Product with Serializable {
   final def toFreeT[G[_]: Applicative]: FreeT[S, G, A] =
     foldMap[FreeT[S, G, ?]](
       λ[S ~> FreeT[S, G, ?]](FreeT.liftF(_))
-    )(FreeT.catsFreeMonadForFreeT[S, G])
+    )
 
   override def toString: String =
     "Free(...)"

--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -183,6 +183,14 @@ sealed abstract class Free[S[_], A] extends Product with Serializable {
   final def inject[G[_]](implicit ev: InjectK[S, G]): Free[G, A] =
     mapK(λ[S ~> G](ev.inj(_)))
 
+  final def toFreeT: FreeT[S, Id, A] =
+    foldMap[FreeT[S, Id, ?]] { // this is safe because Free is stack safe
+      new (S ~> FreeT[S, Id, ?]) {
+        def apply[B](fa: S[B]): FreeT[S, Id, B] = FreeT.liftF((fa))
+      }
+    }(FreeT.catsFreeMonadForFreeT[S,Id])
+
+
   override def toString: String =
     "Free(...)"
 }

--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -190,7 +190,6 @@ sealed abstract class Free[S[_], A] extends Product with Serializable {
       }
     }(FreeT.catsFreeMonadForFreeT[S, G])
 
-
   override def toString: String =
     "Free(...)"
 }

--- a/free/src/test/scala/cats/free/FreeSuite.scala
+++ b/free/src/test/scala/cats/free/FreeSuite.scala
@@ -45,10 +45,6 @@ class FreeSuite extends CatsSuite {
     rr.toString.length should be > 0
   }
 
-  test("toFreeT is stack-safe") {
-    FTestApi.a(0).toFreeT[Id].foldMap(FTestApi.runner) should ===(FTestApi.a(0).foldMap(FTestApi.runner))
-  }
-
   test("compile id") {
     forAll { x: Free[List, Int] =>
       x.compile(FunctionK.id[List]) should ===(x)
@@ -107,6 +103,10 @@ class FreeSuite extends CatsSuite {
 
   test("foldMap is stack safe") {
     assert(10000 == FTestApi.a(0).foldMap(FTestApi.runner))
+  }
+
+  test("toFreeT is stack-safe") {
+    FTestApi.a(0).toFreeT[Id].foldMap(FTestApi.runner) should ===(FTestApi.a(0).foldMap(FTestApi.runner))
   }
 
   test(".runTailRec") {

--- a/free/src/test/scala/cats/free/FreeSuite.scala
+++ b/free/src/test/scala/cats/free/FreeSuite.scala
@@ -46,7 +46,7 @@ class FreeSuite extends CatsSuite {
   }
 
   test("toFreeT is stack-safe") {
-    FTestApi.a(0).toFreeT[Id].foldMap(FTestApi.runner) should === (FTestApi.a(0).foldMap(FTestApi.runner))
+    FTestApi.a(0).toFreeT[Id].foldMap(FTestApi.runner) should ===(FTestApi.a(0).foldMap(FTestApi.runner))
   }
 
   test("compile id") {


### PR DESCRIPTION
so any `Free[S, A]` can be converted to `FreeT[S, G, A]` if there is an Applicative instance of G

