### PR TITLE
Optimize productR in Apply

### DIFF
--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -72,7 +72,7 @@ trait Apply[F[_]] extends Functor[F] with InvariantSemigroupal[F] with ApplyArit
    *
    */
   def productR[A, B](fa: F[A])(fb: F[B]): F[B] =
-    map2(fa, fb)((_, b) => b)
+    ap(map(fa)(_ => (b: B) => b))(fb)
 
   /**
    * Compose two actions, discarding any value produced by the second.


### PR DESCRIPTION
Further improvement similar to #2597 . Resolves problems like this: https://github.com/typelevel/cats-effect/issues/401 .

Reference to `a` was kept unnecessarily by prev implementation with map2:
```
//Expanding productR: map2 => product => ap => flatMap

fa *> fb == 
  fa
    .map(a => (b: B) => (a,b))
    .flatMap(f => fb.map(f)).map((_, b) => b)
```