### PR TITLE
Do not include parent dir of root in build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,12 +18,16 @@ lazy val commonSettings = Seq(
     val bd = baseDirectory.value
     def extraDirs(suffix: String) =
       CrossType.Pure.sharedSrcDir(bd, "main").toList.map(f => file(f.getPath + suffix))
-    CrossVersion.partialVersion(scalaVersion.value) match {
-      case Some((2, y)) if y <= 12 =>
-        extraDirs("-2.12-")
-      case Some((2, y)) if y >= 13 =>
-        extraDirs("-2.13+")
-      case _ => Nil
+    if (moduleName.value == "root") {
+      Seq.empty
+    } else {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((2, y)) if y <= 12 =>
+          extraDirs("-2.12-")
+        case Some((2, y)) if y >= 13 =>
+          extraDirs("-2.13+")
+        case _ => Nil
+      }
     }
   },
   coverageEnabled := {


### PR DESCRIPTION
At the moment, the parent of the root directory is included in the build due to `CrossType.Pure.sharedSrcDir(baseDirectory, "main")` being called on the root (cats) project whose base directory is `"."`. See the output of 
```
sbt:cats> show unmanagedSourceDirectories
...
[info] Compile / unmanagedSourceDirectories
[info] 	List(/Github/cats/src/main/scala-2.12, /Github/cats/src/main/scala, /Github/cats/src/main/java, /Github/src/main/scala-2.12-)
```
Notice that `/Github/src/main` is included in the build!

This PR limits the adding of cross type confs to the `root` build. It would be nice to reference `(cats/modueName).value` instead of the string `"root"` but that results in a circular dependency.

After this build the output is
```
...
[info] Compile / unmanagedSourceDirectories
[info] 	List(/Github/cats/src/main/scala-2.12, /Github/cats/src/main/scala, /Github/cats/src/main/java)
```
with nothing under `Github/` referenced besides `Github/cats`.

I'm not an SBT expert and this is a complicated build so I'm very open to better ways of doing this!

Thanks for reviewing.

See https://youtrack.jetbrains.com/issue/SCL-14951#focus=streamItem-27-3290672-0-0 for context


