### PR TITLE
Add productR/L to semi/subflatMap in EitherT

### DIFF
--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -1,7 +1,6 @@
 package cats
 package data
 
-import cats.Bifunctor
 import cats.instances.either._
 import cats.syntax.either._
 
@@ -108,6 +107,12 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
   def subflatMap[AA >: A, D](f: B => Either[AA, D])(implicit F: Functor[F]): EitherT[F, AA, D] =
     transform(_.flatMap(f))
 
+  def subProductR[AA >: A, D](faad: Either[AA, D])(implicit F: Functor[F]): EitherT[F, AA, D] =
+    subflatMap(_ => faad)
+
+  def subProductL[AA >: A, D](faad: Either[AA, D])(implicit F: Functor[F]): EitherT[F, AA, B] =
+    subflatMap(fab => Functor[Either[AA, ?]].as(faad, fab))
+
   def map[D](f: B => D)(implicit F: Functor[F]): EitherT[F, A, D] = bimap(identity, f)
 
   /**
@@ -117,6 +122,12 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
 
   def semiflatMap[D](f: B => F[D])(implicit F: Monad[F]): EitherT[F, A, D] =
     flatMap(b => EitherT.right(f(b)))
+
+  def semiProductR[D](fd: F[D])(implicit F: Monad[F]): EitherT[F, A, D] =
+    semiflatMap(_ => fd)
+
+  def semiProductL[D](fd: F[D])(implicit F: Monad[F]): EitherT[F, A, B] =
+    semiflatMap(b => F.as(fd, b))
 
   def leftMap[C](f: A => C)(implicit F: Functor[F]): EitherT[F, C, B] = bimap(f, identity)
 

--- a/tests/src/test/scala/cats/tests/EitherTSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherTSuite.scala
@@ -1,7 +1,6 @@
 package cats
 package tests
 
-import cats.Bifunctor
 import cats.data.EitherT
 
 import cats.laws.discipline._
@@ -307,9 +306,39 @@ class EitherTSuite extends CatsSuite {
     }
   }
 
+  test("semiProductR consistent with value.flatMap+pure") {
+    forAll { (eithert: EitherT[List, String, Int], f: List[String]) =>
+      eithert.semiProductR(f) should ===(EitherT(eithert.value.flatMap {
+        case l @ Left(_) => List(l.asInstanceOf[Either[String, String]])
+        case Right(_)    => f.map(Right(_))
+      }))
+    }
+  }
+
+  test("semiProductL consistent with value.flatMap+as") {
+    forAll { (eithert: EitherT[List, String, Int], f: List[String]) =>
+      eithert.semiProductL(f) should ===(EitherT(eithert.value.flatMap {
+        case l @ Left(_)  => List(l.asInstanceOf[Either[String, Int]])
+        case r @ Right(_) => f.as(r)
+      }))
+    }
+  }
+
   test("subflatMap consistent with value.map+flatMap") {
     forAll { (eithert: EitherT[List, String, Int], f: Int => Either[String, Double]) =>
       eithert.subflatMap(f) should ===(EitherT(eithert.value.map(_.flatMap(f))))
+    }
+  }
+
+  test("subProductR consistent with value.map+productR") {
+    forAll { (eithert: EitherT[List, String, Int], f: Either[String, Double]) =>
+      eithert.subProductR(f) should ===(EitherT(eithert.value.map(_.productR(f))))
+    }
+  }
+
+  test("subProductL consistent with value.map+productL") {
+    forAll { (eithert: EitherT[List, String, Int], f: Either[String, Double]) =>
+      eithert.subProductL(f) should ===(EitherT(eithert.value.map(_.productL(f))))
     }
   }
 


### PR DESCRIPTION
I am using cats-effect and regularly find myself writing effectful code (involving F[Unit]) such as :

```scala
EitherT
  .right[String](logger.debug(show"Logging $foo"))
  .subflatMap(_ => parseValue("value"))
```

I think it would be quite useful to have `Functor.as` and `Apply.productR/L` like functionality on some of the monad transformer functions to explicitly drop the unused `Unit` return values. This would allow the better express the above code in the following way :

```scala
EitherT
  .right[String](logger.debug(show"Logging $foo"))
  .subProductR(parseValue("value"))
```  

If this seems interesting to anyone I would also consider reviewing other EitherT functions such as`flatMapF`, `leftSemiflatMap`, `biSemiflatMap`

Of course `OptionT` is also a candidate.

