### PR TITLE
new better release settings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -391,7 +391,7 @@ lazy val cats = project
   .in(file("."))
   .settings(moduleName := "root", crossScalaVersions := Nil)
   .settings(publishSettings) // these settings are needed to release all aggregated modules under this root module
-  .settings(noPublishSettings) // this is to exclue the root module itself from being published. 
+  .settings(noPublishSettings) // this is to exclue the root module itself from being published.
   .aggregate(catsJVM, catsJS)
   .dependsOn(catsJVM, catsJS, tests.jvm % "test-internal -> test")
 

--- a/build.sbt
+++ b/build.sbt
@@ -390,8 +390,8 @@ lazy val docs = project
 lazy val cats = project
   .in(file("."))
   .settings(moduleName := "root", crossScalaVersions := Nil)
-  .settings(publishSettings)
-  .settings(noPublishSettings)
+  .settings(publishSettings) // these settings are needed to release all aggregated modules under this root module
+  .settings(noPublishSettings) // this is to exclue the root module itself from being published. 
   .aggregate(catsJVM, catsJS)
   .dependsOn(catsJVM, catsJS, tests.jvm % "test-internal -> test")
 

--- a/build.sbt
+++ b/build.sbt
@@ -804,7 +804,6 @@ def priorTo2_13(scalaVersion: String): Boolean =
   }
 
 lazy val sharedPublishSettings = Seq(
-  releaseCrossBuild := true,
   releaseTagName := tagName.value,
   releaseVcsSign := true,
   useGpg := true, // bouncycastle has bugs with subkeys, so we use gpg instead

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.7
+sbt.version=1.2.8


### PR DESCRIPTION
The old release steps are from the sbt 0.13 era. Now that modular crossScalaVersions issue is improved in sbt 1.x, we need to switch to this new release steps - i.e. the root module should have a `Nil` `crossScalaVersions` setting, then each module can have their own `crossScalaVersions` settings and release accordingly.
This change also reduced significantly the number of unnecessary settings on the root module - which fixes #2730  

To test this build code, I released a `0.0.1-DONOTUSE`, and tested with cats-tagless
