### PR TITLE
Experiment with modularizing Travis jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,25 +9,78 @@ group: edge
 git:
   depth: 9999
 
-scala:
-  - 2.11.12
-  - 2.13.0-M5
-  - 2.12.7
-
 jdk:
   - oraclejdk8
+
+scala_version_211: &scala_version_211 2.11.12
+scala_version_212: &scala_version_212 2.12.7
+scala_version_213: &scala_version_213 2.13.0-M5
 
 before_install:
  - export PATH=${PATH}:./vendor/bundle
 
-script:
-  - scripts/travis-publish.sh
+stages:
+  - name: test
+  - name: publish snapshot
+    if: (branch = master AND type = push)
 
-# http://austinpray.com/ops/2015/09/20/change-travis-node-version.html
-install:
-  - rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
-  - pip install --user codecov
-  - gem install jekyll -v 2.5
+jobs:
+  include:
+    # it can speed up the overall build to have the longer-running jobs at the top of this list.
+    - env: TEST="coverage"
+      install: pip install --user codecov
+      script: sbt coverage buildJVM bench/test coverageReport && codecov
+
+    - &js_tests
+      env: TEST="JS tests"
+      # http://austinpray.com/ops/2015/09/20/change-travis-node-version.html
+      install: rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
+      script: sbt ++$TRAVIS_SCALA_VERSION! validateJS && sbt ++$TRAVIS_SCALA_VERSION! validateKernelJS && sbt ++$TRAVIS_SCALA_VERSION! validateFreeJS
+      scala: *scala_version_211
+    - <<: *js_tests
+      scala: *scala_version_212
+
+    - &jvm_tests
+      env: TEST="JVM tests"
+      script: sbt ++$TRAVIS_SCALA_VERSION! buildJVM bench/test
+      scala: *scala_version_211
+    - <<: *jvm_tests
+      scala: *scala_version_212
+    - <<: *jvm_tests
+      scala: *scala_version_213
+      # the bench module has dependencies not available in Scala 2.13, so don't test it
+      script: sbt ++$TRAVIS_SCALA_VERSION! buildJVM
+
+    - env: TEST="docs"
+      install: gem install jekyll -v 2.5
+      script: sbt makeMicrosite
+
+    - env: TEST="linting"
+      script: sbt scalastyle fmtCheck
+
+    - env: TEST="scalafix"
+      script: cd scalafix && sbt tests/test
+
+    - &bincompat_check
+      env: TEST="binary compatibility"
+      script: sbt ++$TRAVIS_SCALA_VERSION! validateBC
+      scala: *scala_version_211
+    - <<: *bincompat_check
+      scala: *scala_version_212
+
+    - &publish_snapshot
+      stage: publish snapshot
+      script: |
+        if [[ $(cat version.sbt) =~ "-SNAPSHOT" ]]; then
+          sbt ++$TRAVIS_SCALA_VERSION! publish gitSnapshots publish
+        else
+          echo Not publishing a snapshot because the version does not end with -SNAPSHOT for version $TRAVIS_SCALA_VERSION
+        fi
+      scala: *scala_version_211
+    - <<: *publish_snapshot
+      scala: *scala_version_212
+    - <<: *publish_snapshot
+      scala: *scala_version_213
 
 notifications:
   webhooks:
@@ -38,9 +91,6 @@ notifications:
     on_start: false
 
 env:
-  matrix:
-    - JS_BUILD=false
-    - JS_BUILD=true
   global:
     - secure: Kf44XQFpq2QGe3rn98Dsf5Uz3WXzPDralS54co7sqT5oQGs1mYLYZRYz+I75ZSo5ffZ86H7M+AI9YFofqGwAjBixBbqf1tGkUh3oZp2fN3QfqzazGV3HzC+o41zALG5FL+UBaURev9ChQ5fYeTtFB7YAzejHz4y5E97awk934Rg=
     - secure: QbNAu0jCaKrwjJi7KZtYEBA/pYbTJ91Y1x/eLAJpsamswVOvwnThA/TLYuux+oiZQCiDUpBzP3oxksIrEEUAhl0lMtqRFY3MrcUr+si9NIjX8hmoFwkvZ5o1b7pmLF6Vz3rQeP/EWMLcljLzEwsrRXeK0Ei2E4vFpsg8yz1YXJg=


### PR DESCRIPTION
Resolves #2570

This sets up the Cats Travis build to use Travis's stages feature and
modularizes the Travis jobs. This probably introduces a little bit of
extra overhead since each new job needs to spin up a virtual machine and
pull the cache. However, I think that this extra overhead is offset by a
number of factors (see further below). And in experimenting with builds on
my fork, the build time looks to have gone from ~43 min to ~33 min with this
change. See [here](https://travis-ci.org/ceedubs/cats/builds/494690714) for an example.

# Benefits

We are now only publishing code coverage reports for the default Scala
version (currently 2.12.x). I don't think that publishing multiple
coverage reports for the same commit even has well-defined results, and
I suspect that we didn't really mean to do that. Since running the tests
with code coverage is probably the most time-consuming thing that the
tests do, this is a significant time saver.

Each individual job has a smaller run duration (usually < 20 min). This
means that if an individual job does fail and we have to restart it, we
are waiting for a smaller amount of time than previously.

In theory at least, there's more ability for parallelization. In testing
on my fork, it looks like Travis tends to run 3 to 5 jobs in parallel.
So since we already had that many jobs before, this may not be much of a
win.

Modularizing the build allowed for a few small installation
optimizations (only installing jekyll for the docs job, only installing
node.js for the JS builds, etc).

Lastly, I'm hoping that this sets the stage to move toward releasing via
[sbt-ci-release](https://github.com/olafurpg/sbt-ci-release) instead of
requiring a maintainer to awkwardly publish from their personal
computer. This new Travis configuration allows us to run a bunch of
tests/validation in parallel and then if all goes well, move on to a
stage that is responsible for releasing. Since each job has its own time
limit, we can probably avoid previous problems of releasing from Travis
causing builds to take too long.

# Implementation Notes

Note that Travis stages have awkward interactions with the build matrix,
so I'm now using YAML anchors (essentially templates) to reduce
duplication rather than the build matrix. This allows for finer-grained
control that I think works out pretty nicely.

