### PR TITLE
WIP Selective applicative functors

### DIFF
--- a/core/src/main/scala/cats/Selective.scala
+++ b/core/src/main/scala/cats/Selective.scala
@@ -1,0 +1,44 @@
+package cats
+
+// TODO simulacrum bug? @typeclass doesn't work
+trait Selective[F[_]]  {
+
+  def applicative: Applicative[F]
+
+  def select[A, B](fab: F[Either[A, B]])(fn: F[A => B]): F[B]
+
+  def pure[A](a: A): F[A] = applicative.pure(a)
+
+  def map[A, B](fa: F[A])(f: A => B): F[B] = applicative.map(fa)(f)
+
+  def branch[A, B, C](x: F[Either[A, B]])(l: F[A => C])(r: F[B => C]): F[C] = {
+    val lhs = {
+      val innerLhs: F[Either[A, Either[B, C]]] = map(x)(_.map(Left(_)))
+      val innerRhs: F[A => Either[B, C]] = map(l)(_.andThen(Right(_)))
+      select(innerLhs)(innerRhs)
+    }
+    select(lhs)(r)
+  }
+
+  def ifS[A](x: F[Boolean])(t: F[A])(e: F[A]): F[A] =
+    branch(map(x)(p => if (p) Left(()) else Right(())))(map(t)(a => (_: Unit) => a))(map(e)(a => _ => a))
+
+  // TODO more combinators here
+
+}
+
+
+object Selective {
+
+  def fromMonad[F[_]](implicit M: Monad[F]): Selective[F] =
+    new Selective[F] {
+      val applicative: Applicative[F] = M
+      def select[A, B](fa: F[Either[A, B]])(fn: F[A => B]): F[B] =
+        M.flatMap(fa) {
+          case Right(b) => M.pure(b)
+          case Left(a) => M.map(fn)(_(a))
+        }
+    }
+
+}
+

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -428,6 +428,18 @@ sealed abstract private[data] class ValidatedInstances extends ValidatedInstance
         }
       def raiseError[A](e: E): Validated[E, A] = Validated.Invalid(e)
     }
+
+  implicit def catsDataSelectiveForValidated[E](implicit E: Semigroup[E]): Selective[Validated[E, ?]] =
+    new Selective[Validated[E, ?]] {
+
+      def applicative: Applicative[Validated[E, ?]] = catsDataApplicativeErrorForValidated[E]
+
+      def select[A, B](fab: Validated[E, scala.Either[A, B]])(f: Validated[E, A => B]): Validated[E, B] = fab andThen {
+        case Right(b) => Valid(b)
+        case Left(a) => f.map(fn => fn(a))
+      }
+
+    }
 }
 
 sealed abstract private[data] class ValidatedInstances1 extends ValidatedInstances2 {

--- a/laws/src/main/scala/cats/laws/SelectiveLaws.scala
+++ b/laws/src/main/scala/cats/laws/SelectiveLaws.scala
@@ -1,0 +1,36 @@
+package cats.laws
+
+import cats.Selective
+
+/**
+ * Laws that must be obeyed by any `Selective`.
+ */
+trait SelectiveLaws[F[_]] {
+  implicit def F: Selective[F]
+
+  private def either[A, B, C](f: A => C, g: B => C)(x: Either[A, B]): C =
+    x match {
+      case Left(a) => f(a)
+      case Right(b) => g(b)
+    }
+
+  def selectiveIdentity[A](x: F[Either[A, A]]): IsEq[F[A]] = {
+    F.select(x)(F.pure(Predef.identity)) <-> F.map(x)(either(Predef.identity, Predef.identity))
+  }
+
+  def selectiveDistributivity[A, B](x: Either[A, B], y: F[A => B], z: F[A => B]): IsEq[F[B]] = {
+    val lhs = F.select(F.pure(x))(F.applicative.*>(y)(z))
+    val rhs = F.applicative.*>(F.select(F.pure(x))(y))(F.select(F.pure(x))(z))
+    lhs <-> rhs
+  }
+
+  // TODO associativity law
+
+  // TODO the law for when F is also a monad (must skip unnecessary effects)
+
+}
+
+object SelectiveLaws {
+  def apply[F[_]](implicit ev: Selective[F]): SelectiveLaws[F] =
+    new SelectiveLaws[F] { def F: Selective[F] = ev }
+}

--- a/laws/src/main/scala/cats/laws/discipline/SelectiveTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/SelectiveTests.scala
@@ -1,0 +1,45 @@
+package cats
+package laws
+package discipline
+
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
+import org.scalacheck.Prop._
+import org.scalacheck.{Arbitrary, Cogen}
+import org.typelevel.discipline.Laws
+
+trait SelectiveTests[F[_]] extends Laws {
+  def laws: SelectiveLaws[F]
+
+  // TODO remove unneeded implicits
+  def selective[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
+                                                            ArbFA: Arbitrary[F[A]],
+                                                            ArbFB: Arbitrary[F[B]],
+                                                            ArbFC: Arbitrary[F[C]],
+                                                            ArbFEitherA: Arbitrary[F[Either[A, A]]],
+                                                            ArbFAtoB: Arbitrary[F[A => B]],
+                                                            ArbFBtoC: Arbitrary[F[B => C]],
+                                                            CogenA: Cogen[A],
+                                                            CogenB: Cogen[B],
+                                                            CogenC: Cogen[C],
+                                                            EqFA: Eq[F[A]],
+                                                            EqFB: Eq[F[B]],
+                                                            EqFC: Eq[F[C]],
+                                                            EqFABC: Eq[F[(A, B, C)]],
+                                                            iso: Isomorphisms[F]): RuleSet =
+    new DefaultRuleSet(
+      name = "selective",
+      parent = None,
+      "selective identity" -> forAll(laws.selectiveIdentity[A] _),
+      "selective distributivity" -> forAll(laws.selectiveDistributivity[A, B] _)
+    )
+}
+
+object SelectiveTests {
+
+  def apply[F[_]: Selective]: SelectiveTests[F] =
+    new SelectiveTests[F] { def laws: SelectiveLaws[F] = SelectiveLaws[F] }
+
+  def monad[F[_]: Monad]: SelectiveTests[F] =
+    new SelectiveTests[F] { def laws: SelectiveLaws[F] = SelectiveLaws[F](Selective.fromMonad) }
+
+}

--- a/tests/src/test/scala/cats/tests/ListSuite.scala
+++ b/tests/src/test/scala/cats/tests/ListSuite.scala
@@ -2,16 +2,7 @@ package cats
 package tests
 
 import cats.data.{NonEmptyList, ZipList}
-import cats.laws.discipline.{
-  AlternativeTests,
-  CoflatMapTests,
-  CommutativeApplyTests,
-  MonadTests,
-  SemigroupalTests,
-  SerializableTests,
-  TraverseFilterTests,
-  TraverseTests
-}
+import cats.laws.discipline.{AlternativeTests, CoflatMapTests, CommutativeApplyTests, MonadTests, SelectiveTests, SemigroupalTests, SerializableTests, TraverseFilterTests, TraverseTests}
 import cats.laws.discipline.arbitrary._
 
 class ListSuite extends CatsSuite {
@@ -29,6 +20,11 @@ class ListSuite extends CatsSuite {
   checkAll("Traverse[List]", SerializableTests.serializable(Traverse[List]))
 
   checkAll("List[Int]", MonadTests[List].monad[Int, Int, Int])
+
+  // TODO Added here as an example of testing a monad as a Selective.
+  // Not sure of the best way to add these tests into the suites for all the monad instances.
+  checkAll("List[Int]", SelectiveTests.monad[List].selective[Int, Int, Int])
+
   checkAll("Monad[List]", SerializableTests.serializable(Monad[List]))
 
   checkAll("List[Int]", TraverseFilterTests[List].traverseFilter[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/ValidatedSuite.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedSuite.scala
@@ -25,6 +25,8 @@ class ValidatedSuite extends CatsSuite {
            ApplicativeErrorTests[Validated[String, ?], String].applicativeError[Int, Int, Int])
   checkAll("ApplicativeError[Validated, String]",
            SerializableTests.serializable(ApplicativeError[Validated[String, ?], String]))
+  checkAll("Validated[String, Int]",
+    SelectiveTests[Validated[String, ?]].selective[Int, Int, Int])
 
   checkAll("Validated[String, Int] with Option",
            TraverseTests[Validated[String, ?]].traverse[Int, Int, Int, Int, Option, Option])


### PR DESCRIPTION
This is a collaboration with @hamishdickson. Made a first stab at implementing [Selective Applicative Functors](https://www.staff.ncl.ac.uk/andrey.mokhov/selective-functors.pdf) as suggested in #2745.

* Add Selective type class
* Add instance for Validated
* Start writing laws
* Start writing combinators

Here is the "shapes" example from the paper using Validated:

```
scala> import cats._, cats.data._, cats.data.Validated._
import cats._
import cats.data._
import cats.data.Validated._

scala> type Radius = Int
defined type alias Radius

scala> type Width = Int
defined type alias Width

scala> type Height = Int
defined type alias Height

scala> :paste
// Entering paste mode (ctrl-D to finish)

sealed trait Shape
case class Circle(r: Radius) extends Shape
case class Rectangle(w: Width, h: Height) extends Shape

// Exiting paste mode, now interpreting.

defined trait Shape
defined class Circle
defined class Rectangle

scala> def shape[F[_]](x: F[Boolean], r: F[Radius], w: F[Width], h: F[Height])(implicit F: Selective[F]): F[Shape] =
  F.ifS(x)(F.map(r)(radius => Circle(radius): Shape))(F.applicative.map2(w, h){ case (width, height) => Rectangle(width, height): Shape })
shape: [F[_]](x: F[Boolean], r: F[Radius], w: F[Width], h: F[Height])(implicit F: cats.Selective[F])F[Shape]

scala> type V[A] = Validated[String, A]
defined type alias V

scala> import cats.instances.string._
import cats.instances.string._

scala> shape[V](valid(true), valid(1), invalid("width?"), invalid("height?"))
res1: V[Shape] = Valid(Circle(1))

scala> shape[V](valid(false), invalid("radius?"), valid(2), valid(3))
res2: V[Shape] = Valid(Rectangle(2,3))

scala> shape[V](valid(false), valid(1), invalid("width?"), invalid("height?"))
res3: V[Shape] = Invalid(width?height?)

scala> shape[V](invalid("choice?"), invalid("radius?"), valid(2), invalid("height?"))
res4: V[Shape] = Invalid(choice?)
```

This is a work in progress (see the TODO comments) but happy to receive feedback at this stage.

After getting this far, we're still not sure about whether it's better for `Selective` to extend `Applicative` or to have it as a member. We went for the latter, but it's a bit clumsy to work with.