### PR TITLE
ListSet instances

### DIFF
--- a/core/src/main/scala/cats/instances/listset.scala
+++ b/core/src/main/scala/cats/instances/listset.scala
@@ -1,0 +1,14 @@
+package cats
+package instances
+
+import scala.collection.immutable.ListSet
+
+trait ListSetInstances {
+
+  implicit def catsStdInstancesForListSet: MonoidK[ListSet] =
+    new MonoidK[ListSet] {
+      def empty[A]: ListSet[A] = ListSet.empty[A]
+      def combineK[A](x: ListSet[A], y: ListSet[A]): ListSet[A] =
+        x ++ y
+    }
+}

--- a/core/src/main/scala/cats/instances/package.scala
+++ b/core/src/main/scala/cats/instances/package.scala
@@ -20,6 +20,7 @@ package object instances {
   object int extends IntInstances
   object invariant extends InvariantMonoidalInstances
   object list extends ListInstances with ListInstancesBinCompat0
+  object listset extends ListSetInstances
   object long extends LongInstances
   object option extends OptionInstances with OptionInstancesBinCompat0
   object map extends MapInstances with MapInstancesBinCompat0 with MapInstancesBinCompat1

--- a/kernel-laws/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -14,7 +14,7 @@ import org.scalactic.anyvals.{PosInt, PosZInt}
 import org.scalatest.FunSuite
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
-import scala.collection.immutable.{BitSet, Queue}
+import scala.collection.immutable.{BitSet, ListSet, Queue}
 import scala.util.Random
 
 import java.util.UUID
@@ -196,6 +196,8 @@ class Tests extends FunSuite with Discipline {
   checkAll("Monoid[Map[String, String]]", SerializableTests.serializable(Monoid[Map[String, String]]))
   checkAll("Monoid[Queue[Int]]", MonoidTests[Queue[Int]].monoid)
   checkAll("Monoid[Queue[Int]]", SerializableTests.serializable(Monoid[Queue[Int]]))
+  checkAll("Monoid[ListSet[Int]]", MonoidTests[ListSet[Int]].monoid)
+  checkAll("Monoid[ListSet[Int]]", SerializableTests.serializable(Monoid[ListSet[Int]]))
 
   checkAll("CommutativeMonoid[Map[String, Int]]", CommutativeMonoidTests[Map[String, Int]].commutativeMonoid)
   checkAll("CommutativeMonoid[Map[String, Int]]", SerializableTests.serializable(CommutativeMonoid[Map[String, Int]]))

--- a/kernel/src/main/scala/cats/kernel/instances/all.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/all.scala
@@ -19,6 +19,7 @@ trait AllInstances
     with HashInstances
     with IntInstances
     with ListInstances
+    with ListSetInstances
     with LongInstances
     with MapInstances
     with OptionInstances

--- a/kernel/src/main/scala/cats/kernel/instances/listset.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/listset.scala
@@ -1,0 +1,44 @@
+package cats.kernel
+package instances
+
+import scala.annotation.tailrec
+import scala.collection.immutable.ListSet
+
+object listset extends ListSetInstances
+
+class ListSetEq[A](implicit ev: Eq[A]) extends Eq[ListSet[A]] {
+  def eqv(xs: ListSet[A], ys: ListSet[A]): Boolean = {
+    @tailrec def loop(xs: ListSet[A], ys: ListSet[A]): Boolean =
+      xs match {
+        case _ if xs.isEmpty =>
+          ys.isEmpty
+        case _ =>
+          ys match {
+            case _ if ys.isEmpty =>
+              false
+            case _ =>
+              if (ev.eqv(xs.last, ys.last)) loop(xs.init, ys.init) else false
+          }
+      }
+    (xs eq ys) || loop(xs, ys)
+  }
+}
+
+
+trait ListSetInstances {
+  implicit def catsKernelStdMonoidForListSet[A]: Monoid[ListSet[A]] = new ListSetMonoid[A]
+
+  implicit def catsKernelStdEqForListSet[A: Eq]: Eq[ListSet[A]] = new ListSetEq[A]
+
+  class ListSetMonoid[A] extends Monoid[ListSet[A]] {
+    def empty: ListSet[A] = ListSet.empty[A]
+
+    def combine(x: ListSet[A], y: ListSet[A]): ListSet[A] = x ++ y
+
+    override def combineN(x: ListSet[A], n: Int): ListSet[A] =
+      StaticMethods.combineNIterable(ListSet.newBuilder[A], x, n)
+
+    override def combineAll(xs: TraversableOnce[ListSet[A]]): ListSet[A] =
+      StaticMethods.combineAllIterable(ListSet.newBuilder[A], xs)
+  }
+}


### PR DESCRIPTION
Hello!

I noticed that `ListSet` is entirely missing in cats, although I find it very useful for my purposes.
I've started to put together some instances, but almost immediately stumbled upon failed serialization test:

```
[info] - Monoid[ListSet[Int]].serializable.can serialize and deserialize *** FAILED *** (25 milliseconds)
[info]   NotSerializableException was thrown during property evaluation.
[info]     Message: cats.kernel.instances.all.package$
[info]     Occurred when passed generated values (
[info]
[info]     )
[info]   org.scalatest.exceptions.GeneratorDrivenPropertyCheckFailedException:
[info]   at org.scalatest.enablers.CheckerAsserting$$anon$2.indicateFailure(CheckerAsserting.scala:232)
[info]   at org.scalatest.enablers.CheckerAsserting$$anon$2.indicateFailure(CheckerAsserting.scala:220)
[info]   at org.scalatest.enablers.UnitCheckerAsserting$CheckerAssertingImpl.check(CheckerAsserting.scala:159)
[info]   at org.scalatest.prop.Checkers.check(Checkers.scala:374)
[info]   at org.scalatest.prop.Checkers.check$(Checkers.scala:372)
[info]   at cats.kernel.laws.Tests.check(LawTests.scala:115)
[info]   at org.typelevel.discipline.scalatest.Discipline.$anonfun$checkAll$3(Discipline.scala:14)
[info]   at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
[info]   at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
[info]   at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:22)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:20)
[info]   at org.scalatest.FunSuiteLike$$anon$1.apply(FunSuiteLike.scala:186)
[info]   at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
[info]   at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
[info]   at org.scalatest.FunSuite.withFixture(FunSuite.scala:1560)
[info]   at org.scalatest.FunSuiteLike.invokeWithFixture$1(FunSuiteLike.scala:184)
[info]   at org.scalatest.FunSuiteLike.$anonfun$runTest$1(FunSuiteLike.scala:196)
[info]   at org.scalatest.SuperEngine.runTestImpl(Engine.scala:289)
[info]   at org.scalatest.FunSuiteLike.runTest(FunSuiteLike.scala:196)
[info]   at org.scalatest.FunSuiteLike.runTest$(FunSuiteLike.scala:178)
[info]   at org.scalatest.FunSuite.runTest(FunSuite.scala:1560)
[info]   at org.scalatest.FunSuiteLike.$anonfun$runTests$1(FunSuiteLike.scala:229)
[info]   at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:396)
[info]   at scala.collection.immutable.List.foreach(List.scala:388)
[info]   at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:384)
[info]   at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:379)
[info]   at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:461)
[info]   at org.scalatest.FunSuiteLike.runTests(FunSuiteLike.scala:229)
[info]   at org.scalatest.FunSuiteLike.runTests$(FunSuiteLike.scala:228)
[info]   at org.scalatest.FunSuite.runTests(FunSuite.scala:1560)
[info]   at org.scalatest.Suite.run(Suite.scala:1147)
[info]   at org.scalatest.Suite.run$(Suite.scala:1129)
[info]   at org.scalatest.FunSuite.org$scalatest$FunSuiteLike$$super$run(FunSuite.scala:1560)
[info]   at org.scalatest.FunSuiteLike.$anonfun$run$1(FunSuiteLike.scala:233)
[info]   at org.scalatest.SuperEngine.runImpl(Engine.scala:521)
[info]   at org.scalatest.FunSuiteLike.run(FunSuiteLike.scala:233)
[info]   at org.scalatest.FunSuiteLike.run$(FunSuiteLike.scala:232)
[info]   at org.scalatest.FunSuite.run(FunSuite.scala:1560)
[info]   at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:314)
[info]   at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:507)
[info]   at sbt.ForkMain$Run.lambda$runTest$1(ForkMain.java:304)
[info]   at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[info]   at java.base/java.lang.Thread.run(Thread.java:834)
[info]   Cause: java.io.NotSerializableException: cats.kernel.instances.all.package$
[info]   at java.base/java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1185)
[info]   at java.base/java.io.ObjectOutputStream.defaultWriteFields(ObjectOutputStream.java:1553)
[info]   at java.base/java.io.ObjectOutputStream.writeSerialData(ObjectOutputStream.java:1510)
[info]   at java.base/java.io.ObjectOutputStream.writeOrdinaryObject(ObjectOutputStream.java:1433)
[info]   at java.base/java.io.ObjectOutputStream.writeObject0(ObjectOutputStream.java:1179)
[info]   at java.base/java.io.ObjectOutputStream.writeObject(ObjectOutputStream.java:349)
[info]   at cats.kernel.laws.SerializableLaws$.$anonfun$serializable$1(SerializableLaws.scala:41)
[info]   at org.scalacheck.Prop$.$anonfun$apply$1(Prop.scala:292)
[info]   at org.scalacheck.PropFromFun.apply(Prop.scala:22)
[info]   at org.scalacheck.Prop$.$anonfun$delay$1(Prop.scala:461)
[info]   at org.scalacheck.Prop$.$anonfun$apply$1(Prop.scala:292)
[info]   at org.scalacheck.PropFromFun.apply(Prop.scala:22)
[info]   at org.scalacheck.Test$.workerFun$1(Test.scala:294)
[info]   at org.scalacheck.Test$.$anonfun$check$1(Test.scala:323)
[info]   at org.scalacheck.Test$.$anonfun$check$1$adapted(Test.scala:323)
[info]   at org.scalacheck.Platform$.$anonfun$runWorkers$4(Platform.scala:50)
[info]   at scala.concurrent.BlockContext$DefaultBlockContext$.blockOn(BlockContext.scala:53)
[info]   at scala.concurrent.package$.blocking(package.scala:142)
[info]   at org.scalacheck.Platform$.$anonfun$runWorkers$2(Platform.scala:50)
[info]   at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:654)
[info]   at scala.util.Success.$anonfun$map$1(Try.scala:251)
[info]   at scala.util.Success.map(Try.scala:209)
[info]   at scala.concurrent.Future.$anonfun$map$1(Future.scala:288)
[info]   at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:29)
[info]   at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:29)
[info]   at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:60)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
[info]   at java.base/java.lang.Thread.run(Thread.java:834)
```

So, I'm wondering:

1. Is there something we can do about it?
2. Is there a reason for not adding `ListSet`

P.S. `prePR` also fails