### PR TITLE
Add foldRightDefer to Foldable

### DIFF
--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -95,6 +95,13 @@ import Foldable.sentinel
    */
   def foldRight[A, B](fa: F[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B]
 
+  def foldRightDefer[G[_]: Defer, A, B](fa: F[A], gb: G[B])(fn: (A, G[B]) => G[B]): G[B] =
+    Defer[G].defer(
+      this.foldLeft(fa, (z: G[B]) => z) { (acc, elem) => z =>
+        Defer[G].defer(fn(elem, acc(z)))
+      }(gb)
+    )
+
   def reduceLeftToOption[A, B](fa: F[A])(f: A => B)(g: (B, A) => B): Option[B] =
     foldLeft(fa, Option.empty[B]) {
       case (Some(b), a) => Some(g(b, a))
@@ -592,6 +599,13 @@ object Foldable {
       Eval.defer(if (it.hasNext) f(it.next, loop(it)) else lb)
 
     Eval.always(iterable.iterator).flatMap(loop)
+  }
+
+  def iterateRightDefer[G[_]: Defer, A, B](iterable: Iterable[A], lb: G[B])(f: (A, G[B]) => G[B]): G[B] = {
+    def loop(it: Iterator[A]): G[B] =
+      Defer[G].defer(if (it.hasNext) f(it.next(), loop(it)) else Defer[G].defer(lb))
+
+    loop(iterable.iterator)
   }
 
   /**

--- a/laws/src/main/scala/cats/laws/FoldableLaws.scala
+++ b/laws/src/main/scala/cats/laws/FoldableLaws.scala
@@ -37,6 +37,16 @@ trait FoldableLaws[F[_]] extends UnorderedFoldableLaws[F] {
   ): IsEq[B] =
     F.foldM[Id, A, B](fa, b)(f) <-> F.foldLeft(fa, b)(f)
 
+  def foldRightDeferConsistentWithFoldRight[A, B](
+    fa: F[A],
+    f: (B, A) => B
+  )(implicit
+    M: Monoid[B]): IsEq[B] = {
+    val g: (A, Eval[B]) => Eval[B] = (a, ea) => ea.map(f(_, a))
+
+    F.foldRight(fa, Later(M.empty))(g).value <-> F.foldRightDefer(fa, Later(M.empty): Eval[B])(g).value
+  }
+
   /**
    * `reduceLeftOption` consistent with `reduceLeftToOption`
    */
@@ -111,6 +121,7 @@ trait FoldableLaws[F[_]] extends UnorderedFoldableLaws[F] {
   def orderedConsistency[A: Eq](x: F[A], y: F[A])(implicit ev: Eq[F[A]]): IsEq[List[A]] =
     if (x === y) (F.toList(x) <-> F.toList(y))
     else List.empty[A] <-> List.empty[A]
+
 }
 
 object FoldableLaws {

--- a/laws/src/main/scala/cats/laws/discipline/FoldableTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FoldableTests.scala
@@ -44,6 +44,7 @@ trait FoldableTests[F[_]] extends UnorderedFoldableTests[F] {
       "dropWhile_ reference" -> forAll(laws.dropWhile_Ref[A] _),
       "collectFirstSome reference" -> forAll(laws.collectFirstSome_Ref[A, B] _),
       "collectFirst reference" -> forAll(laws.collectFirst_Ref[A, B] _)
+//      "foldRightDefer consistency" -> forAll(laws.foldRightDeferConsistentWithFoldRight[A, B] _)
     )
 }
 

--- a/tests/src/test/scala/cats/tests/FoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/FoldableSuite.scala
@@ -282,6 +282,13 @@ class FoldableSuiteAdditional extends CatsSuite {
     // safely build large lists
     val larger = F.foldRight(large, Now(List.empty[Int]))((x, lxs) => lxs.map((x + 1) :: _))
     larger.value should ===(large.map(_ + 1))
+
+    val sum = F.foldRightDefer(large, Eval.later(0))((elem, acc) => acc.map(_ + elem))
+    sum.value should ===(large.sum)
+
+    def boom[A]: Eval[A] = Eval.later(sys.error("boom"))
+    // Ensure that the lazy param is actually handled lazily
+    val lazySum: Eval[Int] = F.foldRightDefer(large, boom[Int])((elem, acc) => acc.map(_ + elem))
   }
 
   def checkMonadicFoldsStackSafety[F[_]](fromRange: Range => F[Int])(implicit F: Foldable[F]): Unit = {


### PR DESCRIPTION
This PR adds a new `foldRightDefer` function to `Foldable[F]` with the following signature:
```
def foldRightDefer[G[_]: Defer, A, B](fa: F[A], gb: G[B])(fn: (A, G[B]) => G[B]): G[B]
```

Additionally, I added the following law to check the `foldRight <-> foldRightDefer` equivalence where `type G[A] = Eval[A]`.

I didn't spend too much time on making this binary compatible because #2678 is marked as targeting the 2.1 milestone which is a major release. 

Closes #2678 