### PR TITLE
add FunctionK.apply to summon instances from the implicit scope

### DIFF
--- a/core/src/main/scala/cats/arrow/FunctionK.scala
+++ b/core/src/main/scala/cats/arrow/FunctionK.scala
@@ -66,6 +66,12 @@ trait FunctionK[F[_], G[_]] extends Serializable { self =>
 object FunctionK {
 
   /**
+   * Summon an instance from the implicit scope if such an instance
+   * is available.
+   */
+  def apply[F[_], G[_]](implicit instance: F ~> G): F ~> G = instance
+
+  /**
    * The identity transformation of `F` to `F`
    */
   def id[F[_]]: FunctionK[F, F] = λ[FunctionK[F, F]](fa => fa)

--- a/tests/src/test/scala/cats/tests/FunctionKSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctionKSuite.scala
@@ -104,4 +104,12 @@ class FunctionKSuite extends CatsSuite {
     assertTypeError("FunctionK.lift(sample[Nothing])")
   }
 
+  test("apply ops") {
+    implicit val lToO: List ~> Option = listToOption
+    implicit val oToL: Option ~> List = optionToList
+
+    FunctionK[List, Option] should be(listToOption)
+    FunctionK[Option, List] should be(optionToList)
+  }
+
 }


### PR DESCRIPTION
I'm assuming `FunctionK` would be annotated with `@typeclass`, if simulacrum supported type constructors with more than one argument. This PR adds the `apply` method that I believe simulacrum would have added if it could.