### PR TITLE
[WIP] move to Scala 2.13.0-RC1 (drop -M5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ jdk:
 
 scala_version_211: &scala_version_211 2.11.12
 scala_version_212: &scala_version_212 2.12.7
-scala_version_213: &scala_version_213 2.13.0-M5
+scala_version_213: &scala_version_213 2.13.0-RC1
 
 before_install:
  - export PATH=${PATH}:./vendor/bundle

--- a/build.sbt
+++ b/build.sbt
@@ -83,13 +83,13 @@ lazy val catsSettings = Seq(
     "bintray/non".at("http://dl.bintray.com/non/maven")
   ),
   libraryDependencies ++= Seq(
-    "org.typelevel" %%% "machinist" % "0.6.6",
-    compilerPlugin("org.spire-math" %% "kind-projector" % "0.9.9")
+    "org.typelevel" %%% "machinist" % "0.6.7",
+    compilerPlugin("org.typelevel" %% "kind-projector" % "0.10.0")
   ) ++ macroDependencies(scalaVersion.value),
 ) ++ commonSettings ++ publishSettings ++ scoverageSettings ++ simulacrumSettings
 
 lazy val simulacrumSettings = Seq(
-  libraryDependencies += "com.github.mpilquist" %%% "simulacrum" % "0.15.0" % Provided,
+  libraryDependencies += "com.github.mpilquist" %%% "simulacrum" % "0.16.0" % Provided,
   pomPostProcess := { (node: xml.Node) =>
     new RuleTransformer(new RewriteRule {
       override def transform(node: xml.Node): Seq[xml.Node] = node match {
@@ -153,12 +153,11 @@ lazy val includeGeneratedSrc: Setting[_] = {
 
 val catalystsVersion = "0.8"
 
-def scalatestVersion(scalaVersion: String): String =
-  if (priorTo2_13(scalaVersion)) "3.0.5" else "3.0.6-SNAP5"
+val scalatestVersion = "3.0.8-RC2"
 
 val scalaCheckVersion = "1.14.0"
 
-val disciplineVersion = "0.10.0"
+val disciplineVersion = "0.11.1"
 
 lazy val disciplineDependencies = Seq(
   libraryDependencies += "org.scalacheck" %%% "scalacheck" % scalaCheckVersion,
@@ -168,7 +167,7 @@ lazy val disciplineDependencies = Seq(
 lazy val testingDependencies = Seq(
   libraryDependencies += "org.typelevel" %%% "catalysts-platform" % catalystsVersion,
   libraryDependencies += "org.typelevel" %%% "catalysts-macros" % catalystsVersion % "test",
-  libraryDependencies += "org.scalatest" %%% "scalatest" % scalatestVersion(scalaVersion.value) % "test"
+  libraryDependencies += "org.scalatest" %%% "scalatest" % scalatestVersion % "test"
 )
 
 lazy val docsMappingsAPIDir = settingKey[String]("Name of subdirectory in site target directory for api docs")
@@ -563,7 +562,7 @@ lazy val testkit = crossProject(JSPlatform, JVMPlatform)
   .settings(moduleName := "cats-testkit")
   .settings(catsSettings)
   .settings(disciplineDependencies)
-  .settings(libraryDependencies += "org.scalatest" %%% "scalatest" % scalatestVersion(scalaVersion.value))
+  .settings(libraryDependencies += "org.scalatest" %%% "scalatest" % scalatestVersion)
   .jsSettings(commonJsSettings)
   .jvmSettings(commonJvmSettings)
 
@@ -640,7 +639,7 @@ lazy val binCompatTest = project
         else //We are not testing BC on Scala 2.13 yet.
           "org.typelevel" %% "cats-core" % version.value % Provided
       },
-      "org.scalatest" %%% "scalatest" % scalatestVersion(scalaVersion.value) % Test
+      "org.scalatest" %%% "scalatest" % scalatestVersion % Test
     )
   )
   .dependsOn(core.jvm % Test)

--- a/core/src/main/scala/cats/ApplicativeError.scala
+++ b/core/src/main/scala/cats/ApplicativeError.scala
@@ -82,7 +82,7 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
    * `F[A]` values.
    */
   def recover[A](fa: F[A])(pf: PartialFunction[E, A]): F[A] =
-    handleErrorWith(fa)(e => (pf.andThen(pure)).applyOrElse(e, raiseError))
+    handleErrorWith(fa)(e => (pf.andThen(pure _)).applyOrElse(e, raiseError _))
 
   /**
    * Recover from certain errors by mapping them to an `F[A]` value.

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -357,6 +357,9 @@ sealed private[data] trait WriterTFlatMap1[F[_], L] extends WriterTApply[F, L] w
   implicit override def F0: FlatMap[F]
   implicit def L0: Monoid[L]
 
+  override def ap[A, B](f: WriterT[F, L, A => B])(fa: WriterT[F, L, A]): WriterT[F, L, B] =
+    super[WriterTApply].ap(f)(fa)
+
   def flatMap[A, B](fa: WriterT[F, L, A])(f: A => WriterT[F, L, B]): WriterT[F, L, B] =
     fa.flatMap(f)
 

--- a/core/src/main/scala/cats/syntax/monadError.scala
+++ b/core/src/main/scala/cats/syntax/monadError.scala
@@ -24,7 +24,7 @@ final class MonadErrorOps[F[_], E, A](private val fa: F[A]) extends AnyVal {
    */
   def reject(pf: PartialFunction[A, E])(implicit F: MonadError[F, E]): F[A] =
     F.flatMap(fa) { a =>
-      pf.andThen(F.raiseError[A]).applyOrElse(a, (_: A) => fa)
+      pf.andThen(F.raiseError[A] _).applyOrElse(a, (_: A) => fa)
     }
 
   def adaptError(pf: PartialFunction[E, E])(implicit F: MonadError[F, E]): F[A] =

--- a/kernel/src/main/scala-2.13+/cats/kernel/compat/WrappedMutableMapBase.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/compat/WrappedMutableMapBase.scala
@@ -5,5 +5,5 @@ import scala.collection.mutable
 
 abstract private[kernel] class WrappedMutableMapBase[K, V](m: mutable.Map[K, V]) extends Map[K, V] {
   def updated[V2 >: V](key: K, value: V2): Map[K, V2] = m.toMap + ((key, value))
-  def remove(key: K): Map[K, V] = m.toMap - key
+  def removed(key: K): Map[K, V] = m.toMap - key
 }

--- a/laws/src/main/scala/cats/laws/ApplicativeErrorLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplicativeErrorLaws.scala
@@ -32,7 +32,7 @@ trait ApplicativeErrorLaws[F[_], E] extends ApplicativeLaws[F] {
     F.handleError(fa)(f) <-> F.recover(fa) { case x => f(x) }
 
   def recoverConsistentWithRecoverWith[A](fa: F[A], pf: PartialFunction[E, A]): IsEq[F[A]] =
-    F.recover(fa)(pf) <-> F.recoverWith(fa)(pf.andThen(F.pure))
+    F.recover(fa)(pf) <-> F.recoverWith(fa)(pf.andThen(F.pure _))
 
   def attemptConsistentWithAttemptT[A](fa: F[A]): IsEq[EitherT[F, E, A]] =
     EitherT(F.attempt(fa)) <-> F.attemptT(fa)

--- a/tests/src/test/scala/cats/tests/TrySuite.scala
+++ b/tests/src/test/scala/cats/tests/TrySuite.scala
@@ -17,11 +17,7 @@ class TrySuite extends CatsSuite {
   checkAll("Try[Int]", CoflatMapTests[Try].coflatMap[Int, Int, Int])
   checkAll("CoflatMap[Try]", SerializableTests.serializable(CoflatMap[Try]))
 
-  //temporarily disable this test due to scala.util.Failure regression https://github.com/scala/bug/issues/11242
-  if (BuildInfo.scalaVersion != "2.13.0-M5") {
-    checkAll("Try with Throwable", MonadErrorTests[Try, Throwable].monadError[Int, Int, Int])
-  }
-
+  checkAll("Try with Throwable", MonadErrorTests[Try, Throwable].monadError[Int, Int, Int])
   checkAll("MonadError[Try, Throwable]", SerializableTests.serializable(MonadError[Try, Throwable]))
 
   checkAll("Try[Int] with Option", TraverseTests[Try].traverse[Int, Int, Int, Int, Option, Option])


### PR DESCRIPTION
this is just a sketch to get the ball rolling, I don't intend
to finish it myself

not even sure if it's to the right branch, not sure what the plan is around ScalaCheck 1.14.0 being the only ScalaCheck available for 2.13 (for now? not sure if anyone has tried to push for 1.13.x release on 2.13)