### PR TITLE
Make WrappedMutableMapBase extend Serializable

### DIFF
--- a/kernel/src/main/scala-2.12-/cats/kernel/compat/WrappedMutableMapBase.scala
+++ b/kernel/src/main/scala-2.12-/cats/kernel/compat/WrappedMutableMapBase.scala
@@ -3,7 +3,7 @@ package compat
 
 import scala.collection.mutable
 
-abstract private[kernel] class WrappedMutableMapBase[K, V](m: mutable.Map[K, V]) extends Map[K, V] {
+abstract private[kernel] class WrappedMutableMapBase[K, V](m: mutable.Map[K, V]) extends Map[K, V] with Serializable {
   def +[V2 >: V](kv: (K, V2)): Map[K, V2] = m.toMap + kv
   def -(key: K): Map[K, V] = m.toMap - key
 }

--- a/kernel/src/main/scala-2.13+/cats/kernel/compat/WrappedMutableMapBase.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/compat/WrappedMutableMapBase.scala
@@ -3,7 +3,7 @@ package compat
 
 import scala.collection.mutable
 
-abstract private[kernel] class WrappedMutableMapBase[K, V](m: mutable.Map[K, V]) extends Map[K, V] {
+abstract private[kernel] class WrappedMutableMapBase[K, V](m: mutable.Map[K, V]) extends Map[K, V] with Serializable {
   def updated[V2 >: V](key: K, value: V2): Map[K, V2] = m.toMap + ((key, value))
   def remove(key: K): Map[K, V] = m.toMap - key
 }

--- a/tests/src/test/scala/cats/tests/MapSuite.scala
+++ b/tests/src/test/scala/cats/tests/MapSuite.scala
@@ -12,6 +12,7 @@ import cats.laws.discipline.{
 }
 import cats.laws.discipline.arbitrary._
 import cats.arrow.Compose
+import cats.kernel.instances.StaticMethods.wrapMutableMap
 
 class MapSuite extends CatsSuite {
 
@@ -40,5 +41,10 @@ class MapSuite extends CatsSuite {
       map.show.startsWith("Map(") should ===(true)
       map.show should ===(implicitly[Show[Map[Int, String]]].show(map))
     }
+  }
+
+  {
+    val m = wrapMutableMap(scala.collection.mutable.Map(1 -> "one", 2 -> "two"))
+    checkAll("WrappedMutableMap", SerializableTests.serializable(m))
   }
 }


### PR DESCRIPTION
We are running into Spark `Task not serializable` issues when a closure
that executes on a Spark executor node involves a `Map` that is created
via running `foldMap` on a `List`. This commit makes the
`WrappedMutableMap` hierarchy extend `Serializable` and chex that the
cerealization works (this test failed before extending `Serializable`).