### PR TITLE
Tuning JVM options for throughput

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,8 +1,6 @@
 -Dfile.encoding=UTF8
 -Xms1G
--Xmx3G
+-Xmx4G
 -XX:ReservedCodeCacheSize=250M
 -XX:+TieredCompilation
--XX:-UseGCOverheadLimit
--XX:+CMSClassUnloadingEnabled
--XX:+UseConcMarkSweepGC
+-XX:+UseParallelGC


### PR DESCRIPTION
Changes the JVM options used by SBT somewhat.

Here is the reasoning for each change:

* `-Xmx4G` - the Travis infrastructure that we're using [has 7.5GB of memory](https://docs.travis-ci.com/user/reference/overview/), this could probably be increased further if forking tests was also disabled
* removal of `XX:-UseGCOverheadLimit` - I think that this is just creating zombie builds that are stuck thrashing the GC and will timeout anyway due to lack of progress, better to fail early IMO
* removal of `-XX:+CMSClassUnloadingEnabled` - this is relevant only for the CMS collector
* switch from `-XX:+UseConcMarkSweepGC` to `-XX:+UseParallelGC` - from what I understand the concurrent CMS collector is a response time collector, whereas the parallel GC is a throughput collector (more on this in the [Oracle docs](https://docs.oracle.com/javase/10/gctuning/toc.htm)), which is much more relevant for compiling code IMO

Here is some VisualVM output from running `sbt clean test/clean catsJS/test`, which normally stalls for me locally with the default options.

Before:

![Screenshot 2019-04-17 at 12 43 29](https://user-images.githubusercontent.com/2992938/56285199-92181900-610e-11e9-9ed2-d10a524107f5.png)

Note that I had to kill this build as it got stuck.

After:

![Screenshot 2019-04-17 at 12 43 37](https://user-images.githubusercontent.com/2992938/56285208-95aba000-610e-11e9-9f45-5424d52ef6f7.png)

Hopefully this will translate to improvements on Travis too! Who knows!