### PR TITLE
Add attemptTap to monad error

### DIFF
--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -9,6 +9,7 @@ abstract class AllSyntaxBinCompat
     with AllSyntaxBinCompat3
     with AllSyntaxBinCompat4
     with AllSyntaxBinCompat5
+    with AllSyntaxBinCompat6
 
 trait AllSyntax
     extends AlternativeSyntax
@@ -90,3 +91,5 @@ trait AllSyntaxBinCompat4
     with BitraverseSyntaxBinCompat0
 
 trait AllSyntaxBinCompat5 extends ParallelBitraverseSyntax
+
+trait AllSyntaxBinCompat6 extends MonadErrorSyntaxBinCompat0

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -34,7 +34,7 @@ package object syntax {
   object ior extends IorSyntax
   object list extends ListSyntax with ListSyntaxBinCompat0
   object monad extends MonadSyntax
-  object monadError extends MonadErrorSyntax
+  object monadError extends MonadErrorSyntax with MonadErrorSyntaxBinCompat0
   object monoid extends MonoidSyntax
   object nested extends NestedSyntax
   object option extends OptionSyntax

--- a/testkit/src/main/scala/cats/tests/CatsSuite.scala
+++ b/testkit/src/main/scala/cats/tests/CatsSuite.scala
@@ -48,6 +48,7 @@ trait CatsSuite
     with AllSyntaxBinCompat3
     with AllSyntaxBinCompat4
     with AllSyntaxBinCompat5
+    with AllSyntaxBinCompat6
     with StrictCatsEquality { self: FunSuiteLike =>
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =


### PR DESCRIPTION
Thanks in advance for your time reviewing this and maintaining cats!

This adds `attemptTap` to `MonadError`. This is similar to `flatTap` but gives you access to the error that `attempt` would give you. 


