### PR TITLE
added a new foldRight lazy law, move forallLazy and existLazy laws

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyChain.scala
+++ b/core/src/main/scala/cats/data/NonEmptyChain.scala
@@ -452,7 +452,7 @@ sealed abstract private[data] class NonEmptyChainInstances extends NonEmptyChain
         fa.foldLeft(b)(f)
 
       override def foldRight[A, B](fa: NonEmptyChain[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
-        fa.foldRight(lb)(f)
+        Foldable[Chain].foldRight(fa.toChain, lb)(f)
 
       override def foldMap[A, B](fa: NonEmptyChain[A])(f: A => B)(implicit B: Monoid[B]): B =
         B.combineAll(fa.toChain.iterator.map(f))

--- a/core/src/main/scala/cats/instances/map.scala
+++ b/core/src/main/scala/cats/instances/map.scala
@@ -84,6 +84,10 @@ trait MapInstances extends cats.kernel.instances.MapInstances {
       override def unorderedFold[A](fa: Map[K, A])(implicit A: CommutativeMonoid[A]): A =
         A.combineAll(fa.values)
 
+      override def forall[A](fa: Map[K, A])(p: A => Boolean): Boolean = fa.forall(pair => p(pair._2))
+
+      override def exists[A](fa: Map[K, A])(p: A => Boolean): Boolean = fa.exists(pair => p(pair._2))
+
     }
   // scalastyle:on method.length
 

--- a/core/src/main/scala/cats/instances/set.scala
+++ b/core/src/main/scala/cats/instances/set.scala
@@ -32,7 +32,11 @@ trait SetInstances extends cats.kernel.instances.SetInstances {
       override def forall[A](fa: Set[A])(p: A => Boolean): Boolean =
         fa.forall(p)
 
+      override def exists[A](fa: Set[A])(p: A => Boolean): Boolean =
+        fa.exists(p)
+
       override def isEmpty[A](fa: Set[A]): Boolean = fa.isEmpty
+
     }
 
   implicit def catsStdShowForSet[A: Show]: Show[Set[A]] = new Show[Set[A]] {

--- a/laws/src/main/scala/cats/laws/FoldableLaws.scala
+++ b/laws/src/main/scala/cats/laws/FoldableLaws.scala
@@ -17,16 +17,15 @@ trait FoldableLaws[F[_]] extends UnorderedFoldableLaws[F] {
       b |+| f(a)
     }
 
-
   def foldRightLazy[A](fa: F[A]): Boolean = {
     var i = 0
     F.foldRight(fa, Eval.now("empty")) { (_, _) =>
-      i += 1
-      Eval.now("not empty")
-    }.value
+        i += 1
+        Eval.now("not empty")
+      }
+      .value
     i == (if (F.isEmpty(fa)) 0 else 1)
   }
-
 
   def rightFoldConsistentWithFoldMap[A, B](
     fa: F[A],
@@ -122,7 +121,6 @@ trait FoldableLaws[F[_]] extends UnorderedFoldableLaws[F] {
   def orderedConsistency[A: Eq](x: F[A], y: F[A])(implicit ev: Eq[F[A]]): IsEq[List[A]] =
     if (x === y) (F.toList(x) <-> F.toList(y))
     else List.empty[A] <-> List.empty[A]
-
 
   def existsLazy[A](fa: F[A]): Boolean = {
     var i = 0

--- a/laws/src/main/scala/cats/laws/FoldableLaws.scala
+++ b/laws/src/main/scala/cats/laws/FoldableLaws.scala
@@ -11,9 +11,9 @@ trait FoldableLaws[F[_]] extends UnorderedFoldableLaws[F] {
   def foldRightLazy[A](fa: F[A]): Boolean = {
     var i = 0
     F.foldRight(fa, Eval.now("empty")) { (_, _) =>
-      i += 1
-      Eval.now("not empty")
-    }
+        i += 1
+        Eval.now("not empty")
+      }
       .value
     i == (if (F.isEmpty(fa)) 0 else 1)
   }

--- a/laws/src/main/scala/cats/laws/FoldableLaws.scala
+++ b/laws/src/main/scala/cats/laws/FoldableLaws.scala
@@ -8,6 +8,16 @@ import scala.collection.mutable
 trait FoldableLaws[F[_]] extends UnorderedFoldableLaws[F] {
   implicit def F: Foldable[F]
 
+  def foldRightLazy[A](fa: F[A]): Boolean = {
+    var i = 0
+    F.foldRight(fa, Eval.now("empty")) { (_, _) =>
+      i += 1
+      Eval.now("not empty")
+    }
+      .value
+    i == (if (F.isEmpty(fa)) 0 else 1)
+  }
+
   def leftFoldConsistentWithFoldMap[A, B](
     fa: F[A],
     f: A => B
@@ -16,16 +26,6 @@ trait FoldableLaws[F[_]] extends UnorderedFoldableLaws[F] {
     fa.foldMap(f) <-> fa.foldLeft(M.empty) { (b, a) =>
       b |+| f(a)
     }
-
-  def foldRightLazy[A](fa: F[A]): Boolean = {
-    var i = 0
-    F.foldRight(fa, Eval.now("empty")) { (_, _) =>
-        i += 1
-        Eval.now("not empty")
-      }
-      .value
-    i == (if (F.isEmpty(fa)) 0 else 1)
-  }
 
   def rightFoldConsistentWithFoldMap[A, B](
     fa: F[A],

--- a/laws/src/main/scala/cats/laws/FoldableLaws.scala
+++ b/laws/src/main/scala/cats/laws/FoldableLaws.scala
@@ -17,6 +17,17 @@ trait FoldableLaws[F[_]] extends UnorderedFoldableLaws[F] {
       b |+| f(a)
     }
 
+
+  def foldRightLazy[A](fa: F[A]): Boolean = {
+    var i = 0
+    F.foldRight(fa, Eval.now("empty")) { (_, _) =>
+      i += 1
+      Eval.now("not empty")
+    }.value
+    i == (if (F.isEmpty(fa)) 0 else 1)
+  }
+
+
   def rightFoldConsistentWithFoldMap[A, B](
     fa: F[A],
     f: A => B
@@ -111,6 +122,26 @@ trait FoldableLaws[F[_]] extends UnorderedFoldableLaws[F] {
   def orderedConsistency[A: Eq](x: F[A], y: F[A])(implicit ev: Eq[F[A]]): IsEq[List[A]] =
     if (x === y) (F.toList(x) <-> F.toList(y))
     else List.empty[A] <-> List.empty[A]
+
+
+  def existsLazy[A](fa: F[A]): Boolean = {
+    var i = 0
+    F.exists(fa) { _ =>
+      i = i + 1
+      true
+    }
+    i == (if (F.isEmpty(fa)) 0 else 1)
+  }
+
+  def forallLazy[A](fa: F[A]): Boolean = {
+    var i = 0
+    F.forall(fa) { _ =>
+      i = i + 1
+      false
+    }
+    i == (if (F.isEmpty(fa)) 0 else 1)
+  }
+
 }
 
 object FoldableLaws {

--- a/laws/src/main/scala/cats/laws/FoldableLaws.scala
+++ b/laws/src/main/scala/cats/laws/FoldableLaws.scala
@@ -121,25 +121,6 @@ trait FoldableLaws[F[_]] extends UnorderedFoldableLaws[F] {
   def orderedConsistency[A: Eq](x: F[A], y: F[A])(implicit ev: Eq[F[A]]): IsEq[List[A]] =
     if (x === y) (F.toList(x) <-> F.toList(y))
     else List.empty[A] <-> List.empty[A]
-
-  def existsLazy[A](fa: F[A]): Boolean = {
-    var i = 0
-    F.exists(fa) { _ =>
-      i += 1
-      true
-    }
-    i == (if (F.isEmpty(fa)) 0 else 1)
-  }
-
-  def forallLazy[A](fa: F[A]): Boolean = {
-    var i = 0
-    F.forall(fa) { _ =>
-      i += 1
-      false
-    }
-    i == (if (F.isEmpty(fa)) 0 else 1)
-  }
-
 }
 
 object FoldableLaws {

--- a/laws/src/main/scala/cats/laws/FoldableLaws.scala
+++ b/laws/src/main/scala/cats/laws/FoldableLaws.scala
@@ -125,7 +125,7 @@ trait FoldableLaws[F[_]] extends UnorderedFoldableLaws[F] {
   def existsLazy[A](fa: F[A]): Boolean = {
     var i = 0
     F.exists(fa) { _ =>
-      i = i + 1
+      i += 1
       true
     }
     i == (if (F.isEmpty(fa)) 0 else 1)
@@ -134,7 +134,7 @@ trait FoldableLaws[F[_]] extends UnorderedFoldableLaws[F] {
   def forallLazy[A](fa: F[A]): Boolean = {
     var i = 0
     F.forall(fa) { _ =>
-      i = i + 1
+      i += 1
       false
     }
     i == (if (F.isEmpty(fa)) 0 else 1)

--- a/laws/src/main/scala/cats/laws/UnorderedFoldableLaws.scala
+++ b/laws/src/main/scala/cats/laws/UnorderedFoldableLaws.scala
@@ -21,6 +21,24 @@ trait UnorderedFoldableLaws[F[_]] {
       (F.isEmpty(fa) || F.exists(fa)(p))
     } else true // can't test much in this case
 
+  def existsLazy[A](fa: F[A]): Boolean = {
+    var i = 0
+    F.exists(fa) { _ =>
+      i += 1
+      true
+    }
+    i == (if (F.isEmpty(fa)) 0 else 1)
+  }
+
+  def forallLazy[A](fa: F[A]): Boolean = {
+    var i = 0
+    F.forall(fa) { _ =>
+      i += 1
+      false
+    }
+    i == (if (F.isEmpty(fa)) 0 else 1)
+  }
+
   /**
    * If `F[A]` is empty, forall must return true.
    */

--- a/laws/src/main/scala/cats/laws/UnorderedFoldableLaws.scala
+++ b/laws/src/main/scala/cats/laws/UnorderedFoldableLaws.scala
@@ -21,24 +21,6 @@ trait UnorderedFoldableLaws[F[_]] {
       (F.isEmpty(fa) || F.exists(fa)(p))
     } else true // can't test much in this case
 
-  def existsLazy[A](fa: F[A]): Boolean = {
-    var i = 0
-    F.exists(fa) { _ =>
-      i = i + 1
-      true
-    }
-    i == (if (F.isEmpty(fa)) 0 else 1)
-  }
-
-  def forallLazy[A](fa: F[A]): Boolean = {
-    var i = 0
-    F.forall(fa) { _ =>
-      i = i + 1
-      false
-    }
-    i == (if (F.isEmpty(fa)) 0 else 1)
-  }
-
   /**
    * If `F[A]` is empty, forall must return true.
    */

--- a/laws/src/main/scala/cats/laws/discipline/FoldableTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FoldableTests.scala
@@ -27,6 +27,7 @@ trait FoldableTests[F[_]] extends UnorderedFoldableTests[F] {
       parent = Some(unorderedFoldable[A, B]),
       "foldLeft consistent with foldMap" -> forAll(laws.leftFoldConsistentWithFoldMap[A, B] _),
       "foldRight consistent with foldMap" -> forAll(laws.rightFoldConsistentWithFoldMap[A, B] _),
+      "foldRight is lazy" -> forAll(laws.foldRightLazy[A] _),
       "ordered constistency" -> forAll(laws.orderedConsistency[A] _),
       "exists consistent with find" -> forAll(laws.existsConsistentWithFind[A] _),
       "exists is lazy" -> forAll(laws.existsLazy[A] _),

--- a/laws/src/main/scala/cats/laws/discipline/FoldableTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FoldableTests.scala
@@ -30,8 +30,6 @@ trait FoldableTests[F[_]] extends UnorderedFoldableTests[F] {
       "foldRight is lazy" -> forAll(laws.foldRightLazy[A] _),
       "ordered constistency" -> forAll(laws.orderedConsistency[A] _),
       "exists consistent with find" -> forAll(laws.existsConsistentWithFind[A] _),
-      "exists is lazy" -> forAll(laws.existsLazy[A] _),
-      "forall is lazy" -> forAll(laws.forallLazy[A] _),
       "foldM identity" -> forAll(laws.foldMIdentity[A, B] _),
       "reduceLeftOption consistent with reduceLeftToOption" ->
         forAll(laws.reduceLeftOptionConsistentWithReduceLeftToOption[A] _),

--- a/laws/src/main/scala/cats/laws/discipline/UnorderedFoldableTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/UnorderedFoldableTests.scala
@@ -25,7 +25,9 @@ trait UnorderedFoldableTests[F[_]] extends Laws {
       "unorderedFold consistent with unorderedFoldMap" -> forAll(laws.unorderedFoldConsistentWithUnorderedFoldMap[A] _),
       "forall consistent with exists" -> forAll(laws.forallConsistentWithExists[A] _),
       "forall true if empty" -> forAll(laws.forallEmpty[A] _),
-      "nonEmpty reference" -> forAll(laws.nonEmptyRef[A] _)
+      "nonEmpty reference" -> forAll(laws.nonEmptyRef[A] _),
+      "exists is lazy" -> forAll(laws.existsLazy[A] _),
+      "forall is lazy" -> forAll(laws.forallLazy[A] _)
     )
 }
 

--- a/tests/src/test/scala/cats/tests/UnorderedFoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/UnorderedFoldableSuite.scala
@@ -4,8 +4,10 @@ package tests
 import org.scalacheck.Arbitrary
 import cats.instances.all._
 import cats.kernel.CommutativeMonoid
+import cats.laws.discipline.UnorderedFoldableTests
 
-sealed abstract class UnorderedFoldableSuite[F[_]](name: String)(implicit ArbFString: Arbitrary[F[String]])
+sealed abstract class UnorderedFoldableSuite[F[_]](name: String)(implicit ArbFString: Arbitrary[F[String]],
+                                                                 ArbFInt: Arbitrary[F[Int]])
     extends CatsSuite {
 
   def iterator[T](fa: F[T]): Iterator[T]
@@ -42,6 +44,7 @@ sealed abstract class UnorderedFoldableSuite[F[_]](name: String)(implicit ArbFSt
       fa.count(Function.const(true)) should ===(fa.size)
     }
   }
+  checkAll("F[Int]", UnorderedFoldableTests[F](instance).unorderedFoldable[Int, Int])
 }
 
 final class UnorderedFoldableSetSuite extends UnorderedFoldableSuite[Set]("set") {


### PR DESCRIPTION
I noticed that `foldRight`'s laziness was tested through `forallLazy` and `existLazy` laws. Since `foldRight` is a type class method I think we should have the laziness law on it. In kittens we were caught by the lack of such a law. 

Also I noticed that although `forallLazy` and `existLazy` are defined in `UnorderedFoldableLaws`, they are actually only used in `FoldableTests`. Moreover, implementations in `UnorderedFoldable` breaks these two laws. So I think they should probably be `FoldableLaws`. 


Update: This actually caught a bug in NonEmptyChain whose `Foldable.foldRight` implementation is simply delegating to the native (scala std lib) `foldRight`.  