### PR TITLE
[WIP] Semaphore CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -5,10 +5,6 @@ agent:
     type: e1-standard-4
     os_image: ubuntu1804
 
-scala_version_211: &scala_version_211 2.11.12
-scala_version_212: &scala_version_212 2.12.8
-scala_version_213: &scala_version_213 2.13.0-RC1
-
 blocks:
   - name: Linting
     task:
@@ -23,6 +19,13 @@ blocks:
 
   - name: Bincompat
     task: 
+      env_vars:
+        - name: scala_version_211
+          value: &scala_version_211 2.11.12
+        - name: scala_version_212
+          value: &scala_version_212 2.12.8
+        - name: scala_version_213
+          value: &scala_version_213 2.13.0-RC1
       jobs:
         - name: Check binary compatibility
           commands:
@@ -33,6 +36,13 @@ blocks:
 
   - name: Tests
     task:
+      env_vars:
+        - name: scala_version_211
+          value: &scala_version_211 2.11.12
+        - name: scala_version_212
+          value: &scala_version_212 2.12.8
+        - name: scala_version_213
+          value: &scala_version_213 2.13.0-RC1
       jobs:
         - name: Coverage check
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -8,6 +8,10 @@ agent:
 blocks:
   - name: Linting
     task:
+      prologue:
+        commands:
+          - checkout
+
       jobs:
         - name: Scalastyle and Scalafmt
           commands:
@@ -26,6 +30,11 @@ blocks:
           value: &scala_version_212 2.12.8
         - name: scala_version_213
           value: &scala_version_213 2.13.0-RC1
+
+      prologue:
+        commands:
+          - checkout
+
       jobs:
         - name: Check binary compatibility
           commands:
@@ -43,6 +52,11 @@ blocks:
           value: &scala_version_212 2.12.8
         - name: scala_version_213
           value: &scala_version_213 2.13.0-RC1
+
+      prologue:
+        commands:
+          - checkout
+
       jobs:
         - name: Coverage check
           commands:

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,60 @@
+version: v1.0
+name: Cats
+agent:
+  machine:
+    type: e1-standard-4
+    os_image: ubuntu1804
+
+scala_version_211: &scala_version_211 2.11.12
+scala_version_212: &scala_version_212 2.12.8
+scala_version_213: &scala_version_213 2.13.0-RC1
+
+blocks:
+  - name: Linting
+    task:
+      jobs:
+        - name: Scalastyle and Scalafmt
+          commands:
+            - sbt scalastyle fmtCheck
+
+        - name: Scalafix
+          commands:
+            - cd scalafix && sbt tests/test
+
+  - name: Bincompat
+    task: 
+      jobs:
+        - name: Check binary compatibility
+          commands:
+            - sbt ++$TRAVIS_SCALA_VERSION! validateBC
+          matrix:
+            - env_var: TRAVIS_SCALA_VERSION
+              values: [*scala_version_211, *scala_version_212]
+
+  - name: Tests
+    task:
+      jobs:
+        - name: Coverage check
+          commands:
+            - sbt coverage buildJVM bench/test coverageReport
+
+        - name: JVM tests
+          commands:
+            - sbt ++$TRAVIS_SCALA_VERSION! buildJVM bench/test
+          matrix:
+            - env_var: TRAVIS_SCALA_VERSION
+              values: [*scala_version_211, *scala_version_212]
+
+        - name: JVM tests 2.13
+          commands:
+            - sbt ++TRAVIS_SCALA_VERSION! buildJVM
+          env_vars:
+            - name: TRAVIS_SCALA_VERSION
+              value: *scala_version_213
+
+        - name: JS tests
+          commands:
+            - sbt ++$TRAVIS_SCALA_VERSION! validateJS && sbt ++$TRAVIS_SCALA_VERSION! validateKernelJS && sbt ++$TRAVIS_SCALA_VERSION! validateFreeJS
+          matrix:
+            - env_var: TRAVIS_SCALA_VERSION
+              values: [*scala_version_211, *scala_version_212]

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -8,21 +8,6 @@ agent:
 blocks:
   - name: Linting
     task:
-      prologue:
-        commands:
-          - checkout
-
-      jobs:
-        - name: Scalastyle and Scalafmt
-          commands:
-            - sbt scalastyle fmtCheck
-
-        - name: Scalafix
-          commands:
-            - cd scalafix && sbt tests/test
-
-  - name: Bincompat
-    task: 
       env_vars:
         - name: scala_version_211
           value: &scala_version_211 2.11.12
@@ -36,6 +21,14 @@ blocks:
           - checkout
 
       jobs:
+        - name: Scalastyle and Scalafmt
+          commands:
+            - sbt scalastyle fmtCheck
+
+        - name: Scalafix
+          commands:
+            - cd scalafix && sbt tests/test
+
         - name: Check binary compatibility
           commands:
             - sbt ++$TRAVIS_SCALA_VERSION! validateBC

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -46,6 +46,8 @@ blocks:
   - name: Tests
     task:
       env_vars:
+        - name: TRAVIS
+          value: "true"
         - name: scala_version_211
           value: &scala_version_211 2.11.12
         - name: scala_version_212
@@ -71,7 +73,7 @@ blocks:
 
         - name: JVM tests 2.13
           commands:
-            - sbt ++TRAVIS_SCALA_VERSION! buildJVM
+            - sbt ++$TRAVIS_SCALA_VERSION! buildJVM
           env_vars:
             - name: TRAVIS_SCALA_VERSION
               value: *scala_version_213


### PR DESCRIPTION
This PR is one possible option to fix #2319. It adds configuration for [Semaphore CI](https://semaphoreci.com). This looks like a good option but it's no so clear how or when they plan to support open source, which is strange because I believe Semaphore version 1 did so. The free plan is limited to $20 of build minutes per month at $0.00050/sec, which is ridiculously low.

If you guys think it's worth it I will contact them to try and clarify their policy on open source.

Compared with Travis it is very fast (about 15-16 min per build).

The configuration is well documented [here](https://docs.semaphoreci.com/article/50-pipeline-yaml) and it was reasonably straightforward to set up.

The execution model is easy to understand; each block runs sequentially and jobs within a block run in parallel.

There is also a matrix feature which can be used to declare a build matrix using multiple environment variables if needed.

The only niggle I would mention is that it is not possible to add unspecified keys at the top level to use to hold the scala versions so I had to use `env_vars` blocks for that purpose.

From what I have seen in evaluating different services the flakiest test step which often struggles to run within memory limits is the Applicative.monoid.combineAll test, which frequently hits the GC overhead limit. I will raise that as a separate issue.

![Screenshot 2019-04-30 at 16 55 41](https://user-images.githubusercontent.com/2992938/56975581-028c5480-6b69-11e9-8de5-763c932b6dd1.png)
