### PR TITLE
[WIP] Buildkite CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,0 +1,53 @@
+env:
+  TRAVIS: "true"
+  
+scala_version_211: &scala_version_211 2.11.12
+scala_version_212: &scala_version_212 2.12.8
+scala_version_213: &scala_version_213 2.13.0-RC1
+
+steps:
+  - command: "sbt scalastyle fmtCheck"
+    label: ":scala: Linting"
+
+  - command: "cd scalafix && sbt tests/test"
+    label: ":scala: Scalafix"
+
+  - command: "sbt ++\\$TRAVIS_SCALA_VERSION! validateBC"
+    label: ":scala: Bincompat 2.11"
+    env:
+      TRAVIS_SCALA_VERSION: *scala_version_211
+
+  - command: "sbt ++\\$TRAVIS_SCALA_VERSION! validateBC"
+    label: ":scala: Bincompat 2.12"
+    env:
+      TRAVIS_SCALA_VERSION: *scala_version_212
+
+  - wait
+
+  - command: "sbt coverage buildJVM bench/test coverageReport"
+    label: ":codecov: Coverage"
+
+  - command: "sbt ++\\$TRAVIS_SCALA_VERSION! buildJVM bench/test"
+    label: ":java: JVM Tests 2.11"
+    env:
+      TRAVIS_SCALA_VERSION: *scala_version_211
+
+  - command: "sbt ++\\$TRAVIS_SCALA_VERSION! buildJVM bench/test"
+    label: ":java: JVM Tests 2.12"
+    env:
+      TRAVIS_SCALA_VERSION: *scala_version_212
+
+  - command: "sbt ++\\$TRAVIS_SCALA_VERSION! buildJVM"
+    label: ":java: JVM Tests 2.13"
+    env:
+      TRAVIS_SCALA_VERSION: *scala_version_213
+
+  - command: "sbt ++\\$TRAVIS_SCALA_VERSION! validateJS && sbt ++\\$TRAVIS_SCALA_VERSION! validateKernelJS && sbt ++\\$TRAVIS_SCALA_VERSION! validateFreeJS"
+    label: ":javascript: JavaScript Tests 2.11"
+    env:
+      TRAVIS_SCALA_VERSION: *scala_version_211
+
+  - command: "sbt ++\\$TRAVIS_SCALA_VERSION! validateJS && sbt ++\\$TRAVIS_SCALA_VERSION! validateKernelJS && sbt ++\\$TRAVIS_SCALA_VERSION! validateFreeJS"
+    label: ":javascript: JavaScript Tests 2.12"
+    env:
+      TRAVIS_SCALA_VERSION: *scala_version_212


### PR DESCRIPTION
This PR is one possible option to fix #2319. It adds configuration for [Buildkite CI](https://drone.io), which is free for open source.

Buildkite is a hosted service but it provides only the coordination of builds, not the hardware. You need to install the Buildkite agent on your own hardware in order to run builds.

In order to test this I used a server I provisioned on [Packet](https://packet.com), which was really easy to set up. It's possible to use [cloud-init](https://cloudinit.readthedocs.io/en/latest/) to preconfigure your server so that it's ready to go immediately once it's provisioned. The configuration that I used can be viewed [here](https://gist.github.com/DavidGregory084/b3166d113ab81d13e49cbc296aadfffa). 

Packet do have an [open source policy](https://www.packet.com/developers/open-source/) so it's possible that they would donate build machines if we contact them.

Compared with Travis it is faster but once all of the cross builds were added, with the hardware that I used it's much slower to run a whole build than Drone or Semaphore (about 25-26min). This may just be due to the hardware that I used (4 cores @ 3.5GHz with 32GB RAM).

The configuration is well documented [here](https://buildkite.com/docs/pipelines) and it was straightforward to set up. There is also a visual editor for config on the web interface.

Like Drone there is no build matrix option, so there is a bit of annoying repetition in the config and I plan to tidy this up a bit with YAML anchors.

Our old friend ApplicativeTest.monoid.combineAll makes an appearance here too:

![image](https://user-images.githubusercontent.com/2992938/56931226-35860800-6ad7-11e9-8ba7-b86a715ab0c7.png)
