### PR TITLE
In  Apply.semigroup test replace ` ListWrapper` with `Option`

### DIFF
--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -216,6 +216,13 @@ trait Apply[F[_]] extends Functor[F] with InvariantSemigroupal[F] with ApplyArit
 }
 
 object Apply {
+
+  /**
+   * This semigroup uses a product operation to combine `F`s,
+   * if the `Apply[F].product` result in larger `F` e.g. when `F` is a `List`,
+   * accumulative usage of this instance, such as `combineAll`, will result in
+   * `F`s with exponentially increasing sizes.
+   */
   def semigroup[F[_], A](implicit f: Apply[F], sg: Semigroup[A]): Semigroup[F[A]] =
     new ApplySemigroup[F, A](f, sg)
 }

--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -218,8 +218,8 @@ trait Apply[F[_]] extends Functor[F] with InvariantSemigroupal[F] with ApplyArit
 object Apply {
 
   /**
-   * This semigroup uses a product operation to combine `F`s,
-   * if the `Apply[F].product` result in larger `F` e.g. when `F` is a `List`,
+   * This semigroup uses a product operation to combine `F`s.
+   * If the `Apply[F].product` results in larger `F` (i.e. when `F` is a `List`),
    * accumulative usage of this instance, such as `combineAll`, will result in
    * `F`s with exponentially increasing sizes.
    */

--- a/tests/src/test/scala/cats/tests/ApplicativeSuite.scala
+++ b/tests/src/test/scala/cats/tests/ApplicativeSuite.scala
@@ -49,7 +49,7 @@ class ApplicativeSuite extends CatsSuite {
     val optionSemigroupFromApply = Apply.semigroup[Option, Int]
     checkAll("Apply[Option].semigroup", SemigroupTests[Option[Int]](optionSemigroupFromApply).semigroup)
   }
-  
+
   {
     implicit val listwrapperApplicative = ListWrapper.applicative
     implicit val listwrapperCoflatMap = Applicative.coflatMap[ListWrapper]

--- a/tests/src/test/scala/cats/tests/ApplicativeSuite.scala
+++ b/tests/src/test/scala/cats/tests/ApplicativeSuite.scala
@@ -46,10 +46,10 @@ class ApplicativeSuite extends CatsSuite {
   }
 
   {
-    implicit val listwrapperApply = ListWrapper.applyInstance
-    implicit val listwrapperSemigroup = Apply.semigroup[ListWrapper, Int]
-    checkAll("Apply[ListWrapper].semigroup", SemigroupTests[ListWrapper[Int]].semigroup)
+    val optionSemigroupFromApply = Apply.semigroup[Option, Int]
+    checkAll("Apply[Option].semigroup", SemigroupTests[Option[Int]](optionSemigroupFromApply).semigroup)
   }
+  
   {
     implicit val listwrapperApplicative = ListWrapper.applicative
     implicit val listwrapperCoflatMap = Applicative.coflatMap[ListWrapper]


### PR DESCRIPTION

This is to address the root cause of #2648 and #2319, the target method of this test is the combine method provided by `Apply.semigroup`
https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/Apply.scala#L223-L225
```
def combine(a: F[A], b: F[A]): F[A] =
    f.map2(a, b)(sg.combine)
```
In the case of `F` being a list,  since this is a product operation between the two lists, the result is a list of the size `a.size * b.size`
When this `combine` is used in the `combineAllOption` test, which combine all items in a `Vector[ListWrapper[Int]]`, it exponentially increase the size of the accumulative result list. That leads to a list of millions of items and over limit GC pressure that breaks the build.


I switch it to using `Option` instead. 

