### PR TITLE
Fix Order.max and Oder.min description comments

### DIFF
--- a/kernel/src/main/scala/cats/kernel/Order.scala
+++ b/kernel/src/main/scala/cats/kernel/Order.scala
@@ -38,12 +38,12 @@ trait Order[@sp A] extends Any with PartialOrder[A] { self =>
   def partialCompare(x: A, y: A): Double = compare(x, y).toDouble
 
   /**
-   * If x <= y, return x, else return y.
+   * If x < y, return x, else return y.
    */
   def min(x: A, y: A): A = if (lt(x, y)) x else y
 
   /**
-   * If x >= y, return x, else return y.
+   * If x > y, return x, else return y.
    */
   def max(x: A, y: A): A = if (gt(x, y)) x else y
 


### PR DESCRIPTION
Changed description to better fit their implementation:

* `max` is using `gt` which is: `>` and not `>=`
*  `min` is using `lt` which is: `<` and not `<=`

