### PR TITLE
Kleisli contravariant on input type A

### DIFF
--- a/tests/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/KleisliSuite.scala
@@ -278,6 +278,20 @@ class KleisliSuite extends CatsSuite {
     result.run(()).value
   }
 
+  test("auto contravariant") {
+    trait A1
+    trait A2
+    trait A3
+    object A123 extends A1 with A2 with A3
+
+    val program = for {
+      k1 <- Kleisli((a: A1) => List(1))
+      k2 <- Kleisli((a: A2) => List("2"))
+      k3 <- Kleisli((a: A3) => List(true))
+    } yield (k1, k2, k3)
+
+    program.run(A123) shouldBe (List((1, "2", true)))
+  }
   /**
    * Testing that implicit resolution works. If it compiles, the "test" passes.
    */

--- a/tests/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/KleisliSuite.scala
@@ -282,6 +282,7 @@ class KleisliSuite extends CatsSuite {
     trait A1
     trait A2
     trait A3
+
     object A123 extends A1 with A2 with A3
 
     val program = for {
@@ -292,6 +293,7 @@ class KleisliSuite extends CatsSuite {
 
     program.run(A123) shouldBe (List((1, "2", true)))
   }
+
   /**
    * Testing that implicit resolution works. If it compiles, the "test" passes.
    */


### PR DESCRIPTION
Rationale: #2749
also as described in the test, it's more composable
```scala
    val program = for {
      k1 <- Kleisli((a: A1) => List(1))
      k2 <- Kleisli((a: A2) => List("2"))
      k3 <- Kleisli((a: A3) => List(true))
    } yield (k1, k2, k3)
```
scala can infer type to be `Kleisli[List, A1 with A2 with A3, (Int, String, Boolean)]`
if not using scala subtyping it would looks like
```scala
    val program = for {
      k1 <- Kleisli((a: A1) => List(1)).local(identity[A1 with A2 with A3])
      k2 <- Kleisli((a: A2) => List("2")).local(identity[A1 with A2 with A3])
      k3 <- Kleisli((a: A3) => List(true)).local(identity[A1 with A2 with A3])
    } yield (k1, k2, k3)
```