### PR TITLE
Use Arrow-like parameter syntax for Arrow type-classes

### DIFF
--- a/core/src/main/scala/cats/arrow/Arrow.scala
+++ b/core/src/main/scala/cats/arrow/Arrow.scala
@@ -6,7 +6,7 @@ import simulacrum.typeclass
 /**
  * Must obey the laws defined in cats.laws.ArrowLaws.
  */
-@typeclass trait Arrow[F[_, _]] extends Category[F] with Strong[F] { self =>
+@typeclass trait Arrow[ |==>[_, _]] extends Category[|==>] with Strong[|==>] { self =>
 
   /**
    *  Lift a function into the context of an Arrow.
@@ -14,15 +14,15 @@ import simulacrum.typeclass
    * In the reference articles "Arrows are Promiscuous...", and in the corresponding Haskell
    * library `Control.Arrow`, this function is called `arr`.
    */
-  def lift[A, B](f: A => B): F[A, B]
+  def lift[A, B](f: A => B): A |==> B
 
-  override def id[A]: F[A, A] = lift(identity)
+  override def id[A]: A |==> A = lift(identity)
 
-  override def dimap[A, B, C, D](fab: F[A, B])(f: C => A)(g: B => D): F[C, D] =
+  override def dimap[A, B, C, D](fab: A |==> B)(f: C => A)(g: B => D): C |==> D =
     compose(lift(g), andThen(lift(f), fab))
 
-  override def second[A, B, C](fa: F[A, B]): F[(C, A), (C, B)] = {
-    def swap[X, Y]: F[(X, Y), (Y, X)] = lift[(X, Y), (Y, X)] { case (x, y) => (y, x) }
+  override def second[A, B, C](fa: A |==> B): (C, A) |==> (C, B) = {
+    def swap[X, Y]: (X, Y) |==> (Y, X) = lift[(X, Y), (Y, X)] { case (x, y) => (y, x) }
 
     compose(swap, compose(first[A, B, C](fa), swap))
   }
@@ -46,7 +46,7 @@ import simulacrum.typeclass
    * `f` and `g` in the context of F. This means that `f *** g` may not be equivalent to `g *** f`.
    */
   @simulacrum.op("***", alias = true)
-  def split[A, B, C, D](f: F[A, B], g: F[C, D]): F[(A, C), (B, D)] =
+  def split[A, B, C, D](f: A |==> B, g: C |==> D): (A, C) |==> (B, D) =
     andThen(first(f), second(g))
 
   /**
@@ -61,11 +61,12 @@ import simulacrum.typeclass
    * scala> f(1)
    * res0: (Int, Double) = (1,1.0)
    * }}}
-   *
+  
+ *
    * Note that the arrow laws do not guarantee the non-interference between the _effects_ of
    *  `f` and `g` in the context of F. This means that `f &&& g` may not be equivalent to `g &&& f`.
    */
   @simulacrum.op("&&&", alias = true)
-  def merge[A, B, C](f: F[A, B], g: F[A, C]): F[A, (B, C)] =
+  def merge[A, B, C](f: A |==> B, g: A |==> C): A |==> (B, C) =
     andThen(lift((x: A) => (x, x)), split(f, g))
 }

--- a/core/src/main/scala/cats/arrow/Choice.scala
+++ b/core/src/main/scala/cats/arrow/Choice.scala
@@ -3,7 +3,7 @@ package arrow
 
 import simulacrum.typeclass
 
-@typeclass trait Choice[F[_, _]] extends Category[F] {
+@typeclass trait Choice[|==>[_, _]] extends Category[|==>] {
 
   /**
    * Given two `F`s (`f` and `g`) with a common target type, create a new `F`
@@ -25,7 +25,7 @@ import simulacrum.typeclass
    * }}}
    */
   @simulacrum.op("|||", alias = true)
-  def choice[A, B, C](f: F[A, C], g: F[B, C]): F[Either[A, B], C]
+  def choice[A, B, C](f: A |==> C, g: B |==> C): Either[A, B] |==> C
 
   /**
    * An `F` that, given a source `A` on either the right or left side, will
@@ -43,5 +43,5 @@ import simulacrum.typeclass
    * res1: Int = 3
    * }}}
    */
-  def codiagonal[A]: F[Either[A, A], A] = choice(id, id)
+  def codiagonal[A]: Either[A, A] |==> A = choice(id, id)
 }

--- a/core/src/main/scala/cats/arrow/Compose.scala
+++ b/core/src/main/scala/cats/arrow/Compose.scala
@@ -18,22 +18,22 @@ import simulacrum.typeclass
  * res1: Int = 301
  * }}}
  */
-@typeclass trait Compose[F[_, _]] { self =>
+@typeclass trait Compose[ |==>[_, _]] { self =>
 
   @simulacrum.op("<<<", alias = true)
-  def compose[A, B, C](f: F[B, C], g: F[A, B]): F[A, C]
+  def compose[A, B, C](f: B |==> C, g: A |==> B): A |==> C
 
   @simulacrum.op(">>>", alias = true)
-  def andThen[A, B, C](f: F[A, B], g: F[B, C]): F[A, C] =
+  def andThen[A, B, C](f: A |==> B, g: B |==> C): A |==> C =
     compose(g, f)
 
-  def algebraK: SemigroupK[λ[α => F[α, α]]] =
-    new SemigroupK[λ[α => F[α, α]]] {
-      def combineK[A](f1: F[A, A], f2: F[A, A]): F[A, A] = self.compose(f1, f2)
+  def algebraK: SemigroupK[λ[α => α |==> α]] =
+    new SemigroupK[λ[α => α |==> α]] {
+      def combineK[A](f1: A |==> A, f2: A |==> A): A |==> A = self.compose(f1, f2)
     }
 
-  def algebra[A]: Semigroup[F[A, A]] =
-    new Semigroup[F[A, A]] {
-      def combine(f1: F[A, A], f2: F[A, A]): F[A, A] = self.compose(f1, f2)
+  def algebra[A]: Semigroup[A |==> A] =
+    new Semigroup[A |==> A] {
+      def combine(f1: A |==> A, f2: A |==> A): A |==> A = self.compose(f1, f2)
     }
 }

--- a/core/src/main/scala/cats/arrow/Strong.scala
+++ b/core/src/main/scala/cats/arrow/Strong.scala
@@ -6,7 +6,7 @@ import simulacrum.typeclass
 /**
  * Must obey the laws defined in cats.laws.StrongLaws.
  */
-@typeclass trait Strong[F[_, _]] extends Profunctor[F] {
+@typeclass trait Strong[|==>[_, _]] extends Profunctor[|==>] {
 
   /**
    * Create a new `F` that takes two inputs, but only modifies the first input
@@ -21,7 +21,7 @@ import simulacrum.typeclass
    * res0: (Int, Int) = (4,3)
    * }}}
    */
-  def first[A, B, C](fa: F[A, B]): F[(A, C), (B, C)]
+  def first[A, B, C](fa: A |==> B): (A, C) |==> (B, C)
 
   /**
    * Create a new `F` that takes two inputs, but only modifies the second input
@@ -36,5 +36,5 @@ import simulacrum.typeclass
    * res0: (Int, Int) = (2,6)
    * }}}
    */
-  def second[A, B, C](fa: F[A, B]): F[(C, A), (C, B)]
+  def second[A, B, C](fa: A |==> B): (C, A) |==> (C, B)
 }


### PR DESCRIPTION
This is a syntactic sugaring of the type-class definitions in the `cats.arrow` package. The idea is that, instead of using the `F` symbol, and since Scala has a flexible syntax when it comes to identifiers, let us use a parametric arrow-like symbol. 

Using an arrow-like symbol helps reinforce the idea that an arrow is like a `Function` (or `=>`( with some effects attached. Also, using the arrow symbol makes it easier to put it in infix type notation, which is handy when it comes to operations involving tuples or `Either`. 