### PR TITLE
reduce constraint of foldMapM from Monad to Applicative

### DIFF
--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -302,7 +302,7 @@ import Foldable.sentinel
    * res1: Option[Int] = None
    * }}}
    */
-  def foldMapM[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: Monad[G], B: Monoid[B]): G[B] =
+  def foldMapM[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: Applicative[G], B: Monoid[B]): G[B] =
     foldLeft(fa, G.pure(B.empty))((acc, a) => G.map2(acc, f(a))(B.combine))
 
   /**

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -303,7 +303,7 @@ import Foldable.sentinel
    * }}}
    */
   def foldMapM[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: Monad[G], B: Monoid[B]): G[B] =
-    foldM(fa, B.empty)((b, a) => G.map(f(a))(B.combine(b, _)))
+    foldLeft(fa, G.pure(B.empty))((acc, a) => G.map2(acc, f(a))(B.combine))
 
   /**
    * Traverse `F[A]` using `Applicative[G]`.


### PR DESCRIPTION
fix #2852

I am not sure if it is binary compatible since Applicative extends Monad and it is in a Contravariant position.