### PR TITLE
Don't create the hydra.license if $HydraLicense is empty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,9 @@ scala_version_213: &scala_version_213 2.13.0-RC1
 
 before_install:
  - export PATH=${PATH}:./vendor/bundle
- - mkdir -p  /home/travis/.triplequote/metrics/config && echo "$HydraLicense" > "/home/travis/.triplequote/hydra.license" && cp hydra-metrics-service.conf /home/travis/.triplequote/metrics/config/metrics-service.conf
+ - if [[ ! -z "$HydraLicense" ]]; then
+     mkdir -p  /home/travis/.triplequote/metrics/config && echo "$HydraLicense" > "/home/travis/.triplequote/hydra.license" && cp hydra-metrics-service.conf /home/travis/.triplequote/metrics/config/metrics-service.conf;
+   fi  
 
 stages:
   - name: styling


### PR DESCRIPTION
The sbt-hydra checks if a hydra.license file exists to decide whether it should enable
itself. Therefore, if the $HydraLicense is empty, it's important not to
create the hydra.license file.

The reason why the $HydraLicense can be empty is because its content is a
secret, hence it is available only to PRs created from within the repository.
Otherwise, the secret would be easily leaked.

This commit is a followup fix for 8069e09

---

I'm afraid the PR #2857 needs to include this fix to be validated. Sorry!

Please, don't hesitate to pull me and @dragos in if you hit any hurdle with Hydra.
