### PR TITLE
Backports for a cats-1.6.x patch

### DIFF
--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -72,7 +72,7 @@ trait Apply[F[_]] extends Functor[F] with InvariantSemigroupal[F] with ApplyArit
    *
    */
   def productR[A, B](fa: F[A])(fb: F[B]): F[B] =
-    map2(fa, fb)((_, b) => b)
+    ap(map(fa)(_ => (b: B) => b))(fb)
 
   /**
    * Compose two actions, discarding any value produced by the second.

--- a/core/src/main/scala/cats/syntax/monadError.scala
+++ b/core/src/main/scala/cats/syntax/monadError.scala
@@ -24,7 +24,7 @@ final class MonadErrorOps[F[_], E, A](private val fa: F[A]) extends AnyVal {
    */
   def reject(pf: PartialFunction[A, E])(implicit F: MonadError[F, E]): F[A] =
     F.flatMap(fa) { a =>
-      pf.andThen(F.raiseError[A]).applyOrElse(a, (_: A) => fa)
+      pf.andThen(F.raiseError[A] _).applyOrElse(a, F.pure)
     }
 
   def adaptError(pf: PartialFunction[E, E])(implicit F: MonadError[F, E]): F[A] =

--- a/kernel/src/main/scala-2.12-/cats/kernel/compat/WrappedMutableMapBase.scala
+++ b/kernel/src/main/scala-2.12-/cats/kernel/compat/WrappedMutableMapBase.scala
@@ -3,7 +3,7 @@ package compat
 
 import scala.collection.mutable
 
-abstract private[kernel] class WrappedMutableMapBase[K, V](m: mutable.Map[K, V]) extends Map[K, V] {
+abstract private[kernel] class WrappedMutableMapBase[K, V](m: mutable.Map[K, V]) extends Map[K, V] with Serializable {
   def +[V2 >: V](kv: (K, V2)): Map[K, V2] = m.toMap + kv
   def -(key: K): Map[K, V] = m.toMap - key
 }

--- a/kernel/src/main/scala-2.13+/cats/kernel/compat/WrappedMutableMapBase.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/compat/WrappedMutableMapBase.scala
@@ -3,7 +3,7 @@ package compat
 
 import scala.collection.mutable
 
-abstract private[kernel] class WrappedMutableMapBase[K, V](m: mutable.Map[K, V]) extends Map[K, V] {
+abstract private[kernel] class WrappedMutableMapBase[K, V](m: mutable.Map[K, V]) extends Map[K, V] with Serializable {
   def updated[V2 >: V](key: K, value: V2): Map[K, V2] = m.toMap + ((key, value))
   def remove(key: K): Map[K, V] = m.toMap - key
 }

--- a/kernel/src/main/scala/cats/kernel/Order.scala
+++ b/kernel/src/main/scala/cats/kernel/Order.scala
@@ -38,12 +38,12 @@ trait Order[@sp A] extends Any with PartialOrder[A] { self =>
   def partialCompare(x: A, y: A): Double = compare(x, y).toDouble
 
   /**
-   * If x <= y, return x, else return y.
+   * If x < y, return x, else return y.
    */
   def min(x: A, y: A): A = if (lt(x, y)) x else y
 
   /**
-   * If x >= y, return x, else return y.
+   * If x > y, return x, else return y.
    */
   def max(x: A, y: A): A = if (gt(x, y)) x else y
 

--- a/tests/src/test/scala/cats/tests/MapSuite.scala
+++ b/tests/src/test/scala/cats/tests/MapSuite.scala
@@ -11,6 +11,7 @@ import cats.laws.discipline.{
 }
 import cats.laws.discipline.arbitrary._
 import cats.arrow.Compose
+import cats.kernel.instances.StaticMethods.wrapMutableMap
 
 class MapSuite extends CatsSuite {
   implicit val iso = SemigroupalTests.Isomorphisms.invariant[Map[Int, ?]]
@@ -37,5 +38,10 @@ class MapSuite extends CatsSuite {
       map.show.startsWith("Map(") should ===(true)
       map.show should ===(implicitly[Show[Map[Int, String]]].show(map))
     }
+  }
+
+  {
+    val m = wrapMutableMap(scala.collection.mutable.Map(1 -> "one", 2 -> "two"))
+    checkAll("WrappedMutableMap", SerializableTests.serializable(m))
   }
 }

--- a/tests/src/test/scala/cats/tests/RegressionSuite.scala
+++ b/tests/src/test/scala/cats/tests/RegressionSuite.scala
@@ -1,7 +1,7 @@
 package cats
 package tests
 
-import cats.data.{Const, NonEmptyList}
+import cats.data.{Const, NonEmptyList, StateT}
 import scala.collection.mutable
 import scala.collection.immutable.SortedMap
 class RegressionSuite extends CatsSuite {
@@ -157,4 +157,8 @@ class RegressionSuite extends CatsSuite {
 
   }
 
+  test("#2809 MonadErrorOps.reject runs effects only once") {
+    val program = StateT.modify[Either[Throwable, ?], Int](_ + 1).reject { case _ if false => new Throwable }
+    program.runS(0).right.get should ===(1)
+  }
 }


### PR DESCRIPTION
Some of the features in v2.0.0-M1 and v2.0.0-M2 are suitable for backporting:

For v1.6.x:
* #2810
* #2842
* #2784
* #2728
* #2837 (arguably?)

Alternatively or additionally, we could do a 1.7.x, and get several more while we await 2.0.0:
* #2780 
* #2775 
* #2760 
* #2759 
* #2750 
* #2747 
* #2744 
* #2726 
* #2724 
* #2709 
* #2698 
* #2696 
* #2796 
* #2840 
* #2837, if it's not already on a 1.6.1