### PR TITLE
add attemptNarrow to ApplicativeErrorOps

### DIFF
--- a/core/src/main/scala/cats/ApplicativeError.scala
+++ b/core/src/main/scala/cats/ApplicativeError.scala
@@ -1,6 +1,8 @@
 package cats
 
 import cats.data.EitherT
+
+import scala.reflect.ClassTag
 import scala.util.{Failure, Success, Try}
 import scala.util.control.NonFatal
 
@@ -72,6 +74,12 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
    * convenience.
    */
   def attemptT[A](fa: F[A]): EitherT[F, E, A] = EitherT(attempt(fa))
+
+  /**
+   * Similar to [[attempt]], but it only handles errors of type `EE`.
+   */
+  def attemptNarrow[EE, A](fa: F[A])(implicit tag: ClassTag[EE], ev: EE <:< E): F[Either[EE, A]] =
+    recover(map(fa)(Right[EE, A](_): Either[EE, A])) { case e: EE => Left[EE, A](e) }
 
   /**
    * Recover from certain errors by mapping them to an `A` value.

--- a/core/src/main/scala/cats/syntax/applicativeError.scala
+++ b/core/src/main/scala/cats/syntax/applicativeError.scala
@@ -86,7 +86,7 @@ final class ApplicativeErrorOps[F[_], E, A](private val fa: F[A]) extends AnyVal
     F.attempt(fa)
 
   def attemptNarrow[EE](implicit F: ApplicativeError[F, E], tag: ClassTag[EE], ev: EE <:< E): F[Either[EE, A]] =
-    F.recover(F.map(fa)(Right[EE, A](_): Either[EE, A])) { case e: EE => Left[EE, A](e) }
+    F.attemptNarrow[EE, A](fa)
 
   def attemptT(implicit F: ApplicativeError[F, E]): EitherT[F, E, A] =
     F.attemptT(fa)

--- a/core/src/main/scala/cats/syntax/applicativeError.scala
+++ b/core/src/main/scala/cats/syntax/applicativeError.scala
@@ -85,7 +85,7 @@ final class ApplicativeErrorOps[F[_], E, A](private val fa: F[A]) extends AnyVal
   def attempt(implicit F: ApplicativeError[F, E]): F[Either[E, A]] =
     F.attempt(fa)
 
-  def attemptCase[EE](implicit F: ApplicativeError[F, E], tag: ClassTag[EE], ev: EE <:< E): F[Either[EE, A]] =
+  def attemptNarrow[EE](implicit F: ApplicativeError[F, E], tag: ClassTag[EE], ev: EE <:< E): F[Either[EE, A]] =
     F.recover(F.map(fa)(Right[EE, A](_): Either[EE, A])) { case e: EE => Left[EE, A](e) }
 
   def attemptT(implicit F: ApplicativeError[F, E]): EitherT[F, E, A] =

--- a/core/src/main/scala/cats/syntax/applicativeError.scala
+++ b/core/src/main/scala/cats/syntax/applicativeError.scala
@@ -4,6 +4,8 @@ package syntax
 import cats.data.Validated.{Invalid, Valid}
 import cats.data.{EitherT, Validated}
 
+import scala.reflect.ClassTag
+
 trait ApplicativeErrorSyntax {
   implicit final def catsSyntaxApplicativeErrorId[E](e: E): ApplicativeErrorIdOps[E] =
     new ApplicativeErrorIdOps(e)
@@ -82,6 +84,9 @@ final class ApplicativeErrorOps[F[_], E, A](private val fa: F[A]) extends AnyVal
 
   def attempt(implicit F: ApplicativeError[F, E]): F[Either[E, A]] =
     F.attempt(fa)
+
+  def attemptCase[EE](implicit F: ApplicativeError[F, E], tag: ClassTag[EE], ev: EE <:< E): F[Either[EE, A]] =
+    F.recover(F.map(fa)(Right[EE, A](_): Either[EE, A])) { case e: EE => Left[EE, A](e) }
 
   def attemptT(implicit F: ApplicativeError[F, E]): EitherT[F, E, A] =
     F.attemptT(fa)

--- a/tests/src/test/scala/cats/tests/ApplicativeErrorSuite.scala
+++ b/tests/src/test/scala/cats/tests/ApplicativeErrorSuite.scala
@@ -23,6 +23,21 @@ class ApplicativeErrorSuite extends CatsSuite {
     failed.attempt should ===(Option(Left(())))
   }
 
+  test("attemptCase[EE] syntax creates an F[Either[EE, A]]") {
+    trait Err
+    case class ErrA() extends Err
+    case class ErrB() extends Err
+
+    implicit val eqForErr: Eq[Err] = Eq.fromUniversalEquals[Err]
+    implicit val eqForErrA: Eq[ErrA] = Eq.fromUniversalEquals[ErrA]
+    implicit val eqForErrB: Eq[ErrB] = Eq.fromUniversalEquals[ErrB]
+
+    val failed: Either[Err, Int] = ErrA().raiseError[Either[Err, ?], Int]
+
+    failed.attemptCase[ErrA] should ===(ErrA().asLeft[Int].asRight[Err])
+    failed.attemptCase[ErrB] should ===(Either.left[Err, Either[ErrB, Int]](ErrA()))
+  }
+
   test("attemptT syntax creates an EitherT") {
     failed.attemptT should ===(EitherT[Option, Unit, Int](Option(Left(()))))
   }

--- a/tests/src/test/scala/cats/tests/ApplicativeErrorSuite.scala
+++ b/tests/src/test/scala/cats/tests/ApplicativeErrorSuite.scala
@@ -23,7 +23,7 @@ class ApplicativeErrorSuite extends CatsSuite {
     failed.attempt should ===(Option(Left(())))
   }
 
-  test("attemptCase[EE] syntax creates an F[Either[EE, A]]") {
+  test("attemptNarrow[EE] syntax creates an F[Either[EE, A]]") {
     trait Err
     case class ErrA() extends Err
     case class ErrB() extends Err
@@ -34,8 +34,8 @@ class ApplicativeErrorSuite extends CatsSuite {
 
     val failed: Either[Err, Int] = ErrA().raiseError[Either[Err, ?], Int]
 
-    failed.attemptCase[ErrA] should ===(ErrA().asLeft[Int].asRight[Err])
-    failed.attemptCase[ErrB] should ===(Either.left[Err, Either[ErrB, Int]](ErrA()))
+    failed.attemptNarrow[ErrA] should ===(ErrA().asLeft[Int].asRight[Err])
+    failed.attemptNarrow[ErrB] should ===(Either.left[Err, Either[ErrB, Int]](ErrA()))
   }
 
   test("attemptT syntax creates an EitherT") {


### PR DESCRIPTION
Hello, I already copy-pasted this function in a few places in my codebases, so I thought it could be useful to have it in cats.

Example use case (assuming `F : ApplicativeError[F, Throwable]`):
```scala
def authenticate(r: Request[F]): F[Unit] = ???

val authentication: Kleisli[F, Request[F], Either[AuthenticationException, Unit]] =
  Kleisli { request => authenticate(request).attemptCase[AuthenticationException] }
```