### PR TITLE
Remove sbt-hydra for now

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -19,9 +19,11 @@ addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.9")
 addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
+/* Temporarily disabling sbt-hydra, see #2870.
 resolvers += Resolver.url(
   "Triplequote Plugins Releases",
   url("https://repo.triplequote.com/artifactory/sbt-plugins-release/")
 )(Resolver.ivyStylePatterns)
 
 addSbtPlugin("com.triplequote" % "sbt-hydra" % "2.1.5")
+ */


### PR DESCRIPTION
See #2870 and my comment on #2848:
> I wish this change had been put forward for more public discussion before being merged. I personally didn't hear anything about this before seeing all the tweets about it after it was done.

> I think there are many good reasons to avoid requiring a closed-source sbt plugin to run the Cats build, and that's even if it had been tested thoroughly and we had established that it wasn't likely to cause problems. As it is right now running `sbt prePR` from a clean checkout crashes with [this error](https://github.com/typelevel/cats/issues/2870) on both my Mac laptop and Linux desktop, and it's completely impossible to investigate because sbt-hydra is just a binary from a commercial repo.

> I appreciate Triplequote's generosity, but the Cats build already has plenty of sharp edges, especially for new contributors, and I really don't think throwing a WIP closed-source sbt plugin into the mix was a good idea.

If we're going to use a closed-source sbt plugin in the Cats build, I think there's a pretty clear case for it being gated behind an environmental variable (Guillaume Martres pointed out [this example](https://github.com/scala/scala/blob/3274effb944f58cc6ac6cd99bcfd51abd6eab7a1/project/plugins.sbt#L39-L42) for sbt-dotty). This PR doesn't do that—it just disables the plugin for now so that when we tell people to run `sbt prePR` they don't get an opaque error message.