### PR TITLE
Improve MonadError rethrow syntax to be more flexible

### DIFF
--- a/core/src/main/scala/cats/MonadError.scala
+++ b/core/src/main/scala/cats/MonadError.scala
@@ -63,7 +63,7 @@ trait MonadError[F[_], E] extends ApplicativeError[F, E] with Monad[F] {
    * res1: scala.util.Try[Int] = Success(1)
    * }}}
    */
-  def rethrow[A](fa: F[Either[E, A]]): F[A] =
+  def rethrow[A, EE <: E](fa: F[Either[EE, A]]): F[A] =
     flatMap(fa)(_.fold(raiseError, pure))
 }
 

--- a/core/src/main/scala/cats/syntax/monadError.scala
+++ b/core/src/main/scala/cats/syntax/monadError.scala
@@ -7,7 +7,7 @@ trait MonadErrorSyntax {
 
   implicit final def catsSyntaxMonadErrorRethrow[F[_], E, A](
     fea: F[Either[E, A]]
-  )(implicit F: MonadError[F, E]): MonadErrorRethrowOps[F, E, A] =
+  )(implicit F: MonadError[F, _ >: E]): MonadErrorRethrowOps[F, E, A] =
     new MonadErrorRethrowOps(fea)
 }
 
@@ -32,5 +32,6 @@ final class MonadErrorOps[F[_], E, A](private val fa: F[A]) extends AnyVal {
 }
 
 final class MonadErrorRethrowOps[F[_], E, A](private val fea: F[Either[E, A]]) extends AnyVal {
-  def rethrow(implicit F: MonadError[F, E]): F[A] = F.rethrow(fea)
+  def rethrow(implicit F: MonadError[F, _ >: E]): F[A] =
+    F.flatMap(fea)(_.fold(F.raiseError, F.pure)) // dup from the type class impl, due to https://github.com/scala/bug/issues/11562. Once fixed should be able to replace with `F.rethrow(fea)`
 }

--- a/tests/src/test/scala/cats/tests/MonadErrorSuite.scala
+++ b/tests/src/test/scala/cats/tests/MonadErrorSuite.scala
@@ -63,4 +63,12 @@ class MonadErrorSuite extends CatsSuite {
   test("rethrow returns the successful value, when applied to a Right of a successful value") {
     successful.attempt.rethrow should ===(successful)
   }
+
+  test("rethrow returns the failure, when applied to a Left of a specialized failure") {
+    failed.attempt.asInstanceOf[Try[Either[IllegalArgumentException, Int]]].rethrow should ===(failed)
+  }
+
+  test("rethrow returns the successful value, when applied to a Right of a specialized successful value") {
+    successful.attempt.asInstanceOf[Try[Either[IllegalArgumentException, Int]]].rethrow should ===(successful)
+  }
 }


### PR DESCRIPTION
This allows calling `MonadError`'s `rethrow` directly on an `F[Either[E, A]]`, where `E <: Throwable`. Currently I don't think this is possible: one has to explicitly `leftWiden` to `Throwable`.
