### PR TITLE
Replace ⇒ with => to avoid Scala 2.13 warnings

### DIFF
--- a/core/src/main/scala/cats/arrow/FunctionK.scala
+++ b/core/src/main/scala/cats/arrow/FunctionK.scala
@@ -134,7 +134,7 @@ private[arrow] object FunctionKMacros {
 
     private[this] def unblock(tree: Tree): Tree = tree match {
       case Block(Nil, expr) => expr
-      case _ => tree
+      case _                => tree
     }
 
     private[this] def punchHole(tpe: Type): Tree = tpe match {

--- a/core/src/main/scala/cats/arrow/FunctionK.scala
+++ b/core/src/main/scala/cats/arrow/FunctionK.scala
@@ -89,7 +89,7 @@ object FunctionK {
    *
    * Additionally, the type parameters on `f` must not be specified.
    */
-  def lift[F[_], G[_]](f: (F[α] ⇒ G[α]) forSome { type α }): FunctionK[F, G] =
+  def lift[F[_], G[_]](f: (F[α] => G[α]) forSome { type α }): FunctionK[F, G] =
     macro FunctionKMacros.lift[F, G]
 
 }
@@ -97,7 +97,7 @@ object FunctionK {
 private[arrow] object FunctionKMacros {
 
   def lift[F[_], G[_]](c: Context)(
-    f: c.Expr[(F[α] ⇒ G[α]) forSome { type α }]
+    f: c.Expr[(F[α] => G[α]) forSome { type α }]
   )(
     implicit evF: c.WeakTypeTag[F[_]],
     evG: c.WeakTypeTag[G[_]]
@@ -112,7 +112,7 @@ private[arrow] object FunctionKMacros {
       implicit evF: c.WeakTypeTag[F[_]],
       evG: c.WeakTypeTag[G[_]]
     ): Tree = unblock(tree) match {
-      case q"($param) => $trans[..$typeArgs](${arg: Ident})" if param.name == arg.name ⇒
+      case q"($param) => $trans[..$typeArgs](${arg: Ident})" if param.name == arg.name =>
         typeArgs
           .collect { case tt: TypeTree => tt }
           .find(tt => Option(tt.original).isDefined)
@@ -128,17 +128,17 @@ private[arrow] object FunctionKMacros {
           def apply[A](fa: $F[A]): $G[A] = $trans(fa)
         }
        """
-      case other ⇒
+      case other =>
         c.abort(other.pos, s"Unexpected tree $other when lifting to FunctionK")
     }
 
     private[this] def unblock(tree: Tree): Tree = tree match {
-      case Block(Nil, expr) ⇒ expr
-      case _ ⇒ tree
+      case Block(Nil, expr) => expr
+      case _ => tree
     }
 
     private[this] def punchHole(tpe: Type): Tree = tpe match {
-      case PolyType(undet :: Nil, underlying: TypeRef) ⇒
+      case PolyType(undet :: Nil, underlying: TypeRef) =>
         val α = TypeName("α")
         def rebind(typeRef: TypeRef): Tree =
           if (typeRef.sym == undet) tq"$α"
@@ -151,7 +151,7 @@ private[arrow] object FunctionKMacros {
           }
         val rebound = rebind(underlying)
         tq"""({type λ[$α] = $rebound})#λ"""
-      case TypeRef(pre, sym, Nil) ⇒
+      case TypeRef(pre, sym, Nil) =>
         tq"$sym"
       case _ =>
         c.abort(c.enclosingPosition, s"Unexpected type $tpe when lifting to FunctionK")

--- a/core/src/main/scala/cats/data/NonEmptyChain.scala
+++ b/core/src/main/scala/cats/data/NonEmptyChain.scala
@@ -215,17 +215,17 @@ class NonEmptyChainOps[A](private val value: NonEmptyChain[A]) extends AnyVal {
   /**
    * Tests whether a predicate holds for all elements of this chain.
    */
-  final def forall(p: A ⇒ Boolean): Boolean = toChain.forall(p)
+  final def forall(p: A => Boolean): Boolean = toChain.forall(p)
 
   /**
    * Tests whether a predicate holds for at least one element of this chain.
    */
-  final def exists(f: A ⇒ Boolean): Boolean = toChain.exists(f)
+  final def exists(f: A => Boolean): Boolean = toChain.exists(f)
 
   /**
    * Returns the first value that matches the given predicate.
    */
-  final def find(f: A ⇒ Boolean): Option[A] = toChain.find(f)
+  final def find(f: A => Boolean): Option[A] = toChain.find(f)
 
   /**
    * Returns a new `Chain` containing all elements where the result of `pf` is final defined.
@@ -254,12 +254,12 @@ class NonEmptyChainOps[A](private val value: NonEmptyChain[A]) extends AnyVal {
   /**
    * Filters all elements of this chain that do not satisfy the given predicate.
    */
-  final def filter(p: A ⇒ Boolean): Chain[A] = toChain.filter(p)
+  final def filter(p: A => Boolean): Chain[A] = toChain.filter(p)
 
   /**
    * Filters all elements of this chain that satisfy the given predicate.
    */
-  final def filterNot(p: A ⇒ Boolean): Chain[A] = filter(t => !p(t))
+  final def filterNot(p: A => Boolean): Chain[A] = filter(t => !p(t))
 
   /**
    * Left-associative fold using f.

--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -85,7 +85,7 @@ sealed class NonEmptyMapOps[K, A](val value: NonEmptyMap[K, A]) {
   /**
    * Applies f to all the elements
    */
-  def map[B](f: A ⇒ B): NonEmptyMap[K, B] =
+  def map[B](f: A => B): NonEmptyMap[K, B] =
     NonEmptyMapImpl.create(Functor[SortedMap[K, ?]].map(toSortedMap)(f))
 
   /**
@@ -135,27 +135,27 @@ sealed class NonEmptyMapOps[K, A](val value: NonEmptyMap[K, A]) {
   /**
    * Tests whether a predicate holds for all elements of this map.
    */
-  def forall(p: A ⇒ Boolean): Boolean = toSortedMap.forall { case (_, a) => p(a) }
+  def forall(p: A => Boolean): Boolean = toSortedMap.forall { case (_, a) => p(a) }
 
   /**
    * Tests whether a predicate holds for at least one element of this map.
    */
-  def exists(f: A ⇒ Boolean): Boolean = toSortedMap.exists { case (_, a) => f(a) }
+  def exists(f: A => Boolean): Boolean = toSortedMap.exists { case (_, a) => f(a) }
 
   /**
    * Returns the first value along with its key, that matches the given predicate.
    */
-  def find(f: A ⇒ Boolean): Option[(K, A)] = toSortedMap.find { case (_, a) => f(a) }
+  def find(f: A => Boolean): Option[(K, A)] = toSortedMap.find { case (_, a) => f(a) }
 
   /**
    * Filters all elements of this map that do not satisfy the given predicate.
    */
-  def filter(p: A ⇒ Boolean): SortedMap[K, A] = toSortedMap.filter { case (_, a) => p(a) }
+  def filter(p: A => Boolean): SortedMap[K, A] = toSortedMap.filter { case (_, a) => p(a) }
 
   /**
    * Filters all elements of this map that satisfy the given predicate.
    */
-  def filterNot(p: A ⇒ Boolean): SortedMap[K, A] = filter(t => !p(t))
+  def filterNot(p: A => Boolean): SortedMap[K, A] = filter(t => !p(t))
 
   /**
    * Left-associative fold using f.

--- a/core/src/main/scala/cats/data/NonEmptySet.scala
+++ b/core/src/main/scala/cats/data/NonEmptySet.scala
@@ -200,17 +200,17 @@ sealed class NonEmptySetOps[A](val value: NonEmptySet[A]) {
   /**
    * Tests whether a predicate holds for all elements of this set.
    */
-  def forall(p: A ⇒ Boolean): Boolean = toSortedSet.forall(p)
+  def forall(p: A => Boolean): Boolean = toSortedSet.forall(p)
 
   /**
    * Tests whether a predicate holds for at least one element of this set.
    */
-  def exists(f: A ⇒ Boolean): Boolean = toSortedSet.exists(f)
+  def exists(f: A => Boolean): Boolean = toSortedSet.exists(f)
 
   /**
    * Returns the first value that matches the given predicate.
    */
-  def find(f: A ⇒ Boolean): Option[A] = toSortedSet.find(f)
+  def find(f: A => Boolean): Option[A] = toSortedSet.find(f)
 
   /**
    * Returns a new `SortedSet` containing all elements where the result of `pf` is defined.
@@ -223,12 +223,12 @@ sealed class NonEmptySetOps[A](val value: NonEmptySet[A]) {
   /**
    * Filters all elements of this set that do not satisfy the given predicate.
    */
-  def filter(p: A ⇒ Boolean): SortedSet[A] = toSortedSet.filter(p)
+  def filter(p: A => Boolean): SortedSet[A] = toSortedSet.filter(p)
 
   /**
    * Filters all elements of this set that satisfy the given predicate.
    */
-  def filterNot(p: A ⇒ Boolean): SortedSet[A] = filter(t => !p(t))
+  def filterNot(p: A => Boolean): SortedSet[A] = filter(t => !p(t))
 
   /**
    * Left-associative fold using f.

--- a/core/src/main/scala/cats/syntax/foldable.scala
+++ b/core/src/main/scala/cats/syntax/foldable.scala
@@ -182,7 +182,7 @@ final class FoldableOps[F[_], A](private val fa: F[A]) extends AnyVal {
    *}}}
    */
   def collectFold[M](f: PartialFunction[A, M])(implicit F: Foldable[F], M: Monoid[M]): M =
-    F.foldLeft(fa, M.empty)((acc, a) ⇒ M.combine(acc, f.applyOrElse(a, (_: A) ⇒ M.empty)))
+    F.foldLeft(fa, M.empty)((acc, a) => M.combine(acc, f.applyOrElse(a, (_: A) ⇒ M.empty)))
 
   /**
    * Tear down a subset of this structure using a `A => Option[M]`.
@@ -194,12 +194,12 @@ final class FoldableOps[F[_], A](private val fa: F[A]) extends AnyVal {
    * res0: Int = 6
    *}}}
    */
-  def collectSomeFold[M](f: A ⇒ Option[M])(implicit F: Foldable[F], M: Monoid[M]): M =
+  def collectSomeFold[M](f: A => Option[M])(implicit F: Foldable[F], M: Monoid[M]): M =
     F.foldLeft(fa, M.empty)(
-      (acc, a) ⇒
+      (acc, a) =>
         f(a) match {
-          case Some(x) ⇒ M.combine(acc, x)
-          case None ⇒ acc
+          case Some(x) => M.combine(acc, x)
+          case None => acc
       }
     )
 }

--- a/core/src/main/scala/cats/syntax/foldable.scala
+++ b/core/src/main/scala/cats/syntax/foldable.scala
@@ -182,7 +182,7 @@ final class FoldableOps[F[_], A](private val fa: F[A]) extends AnyVal {
    *}}}
    */
   def collectFold[M](f: PartialFunction[A, M])(implicit F: Foldable[F], M: Monoid[M]): M =
-    F.foldLeft(fa, M.empty)((acc, a) => M.combine(acc, f.applyOrElse(a, (_: A) ⇒ M.empty)))
+    F.foldLeft(fa, M.empty)((acc, a) => M.combine(acc, f.applyOrElse(a, (_: A) => M.empty)))
 
   /**
    * Tear down a subset of this structure using a `A => Option[M]`.
@@ -199,7 +199,7 @@ final class FoldableOps[F[_], A](private val fa: F[A]) extends AnyVal {
       (acc, a) =>
         f(a) match {
           case Some(x) => M.combine(acc, x)
-          case None => acc
+          case None    => acc
       }
     )
 }

--- a/tests/src/test/scala/cats/tests/FoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/FoldableSuite.scala
@@ -140,7 +140,7 @@ abstract class FoldableSuite[F[_]: Foldable](name: String)(implicit ArbFInt: Arb
   }
 
   test(s"Foldable[$name] partial summation") {
-    forAll { (fa: F[String], f: String => Boolean) ⇒
+    forAll { (fa: F[String], f: String => Boolean) =>
       val m: Monoid[String] = Monoid[String]
 
       val pf: PartialFunction[String, String] = {

--- a/tests/src/test/scala/cats/tests/FoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/FoldableSuite.scala
@@ -140,11 +140,11 @@ abstract class FoldableSuite[F[_]: Foldable](name: String)(implicit ArbFInt: Arb
   }
 
   test(s"Foldable[$name] partial summation") {
-    forAll { (fa: F[String], f: String ⇒ Boolean) ⇒
+    forAll { (fa: F[String], f: String => Boolean) ⇒
       val m: Monoid[String] = Monoid[String]
 
       val pf: PartialFunction[String, String] = {
-        case n if f(n) ⇒ n
+        case n if f(n) => n
       }
       fa.collectFold(pf) should ===(fa.toList.collect(pf).fold(m.empty)(m.combine))
 

--- a/tests/src/test/scala/cats/tests/FunctionKSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctionKSuite.scala
@@ -92,7 +92,7 @@ class FunctionKSuite extends CatsSuite {
   }
 
   test("lift compound unary") {
-    val fNelFromList = FunctionK.lift[List, λ[α ⇒ Option[NonEmptyList[α]]]](NonEmptyList.fromList _)
+    val fNelFromList = FunctionK.lift[List, λ[α => Option[NonEmptyList[α]]]](NonEmptyList.fromList _)
     forAll { (a: List[String]) =>
       fNelFromList(a) should ===(NonEmptyList.fromList(a))
     }

--- a/tests/src/test/scala/cats/tests/ValidatedSuite.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedSuite.scala
@@ -103,7 +103,7 @@ class ValidatedSuite extends CatsSuite {
   }
 
   test("ValidatedNec") {
-    forAll { (e: String) ⇒
+    forAll { (e: String) =>
       val manual = Validated.invalid[NonEmptyChain[String], Int](NonEmptyChain.one(e))
       Validated.invalidNec[String, Int](e) should ===(manual)
       Validated.invalid[String, Int](e).toValidatedNec should ===(manual)


### PR DESCRIPTION
Related to #2893. I thought I'd done this for Cats but it must have been other projects.
