### PR TITLE
Update sbt-scalafix to 0.9.5

### DIFF
--- a/scalafix/build.sbt
+++ b/scalafix/build.sbt
@@ -1,4 +1,4 @@
-val V = _root_.scalafix.Versions
+val V = _root_.scalafix.sbt.BuildInfo
 
 inThisBuild(
   List(
@@ -8,14 +8,10 @@ inThisBuild(
   ))
 
 lazy val rules = project.settings(
-  libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % V.version
+  libraryDependencies += "ch.epfl.scala" %% "scalafix-core" % V.scalafixVersion
 )
 
 lazy val input = project.settings(
-  scalacOptions += {
-    val sourceroot = sourceDirectory.in(Compile).value / "scala"
-    s"-P:semanticdb:sourceroot:$sourceroot"
-  },
   libraryDependencies ++= Seq(
     "org.typelevel" %% "cats" % "0.9.0"
   ),
@@ -32,7 +28,9 @@ lazy val output = project.settings(
 
 lazy val tests = project
   .settings(
-    libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % V.version % Test cross CrossVersion.full,
+    libraryDependencies += "ch.epfl.scala" % "scalafix-testkit" % V.scalafixVersion % Test cross CrossVersion.full,
+    compile.in(Compile) :=
+      compile.in(Compile).dependsOn(compile.in(input, Compile)).value,
     scalafixTestkitOutputSourceDirectories :=
       sourceDirectories.in(output, Compile).value,
     scalafixTestkitInputSourceDirectories :=

--- a/scalafix/project/build.properties
+++ b/scalafix/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=1.2.8

--- a/scalafix/project/plugins.sbt
+++ b/scalafix/project/plugins.sbt
@@ -1,4 +1,3 @@
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.5.2")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.6.0-M9")
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.2")
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.2")

--- a/scalafix/project/plugins.sbt
+++ b/scalafix/project/plugins.sbt
@@ -1,3 +1,3 @@
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.6.0-M9")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.5")
 addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.2")
 addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.2")

--- a/scalafix/rules/src/main/scala/fix/Cats_v1_0_0.scala
+++ b/scalafix/rules/src/main/scala/fix/Cats_v1_0_0.scala
@@ -1,9 +1,8 @@
 package fix
 package v1_0_0
 
-import scalafix._
+import scalafix.v0._
 import scalafix.syntax._
-import scalafix.util.SymbolMatcher
 import scala.meta._
 import scala.meta.contrib._
 

--- a/scalafix/rules/src/main/scala/fix/Cats_v1_0_0.scala
+++ b/scalafix/rules/src/main/scala/fix/Cats_v1_0_0.scala
@@ -11,22 +11,22 @@ case class RemoveCartesianBuilder(index: SemanticdbIndex)
     extends SemanticRule(index, "RemoveCartesianBuilder") {
 
   private[this] val cartesianBuilders = SymbolMatcher.normalized(
-    Symbol("_root_.cats.syntax.CartesianOps.`|@|`.") ::
+    Symbol("cats/syntax/CartesianOps#`|@|`().") ::
       (1 to 22).toList.map(arity =>
       Symbol(
-        s"_root_.cats.syntax.CartesianBuilder.CartesianBuilder$arity.`|@|`.")): _*
+        s"cats/syntax/CartesianBuilder#CartesianBuilder$arity#`|@|`().")): _*
   )
 
   private[this] val partialApplies = SymbolMatcher.normalized(
-    Symbol(s"_root_.cats.syntax.CartesianOps.`*>`."),
-    Symbol(s"_root_.cats.syntax.CartesianOps.`<*`.")
+    Symbol(s"cats/syntax/CartesianOps#`*>`()."),
+    Symbol(s"cats/syntax/CartesianOps#`<*`().")
   )
 
   private[this] val renames: Map[String, String] = (1 to 22).flatMap { arity =>
     Seq(
-      s"_root_.cats.syntax.CartesianBuilder.CartesianBuilder$arity.map." -> "mapN",
-      s"_root_.cats.syntax.CartesianBuilder.CartesianBuilder$arity.imap." -> "imapN",
-      s"_root_.cats.syntax.CartesianBuilder.CartesianBuilder$arity.contramap." -> "contramapN"
+      s"cats/syntax/CartesianBuilder#CartesianBuilder$arity#map()." -> "mapN",
+      s"cats/syntax/CartesianBuilder#CartesianBuilder$arity#imap()." -> "imapN",
+      s"cats/syntax/CartesianBuilder#CartesianBuilder$arity#contramap()." -> "contramapN"
     )
   }.toMap
 
@@ -79,9 +79,9 @@ case class ContraMapToLMap(index: SemanticdbIndex)
 
   override def fix(ctx: RuleCtx): Patch = {
 
-    val contraMatcher = SymbolMatcher.normalized(Symbol("_root_.cats.functor.Contravariant.Ops.`contramap`."))
+    val contraMatcher = SymbolMatcher.normalized(Symbol("cats/functor/Contravariant.Ops#contramap()."))
 
-    val unApplyName = "catsUnapply2left"
+    val unApplyName = "catsSyntaxUContravariant"
 
     ctx.tree.collect {
       case Term.Apply(Term.Select(f, contraMatcher(contramap)), _) if f.denotation.exists(_.name == unApplyName) =>
@@ -95,14 +95,14 @@ case class RemoveUnapply(index: SemanticdbIndex)
     extends SemanticRule(index, "RemoveUnapply") {
 
   override def fix(ctx: RuleCtx): Patch = ctx.replaceSymbols(
-    "_root_.cats.Traverse.Ops.traverseU." -> "traverse",
-    "_root_.cats.Foldable.Ops.traverseU_." -> "traverse_",
-    "_root_.cats.Foldable.traverseU_." -> "traverse_",
-    "_root_.cats.Traverse.Ops.sequenceU." -> "sequence",
-    "_root_.cats.Foldable.Ops.sequenceU_." -> "sequence_",
-    "_root_.cats.Foldable.sequenceU_." -> "sequence_",
-    "_root_.cats.data.Func.appFuncU." -> "appFunc",
-    "_root_.cats.free.FreeT.liftTU." -> "liftT"
+    "cats/Traverse.Ops#traverseU()." -> "traverse",
+    "cats/Foldable.Ops#traverseU_()." -> "traverse_",
+    "cats/Foldable#traverseU_()." -> "traverse_",
+    "cats/Traverse.Ops#sequenceU()." -> "sequence",
+    "cats/Foldable.Ops#sequenceU_()." -> "sequence_",
+    "cats/Foldable#sequenceU_()." -> "sequence_",
+    "cats/data/Func.appFuncU()." -> "appFunc",
+    "cats/free/FreeT.liftTU()." -> "liftT"
   )
 }
 
@@ -111,8 +111,8 @@ case class RenameFreeSuspend(index: SemanticdbIndex)
     extends SemanticRule(index, "RenameFreeSuspend") {
 
   override def fix(ctx: RuleCtx): Patch = ctx.replaceSymbols(
-    "_root_.cats.free.Free.suspend." -> "defer",
-    "_root_.cats.free.TrampolineFunctions.suspend." -> "defer"
+    "cats/free/Free.suspend()." -> "defer",
+    "cats/free/TrampolineFunctions#suspend()." -> "defer"
   )
 
 }
@@ -122,12 +122,12 @@ case class RenameReducibleMethods(index: SemanticdbIndex)
     extends SemanticRule(index, "RenameReducibleMethods") {
 
   override def fix(ctx: RuleCtx): Patch = ctx.replaceSymbols(
-    "_root_.cats.Reducible.traverse1_." -> "nonEmptyTraverse_",
-    "_root_.cats.Reducible.Ops.traverse1_." -> "nonEmptyTraverse_",
-    "_root_.cats.Reducible.intercalate1." -> "nonEmptyIntercalate",
-    "_root_.cats.Reducible.Ops.intercalate1." -> "nonEmptyIntercalate",
-    "_root_.cats.Reducible.sequence1_." -> "nonEmptySequence_",
-    "_root_.cats.Reducible.Ops.sequence1_." -> "nonEmptySequence_"
+    "cats/Reducible#traverse1_()." -> "nonEmptyTraverse_",
+    "cats/Reducible.Ops#traverse1_()." -> "nonEmptyTraverse_",
+    "cats/Reducible#intercalate1()." -> "nonEmptyIntercalate",
+    "cats/Reducible.Ops#intercalate1()." -> "nonEmptyIntercalate",
+    "cats/Reducible#sequence1_()." -> "nonEmptySequence_",
+    "cats/Reducible.Ops#sequence1_()." -> "nonEmptySequence_"
   )
 
 }
@@ -137,10 +137,10 @@ case class SimplifyEitherTLift(index: SemanticdbIndex)
     extends SemanticRule(index, "SimplifyEitherTLift") {
 
   private[this] val leftSymbol = SymbolMatcher.normalized(
-    Symbol("_root_.cats.data.EitherTFunctions.left.")
+    Symbol("cats/data/EitherTFunctions/left.")
   )
   private[this] val rightSymbol = SymbolMatcher.normalized(
-    Symbol("_root_.cats.data.EitherTFunctions.right.")
+    Symbol("cats/data/EitherTFunctions/right.")
   )
 
   private[this] def removeWithLeadingComma(ctx: RuleCtx, t: Tree): Patch =
@@ -172,9 +172,9 @@ case class RenameInjectProdAndCoproduct(index: SemanticdbIndex)
     extends SemanticRule(index, "RenameInjectProdAndCoproduct") {
 
   override def fix(ctx: RuleCtx): Patch = ctx.replaceSymbols(
-    "_root_.cats.free.Inject." -> "_root_.cats.InjectK.",
-    "_root_.cats.data.Prod." -> "_root_.cats.data.Tuple2K.",
-    "_root_.cats.data.Coproduct." -> "_root_.cats.data.EitherK."
+    "cats/free/Inject." -> "cats/InjectK.",
+    "cats/data/Prod." -> "cats/data/Tuple2K.",
+    "cats/data/Coproduct." -> "cats/data/EitherK."
   )
 
 }
@@ -187,9 +187,9 @@ case class RenameTupleApplySyntax(index: SemanticdbIndex)
     ctx.replaceSymbols(
       (1 to 22).flatMap { arity =>
         Seq(
-          s"_root_.cats.syntax.Tuple${arity}CartesianOps.map$arity." -> "mapN",
-          s"_root_.cats.syntax.Tuple${arity}CartesianOps.contramap$arity." -> "contramapN",
-          s"_root_.cats.syntax.Tuple${arity}CartesianOps.imap$arity." -> "imapN"
+          s"cats/syntax/Tuple${arity}CartesianOps#map$arity()." -> "mapN",
+          s"cats/syntax/Tuple${arity}CartesianOps#contramap$arity()." -> "contramapN",
+          s"cats/syntax/Tuple${arity}CartesianOps#imap$arity()." -> "imapN"
         )
       }: _*
     ) ++
@@ -206,7 +206,7 @@ case class RemoveSplit(index: SemanticdbIndex)
 
   override def fix(ctx: RuleCtx): Patch = {
     ctx.replaceSymbols(
-      "_root_.cats.arrow.Split." -> "_root_.cats.arrow.Arrow."
+      "cats/arrow/Split." -> "cats/arrow/Arrow."
     ) + ctx.tree.collect {
       case t @ q"import cats.syntax.split._" =>
         ctx.replaceTree(t, "import cats.syntax.arrow._")
@@ -221,7 +221,7 @@ case class RenameEitherTLiftT(index: SemanticdbIndex)
 
   override def fix(ctx: RuleCtx): Patch =
     ctx.replaceSymbols(
-      "_root_.cats.data.EitherTFunctions.liftT." -> "liftF"
+      "cats/data/EitherTFunctions#liftT()." -> "liftF",
     )
 
 }
@@ -232,11 +232,11 @@ case class RenameTransformersLift(index: SemanticdbIndex)
 
   override def fix(ctx: RuleCtx): Patch =
     ctx.replaceSymbols(
-      "_root_.cats.data.WriterT.lift." -> "liftF",
-      "_root_.cats.data.StateT.lift." -> "liftF",
-      "_root_.cats.data.CommonStateTConstructors.lift." -> "liftF",
-      "_root_.cats.data.CommonIRWSTConstructors.lift." -> "liftF",
-      "_root_.cats.data.KleisliFunctions.lift." -> "liftF"
+      "cats/data/WriterT.lift()." -> "liftF",
+      "cats/data/StateT.lift()." -> "liftF",
+      "cats/data/CommonStateTConstructors#lift()." -> "liftF",
+      "cats/data/CommonIRWSTConstructors#lift()." -> "liftF",
+      "cats/data/KleisliFunctions#lift()." -> "liftF"
     )
 
 }
@@ -246,14 +246,14 @@ case class RenameApplyApConst(index: SemanticdbIndex)
 
   override def fix(ctx: RuleCtx): Patch =
     ctx.replaceSymbols(
-      "_root_.cats.Apply.forEffect." -> "productL",
-      "_root_.cats.Apply.followedBy." -> "productR",
-      "_root_.cats.Apply.Ops.forEffect." -> "productL",
-      "_root_.cats.Apply.Ops.followedBy." -> "productR",
-      "_root_.cats.NonEmptyParallel.parForEffect." -> "parProductL",
-      "_root_.cats.NonEmptyParallel.parFollowedBy." -> "parProductR",
-      "_root_.cats.FlatMap.forEffectEval." -> "productLEval",
-      "_root_.cats.FlatMap.followedByEval." -> "productREval"
+      "cats/Apply#forEffect()." -> "productL",
+      "cats/Apply#followedBy()." -> "productR",
+      "cats/Apply.Ops#forEffect()." -> "productL",
+      "cats/Apply.Ops#followedBy()." -> "productR",
+      "cats/NonEmptyParallel#parForEffect()." -> "parProductL",
+      "cats/NonEmptyParallel#parFollowedBy()." -> "parProductR",
+      "cats/FlatMap#forEffectEval()." -> "productLEval",
+      "cats/FlatMap#followedByEval()." -> "productREval"
     )
 
 }
@@ -265,7 +265,7 @@ case class RenameCartesian(index: SemanticdbIndex)
 
   override def fix(ctx: RuleCtx): Patch = {
     ctx.replaceSymbols(
-      "_root_.cats.Cartesian." -> "_root_.cats.Semigroupal."
+      "cats/Cartesian." -> "cats/Semigroupal."
     )+ ctx.tree.collect {
       case t @ q"import cats.syntax.cartesian._" =>
         ctx.replaceTree(t, "import cats.syntax.semigroupal._")

--- a/scalafix/tests/src/test/scala/fix/Cats_Tests.scala
+++ b/scalafix/tests/src/test/scala/fix/Cats_Tests.scala
@@ -1,13 +1,7 @@
 package fix
 
-import scala.meta._
 import scalafix.testkit._
 
-class Cats_Tests
-  extends SemanticRuleSuite(
-    Database.load(Classpath(AbsolutePath(BuildInfo.inputClassdirectory))),
-    AbsolutePath(BuildInfo.inputSourceroot),
-    Seq(AbsolutePath(BuildInfo.outputSourceroot))
-  ) {
+class Cats_Tests extends SemanticRuleSuite() {
   runAllTests()
 }


### PR DESCRIPTION
This updates Scalafix to 0.6.0-M9 by applying [this diff](https://github.com/scalacenter/scalafix.g8/blob/c22ae75cabb629aa4a83a95d5fdd8f99691cd92b/scalafix/readme.md). I've checked locally that the Scalafix tests still pass.

My ultimate goal is to update Scalafix to 0.9.x so that this rule (and potential future rules) can be used by Scala Steward (https://github.com/fthomas/scala-steward/pull/611) but it is currently unclear to me if updating to 0.9.x means that this rule needs to rewritten with Scalafix' `v1` API. @olafurpg do `v0` rules also work with 0.9.x?



