### PR TITLE
Update sbt-scalafmt to 2.0.1

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,3 +1,6 @@
+version=2.0.0-RC8
+align.openParenCallSite = true
+align.openParenDefnSite = true
 maxColumn = 120
 continuationIndent.defnSite = 2
 assumeStandardLibraryStripMargin = true

--- a/build.sbt
+++ b/build.sbt
@@ -98,7 +98,7 @@ lazy val catsSettings = Seq(
   libraryDependencies ++= Seq(
     "org.typelevel" %%% "machinist" % "0.6.8",
     compilerPlugin("org.typelevel" %% "kind-projector" % kindProjectorVersion)
-  ) ++ macroDependencies(scalaVersion.value),
+  ) ++ macroDependencies(scalaVersion.value)
 ) ++ commonSettings ++ publishSettings ++ scoverageSettings ++ simulacrumSettings
 
 lazy val simulacrumSettings = Seq(
@@ -304,7 +304,7 @@ def mimaSettings(moduleName: String) =
         exclude[DirectMissingMethodProblem]("cats.data.KleisliInstances4.catsDataCommutativeFlatMapForKleisli"),
         exclude[DirectMissingMethodProblem]("cats.data.IRWSTInstances1.catsDataStrongForIRWST"),
         exclude[DirectMissingMethodProblem]("cats.data.OptionTInstances1.catsDataMonadErrorMonadForOptionT"),
-        exclude[DirectMissingMethodProblem]("cats.data.OptionTInstances1.catsDataMonadErrorForOptionT"),
+        exclude[DirectMissingMethodProblem]("cats.data.OptionTInstances1.catsDataMonadErrorForOptionT")
       ) ++
         //These things are Ops classes that shouldn't have the `value` exposed. These should have never been public because they don't
         //provide any value. Making them private because of issues like #2514 and #2613.

--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -84,7 +84,7 @@ sealed abstract class Eval[+A] extends Serializable { self =>
               type Start = A
               val start = () => c.run(s)
               val run = f
-          }
+            }
         }
       case c: Eval.Defer[A] =>
         new Eval.FlatMap[B] {

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -502,7 +502,7 @@ import Foldable.sentinel
         f(a) match {
           case Right(c) => (A.empty[B], A.pure(c))
           case Left(b)  => (A.pure(b), A.empty[C])
-      }
+        }
     )
   }
 

--- a/core/src/main/scala/cats/Monad.scala
+++ b/core/src/main/scala/cats/Monad.scala
@@ -33,7 +33,7 @@ import simulacrum.typeclass
             }
           },
           ifFalse = pure(Right(xs))
-      )
+        )
     )
   }
 
@@ -53,7 +53,7 @@ import simulacrum.typeclass
             map(b.value)(_ => continue)
           },
           ifFalse = stop
-      )
+        )
     )
   }
 

--- a/core/src/main/scala/cats/Reducible.scala
+++ b/core/src/main/scala/cats/Reducible.scala
@@ -199,7 +199,7 @@ import simulacrum.typeclass
             case (Right(c), _)           => ior.map(c :: _)
             case (Left(b), Ior.Right(r)) => Ior.bothNel(b, r)
             case (Left(b), _)            => ior.leftMap(b :: _)
-        }
+          }
       )
 
     reduceRightTo(fa)(a => f(a).bimap(NonEmptyList.one, NonEmptyList.one).toIor)(g).value

--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -421,7 +421,9 @@ sealed abstract class Chain[+A] {
     var first = true
 
     foreach { a =>
-      if (first) { builder ++= AA.show(a); first = false } else builder ++= ", " + AA.show(a)
+      if (first) {
+        builder ++= AA.show(a); first = false
+      } else builder ++= ", " + AA.show(a)
       ()
     }
     builder += ')'

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -646,7 +646,7 @@ private[data] trait EitherTMonad[F[_], L] extends Monad[EitherT[F, L, ?]] with E
             case Left(l)         => Right(Left(l))
             case Right(Left(a1)) => Left(a1)
             case Right(Right(b)) => Right(Right(b))
-        }
+          }
       )
     )
 }

--- a/core/src/main/scala/cats/data/IndexedStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedStateT.scala
@@ -144,12 +144,13 @@ final class IndexedStateT[F[_], SA, SB, A](val runF: F[SA => F[(SB, A)]]) extend
    * }}}
    */
   def transformS[R](f: R => SA, g: (R, SB) => R)(implicit F: Functor[F]): IndexedStateT[F, R, R, A] =
-    StateT.applyF(F.map(runF) { sfsa =>
-      { r: R =>
-        val sa = f(r)
-        val fsba = sfsa(sa)
-        F.map(fsba) { case (sb, a) => (g(r, sb), a) }
-      }
+    StateT.applyF(F.map(runF) {
+      sfsa =>
+        { r: R =>
+          val sa = f(r)
+          val fsba = sfsa(sa)
+          F.map(fsba) { case (sb, a) => (g(r, sb), a) }
+        }
     })
 
   /**
@@ -438,7 +439,7 @@ sealed abstract private[data] class IndexedStateTMonad[F[_], S]
       s =>
         F.tailRecM[(S, A), (S, B)]((s, a)) {
           case (s, a) => F.map(f(a).run(s)) { case (s, ab) => ab.bimap((s, _), (s, _)) }
-      }
+        }
     )
 }
 
@@ -475,7 +476,7 @@ sealed abstract private[data] class IndexedStateTContravariantMonoidal[F[_], S]
             (tup: (S, A)) =>
               f(tup._2) match {
                 case (b, c) => (G.pure((tup._1, b)), G.pure((tup._1, c)))
-            }
+              }
           )(G, F)
       )
     )

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -481,7 +481,7 @@ private[data] trait KleisliArrowChoice[F[_]]
         fe match {
           case Left(a)  => F.map(f(a))(Left.apply _)
           case Right(b) => F.map(g(b))(Right.apply _)
-      }
+        }
     )
 }
 

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -258,7 +258,10 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) {
 
     val buf = ListBuffer.empty[AA]
     tail.foldLeft(TreeSet(head: AA)) { (elementsSoFar, b) =>
-      if (elementsSoFar(b)) elementsSoFar else { buf += b; elementsSoFar + b }
+      if (elementsSoFar(b)) elementsSoFar
+      else {
+        buf += b; elementsSoFar + b
+      }
     }
 
     NonEmptyList(head, buf.toList)
@@ -592,7 +595,7 @@ sealed abstract private[data] class NonEmptyListInstances extends NonEmptyListIn
               case (Right(c), _)           => ior.map(c :: _)
               case (Left(b), Ior.Right(r)) => Ior.bothNel(b, r)
               case (Left(b), _)            => ior.leftMap(b :: _)
-          }
+            }
         )
 
       }

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -197,7 +197,10 @@ final class NonEmptyVector[+A] private (val toVector: Vector[A]) extends AnyVal 
 
     val buf = Vector.newBuilder[AA]
     tail.foldLeft(TreeSet(head: AA)) { (elementsSoFar, a) =>
-      if (elementsSoFar(a)) elementsSoFar else { buf += a; elementsSoFar + a }
+      if (elementsSoFar(a)) elementsSoFar
+      else {
+        buf += a; elementsSoFar + a
+      }
     }
 
     NonEmptyVector(head, buf.result())
@@ -315,7 +318,7 @@ sealed abstract private[data] class NonEmptyVectorInstances {
               case (Right(c), _)           => ior.map(_ :+ c)
               case (Left(b), Ior.Right(_)) => ior.putLeft(NonEmptyVector.one(b))
               case (Left(b), _)            => ior.leftMap(_ :+ b)
-          }
+            }
         ).bimap(_.toNonEmptyList, _.toNonEmptyList)
 
       }

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -363,7 +363,7 @@ private[data] trait OptionTMonad[F[_]] extends Monad[OptionT[F, ?]] {
         a0 =>
           F.map(f(a0).value)(
             _.fold(Either.right[A, Option[B]](None))(_.map(b => Some(b): Option[B]))
-        )
+          )
       )
     )
 }
@@ -405,7 +405,7 @@ private trait OptionTContravariantMonoidal[F[_]] extends ContravariantMonoidal[O
           t match {
             case Some((x, y)) => (Some(x), Some(y))
             case None         => (None, None)
-        }
+          }
       )
     )
 }

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -479,7 +479,7 @@ sealed private[data] trait WriterTContravariantMonoidal[F[_], L] extends Contrav
         (t: (L, (A, B))) =>
           t match {
             case (l, (a, b)) => ((l, a), (l, b))
-        }
+          }
       )
     )
 }

--- a/core/src/main/scala/cats/evidence/As.scala
+++ b/core/src/main/scala/cats/evidence/As.scala
@@ -27,7 +27,7 @@ sealed abstract class As[-A, +B] extends Serializable {
    * to a function, such as F in: `type F[-B] = B => String`. In this
    * case, we could use A As B to turn an F[B] Into F[A].
    */
-  def substitute[F[- _]](p: F[B]): F[A]
+  def substitute[F[-_]](p: F[B]): F[A]
 
   @inline final def andThen[C](that: (B As C)): (A As C) = As.compose(that, this)
 
@@ -56,7 +56,7 @@ object As extends AsInstances {
    * single value.
    */
   private[this] val reflAny = new (Any As Any) {
-    def substitute[F[- _]](fa: F[Any]) = fa
+    def substitute[F[-_]](fa: F[Any]) = fa
   }
 
   /**
@@ -94,30 +94,30 @@ object As extends AsInstances {
   /**
    * We can lift subtyping into any covariant type constructor
    */
-  def co[T[+ _], A, A2](a: A As A2): (T[A] As T[A2]) =
+  def co[T[+_], A, A2](a: A As A2): (T[A] As T[A2]) =
     a.substitute[λ[`-α` => T[α] As T[A2]]](refl)
 
   // Similarly, we can do this any time we find a covariant type
   // parameter. Here we provide the proof for what we expect to be the
   // most common shapes.
 
-  def co2[T[+ _, _], Z, A, B](a: A As Z): T[A, B] As T[Z, B] =
+  def co2[T[+_, _], Z, A, B](a: A As Z): T[A, B] As T[Z, B] =
     a.substitute[λ[`-α` => T[α, B] As T[Z, B]]](refl)
 
   /**
    * Widen a F[X,+A] to a F[X,B] if (A As B). This can be used to widen
    * the output of a Function1, for example.
    */
-  def co2_2[T[_, + _], Z, A, B](a: B As Z): T[A, B] As T[A, Z] =
+  def co2_2[T[_, +_], Z, A, B](a: B As Z): T[A, B] As T[A, Z] =
     a.substitute[λ[`-α` => T[A, α] As T[A, Z]]](refl)
 
-  def co3[T[+ _, _, _], Z, A, B, C](a: A As Z): T[A, B, C] As T[Z, B, C] =
+  def co3[T[+_, _, _], Z, A, B, C](a: A As Z): T[A, B, C] As T[Z, B, C] =
     a.substitute[λ[`-α` => T[α, B, C] As T[Z, B, C]]](refl)
 
-  def co3_2[T[_, + _, _], Z, A, B, C](a: B As Z): T[A, B, C] As T[A, Z, C] =
+  def co3_2[T[_, +_, _], Z, A, B, C](a: B As Z): T[A, B, C] As T[A, Z, C] =
     a.substitute[λ[`-α` => T[A, α, C] As T[A, Z, C]]](refl)
 
-  def co3_3[T[+ _, _, + _], Z, A, B, C](a: C As Z): T[A, B, C] As T[A, B, Z] =
+  def co3_3[T[+_, _, +_], Z, A, B, C](a: C As Z): T[A, B, C] As T[A, B, Z] =
     a.substitute[λ[`-α` => T[A, B, α] As T[A, B, Z]]](refl)
 
   /**
@@ -131,7 +131,7 @@ object As extends AsInstances {
    *
    * lift2(a,b) = co1_2(a) compose co2_2(b)
    */
-  def lift2[T[+ _, + _], A, A2, B, B2](
+  def lift2[T[+_, +_], A, A2, B, B2](
     a: A As A2,
     b: B As B2
   ): (T[A, B] As T[A2, B2]) = {
@@ -147,26 +147,26 @@ object As extends AsInstances {
    *  Given that F has the shape: F[-_], we show that:
    *     (A As B) implies (F[B] As F[A])
    */
-  def contra[T[- _], A, B](a: A As B): (T[B] As T[A]) =
+  def contra[T[-_], A, B](a: A As B): (T[B] As T[A]) =
     a.substitute[λ[`-α` => T[B] As T[α]]](refl)
 
   // Similarly, we can do this any time we find a contravariant type
   // parameter. Here we provide the proof for what we expect to be the
   // most common shapes.
 
-  def contra1_2[T[- _, _], Z, A, B](a: A As Z): (T[Z, B] As T[A, B]) =
+  def contra1_2[T[-_, _], Z, A, B](a: A As Z): (T[Z, B] As T[A, B]) =
     a.substitute[λ[`-α` => T[Z, B] As T[α, B]]](refl)
 
-  def contra2_2[T[_, - _], Z, A, B](a: B As Z): (T[A, Z] As T[A, B]) =
+  def contra2_2[T[_, -_], Z, A, B](a: B As Z): (T[A, Z] As T[A, B]) =
     a.substitute[λ[`-α` => T[A, Z] As T[A, α]]](refl)
 
-  def contra1_3[T[- _, _, _], Z, A, B, C](a: A As Z): (T[Z, B, C] As T[A, B, C]) =
+  def contra1_3[T[-_, _, _], Z, A, B, C](a: A As Z): (T[Z, B, C] As T[A, B, C]) =
     a.substitute[λ[`-α` => T[Z, B, C] As T[α, B, C]]](refl)
 
-  def contra2_3[T[_, - _, _], Z, A, B, C](a: B As Z): (T[A, Z, C] As T[A, B, C]) =
+  def contra2_3[T[_, -_, _], Z, A, B, C](a: B As Z): (T[A, Z, C] As T[A, B, C]) =
     a.substitute[λ[`-α` => T[A, Z, C] As T[A, α, C]]](refl)
 
-  def contra3_3[T[_, _, - _], Z, A, B, C](a: C As Z): (T[A, B, Z] As T[A, B, C]) =
+  def contra3_3[T[_, _, -_], Z, A, B, C](a: C As Z): (T[A, B, Z] As T[A, B, C]) =
     a.substitute[λ[`-α` => T[A, B, Z] As T[A, B, α]]](refl)
 
   /**

--- a/core/src/main/scala/cats/instances/function.scala
+++ b/core/src/main/scala/cats/instances/function.scala
@@ -107,7 +107,7 @@ sealed private[instances] trait Function1Instances extends Function1Instances0 {
         (ab: (A, B)) =>
           ab match {
             case (a, b) => Monoid[R].combine(fa(a), fb(b))
-        }
+          }
     }
 
   implicit def catsStdMonadForFunction1[T1]: Monad[T1 => ?] =

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -88,7 +88,7 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
             f(a) match {
               case Left(b)  => (b :: acc._1, acc._2)
               case Right(c) => (acc._1, c :: acc._2)
-          }
+            }
         )
 
       @tailrec

--- a/core/src/main/scala/cats/syntax/foldable.scala
+++ b/core/src/main/scala/cats/syntax/foldable.scala
@@ -200,7 +200,7 @@ final class FoldableOps[F[_], A](private val fa: F[A]) extends AnyVal {
         f(a) match {
           case Some(x) => M.combine(acc, x)
           case None    => acc
-      }
+        }
     )
 }
 
@@ -356,7 +356,7 @@ final class FoldableOps1[F[_]](private val F: Foldable[F]) extends AnyVal {
       a =>
         M.map(f(a)) {
           H.bifoldMap[B, C, (F[B], F[C])](_)(b => (A.pure(b), A.empty[C]), c => (A.empty[B], A.pure(c)))
-      }
+        }
     )
   }
 

--- a/free/src/test/scala/cats/free/CofreeSuite.scala
+++ b/free/src/test/scala/cats/free/CofreeSuite.scala
@@ -72,7 +72,7 @@ class CofreeSuite extends CatsSuite {
           } else {
             spooky.increment()
             Some(spooky.counter)
-        }
+          }
       )
     spooky.counter should ===(0)
     incrementor.forceAll
@@ -163,7 +163,7 @@ sealed trait CofreeSuiteInstances {
           (l.head, l.tail) match {
             case (h, Nil) => nelToCofNel(NonEmptyList(h, Nil))
             case (h, t)   => nelToCofNel(NonEmptyList(h, t))
-        }
+          }
       )
     }
   }

--- a/kernel/src/main/scala/cats/kernel/instances/DoubleInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/DoubleInstances.scala
@@ -8,7 +8,7 @@ trait DoubleInstances {
 
 class DoubleGroup extends CommutativeGroup[Double] {
   def combine(x: Double, y: Double): Double = x + y
-  def empty: Double = 0D
+  def empty: Double = 0d
   def inverse(x: Double): Double = -x
   override def remove(x: Double, y: Double): Double = x - y
 }

--- a/kernel/src/main/scala/cats/kernel/instances/FloatInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/FloatInstances.scala
@@ -11,7 +11,7 @@ trait FloatInstances {
  */
 class FloatGroup extends CommutativeGroup[Float] {
   def combine(x: Float, y: Float): Float = x + y
-  def empty: Float = 0F
+  def empty: Float = 0f
   def inverse(x: Float): Float = -x
   override def remove(x: Float, y: Float): Float = x - y
 }

--- a/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Arbitrary.scala
@@ -28,7 +28,7 @@ object arbitrary extends ArbitraryInstances0 {
         x match {
           case Success(a) => A.perturb(seed, a)
           case Failure(e) => Cogen[Throwable].perturb(seed, e)
-      }
+        }
     )
 
   // this instance is not available in ScalaCheck 1.13.2.
@@ -208,7 +208,7 @@ object arbitrary extends ArbitraryInstances0 {
         f =>
           new Eq[A] {
             def eqv(x: A, y: A): Boolean = f(x.##) == f(y.##)
-        }
+          }
       )
     )
 
@@ -222,7 +222,7 @@ object arbitrary extends ArbitraryInstances0 {
           new PartialOrder[A] {
             def partialCompare(x: A, y: A): Double =
               if (x.## == y.##) 0.0 else f(x.##) - f(y.##)
-        }
+          }
       )
     )
 
@@ -235,7 +235,7 @@ object arbitrary extends ArbitraryInstances0 {
         f =>
           new Order[A] {
             def compare(x: A, y: A): Int = java.lang.Integer.compare(f(x.##), f(y.##))
-        }
+          }
       )
     )
 

--- a/laws/src/main/scala/cats/laws/discipline/Eq.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Eq.scala
@@ -72,7 +72,7 @@ object eq {
             f.combine(f.inverse(x), x) === f.empty && f.combine(x, f.inverse(x)) === f.empty &&
               f.combine(f.inverse(y), y) === f.empty && f.combine(y, f.inverse(y)) === f.empty &&
               f.inverse(f.empty) == f.empty
-      )
+          )
     )
 
   implicit def catsLawsEqForMonoid[A](implicit eqSA: Eq[Semigroup[A]], eqA: Eq[A]): Eq[Monoid[A]] = new Eq[Monoid[A]] {
@@ -243,8 +243,8 @@ object eq {
               f.combine(f.inverse(x), x) === f.empty && f.combine(x, f.inverse(x)) === f.empty &&
                 f.combine(f.inverse(y), y) === f.empty && f.combine(y, f.inverse(y)) === f.empty &&
                 f.inverse(f.empty) == f.empty
-          )
-      )
+            )
+        )
     )(catsLawsEqForFn1[(A, A), (A, Boolean)])
 
     Eq.instance((f, g) => eqMA.eqv(f, g) && inverseEq.eqv(f, g))

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -112,7 +112,11 @@ object Boilerplate {
         ""
       }
 
-      val n = if (arity == 1) { "" } else { arity.toString }
+      val n = if (arity == 1) {
+        ""
+      } else {
+        arity.toString
+      }
 
       val map =
         if (arity == 1)
@@ -188,7 +192,12 @@ object Boilerplate {
           "a" + n + ":A" + n
         }
         .mkString(",")
-      def apN(n: Int) = if (n == 1) { "ap" } else { s"ap$n" }
+      def apN(n: Int) =
+        if (n == 1) {
+          "ap"
+        } else {
+          s"ap$n"
+        }
       def allArgs = (0 until arity).map { "a" + _ }.mkString(",")
 
       val apply =
@@ -381,7 +390,11 @@ object Boilerplate {
       val tupleTpe = s"t$arity: $tuple"
       val tupleArgs = (1 to arity).map { case n => s"t$arity._$n" }.mkString(", ")
 
-      val n = if (arity == 1) { "" } else { arity.toString }
+      val n = if (arity == 1) {
+        ""
+      } else {
+        arity.toString
+      }
 
       val parMap =
         if (arity == 1)
@@ -428,7 +441,11 @@ object Boilerplate {
       val tupleTpe = s"t$arity: $tuple"
       val tupleArgs = (1 to arity).map { case n => s"t$arity._$n" }.mkString(", ")
 
-      val n = if (arity == 1) { "" } else { arity.toString }
+      val n = if (arity == 1) {
+        ""
+      } else {
+        arity.toString
+      }
 
       val map =
         if (arity == 1)

--- a/project/KernelBoiler.scala
+++ b/project/KernelBoiler.scala
@@ -166,7 +166,7 @@ object KernelBoiler {
                     def empty: ${`(A..N)`} = ${nullaryTuple("empty")}
                   }
               """
-          }
+            }
         ),
         InstanceDef(
           "trait TupleInstances1 extends TupleInstances2 {",
@@ -208,7 +208,7 @@ object KernelBoiler {
                       ${binMethod("partialCompare").mkString("Array(", ", ", ")")}.find(_ != 0.0).getOrElse(0.0)
                 }
         """
-          }
+            }
         ),
         InstanceDef(
           "trait TupleInstances2 extends TupleInstances3 {",
@@ -235,7 +235,7 @@ object KernelBoiler {
                     def empty: ${`(A..N)`} = ${nullaryTuple("empty")}
                   }
               """
-          }
+            }
         ),
         InstanceDef(
           "trait TupleInstances3 {",
@@ -254,7 +254,7 @@ object KernelBoiler {
                     def eqv(x: ${`(A..N)`}, y: ${`(A..N)`}): Boolean = ${binMethod("eqv").mkString(" && ")}
                   }
               """
-          }
+            }
         )
       )
   }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,7 +16,7 @@ addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.0")
 addSbtPlugin("org.portable-scala" % "sbt-scala-native-crossproject" % "0.6.0")
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.28")
 addSbtPlugin("org.scala-native" % "sbt-scala-native" % "0.3.9")
-addSbtPlugin("com.geirsson" % "sbt-scalafmt" % "1.5.1")
+addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.0.1")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
 /* Temporarily disabling sbt-hydra, see #2870.

--- a/tests/src/test/scala/cats/tests/AndThenSuite.scala
+++ b/tests/src/test/scala/cats/tests/AndThenSuite.scala
@@ -57,9 +57,7 @@ class AndThenSuite extends CatsSuite {
 
   test("andThen is stack safe") {
     val count = if (Platform.isJvm) 500000 else 1000
-    val fs = (0 until count).map(_ => { i: Int =>
-      i + 1
-    })
+    val fs = (0 until count).map(_ => { i: Int => i + 1 })
     val result = fs.foldLeft(AndThen((x: Int) => x))(_.andThen(_))(42)
 
     result shouldEqual (count + 42)
@@ -67,9 +65,7 @@ class AndThenSuite extends CatsSuite {
 
   test("compose is stack safe") {
     val count = if (Platform.isJvm) 500000 else 1000
-    val fs = (0 until count).map(_ => { i: Int =>
-      i + 1
-    })
+    val fs = (0 until count).map(_ => { i: Int => i + 1 })
     val result = fs.foldLeft(AndThen((x: Int) => x))(_.compose(_))(42)
 
     result shouldEqual (count + 42)

--- a/tests/src/test/scala/cats/tests/ParallelSuite.scala
+++ b/tests/src/test/scala/cats/tests/ParallelSuite.scala
@@ -372,7 +372,9 @@ class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest {
     }
 
     def checkMarker[A](f: => A): Option[String] =
-      try { f; None } catch {
+      try {
+        f; None
+      } catch {
         case marker: Marker => marker.value.some
         case _: Throwable   => None
       }


### PR DESCRIPTION
I tried keeping the diff small by setting
```
align.openParenCallSite = true
align.openParenDefnSite = true
```
There might be other options to keep it even smaller, but if they exist, they weren't obvious to me. Suggestions welcome!

This should unblock #2900.