### PR TITLE
Migrate to new kind-projector symbol

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .hydra
+.bloop
+.metals
 project/boot
 target
 .ensime

--- a/alleycats-core/src/main/scala/alleycats/std/map.scala
+++ b/alleycats-core/src/main/scala/alleycats/std/map.scala
@@ -8,8 +8,8 @@ object map extends MapInstances
 trait MapInstances {
 
   // toList is inconsistent. See https://github.com/typelevel/cats/issues/1831
-  implicit def alleycatsStdInstancesForMap[K]: Traverse[Map[K, ?]] =
-    new Traverse[Map[K, ?]] {
+  implicit def alleycatsStdInstancesForMap[K]: Traverse[Map[K, *]] =
+    new Traverse[Map[K, *]] {
 
       def traverse[G[_], A, B](fa: Map[K, A])(f: A => G[B])(implicit G: Applicative[G]): G[Map[K, B]] = {
         val gba: Eval[G[Map[K, B]]] = Always(G.pure(Map.empty))
@@ -59,9 +59,9 @@ trait MapInstances {
         collectFirst(fa)(Function.unlift(f))
     }
 
-  implicit def alleycatsStdMapTraverseFilter[K]: TraverseFilter[Map[K, ?]] =
-    new TraverseFilter[Map[K, ?]] {
-      def traverse: Traverse[Map[K, ?]] = alleycatsStdInstancesForMap
+  implicit def alleycatsStdMapTraverseFilter[K]: TraverseFilter[Map[K, *]] =
+    new TraverseFilter[Map[K, *]] {
+      def traverse: Traverse[Map[K, *]] = alleycatsStdInstancesForMap
 
       def traverseFilter[G[_], A, B](fa: Map[K, A])(f: A => G[Option[B]])(implicit G: Applicative[G]): G[Map[K, B]] = {
         val gba: Eval[G[Map[K, B]]] = Always(G.pure(Map.empty))

--- a/alleycats-tests/shared/src/test/scala/alleycats/tests/MapSuite.scala
+++ b/alleycats-tests/shared/src/test/scala/alleycats/tests/MapSuite.scala
@@ -5,7 +5,7 @@ import cats.laws.discipline.{SerializableTests, TraverseFilterTests}
 import cats.Traverse
 
 class MapSuite extends AlleycatsSuite {
-  checkAll("Traverse[Map[Int, ?]]", SerializableTests.serializable(Traverse[Map[Int, ?]]))
+  checkAll("Traverse[Map[Int, *]]", SerializableTests.serializable(Traverse[Map[Int, *]]))
 
-  checkAll("TraverseFilter[Map[Int, ?]]", TraverseFilterTests[Map[Int, ?]].traverseFilter[Int, Int, Int])
+  checkAll("TraverseFilter[Map[Int, *]]", TraverseFilterTests[Map[Int, *]].traverseFilter[Int, Int, Int])
 }

--- a/bench/src/main/scala/cats/bench/FoldBench.scala
+++ b/bench/src/main/scala/cats/bench/FoldBench.scala
@@ -23,7 +23,7 @@ class FoldBench {
   /** Benchmark fold using traverse with Const */
   @Benchmark
   def traverseConst(): String =
-    Traverse[List].traverse[Const[String, ?], String, String](chars)(Const(_)).getConst
+    Traverse[List].traverse[Const[String, *], String, String](chars)(Const(_)).getConst
 
   @Benchmark
   def vectorToListFoldM(): Option[String] =

--- a/binCompatTest/src/main/scala/catsBC/MimaExceptions.scala
+++ b/binCompatTest/src/main/scala/catsBC/MimaExceptions.scala
@@ -8,7 +8,7 @@ object MimaExceptions {
   import cats.arrow.FunctionK // needs to be imported because of a hygiene problem
 
   def isBinaryCompatible = (
-    cats.Monad[cats.data.OptionT[List, ?]],
+    cats.Monad[cats.data.OptionT[List, *]],
     cats.data.OptionT.catsDataTraverseForOptionT[List],
     cats.data.Kleisli.catsDataCommutativeArrowForKleisliId,
     cats.data.OptionT.catsDataMonoidKForOptionT[List],
@@ -19,8 +19,8 @@ object MimaExceptions {
     cats.data.IRWST.catsDataStrongForIRWST[List, Int, Int, Int],
     cats.data.OptionT.catsDataMonadErrorMonadForOptionT[List],
     FunctionK.lift(headOption),
-    cats.data.OptionT.catsDataMonadErrorForOptionT[Either[String, ?], String],
-    cats.data.OptionT[Either[String, ?], Int](Right(Some(17))).ensure("error")(_ => true),
+    cats.data.OptionT.catsDataMonadErrorForOptionT[Either[String, *], String],
+    cats.data.OptionT[Either[String, *], Int](Right(Some(17))).ensure("error")(_ => true),
     "blah".leftNec[Int],
     List(Some(4), None).nested,
     cats.data.EitherT.left[Int](Option("err")),

--- a/core/src/main/scala/cats/Applicative.scala
+++ b/core/src/main/scala/cats/Applicative.scala
@@ -206,7 +206,7 @@ object Applicative {
    * res0: (Long, Int) = (3,6)
    * }}}
    */
-  implicit def catsApplicativeForArrow[F[_, _], A](implicit F: Arrow[F]): Applicative[F[A, ?]] =
+  implicit def catsApplicativeForArrow[F[_, _], A](implicit F: Arrow[F]): Applicative[F[A, *]] =
     new ArrowApplicative[F, A](F)
 
   /**
@@ -237,7 +237,7 @@ private[cats] class ApplicativeMonoid[F[_], A](f: Applicative[F], monoid: Monoid
   def empty: F[A] = f.pure(monoid.empty)
 }
 
-private[cats] class ArrowApplicative[F[_, _], A](F: Arrow[F]) extends Applicative[F[A, ?]] {
+private[cats] class ArrowApplicative[F[_, _], A](F: Arrow[F]) extends Applicative[F[A, *]] {
   def pure[B](b: B): F[A, B] = F.lift[A, B](_ => b)
   override def map[B, C](fb: F[A, B])(f: B => C): F[A, C] = F.rmap(fb)(f)
   def ap[B, C](ff: F[A, B => C])(fb: F[A, B]): F[A, C] =

--- a/core/src/main/scala/cats/ApplicativeError.scala
+++ b/core/src/main/scala/cats/ApplicativeError.scala
@@ -108,7 +108,7 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
    *
    * scala> case class Err(msg: String)
    *
-   * scala> type F[A] = EitherT[State[String, ?], Err, A]
+   * scala> type F[A] = EitherT[State[String, *], Err, A]
    *
    * scala> val action: PartialFunction[Err, F[Unit]] = {
    *      |   case Err("one") => EitherT.liftF(State.set("one"))
@@ -199,10 +199,10 @@ object ApplicativeError {
    * scala> import cats.implicits._
    * scala> import cats.ApplicativeError
    *
-   * scala> ApplicativeError.liftFromOption[Either[String, ?]](Some(1), "Empty")
+   * scala> ApplicativeError.liftFromOption[Either[String, *]](Some(1), "Empty")
    * res0: scala.Either[String, Int] = Right(1)
    *
-   * scala> ApplicativeError.liftFromOption[Either[String, ?]](Option.empty[Int], "Empty")
+   * scala> ApplicativeError.liftFromOption[Either[String, *]](Option.empty[Int], "Empty")
    * res1: scala.Either[String, Int] = Left(Empty)
    * }}}
    */

--- a/core/src/main/scala/cats/Bifunctor.scala
+++ b/core/src/main/scala/cats/Bifunctor.scala
@@ -22,10 +22,10 @@ import simulacrum.typeclass
    */
   def bimap[A, B, C, D](fab: F[A, B])(f: A => C, g: B => D): F[C, D]
 
-  def rightFunctor[X]: Functor[F[X, ?]] =
+  def rightFunctor[X]: Functor[F[X, *]] =
     new RightFunctor[F, X] { val F = self }
 
-  def leftFunctor[X]: Functor[F[?, X]] =
+  def leftFunctor[X]: Functor[F[*, X]] =
     new LeftFunctor[F, X] { val F = self }
 
   // derived methods
@@ -65,14 +65,14 @@ private[cats] trait ComposedBifunctor[F[_, _], G[_, _]] extends Bifunctor[λ[(A,
   }
 }
 
-abstract private class LeftFunctor[F[_, _], X] extends Functor[F[?, X]] {
+abstract private class LeftFunctor[F[_, _], X] extends Functor[F[*, X]] {
   implicit val F: Bifunctor[F]
 
   override def map[A, C](fax: F[A, X])(f: A => C): F[C, X] =
     F.bimap(fax)(f, identity)
 }
 
-abstract private class RightFunctor[F[_, _], X] extends Functor[F[X, ?]] {
+abstract private class RightFunctor[F[_, _], X] extends Functor[F[X, *]] {
   implicit val F: Bifunctor[F]
 
   override def map[A, C](fxa: F[X, A])(f: A => C): F[X, C] =

--- a/core/src/main/scala/cats/FlatMap.scala
+++ b/core/src/main/scala/cats/FlatMap.scala
@@ -10,7 +10,7 @@ import simulacrum.noop
  *
  * One motivation for separating this out from Monad is that there are
  * situations where we can implement flatMap but not pure.  For example,
- * we can implement map or flatMap that transforms the values of Map[K, ?],
+ * we can implement map or flatMap that transforms the values of Map[K, *],
  * but we can't implement pure (because we wouldn't know what key to use
  * when instantiating the new Map).
  *

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -199,7 +199,7 @@ import Foldable.sentinel
   def get[A](fa: F[A])(idx: Long): Option[A] =
     if (idx < 0L) None
     else
-      foldM[Either[A, ?], A, Long](fa, 0L) { (i, a) =>
+      foldM[Either[A, *], A, Long](fa, 0L) { (i, a) =>
         if (i == idx) Left(a) else Right(i + 1L)
       } match {
         case Left(a)  => Some(a)

--- a/core/src/main/scala/cats/InjectK.scala
+++ b/core/src/main/scala/cats/InjectK.scala
@@ -42,18 +42,18 @@ sealed abstract private[cats] class InjectKInstances {
       val prj = λ[FunctionK[F, λ[α => Option[F[α]]]]](Some(_))
     }
 
-  implicit def catsLeftInjectKInstance[F[_], G[_]]: InjectK[F, EitherK[F, G, ?]] =
-    new InjectK[F, EitherK[F, G, ?]] {
-      val inj = λ[FunctionK[F, EitherK[F, G, ?]]](EitherK.leftc(_))
+  implicit def catsLeftInjectKInstance[F[_], G[_]]: InjectK[F, EitherK[F, G, *]] =
+    new InjectK[F, EitherK[F, G, *]] {
+      val inj = λ[FunctionK[F, EitherK[F, G, *]]](EitherK.leftc(_))
 
-      val prj = λ[FunctionK[EitherK[F, G, ?], λ[α => Option[F[α]]]]](_.run.left.toOption)
+      val prj = λ[FunctionK[EitherK[F, G, *], λ[α => Option[F[α]]]]](_.run.left.toOption)
     }
 
-  implicit def catsRightInjectKInstance[F[_], G[_], H[_]](implicit I: InjectK[F, G]): InjectK[F, EitherK[H, G, ?]] =
-    new InjectK[F, EitherK[H, G, ?]] {
-      val inj = λ[FunctionK[G, EitherK[H, G, ?]]](EitherK.rightc(_)).compose(I.inj)
+  implicit def catsRightInjectKInstance[F[_], G[_], H[_]](implicit I: InjectK[F, G]): InjectK[F, EitherK[H, G, *]] =
+    new InjectK[F, EitherK[H, G, *]] {
+      val inj = λ[FunctionK[G, EitherK[H, G, *]]](EitherK.rightc(_)).compose(I.inj)
 
-      val prj = λ[FunctionK[EitherK[H, G, ?], λ[α => Option[F[α]]]]](_.run.toOption.flatMap(I.prj(_)))
+      val prj = λ[FunctionK[EitherK[H, G, *], λ[α => Option[F[α]]]]](_.run.toOption.flatMap(I.prj(_)))
     }
 }
 

--- a/core/src/main/scala/cats/arrow/FunctionK.scala
+++ b/core/src/main/scala/cats/arrow/FunctionK.scala
@@ -43,8 +43,8 @@ trait FunctionK[F[_], G[_]] extends Serializable { self =>
    * This transformation will be used to transform left `F` values while
    * `h` will be used to transform right `H` values.
    */
-  def or[H[_]](h: FunctionK[H, G]): FunctionK[EitherK[F, H, ?], G] =
-    λ[FunctionK[EitherK[F, H, ?], G]](fa => fa.fold(self, h))
+  def or[H[_]](h: FunctionK[H, G]): FunctionK[EitherK[F, H, *], G] =
+    λ[FunctionK[EitherK[F, H, *], G]](fa => fa.fold(self, h))
 
   /**
    * Composes two instances of `FunctionK` into a new `FunctionK` that transforms
@@ -59,8 +59,8 @@ trait FunctionK[F[_], G[_]] extends Serializable { self =>
    * res0: cats.data.Tuple2K[Option,Vector,Int] = Tuple2K(Some(1),Vector(1, 2, 3))
    * }}}
    */
-  def and[H[_]](h: FunctionK[F, H]): FunctionK[F, Tuple2K[G, H, ?]] =
-    λ[FunctionK[F, Tuple2K[G, H, ?]]](fa => Tuple2K(self(fa), h(fa)))
+  def and[H[_]](h: FunctionK[F, H]): FunctionK[F, Tuple2K[G, H, *]] =
+    λ[FunctionK[F, Tuple2K[G, H, *]]](fa => Tuple2K(self(fa), h(fa)))
 }
 
 object FunctionK {

--- a/core/src/main/scala/cats/data/AndThen.scala
+++ b/core/src/main/scala/cats/data/AndThen.scala
@@ -168,8 +168,8 @@ abstract private[data] class AndThenInstances0 extends AndThenInstances1 {
   /**
    * [[cats.Monad]] instance for [[AndThen]].
    */
-  implicit def catsDataMonadForAndThen[T]: Monad[AndThen[T, ?]] =
-    new Monad[AndThen[T, ?]] {
+  implicit def catsDataMonadForAndThen[T]: Monad[AndThen[T, *]] =
+    new Monad[AndThen[T, *]] {
       // Piggybacking on the instance for Function1
       private[this] val fn1 = instances.all.catsStdMonadForFunction1[T]
 
@@ -189,8 +189,8 @@ abstract private[data] class AndThenInstances0 extends AndThenInstances1 {
   /**
    * [[cats.ContravariantMonoidal]] instance for [[AndThen]].
    */
-  implicit def catsDataContravariantMonoidalForAndThen[R: Monoid]: ContravariantMonoidal[AndThen[?, R]] =
-    new ContravariantMonoidal[AndThen[?, R]] {
+  implicit def catsDataContravariantMonoidalForAndThen[R: Monoid]: ContravariantMonoidal[AndThen[*, R]] =
+    new ContravariantMonoidal[AndThen[*, R]] {
       // Piggybacking on the instance for Function1
       private[this] val fn1 = instances.all.catsStdContravariantMonoidalForFunction1[R]
 
@@ -236,8 +236,8 @@ abstract private[data] class AndThenInstances1 {
   /**
    * [[cats.Contravariant]] instance for [[AndThen]].
    */
-  implicit def catsDataContravariantForAndThen[R]: Contravariant[AndThen[?, R]] =
-    new Contravariant[AndThen[?, R]] {
+  implicit def catsDataContravariantForAndThen[R]: Contravariant[AndThen[*, R]] =
+    new Contravariant[AndThen[*, R]] {
       def contramap[T1, T0](fa: AndThen[T1, R])(f: T0 => T1): AndThen[T0, R] =
         fa.compose(f)
     }

--- a/core/src/main/scala/cats/data/Binested.scala
+++ b/core/src/main/scala/cats/data/Binested.scala
@@ -6,7 +6,7 @@ import cats.arrow._
 /** Compose a two-slot type constructor `F[_, _]` with two single-slot type constructors
  *  `G[_]` and `H[_]`, resulting in a two-slot type constructor with respect to the inner types.
  *  For example, `List` and `Option` both have `Functor` instances, and `Either` has a
- *  `Bifunctor` instance. Therefore, `Binested[Either, List, Option, ?, ?]` has a `Bifunctor`
+ *  `Bifunctor` instance. Therefore, `Binested[Either, List, Option, *, *]` has a `Bifunctor`
  *  instance as well:
  *
  * {{{
@@ -17,7 +17,7 @@ import cats.arrow._
  * scala> val f: Int => String = _.toString
  * scala> val g: String => String = _ + "-bifunctor"
  * scala> val binested = Binested(eitherListOption)
- * scala> val bimapped = Bifunctor[Binested[Either, List, Option, ?, ?]].bimap(binested)(f, g).value
+ * scala> val bimapped = Bifunctor[Binested[Either, List, Option, *, *]].bimap(binested)(f, g).value
  * res0: Either[List[String], Option[String]] = Right(Some("cats-bifunctor"))
  * }}}
  */
@@ -33,8 +33,8 @@ trait BinestedInstances extends BinestedInstances0 {
 
   implicit def catsDataProfunctorForBinested[F[_, _], G[_], H[_]](implicit F: Profunctor[F],
                                                                   G: Functor[G],
-                                                                  H: Functor[H]): Profunctor[Binested[F, G, H, ?, ?]] =
-    new Profunctor[Binested[F, G, H, ?, ?]] {
+                                                                  H: Functor[H]): Profunctor[Binested[F, G, H, *, *]] =
+    new Profunctor[Binested[F, G, H, *, *]] {
       def dimap[A, B, C, D](fab: Binested[F, G, H, A, B])(f: C => A)(g: B => D): Binested[F, G, H, C, D] =
         Binested(F.dimap(fab.value)(G.map(_: G[C])(f))(H.map(_)(g)))
     }
@@ -43,7 +43,7 @@ trait BinestedInstances extends BinestedInstances0 {
     implicit F0: Bitraverse[F],
     H0: Traverse[H],
     G0: Traverse[G]
-  ): Bitraverse[Binested[F, G, H, ?, ?]] =
+  ): Bitraverse[Binested[F, G, H, *, *]] =
     new BinestedBitraverse[F, G, H] {
       implicit override def F: Bitraverse[F] = F0
       implicit override def G: Traverse[G] = G0
@@ -56,7 +56,7 @@ trait BinestedInstances0 {
     implicit F0: Bifoldable[F],
     G0: Foldable[G],
     H0: Foldable[H]
-  ): Bifoldable[Binested[F, G, H, ?, ?]] =
+  ): Bifoldable[Binested[F, G, H, *, *]] =
     new BinestedBifoldable[F, G, H] {
       implicit override def F: Bifoldable[F] = F0
       implicit override def G: Foldable[G] = G0
@@ -65,14 +65,14 @@ trait BinestedInstances0 {
 
   implicit def catsDataBifunctorForBinested[F[_, _], G[_], H[_]](implicit F: Bifunctor[F],
                                                                  G: Functor[G],
-                                                                 H: Functor[H]): Bifunctor[Binested[F, G, H, ?, ?]] =
-    new Bifunctor[Binested[F, G, H, ?, ?]] {
+                                                                 H: Functor[H]): Bifunctor[Binested[F, G, H, *, *]] =
+    new Bifunctor[Binested[F, G, H, *, *]] {
       def bimap[A, B, C, D](fab: Binested[F, G, H, A, B])(f: A => C, g: B => D): Binested[F, G, H, C, D] =
         Binested(F.bimap(fab.value)(G.map(_)(f), H.map(_)(g)))
     }
 }
 
-sealed abstract class BinestedBifoldable[F[_, _], G[_], H[_]] extends Bifoldable[Binested[F, G, H, ?, ?]] {
+sealed abstract class BinestedBifoldable[F[_, _], G[_], H[_]] extends Bifoldable[Binested[F, G, H, *, *]] {
   implicit def F: Bifoldable[F]
   implicit def G: Foldable[G]
   implicit def H: Foldable[H]
@@ -93,7 +93,7 @@ sealed abstract class BinestedBifoldable[F[_, _], G[_], H[_]] extends Bifoldable
 
 sealed abstract class BinestedBitraverse[F[_, _], G[_], H[_]]
     extends BinestedBifoldable[F, G, H]
-    with Bitraverse[Binested[F, G, H, ?, ?]] {
+    with Bitraverse[Binested[F, G, H, *, *]] {
   implicit override def F: Bitraverse[F]
   implicit override def G: Traverse[G]
   implicit override def H: Traverse[H]

--- a/core/src/main/scala/cats/data/Cokleisli.scala
+++ b/core/src/main/scala/cats/data/Cokleisli.scala
@@ -78,40 +78,40 @@ object Cokleisli extends CokleisliInstances {
 
 sealed abstract private[data] class CokleisliInstances extends CokleisliInstances0 {
 
-  implicit val catsDataCommutativeArrowForCokleisliId: CommutativeArrow[Cokleisli[Id, ?, ?]] =
-    new CokleisliArrow[Id] with CommutativeArrow[Cokleisli[Id, ?, ?]] {
+  implicit val catsDataCommutativeArrowForCokleisliId: CommutativeArrow[Cokleisli[Id, *, *]] =
+    new CokleisliArrow[Id] with CommutativeArrow[Cokleisli[Id, *, *]] {
       def F: Comonad[Id] = Comonad[Id]
     }
 
-  implicit def catsDataMonadForCokleisli[F[_], A]: Monad[Cokleisli[F, A, ?]] =
+  implicit def catsDataMonadForCokleisli[F[_], A]: Monad[Cokleisli[F, A, *]] =
     new CokleisliMonad[F, A]
 
   implicit def catsDataMonoidKForCokleisli[F[_]](implicit ev: Comonad[F]): MonoidK[λ[α => Cokleisli[F, α, α]]] =
-    Category[Cokleisli[F, ?, ?]].algebraK
+    Category[Cokleisli[F, *, *]].algebraK
 }
 
 sealed abstract private[data] class CokleisliInstances0 extends CokleisliInstances1 {
-  implicit def catsDataArrowForCokleisli[F[_]](implicit ev: Comonad[F]): Arrow[Cokleisli[F, ?, ?]] =
+  implicit def catsDataArrowForCokleisli[F[_]](implicit ev: Comonad[F]): Arrow[Cokleisli[F, *, *]] =
     new CokleisliArrow[F] { def F: Comonad[F] = ev }
 }
 
 sealed abstract private[data] class CokleisliInstances1 {
-  implicit def catsDataComposeForCokleisli[F[_]](implicit ev: CoflatMap[F]): Compose[Cokleisli[F, ?, ?]] =
+  implicit def catsDataComposeForCokleisli[F[_]](implicit ev: CoflatMap[F]): Compose[Cokleisli[F, *, *]] =
     new CokleisliCompose[F] { def F: CoflatMap[F] = ev }
 
-  implicit def catsDataProfunctorForCokleisli[F[_]](implicit ev: Functor[F]): Profunctor[Cokleisli[F, ?, ?]] =
+  implicit def catsDataProfunctorForCokleisli[F[_]](implicit ev: Functor[F]): Profunctor[Cokleisli[F, *, *]] =
     new CokleisliProfunctor[F] { def F: Functor[F] = ev }
 
   implicit def catsDataSemigroupKForCokleisli[F[_]](implicit ev: CoflatMap[F]): SemigroupK[λ[α => Cokleisli[F, α, α]]] =
-    Compose[Cokleisli[F, ?, ?]].algebraK
+    Compose[Cokleisli[F, *, *]].algebraK
 
-  implicit def catsDataContravariantForCokleisli[F[_]: Functor, A]: Contravariant[Cokleisli[F, ?, A]] =
-    new Contravariant[Cokleisli[F, ?, A]] {
+  implicit def catsDataContravariantForCokleisli[F[_]: Functor, A]: Contravariant[Cokleisli[F, *, A]] =
+    new Contravariant[Cokleisli[F, *, A]] {
       def contramap[B, C](fbc: Cokleisli[F, B, A])(f: C => B): Cokleisli[F, C, A] = fbc.lmap(f)
     }
 }
 
-private[data] class CokleisliMonad[F[_], A] extends Monad[Cokleisli[F, A, ?]] {
+private[data] class CokleisliMonad[F[_], A] extends Monad[Cokleisli[F, A, *]] {
 
   def pure[B](x: B): Cokleisli[F, A, B] =
     Cokleisli.pure(x)
@@ -135,7 +135,7 @@ private[data] class CokleisliMonad[F[_], A] extends Monad[Cokleisli[F, A, ?]] {
 }
 
 private trait CokleisliArrow[F[_]]
-    extends Arrow[Cokleisli[F, ?, ?]]
+    extends Arrow[Cokleisli[F, *, *]]
     with CokleisliCompose[F]
     with CokleisliProfunctor[F] {
   implicit def F: Comonad[F]
@@ -156,14 +156,14 @@ private trait CokleisliArrow[F[_]]
     Cokleisli(fac => f.run(F.map(fac)(_._1)) -> g.run(F.map(fac)(_._2)))
 }
 
-private trait CokleisliCompose[F[_]] extends Compose[Cokleisli[F, ?, ?]] {
+private trait CokleisliCompose[F[_]] extends Compose[Cokleisli[F, *, *]] {
   implicit def F: CoflatMap[F]
 
   def compose[A, B, C](f: Cokleisli[F, B, C], g: Cokleisli[F, A, B]): Cokleisli[F, A, C] =
     f.compose(g)
 }
 
-private trait CokleisliProfunctor[F[_]] extends Profunctor[Cokleisli[F, ?, ?]] {
+private trait CokleisliProfunctor[F[_]] extends Profunctor[Cokleisli[F, *, *]] {
   implicit def F: Functor[F]
 
   def dimap[A, B, C, D](fab: Cokleisli[F, A, B])(f: C => A)(g: B => D): Cokleisli[F, C, D] =

--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -78,7 +78,7 @@ sealed abstract private[data] class ConstInstances extends ConstInstances0 {
     def show(f: Const[A, B]): String = f.show
   }
 
-  implicit def catsDataTraverseForConst[C]: Traverse[Const[C, ?]] = new Traverse[Const[C, ?]] {
+  implicit def catsDataTraverseForConst[C]: Traverse[Const[C, *]] = new Traverse[Const[C, *]] {
     def foldLeft[A, B](fa: Const[C, A], b: B)(f: (B, A) => B): B = b
 
     def foldRight[A, B](fa: Const[C, A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] = lb
@@ -91,7 +91,7 @@ sealed abstract private[data] class ConstInstances extends ConstInstances0 {
       fa.traverse(f)
   }
 
-  implicit def catsDataTraverseFilterForConst[C]: TraverseFilter[Const[C, ?]] = new TraverseFilter[Const[C, ?]] {
+  implicit def catsDataTraverseFilterForConst[C]: TraverseFilter[Const[C, *]] = new TraverseFilter[Const[C, *]] {
 
     override def mapFilter[A, B](fa: Const[C, A])(f: (A) => Option[B]): Const[C, B] = fa.retag
 
@@ -109,7 +109,7 @@ sealed abstract private[data] class ConstInstances extends ConstInstances0 {
     override def filterA[G[_], A](fa: Const[C, A])(f: (A) => G[Boolean])(implicit G: Applicative[G]): G[Const[C, A]] =
       G.pure(fa)
 
-    val traverse: Traverse[Const[C, ?]] = Const.catsDataTraverseForConst[C]
+    val traverse: Traverse[Const[C, *]] = Const.catsDataTraverseForConst[C]
   }
 
   implicit def catsDataMonoidForConst[A: Monoid, B]: Monoid[Const[A, B]] = new Monoid[Const[A, B]] {
@@ -133,8 +133,8 @@ sealed abstract private[data] class ConstInstances extends ConstInstances0 {
 
 sealed abstract private[data] class ConstInstances0 extends ConstInstances1 {
 
-  implicit def catsDataContravariantMonoidalForConst[D: Monoid]: ContravariantMonoidal[Const[D, ?]] =
-    new ContravariantMonoidal[Const[D, ?]] {
+  implicit def catsDataContravariantMonoidalForConst[D: Monoid]: ContravariantMonoidal[Const[D, *]] =
+    new ContravariantMonoidal[Const[D, *]] {
       override def unit = Const.empty[D, Unit]
       override def contramap[A, B](fa: Const[D, A])(f: B => A): Const[D, B] =
         fa.retag[B]
@@ -144,14 +144,14 @@ sealed abstract private[data] class ConstInstances0 extends ConstInstances1 {
 
   implicit def catsDataCommutativeApplicativeForConst[C](
     implicit C: CommutativeMonoid[C]
-  ): CommutativeApplicative[Const[C, ?]] =
-    new ConstApplicative[C] with CommutativeApplicative[Const[C, ?]] { val C0: CommutativeMonoid[C] = C }
+  ): CommutativeApplicative[Const[C, *]] =
+    new ConstApplicative[C] with CommutativeApplicative[Const[C, *]] { val C0: CommutativeMonoid[C] = C }
 }
 
 sealed abstract private[data] class ConstInstances1 extends ConstInstances2 {
 
-  implicit def catsDataCommutativeApplyForConst[C](implicit C: CommutativeSemigroup[C]): CommutativeApply[Const[C, ?]] =
-    new ConstApply[C] with CommutativeApply[Const[C, ?]] { val C0: CommutativeSemigroup[C] = C }
+  implicit def catsDataCommutativeApplyForConst[C](implicit C: CommutativeSemigroup[C]): CommutativeApply[Const[C, *]] =
+    new ConstApply[C] with CommutativeApply[Const[C, *]] { val C0: CommutativeSemigroup[C] = C }
 }
 
 sealed abstract private[data] class ConstInstances2 extends ConstInstances3 {
@@ -166,7 +166,7 @@ sealed abstract private[data] class ConstInstances2 extends ConstInstances3 {
         x.partialCompare(y)
     }
 
-  implicit def catsDataApplicativeForConst[C](implicit C: Monoid[C]): Applicative[Const[C, ?]] =
+  implicit def catsDataApplicativeForConst[C](implicit C: Monoid[C]): Applicative[Const[C, *]] =
     new ConstApplicative[C] { val C0: Monoid[C] = C }
 }
 
@@ -177,30 +177,30 @@ sealed abstract private[data] class ConstInstances3 extends ConstInstances4 {
       x === y
   }
 
-  implicit def catsDataApplyForConst[C](implicit C: Semigroup[C]): Apply[Const[C, ?]] =
+  implicit def catsDataApplyForConst[C](implicit C: Semigroup[C]): Apply[Const[C, *]] =
     new ConstApply[C] { val C0: Semigroup[C] = C }
 }
 
 sealed abstract private[data] class ConstInstances4 {
 
-  implicit def catsDataFunctorForConst[C]: Functor[Const[C, ?]] =
+  implicit def catsDataFunctorForConst[C]: Functor[Const[C, *]] =
     new ConstFunctor[C] {}
 
-  implicit def catsDataContravariantForConst[C]: Contravariant[Const[C, ?]] =
+  implicit def catsDataContravariantForConst[C]: Contravariant[Const[C, *]] =
     new ConstContravariant[C] {}
 }
 
-sealed private[data] trait ConstFunctor[C] extends Functor[Const[C, ?]] {
+sealed private[data] trait ConstFunctor[C] extends Functor[Const[C, *]] {
   def map[A, B](fa: Const[C, A])(f: A => B): Const[C, B] =
     fa.retag[B]
 }
 
-sealed private[data] trait ConstContravariant[C] extends Contravariant[Const[C, ?]] {
+sealed private[data] trait ConstContravariant[C] extends Contravariant[Const[C, *]] {
   override def contramap[A, B](fa: Const[C, A])(f: B => A): Const[C, B] =
     fa.retag[B]
 }
 
-sealed private[data] trait ConstApply[C] extends ConstFunctor[C] with Apply[Const[C, ?]] {
+sealed private[data] trait ConstApply[C] extends ConstFunctor[C] with Apply[Const[C, *]] {
 
   implicit def C0: Semigroup[C]
 
@@ -211,7 +211,7 @@ sealed private[data] trait ConstApply[C] extends ConstFunctor[C] with Apply[Cons
     fa.retag[(A, B)].combine(fb.retag[(A, B)])
 }
 
-sealed private[data] trait ConstApplicative[C] extends ConstApply[C] with Applicative[Const[C, ?]] {
+sealed private[data] trait ConstApplicative[C] extends ConstApply[C] with Applicative[Const[C, *]] {
 
   implicit def C0: Monoid[C]
 

--- a/core/src/main/scala/cats/data/ContT.scala
+++ b/core/src/main/scala/cats/data/ContT.scala
@@ -135,14 +135,14 @@ object ContT {
       go(a)
     }
 
-  implicit def catsDataContTDefer[M[_], B]: Defer[ContT[M, B, ?]] =
-    new Defer[ContT[M, B, ?]] {
+  implicit def catsDataContTDefer[M[_], B]: Defer[ContT[M, B, *]] =
+    new Defer[ContT[M, B, *]] {
       def defer[A](c: => ContT[M, B, A]): ContT[M, B, A] =
         DeferCont(() => c)
     }
 
-  implicit def catsDataContTMonad[M[_]: Defer, A]: Monad[ContT[M, A, ?]] =
-    new Monad[ContT[M, A, ?]] {
+  implicit def catsDataContTMonad[M[_]: Defer, A]: Monad[ContT[M, A, *]] =
+    new Monad[ContT[M, A, *]] {
       def pure[B](b: B): ContT[M, A, B] =
         ContT.pure(b)
 

--- a/core/src/main/scala/cats/data/EitherK.scala
+++ b/core/src/main/scala/cats/data/EitherK.scala
@@ -111,7 +111,7 @@ sealed abstract private[data] class EitherKInstances3 {
     Eq.by(_.run)
 
   implicit def catsDataFunctorForEitherK[F[_], G[_]](implicit F0: Functor[F],
-                                                     G0: Functor[G]): Functor[EitherK[F, G, ?]] =
+                                                     G0: Functor[G]): Functor[EitherK[F, G, *]] =
     new EitherKFunctor[F, G] {
       implicit def F: Functor[F] = F0
 
@@ -119,7 +119,7 @@ sealed abstract private[data] class EitherKInstances3 {
     }
 
   implicit def catsDataFoldableForEitherK[F[_], G[_]](implicit F0: Foldable[F],
-                                                      G0: Foldable[G]): Foldable[EitherK[F, G, ?]] =
+                                                      G0: Foldable[G]): Foldable[EitherK[F, G, *]] =
     new EitherKFoldable[F, G] {
       implicit def F: Foldable[F] = F0
 
@@ -130,7 +130,7 @@ sealed abstract private[data] class EitherKInstances3 {
 sealed abstract private[data] class EitherKInstances2 extends EitherKInstances3 {
 
   implicit def catsDataContravariantForEitherK[F[_], G[_]](implicit F0: Contravariant[F],
-                                                           G0: Contravariant[G]): Contravariant[EitherK[F, G, ?]] =
+                                                           G0: Contravariant[G]): Contravariant[EitherK[F, G, *]] =
     new EitherKContravariant[F, G] {
       implicit def F: Contravariant[F] = F0
 
@@ -140,7 +140,7 @@ sealed abstract private[data] class EitherKInstances2 extends EitherKInstances3 
 
 sealed abstract private[data] class EitherKInstances1 extends EitherKInstances2 {
   implicit def catsDataCoflatMapForEitherK[F[_], G[_]](implicit F0: CoflatMap[F],
-                                                       G0: CoflatMap[G]): CoflatMap[EitherK[F, G, ?]] =
+                                                       G0: CoflatMap[G]): CoflatMap[EitherK[F, G, *]] =
     new EitherKCoflatMap[F, G] with EitherKFunctor[F, G] {
       implicit def F: CoflatMap[F] = F0
 
@@ -150,7 +150,7 @@ sealed abstract private[data] class EitherKInstances1 extends EitherKInstances2 
 
 sealed abstract private[data] class EitherKInstances0 extends EitherKInstances1 {
   implicit def catsDataTraverseForEitherK[F[_], G[_]](implicit F0: Traverse[F],
-                                                      G0: Traverse[G]): Traverse[EitherK[F, G, ?]] =
+                                                      G0: Traverse[G]): Traverse[EitherK[F, G, *]] =
     new EitherKTraverse[F, G] with EitherKFunctor[F, G] {
       implicit def F: Traverse[F] = F0
 
@@ -161,7 +161,7 @@ sealed abstract private[data] class EitherKInstances0 extends EitherKInstances1 
 sealed abstract private[data] class EitherKInstances extends EitherKInstances0 {
 
   implicit def catsDataComonadForEitherK[F[_], G[_]](implicit F0: Comonad[F],
-                                                     G0: Comonad[G]): Comonad[EitherK[F, G, ?]] =
+                                                     G0: Comonad[G]): Comonad[EitherK[F, G, *]] =
     new EitherKComonad[F, G] with EitherKFunctor[F, G] {
       implicit def F: Comonad[F] = F0
 
@@ -169,7 +169,7 @@ sealed abstract private[data] class EitherKInstances extends EitherKInstances0 {
     }
 }
 
-private[data] trait EitherKFunctor[F[_], G[_]] extends Functor[EitherK[F, G, ?]] {
+private[data] trait EitherKFunctor[F[_], G[_]] extends Functor[EitherK[F, G, *]] {
   implicit def F: Functor[F]
 
   implicit def G: Functor[G]
@@ -178,7 +178,7 @@ private[data] trait EitherKFunctor[F[_], G[_]] extends Functor[EitherK[F, G, ?]]
     a.map(f)
 }
 
-private[data] trait EitherKContravariant[F[_], G[_]] extends Contravariant[EitherK[F, G, ?]] {
+private[data] trait EitherKContravariant[F[_], G[_]] extends Contravariant[EitherK[F, G, *]] {
   implicit def F: Contravariant[F]
 
   implicit def G: Contravariant[G]
@@ -187,7 +187,7 @@ private[data] trait EitherKContravariant[F[_], G[_]] extends Contravariant[Eithe
     a.contramap(f)
 }
 
-private[data] trait EitherKFoldable[F[_], G[_]] extends Foldable[EitherK[F, G, ?]] {
+private[data] trait EitherKFoldable[F[_], G[_]] extends Foldable[EitherK[F, G, *]] {
   implicit def F: Foldable[F]
 
   implicit def G: Foldable[G]
@@ -208,7 +208,7 @@ private[data] trait EitherKFoldable[F[_], G[_]] extends Foldable[EitherK[F, G, ?
     fa.foldMap(f)
 }
 
-private[data] trait EitherKTraverse[F[_], G[_]] extends EitherKFoldable[F, G] with Traverse[EitherK[F, G, ?]] {
+private[data] trait EitherKTraverse[F[_], G[_]] extends EitherKFoldable[F, G] with Traverse[EitherK[F, G, *]] {
   implicit def F: Traverse[F]
 
   implicit def G: Traverse[G]
@@ -220,7 +220,7 @@ private[data] trait EitherKTraverse[F[_], G[_]] extends EitherKFoldable[F, G] wi
     fa.traverse(f)
 }
 
-private[data] trait EitherKCoflatMap[F[_], G[_]] extends CoflatMap[EitherK[F, G, ?]] {
+private[data] trait EitherKCoflatMap[F[_], G[_]] extends CoflatMap[EitherK[F, G, *]] {
   implicit def F: CoflatMap[F]
 
   implicit def G: CoflatMap[G]
@@ -235,7 +235,7 @@ private[data] trait EitherKCoflatMap[F[_], G[_]] extends CoflatMap[EitherK[F, G,
     fa.coflatten
 }
 
-private[data] trait EitherKComonad[F[_], G[_]] extends Comonad[EitherK[F, G, ?]] with EitherKCoflatMap[F, G] {
+private[data] trait EitherKComonad[F[_], G[_]] extends Comonad[EitherK[F, G, *]] with EitherKCoflatMap[F, G] {
   implicit def F: Comonad[F]
 
   implicit def G: Comonad[G]

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -92,7 +92,7 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
     })
 
   def applyAlt[D](ff: EitherT[F, A, B => D])(implicit F: Apply[F]): EitherT[F, A, D] =
-    EitherT[F, A, D](F.map2(this.value, ff.value)((xb, xbd) => Apply[Either[A, ?]].ap(xbd)(xb)))
+    EitherT[F, A, D](F.map2(this.value, ff.value)((xb, xbd) => Apply[Either[A, *]].ap(xbd)(xb)))
 
   def flatMap[AA >: A, D](f: B => EitherT[F, AA, D])(implicit F: Monad[F]): EitherT[F, AA, D] =
     EitherT(F.flatMap(value) {
@@ -171,7 +171,7 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
 
   def traverse[G[_], D](f: B => G[D])(implicit traverseF: Traverse[F],
                                       applicativeG: Applicative[G]): G[EitherT[F, A, D]] =
-    applicativeG.map(traverseF.traverse(value)(axb => Traverse[Either[A, ?]].traverse(axb)(f)))(EitherT.apply)
+    applicativeG.map(traverseF.traverse(value)(axb => Traverse[Either[A, *]].traverse(axb)(f)))(EitherT.apply)
 
   def foldLeft[C](c: C)(f: (C, B) => C)(implicit F: Foldable[F]): C =
     F.foldLeft(value, c)((c, axb) => axb.foldLeft(c)(f))
@@ -253,10 +253,10 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
   def show(implicit show: Show[F[Either[A, B]]]): String = show.show(value)
 
   /**
-   * Transform this `EitherT[F, A, B]` into a `[[Nested]][F, Either[A, ?], B]`.
+   * Transform this `EitherT[F, A, B]` into a `[[Nested]][F, Either[A, *], B]`.
    *
    * An example where `toNested` can be used, is to get the `Apply.ap` function with the
-   * behavior from the composed `Apply` instances from `F` and `Either[A, ?]`, which is
+   * behavior from the composed `Apply` instances from `F` and `Either[A, *]`, which is
    * inconsistent with the behavior of the `ap` from `Monad` of `EitherT`.
    *
    * {{{
@@ -273,10 +273,10 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
    * }}}
    *
    */
-  def toNested: Nested[F, Either[A, ?], B] = Nested[F, Either[A, ?], B](value)
+  def toNested: Nested[F, Either[A, *], B] = Nested[F, Either[A, *], B](value)
 
   /**
-   * Transform this `EitherT[F, A, B]` into a `[[Nested]][F, Validated[A, ?], B]`.
+   * Transform this `EitherT[F, A, B]` into a `[[Nested]][F, Validated[A, *], B]`.
    *
    * Example:
    * {{{
@@ -292,20 +292,20 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
    * res0: cats.data.Nested[Option,ErrorOr,String] = Nested(Some(Valid(20)))
    * }}}
    */
-  def toNestedValidated(implicit F: Functor[F]): Nested[F, Validated[A, ?], B] =
-    Nested[F, Validated[A, ?], B](F.map(value)(_.toValidated))
+  def toNestedValidated(implicit F: Functor[F]): Nested[F, Validated[A, *], B] =
+    Nested[F, Validated[A, *], B](F.map(value)(_.toValidated))
 
   /**
-   * Transform this `EitherT[F, A, B]` into a `[[Nested]][F, ValidatedNel[A, ?], B]`.
+   * Transform this `EitherT[F, A, B]` into a `[[Nested]][F, ValidatedNel[A, *], B]`.
    */
-  def toNestedValidatedNel(implicit F: Functor[F]): Nested[F, ValidatedNel[A, ?], B] =
-    Nested[F, ValidatedNel[A, ?], B](F.map(value)(_.toValidatedNel))
+  def toNestedValidatedNel(implicit F: Functor[F]): Nested[F, ValidatedNel[A, *], B] =
+    Nested[F, ValidatedNel[A, *], B](F.map(value)(_.toValidatedNel))
 
   /**
-   * Transform this `EitherT[F, A, B]` into a `[[Nested]][F, ValidatedNec[A, ?], B]`.
+   * Transform this `EitherT[F, A, B]` into a `[[Nested]][F, ValidatedNec[A, *], B]`.
    */
-  def toNestedValidatedNec(implicit F: Functor[F]): Nested[F, ValidatedNec[A, ?], B] =
-    Nested[F, ValidatedNec[A, ?], B](F.map(value)(_.toValidatedNec))
+  def toNestedValidatedNec(implicit F: Functor[F]): Nested[F, ValidatedNec[A, *], B] =
+    Nested[F, ValidatedNec[A, *], B](F.map(value)(_.toValidatedNec))
 }
 
 object EitherT extends EitherTInstances {
@@ -412,14 +412,14 @@ object EitherT extends EitherTInstances {
    * Same as [[liftF]], but expressed as a FunctionK for use with mapK
    * {{{
    * scala> import cats._, data._, implicits._
-   * scala> val a: OptionT[Eval, Int] = 1.pure[OptionT[Eval, ?]]
-   * scala> val b: OptionT[EitherT[Eval, String, ?], Int] = a.mapK(EitherT.liftK)
+   * scala> val a: OptionT[Eval, Int] = 1.pure[OptionT[Eval, *]]
+   * scala> val b: OptionT[EitherT[Eval, String, *], Int] = a.mapK(EitherT.liftK)
    * scala> b.value.value.value
    * res0: Either[String,Option[Int]] = Right(Some(1))
    * }}}
    */
-  final def liftK[F[_], A](implicit F: Functor[F]): F ~> EitherT[F, A, ?] =
-    λ[F ~> EitherT[F, A, ?]](right(_))
+  final def liftK[F[_], A](implicit F: Functor[F]): F ~> EitherT[F, A, *] =
+    λ[F ~> EitherT[F, A, *]](right(_))
 
   @deprecated("Use EitherT.liftF.", "1.0.0-RC1")
   final def liftT[F[_], A, B](fb: F[B])(implicit F: Functor[F]): EitherT[F, A, B] = right(fb)
@@ -517,12 +517,12 @@ abstract private[data] class EitherTInstances extends EitherTInstances1 {
   implicit def catsDataShowForEitherT[F[_], L, R](implicit sh: Show[F[Either[L, R]]]): Show[EitherT[F, L, R]] =
     Contravariant[Show].contramap(sh)(_.value)
 
-  implicit def catsDataBifunctorForEitherT[F[_]](implicit F: Functor[F]): Bifunctor[EitherT[F, ?, ?]] =
+  implicit def catsDataBifunctorForEitherT[F[_]](implicit F: Functor[F]): Bifunctor[EitherT[F, *, *]] =
     new EitherTBifunctor[F] {
       val F0: Functor[F] = F
     }
 
-  implicit def catsDataTraverseForEitherT[F[_], L](implicit FF: Traverse[F]): Traverse[EitherT[F, L, ?]] =
+  implicit def catsDataTraverseForEitherT[F[_], L](implicit FF: Traverse[F]): Traverse[EitherT[F, L, *]] =
     new EitherTTraverse[F, L] with EitherTFunctor[F, L] {
       val F0: Traverse[F] = FF
       val F: Functor[F] = FF
@@ -531,8 +531,8 @@ abstract private[data] class EitherTInstances extends EitherTInstances1 {
   implicit def catsMonoidForEitherT[F[_], L, A](implicit F: Monoid[F[Either[L, A]]]): Monoid[EitherT[F, L, A]] =
     new EitherTMonoid[F, L, A] { implicit val F0 = F }
 
-  implicit def catsDataDeferForEitherT[F[_], L](implicit F: Defer[F]): Defer[EitherT[F, L, ?]] =
-    new Defer[EitherT[F, L, ?]] {
+  implicit def catsDataDeferForEitherT[F[_], L](implicit F: Defer[F]): Defer[EitherT[F, L, *]] =
+    new Defer[EitherT[F, L, *]] {
       def defer[A](fa: => EitherT[F, L, A]): EitherT[F, L, A] =
         EitherT(F.defer(fa.value))
     }
@@ -545,7 +545,7 @@ abstract private[data] class EitherTInstances1 extends EitherTInstances2 {
   ): Semigroup[EitherT[F, L, A]] =
     new EitherTSemigroup[F, L, A] { implicit val F0 = F }
 
-  implicit def catsDataFoldableForEitherT[F[_], L](implicit F: Foldable[F]): Foldable[EitherT[F, L, ?]] =
+  implicit def catsDataFoldableForEitherT[F[_], L](implicit F: Foldable[F]): Foldable[EitherT[F, L, *]] =
     new EitherTFoldable[F, L] {
       val F0: Foldable[F] = F
     }
@@ -557,12 +557,12 @@ abstract private[data] class EitherTInstances1 extends EitherTInstances2 {
       val F0: PartialOrder[F[Either[L, R]]] = F
     }
 
-  implicit def catsDataBitraverseForEitherT[F[_]](implicit F: Traverse[F]): Bitraverse[EitherT[F, ?, ?]] =
+  implicit def catsDataBitraverseForEitherT[F[_]](implicit F: Traverse[F]): Bitraverse[EitherT[F, *, *]] =
     new EitherTBitraverse[F] with EitherTBifunctor[F] {
       val F0: Traverse[F] = F
     }
 
-  implicit def catsDataMonadErrorForEitherT[F[_], L](implicit F0: Monad[F]): MonadError[EitherT[F, L, ?], L] =
+  implicit def catsDataMonadErrorForEitherT[F[_], L](implicit F0: Monad[F]): MonadError[EitherT[F, L, *], L] =
     new EitherTMonadError[F, L] {
       implicit val F = F0
       override def ensure[A](fa: EitherT[F, L, A])(error: => L)(predicate: (A) => Boolean): EitherT[F, L, A] =
@@ -584,17 +584,17 @@ abstract private[data] class EitherTInstances2 extends EitherTInstances3 {
    * scala> import cats.instances.option._
    * scala> val noInt: Option[Either[String, Int]] = None
    * scala> val et = EitherT[Option, String, Int](noInt)
-   * scala> val me = MonadError[EitherT[Option, String, ?], Unit]
+   * scala> val me = MonadError[EitherT[Option, String, *], Unit]
    * scala> me.recover(et) { case () => 1 }
    * res0: cats.data.EitherT[Option,String,Int] = EitherT(Some(Right(1)))
    * }}}
    */
   implicit def catsDataMonadErrorFForEitherT[F[_], E, L](
     implicit FE0: MonadError[F, E]
-  ): MonadError[EitherT[F, L, ?], E] =
+  ): MonadError[EitherT[F, L, *], E] =
     new EitherTMonadErrorF[F, E, L] { implicit val F = FE0 }
 
-  implicit def catsDataSemigroupKForEitherT[F[_], L](implicit F0: Monad[F]): SemigroupK[EitherT[F, L, ?]] =
+  implicit def catsDataSemigroupKForEitherT[F[_], L](implicit F0: Monad[F]): SemigroupK[EitherT[F, L, *]] =
     new EitherTSemigroupK[F, L] { implicit val F = F0 }
 
   implicit def catsDataEqForEitherT[F[_], L, R](implicit F: Eq[F[Either[L, R]]]): Eq[EitherT[F, L, R]] =
@@ -604,7 +604,7 @@ abstract private[data] class EitherTInstances2 extends EitherTInstances3 {
 }
 
 abstract private[data] class EitherTInstances3 {
-  implicit def catsDataFunctorForEitherT[F[_], L](implicit F0: Functor[F]): Functor[EitherT[F, L, ?]] =
+  implicit def catsDataFunctorForEitherT[F[_], L](implicit F0: Functor[F]): Functor[EitherT[F, L, *]] =
     new EitherTFunctor[F, L] { implicit val F = F0 }
 }
 
@@ -619,7 +619,7 @@ private[data] trait EitherTMonoid[F[_], L, A] extends Monoid[EitherT[F, L, A]] w
   def empty: EitherT[F, L, A] = EitherT(F0.empty)
 }
 
-private[data] trait EitherTSemigroupK[F[_], L] extends SemigroupK[EitherT[F, L, ?]] {
+private[data] trait EitherTSemigroupK[F[_], L] extends SemigroupK[EitherT[F, L, *]] {
   implicit val F: Monad[F]
   def combineK[A](x: EitherT[F, L, A], y: EitherT[F, L, A]): EitherT[F, L, A] =
     EitherT(F.flatMap(x.value) {
@@ -628,12 +628,12 @@ private[data] trait EitherTSemigroupK[F[_], L] extends SemigroupK[EitherT[F, L, 
     })
 }
 
-private[data] trait EitherTFunctor[F[_], L] extends Functor[EitherT[F, L, ?]] {
+private[data] trait EitherTFunctor[F[_], L] extends Functor[EitherT[F, L, *]] {
   implicit val F: Functor[F]
   override def map[A, B](fa: EitherT[F, L, A])(f: A => B): EitherT[F, L, B] = fa.map(f)
 }
 
-private[data] trait EitherTMonad[F[_], L] extends Monad[EitherT[F, L, ?]] with EitherTFunctor[F, L] {
+private[data] trait EitherTMonad[F[_], L] extends Monad[EitherT[F, L, *]] with EitherTFunctor[F, L] {
   implicit val F: Monad[F]
   def pure[A](a: A): EitherT[F, L, A] = EitherT.pure(a)
 
@@ -651,7 +651,7 @@ private[data] trait EitherTMonad[F[_], L] extends Monad[EitherT[F, L, ?]] with E
     )
 }
 
-private[data] trait EitherTMonadErrorF[F[_], E, L] extends MonadError[EitherT[F, L, ?], E] with EitherTMonad[F, L] {
+private[data] trait EitherTMonadErrorF[F[_], E, L] extends MonadError[EitherT[F, L, *], E] with EitherTMonad[F, L] {
   implicit val F: MonadError[F, E]
 
   def handleErrorWith[A](fea: EitherT[F, L, A])(f: E => EitherT[F, L, A]): EitherT[F, L, A] =
@@ -660,7 +660,7 @@ private[data] trait EitherTMonadErrorF[F[_], E, L] extends MonadError[EitherT[F,
   def raiseError[A](e: E): EitherT[F, L, A] = EitherT(F.raiseError(e))
 }
 
-private[data] trait EitherTMonadError[F[_], L] extends MonadError[EitherT[F, L, ?], L] with EitherTMonad[F, L] {
+private[data] trait EitherTMonadError[F[_], L] extends MonadError[EitherT[F, L, *], L] with EitherTMonad[F, L] {
   def handleErrorWith[A](fea: EitherT[F, L, A])(f: L => EitherT[F, L, A]): EitherT[F, L, A] =
     EitherT(F.flatMap(fea.value) {
       case Left(e)      => f(e).value
@@ -679,7 +679,7 @@ private[data] trait EitherTMonadError[F[_], L] extends MonadError[EitherT[F, L, 
     fla.recoverWith(pf)
 }
 
-sealed private[data] trait EitherTFoldable[F[_], L] extends Foldable[EitherT[F, L, ?]] {
+sealed private[data] trait EitherTFoldable[F[_], L] extends Foldable[EitherT[F, L, *]] {
   implicit def F0: Foldable[F]
 
   def foldLeft[A, B](fa: EitherT[F, L, A], b: B)(f: (B, A) => B): B =
@@ -689,14 +689,14 @@ sealed private[data] trait EitherTFoldable[F[_], L] extends Foldable[EitherT[F, 
     fa.foldRight(lb)(f)
 }
 
-sealed private[data] trait EitherTTraverse[F[_], L] extends Traverse[EitherT[F, L, ?]] with EitherTFoldable[F, L] {
+sealed private[data] trait EitherTTraverse[F[_], L] extends Traverse[EitherT[F, L, *]] with EitherTFoldable[F, L] {
   implicit override def F0: Traverse[F]
 
   override def traverse[G[_]: Applicative, A, B](fa: EitherT[F, L, A])(f: A => G[B]): G[EitherT[F, L, B]] =
     fa.traverse(f)
 }
 
-sealed private[data] trait EitherTBifoldable[F[_]] extends Bifoldable[EitherT[F, ?, ?]] {
+sealed private[data] trait EitherTBifoldable[F[_]] extends Bifoldable[EitherT[F, *, *]] {
   implicit def F0: Foldable[F]
 
   def bifoldLeft[A, B, C](fab: EitherT[F, A, B], c: C)(f: (C, A) => C, g: (C, B) => C): C =
@@ -707,7 +707,7 @@ sealed private[data] trait EitherTBifoldable[F[_]] extends Bifoldable[EitherT[F,
     F0.foldRight(fab.value, c)((axb, acc) => Bifoldable[Either].bifoldRight(axb, acc)(f, g))
 }
 
-sealed private[data] trait EitherTBitraverse[F[_]] extends Bitraverse[EitherT[F, ?, ?]] with EitherTBifoldable[F] {
+sealed private[data] trait EitherTBitraverse[F[_]] extends Bitraverse[EitherT[F, *, *]] with EitherTBifoldable[F] {
   implicit override def F0: Traverse[F]
 
   override def bitraverse[G[_], A, B, C, D](
@@ -716,7 +716,7 @@ sealed private[data] trait EitherTBitraverse[F[_]] extends Bitraverse[EitherT[F,
     fab.bitraverse(f, g)
 }
 
-sealed private[data] trait EitherTBifunctor[F[_]] extends Bifunctor[EitherT[F, ?, ?]] {
+sealed private[data] trait EitherTBifunctor[F[_]] extends Bifunctor[EitherT[F, *, *]] {
   implicit def F0: Functor[F]
 
   override def bimap[A, B, C, D](fab: EitherT[F, A, B])(f: A => C, g: B => D): EitherT[F, C, D] = fab.bimap(f, g)

--- a/core/src/main/scala/cats/data/Func.scala
+++ b/core/src/main/scala/cats/data/Func.scala
@@ -105,14 +105,14 @@ sealed abstract class AppFunc[F[_], A, B] extends Func[F, A, B] { self =>
     }
   }
 
-  def compose[G[_], C](g: AppFunc[G, C, A]): AppFunc[Nested[G, F, ?], C, B] = {
-    implicit val gfApplicative: Applicative[Nested[G, F, ?]] = Nested.catsDataApplicativeForNested[G, F](g.F, F)
-    Func.appFunc[Nested[G, F, ?], C, B]({ c: C =>
+  def compose[G[_], C](g: AppFunc[G, C, A]): AppFunc[Nested[G, F, *], C, B] = {
+    implicit val gfApplicative: Applicative[Nested[G, F, *]] = Nested.catsDataApplicativeForNested[G, F](g.F, F)
+    Func.appFunc[Nested[G, F, *], C, B]({ c: C =>
       Nested(g.F.map(g.run(c))(self.run))
     })
   }
 
-  def andThen[G[_], C](g: AppFunc[G, B, C]): AppFunc[Nested[F, G, ?], A, C] =
+  def andThen[G[_], C](g: AppFunc[G, B, C]): AppFunc[Nested[F, G, *], A, C] =
     g.compose(self)
 
   def map[C](f: B => C): AppFunc[F, A, C] = {

--- a/core/src/main/scala/cats/data/IdT.scala
+++ b/core/src/main/scala/cats/data/IdT.scala
@@ -50,14 +50,14 @@ object IdT extends IdTInstances {
     IdT(F.pure(a))
 }
 
-sealed private[data] trait IdTFunctor[F[_]] extends Functor[IdT[F, ?]] {
+sealed private[data] trait IdTFunctor[F[_]] extends Functor[IdT[F, *]] {
   implicit val F0: Functor[F]
 
   override def map[A, B](fa: IdT[F, A])(f: A => B): IdT[F, B] =
     fa.map(f)
 }
 
-sealed private[data] trait IdTApply[F[_]] extends Apply[IdT[F, ?]] with IdTFunctor[F] {
+sealed private[data] trait IdTApply[F[_]] extends Apply[IdT[F, *]] with IdTFunctor[F] {
   implicit val F0: Apply[F]
 
   override def ap[A, B](ff: IdT[F, A => B])(fa: IdT[F, A]): IdT[F, B] = fa.ap(ff)
@@ -67,13 +67,13 @@ sealed private[data] trait IdTApply[F[_]] extends Apply[IdT[F, ?]] with IdTFunct
       .map(IdT(_))
 }
 
-sealed private[data] trait IdTApplicative[F[_]] extends Applicative[IdT[F, ?]] with IdTApply[F] {
+sealed private[data] trait IdTApplicative[F[_]] extends Applicative[IdT[F, *]] with IdTApply[F] {
   implicit val F0: Applicative[F]
 
   def pure[A](a: A): IdT[F, A] = IdT.pure(a)
 }
 
-sealed private[data] trait IdTContravariantMonoidal[F[_]] extends ContravariantMonoidal[IdT[F, ?]] {
+sealed private[data] trait IdTContravariantMonoidal[F[_]] extends ContravariantMonoidal[IdT[F, *]] {
   implicit val F0: ContravariantMonoidal[F]
 
   override def unit: IdT[F, Unit] = IdT(F0.unit)
@@ -85,7 +85,7 @@ sealed private[data] trait IdTContravariantMonoidal[F[_]] extends ContravariantM
     IdT(F0.product(fa.value, fb.value))
 }
 
-sealed private[data] trait IdTFlatMap[F[_]] extends FlatMap[IdT[F, ?]] with IdTApply[F] {
+sealed private[data] trait IdTFlatMap[F[_]] extends FlatMap[IdT[F, *]] with IdTApply[F] {
   implicit val F0: FlatMap[F]
 
   def flatMap[A, B](fa: IdT[F, A])(f: A => IdT[F, B]): IdT[F, B] =
@@ -95,11 +95,11 @@ sealed private[data] trait IdTFlatMap[F[_]] extends FlatMap[IdT[F, ?]] with IdTA
     IdT(F0.tailRecM(a)(f(_).value))
 }
 
-sealed private[data] trait IdTMonad[F[_]] extends Monad[IdT[F, ?]] with IdTApplicative[F] with IdTFlatMap[F] {
+sealed private[data] trait IdTMonad[F[_]] extends Monad[IdT[F, *]] with IdTApplicative[F] with IdTFlatMap[F] {
   implicit val F0: Monad[F]
 }
 
-sealed private[data] trait IdTFoldable[F[_]] extends Foldable[IdT[F, ?]] {
+sealed private[data] trait IdTFoldable[F[_]] extends Foldable[IdT[F, *]] {
   implicit val F0: Foldable[F]
 
   def foldLeft[A, B](fa: IdT[F, A], b: B)(f: (B, A) => B): B =
@@ -115,7 +115,7 @@ sealed private[data] trait IdTFoldable[F[_]] extends Foldable[IdT[F, ?]] {
     F0.get(fa.value)(idx)
 }
 
-sealed private[data] trait IdTTraverse[F[_]] extends Traverse[IdT[F, ?]] with IdTFoldable[F] with IdTFunctor[F] {
+sealed private[data] trait IdTTraverse[F[_]] extends Traverse[IdT[F, *]] with IdTFoldable[F] with IdTFunctor[F] {
   implicit val F0: Traverse[F]
 
   def traverse[G[_]: Applicative, A, B](fa: IdT[F, A])(f: A => G[B]): G[IdT[F, B]] =
@@ -124,7 +124,7 @@ sealed private[data] trait IdTTraverse[F[_]] extends Traverse[IdT[F, ?]] with Id
 
 sealed private[data] trait IdTNonEmptyTraverse[F[_]]
     extends IdTTraverse[F]
-    with NonEmptyTraverse[IdT[F, ?]]
+    with NonEmptyTraverse[IdT[F, *]]
     with IdTFunctor[F] {
   implicit val F0: NonEmptyTraverse[F]
 
@@ -141,53 +141,53 @@ sealed private[data] trait IdTNonEmptyTraverse[F[_]]
 sealed abstract private[data] class IdTInstances8 {
   implicit def catsDataCommutativeFlatMapForIdT[F[_]](
     implicit F: CommutativeFlatMap[F]
-  ): CommutativeFlatMap[IdT[F, ?]] =
-    new IdTFlatMap[F] with CommutativeFlatMap[IdT[F, ?]] { implicit val F0: CommutativeFlatMap[F] = F }
+  ): CommutativeFlatMap[IdT[F, *]] =
+    new IdTFlatMap[F] with CommutativeFlatMap[IdT[F, *]] { implicit val F0: CommutativeFlatMap[F] = F }
 }
 
 sealed abstract private[data] class IdTInstances7 extends IdTInstances8 {
-  implicit def catsDataCommutativeMonadForIdT[F[_]](implicit F: CommutativeMonad[F]): CommutativeMonad[IdT[F, ?]] =
-    new IdTMonad[F] with CommutativeMonad[IdT[F, ?]] { implicit val F0: CommutativeMonad[F] = F }
+  implicit def catsDataCommutativeMonadForIdT[F[_]](implicit F: CommutativeMonad[F]): CommutativeMonad[IdT[F, *]] =
+    new IdTMonad[F] with CommutativeMonad[IdT[F, *]] { implicit val F0: CommutativeMonad[F] = F }
 }
 
 sealed abstract private[data] class IdTInstances6 extends IdTInstances7 {
   implicit def catsDataContravariantMonoidalForIdT[F[_]](
     implicit F: ContravariantMonoidal[F]
-  ): ContravariantMonoidal[IdT[F, ?]] =
+  ): ContravariantMonoidal[IdT[F, *]] =
     new IdTContravariantMonoidal[F] { implicit val F0: ContravariantMonoidal[F] = F }
 }
 
 sealed abstract private[data] class IdTInstances5 extends IdTInstances6 {
-  implicit def catsDataFunctorForIdT[F[_]](implicit F: Functor[F]): Functor[IdT[F, ?]] =
+  implicit def catsDataFunctorForIdT[F[_]](implicit F: Functor[F]): Functor[IdT[F, *]] =
     new IdTFunctor[F] { implicit val F0: Functor[F] = F }
 }
 
 sealed abstract private[data] class IdTInstances4 extends IdTInstances5 {
-  implicit def catsDataApplyForIdT[F[_]](implicit F: Apply[F]): Apply[IdT[F, ?]] =
+  implicit def catsDataApplyForIdT[F[_]](implicit F: Apply[F]): Apply[IdT[F, *]] =
     new IdTApply[F] { implicit val F0: Apply[F] = F }
 }
 
 sealed abstract private[data] class IdTInstances3 extends IdTInstances4 {
-  implicit def catsDataApplicativeForIdT[F[_]](implicit F: Applicative[F]): Applicative[IdT[F, ?]] =
+  implicit def catsDataApplicativeForIdT[F[_]](implicit F: Applicative[F]): Applicative[IdT[F, *]] =
     new IdTApplicative[F] { implicit val F0: Applicative[F] = F }
 }
 
 sealed abstract private[data] class IdTInstances2 extends IdTInstances3 {
-  implicit def catsDataFlatMapForIdT[F[_]](implicit F: FlatMap[F]): FlatMap[IdT[F, ?]] =
+  implicit def catsDataFlatMapForIdT[F[_]](implicit F: FlatMap[F]): FlatMap[IdT[F, *]] =
     new IdTFlatMap[F] { implicit val F0: FlatMap[F] = F }
 }
 
 sealed abstract private[data] class IdTInstances1 extends IdTInstances2 {
-  implicit def catsDataMonadForIdT[F[_]](implicit F: Monad[F]): Monad[IdT[F, ?]] =
+  implicit def catsDataMonadForIdT[F[_]](implicit F: Monad[F]): Monad[IdT[F, *]] =
     new IdTMonad[F] { implicit val F0: Monad[F] = F }
 
-  implicit def catsDataFoldableForIdT[F[_]](implicit F: Foldable[F]): Foldable[IdT[F, ?]] =
+  implicit def catsDataFoldableForIdT[F[_]](implicit F: Foldable[F]): Foldable[IdT[F, *]] =
     new IdTFoldable[F] { implicit val F0: Foldable[F] = F }
 }
 
 sealed abstract private[data] class IdTInstances0 extends IdTInstances1 {
 
-  implicit def catsDataTraverseForIdT[F[_]](implicit F: Traverse[F]): Traverse[IdT[F, ?]] =
+  implicit def catsDataTraverseForIdT[F[_]](implicit F: Traverse[F]): Traverse[IdT[F, *]] =
     new IdTTraverse[F] { implicit val F0: Traverse[F] = F }
 
   implicit def catsDataEqForIdT[F[_], A](implicit F: Eq[F[A]]): Eq[IdT[F, A]] =
@@ -196,7 +196,7 @@ sealed abstract private[data] class IdTInstances0 extends IdTInstances1 {
 
 sealed abstract private[data] class IdTInstances extends IdTInstances0 {
 
-  implicit def catsDataNonEmptyTraverseForIdT[F[_]](implicit F: NonEmptyTraverse[F]): NonEmptyTraverse[IdT[F, ?]] =
+  implicit def catsDataNonEmptyTraverseForIdT[F[_]](implicit F: NonEmptyTraverse[F]): NonEmptyTraverse[IdT[F, *]] =
     new IdTNonEmptyTraverse[F] { implicit val F0: NonEmptyTraverse[F] = F }
 
   implicit def catsDataOrderForIdT[F[_], A](implicit F: Order[F[A]]): Order[IdT[F, A]] =

--- a/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
@@ -294,14 +294,14 @@ sealed private[data] trait CommonIRWSTConstructors {
    * Same as [[liftF]], but expressed as a FunctionK for use with mapK
    * {{{
    * scala> import cats._, data._, implicits._
-   * scala> val a: OptionT[Eval, Int] = 1.pure[OptionT[Eval, ?]]
-   * scala> val b: OptionT[RWST[Eval, Boolean, List[String], String, ?], Int] = a.mapK(RWST.liftK)
+   * scala> val a: OptionT[Eval, Int] = 1.pure[OptionT[Eval, *]]
+   * scala> val b: OptionT[RWST[Eval, Boolean, List[String], String, *], Int] = a.mapK(RWST.liftK)
    * scala> b.value.runEmpty(true).value
    * res0: (List[String], String, Option[Int]) = (List(),"",Some(1))
    * }}}
    */
-  def liftK[F[_], E, L, S](implicit F: Applicative[F], L: Monoid[L]): F ~> IndexedReaderWriterStateT[F, E, L, S, S, ?] =
-    λ[F ~> IndexedReaderWriterStateT[F, E, L, S, S, ?]](IndexedReaderWriterStateT.liftF(_))
+  def liftK[F[_], E, L, S](implicit F: Applicative[F], L: Monoid[L]): F ~> IndexedReaderWriterStateT[F, E, L, S, S, *] =
+    λ[F ~> IndexedReaderWriterStateT[F, E, L, S, S, *]](IndexedReaderWriterStateT.liftF(_))
 
   @deprecated("Use liftF instead", "1.0.0-RC2")
   def lift[F[_], E, L, S, A](fa: F[A])(implicit F: Applicative[F],
@@ -480,21 +480,21 @@ sealed abstract private[data] class IRWSTInstances extends IRWSTInstances1 {
 
   implicit def catsDataStrongForIRWST[F[_], E, L, T](
     implicit F0: Monad[F]
-  ): Strong[IndexedReaderWriterStateT[F, E, L, ?, ?, T]] =
+  ): Strong[IndexedReaderWriterStateT[F, E, L, *, *, T]] =
     new IRWSTStrong[F, E, L, T] {
       implicit def F: Monad[F] = F0
     }
 
   implicit def catsDataBifunctorForIRWST[F[_], E, L, SA](
     implicit F0: Functor[F]
-  ): Bifunctor[IndexedReaderWriterStateT[F, E, L, SA, ?, ?]] =
+  ): Bifunctor[IndexedReaderWriterStateT[F, E, L, SA, *, *]] =
     new IRWSTBifunctor[F, E, L, SA] {
       implicit def F: Functor[F] = F0
     }
 
   implicit def catsDataContravariantForIRWST[F[_], E, L, SB, T](
     implicit F0: Functor[F]
-  ): Contravariant[IndexedReaderWriterStateT[F, E, L, ?, SB, T]] =
+  ): Contravariant[IndexedReaderWriterStateT[F, E, L, *, SB, T]] =
     new IRWSTContravariant[F, E, L, SB, T] {
       implicit def F: Functor[F] = F0
     }
@@ -502,7 +502,7 @@ sealed abstract private[data] class IRWSTInstances extends IRWSTInstances1 {
   implicit def catsDataMonadErrorForIRWST[F[_], E, L, S, R](
     implicit F0: MonadError[F, R],
     L0: Monoid[L]
-  ): MonadError[IndexedReaderWriterStateT[F, E, L, S, S, ?], R] =
+  ): MonadError[IndexedReaderWriterStateT[F, E, L, S, S, *], R] =
     new RWSTMonadError[F, E, L, S, R] {
       implicit def F: MonadError[F, R] = F0
       implicit def L: Monoid[L] = L0
@@ -510,8 +510,8 @@ sealed abstract private[data] class IRWSTInstances extends IRWSTInstances1 {
 
   implicit def catsDataDeferForIRWST[F[_], E, L, SA, SB](
     implicit F: Defer[F]
-  ): Defer[IndexedReaderWriterStateT[F, E, L, SA, SB, ?]] =
-    new Defer[IndexedReaderWriterStateT[F, E, L, SA, SB, ?]] {
+  ): Defer[IndexedReaderWriterStateT[F, E, L, SA, SB, *]] =
+    new Defer[IndexedReaderWriterStateT[F, E, L, SA, SB, *]] {
       def defer[A](
         fa: => IndexedReaderWriterStateT[F, E, L, SA, SB, A]
       ): IndexedReaderWriterStateT[F, E, L, SA, SB, A] =
@@ -522,7 +522,7 @@ sealed abstract private[data] class IRWSTInstances extends IRWSTInstances1 {
 
 sealed abstract private[data] class IRWSTInstances1 extends IRWSTInstances2 {
   implicit def catsDataMonadForRWST[F[_], E, L, S](implicit F0: Monad[F],
-                                                   L0: Monoid[L]): Monad[ReaderWriterStateT[F, E, L, S, ?]] =
+                                                   L0: Monoid[L]): Monad[ReaderWriterStateT[F, E, L, S, *]] =
     new RWSTMonad[F, E, L, S] {
       implicit def F: Monad[F] = F0
       implicit def L: Monoid[L] = L0
@@ -530,7 +530,7 @@ sealed abstract private[data] class IRWSTInstances1 extends IRWSTInstances2 {
 
   implicit def catsDataProfunctorForIRWST[F[_], E, L, T](
     implicit F0: Functor[F]
-  ): Profunctor[IndexedReaderWriterStateT[F, E, L, ?, ?, T]] =
+  ): Profunctor[IndexedReaderWriterStateT[F, E, L, *, *, T]] =
     new IRWSTProfunctor[F, E, L, T] {
       implicit def F: Functor[F] = F0
     }
@@ -542,7 +542,7 @@ sealed abstract private[data] class IRWSTInstances2 extends IRWSTInstances3 {
     implicit FM: Monad[F],
     FA: Alternative[F],
     L0: Monoid[L]
-  ): Alternative[IndexedReaderWriterStateT[F, E, L, S, S, ?]] =
+  ): Alternative[IndexedReaderWriterStateT[F, E, L, S, S, *]] =
     new RWSTAlternative[F, E, L, S] {
       implicit def G: Alternative[F] = FA
       implicit def F: Monad[F] = FM
@@ -554,7 +554,7 @@ sealed abstract private[data] class IRWSTInstances3 {
   implicit def catsDataSemigroupKForIRWST[F[_], E, L, SA, SB](
     implicit F0: Monad[F],
     G0: SemigroupK[F]
-  ): SemigroupK[IndexedReaderWriterStateT[F, E, L, SA, SB, ?]] =
+  ): SemigroupK[IndexedReaderWriterStateT[F, E, L, SA, SB, *]] =
     new IRWSTSemigroupK[F, E, L, SA, SB] {
       implicit def F: Monad[F] = F0
       implicit def G: SemigroupK[F] = G0
@@ -562,14 +562,14 @@ sealed abstract private[data] class IRWSTInstances3 {
 
   implicit def catsDataFunctorForIRWST[F[_], E, L, SA, SB](
     implicit F0: Functor[F]
-  ): Functor[IndexedReaderWriterStateT[F, E, L, SA, SB, ?]] =
+  ): Functor[IndexedReaderWriterStateT[F, E, L, SA, SB, *]] =
     new IRWSTFunctor[F, E, L, SA, SB] {
       implicit def F: Functor[F] = F0
     }
 }
 
 sealed abstract private[data] class IRWSTFunctor[F[_], E, L, SA, SB]
-    extends Functor[IndexedReaderWriterStateT[F, E, L, SA, SB, ?]] {
+    extends Functor[IndexedReaderWriterStateT[F, E, L, SA, SB, *]] {
   implicit def F: Functor[F]
 
   override def map[A, B](
@@ -579,7 +579,7 @@ sealed abstract private[data] class IRWSTFunctor[F[_], E, L, SA, SB]
 }
 
 sealed abstract private[data] class IRWSTContravariant[F[_], E, L, SB, T]
-    extends Contravariant[IndexedReaderWriterStateT[F, E, L, ?, SB, T]] {
+    extends Contravariant[IndexedReaderWriterStateT[F, E, L, *, SB, T]] {
   implicit def F: Functor[F]
 
   override def contramap[A, B](
@@ -589,7 +589,7 @@ sealed abstract private[data] class IRWSTContravariant[F[_], E, L, SB, T]
 }
 
 sealed abstract private[data] class IRWSTProfunctor[F[_], E, L, T]
-    extends Profunctor[IndexedReaderWriterStateT[F, E, L, ?, ?, T]] {
+    extends Profunctor[IndexedReaderWriterStateT[F, E, L, *, *, T]] {
   implicit def F: Functor[F]
 
   override def dimap[A, B, C, D](
@@ -600,7 +600,7 @@ sealed abstract private[data] class IRWSTProfunctor[F[_], E, L, T]
 
 sealed abstract private[data] class IRWSTStrong[F[_], E, L, T]
     extends IRWSTProfunctor[F, E, L, T]
-    with Strong[IndexedReaderWriterStateT[F, E, L, ?, ?, T]] {
+    with Strong[IndexedReaderWriterStateT[F, E, L, *, *, T]] {
   implicit def F: Monad[F]
 
   def first[A, B, C](
@@ -621,7 +621,7 @@ sealed abstract private[data] class IRWSTStrong[F[_], E, L, T]
 }
 
 sealed abstract private[data] class IRWSTBifunctor[F[_], E, L, SA]
-    extends Bifunctor[IndexedReaderWriterStateT[F, E, L, SA, ?, ?]] {
+    extends Bifunctor[IndexedReaderWriterStateT[F, E, L, SA, *, *]] {
   implicit def F: Functor[F]
 
   override def bimap[A, B, C, D](
@@ -632,7 +632,7 @@ sealed abstract private[data] class IRWSTBifunctor[F[_], E, L, SA]
 
 sealed abstract private[data] class RWSTMonad[F[_], E, L, S]
     extends IRWSTFunctor[F, E, L, S, S]
-    with Monad[ReaderWriterStateT[F, E, L, S, ?]] {
+    with Monad[ReaderWriterStateT[F, E, L, S, *]] {
   implicit def F: Monad[F]
   implicit def L: Monoid[L]
 
@@ -666,7 +666,7 @@ sealed abstract private[data] class RWSTAlternative[F[_], E, L, S]
 
 sealed abstract private[data] class RWSTMonadError[F[_], E, L, S, R]
     extends RWSTMonad[F, E, L, S]
-    with MonadError[ReaderWriterStateT[F, E, L, S, ?], R] {
+    with MonadError[ReaderWriterStateT[F, E, L, S, *], R] {
 
   implicit def F: MonadError[F, R]
 
@@ -680,7 +680,7 @@ sealed abstract private[data] class RWSTMonadError[F[_], E, L, S, R]
     }
 }
 
-private trait IRWSTSemigroupK1[F[_], E, L, SA, SB] extends SemigroupK[IndexedReaderWriterStateT[F, E, L, SA, SB, ?]] {
+private trait IRWSTSemigroupK1[F[_], E, L, SA, SB] extends SemigroupK[IndexedReaderWriterStateT[F, E, L, SA, SB, *]] {
   implicit def F: Monad[F]
   implicit def G: SemigroupK[F]
 
@@ -693,7 +693,7 @@ private trait IRWSTSemigroupK1[F[_], E, L, SA, SB] extends SemigroupK[IndexedRea
 
 private trait RWSTAlternative1[F[_], E, L, S]
     extends IRWSTSemigroupK1[F, E, L, S, S]
-    with Alternative[ReaderWriterStateT[F, E, L, S, ?]] {
+    with Alternative[ReaderWriterStateT[F, E, L, S, *]] {
 
   implicit def F: Monad[F]
   def G: Alternative[F]

--- a/core/src/main/scala/cats/data/IndexedStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedStateT.scala
@@ -183,14 +183,14 @@ private[data] trait CommonStateTConstructors {
    * Same as [[liftF]], but expressed as a FunctionK for use with mapK
    * {{{
    * scala> import cats._, data._, implicits._
-   * scala> val a: OptionT[Eval, Int] = 1.pure[OptionT[Eval, ?]]
-   * scala> val b: OptionT[StateT[Eval, String, ?], Int] = a.mapK(StateT.liftK)
+   * scala> val a: OptionT[Eval, Int] = 1.pure[OptionT[Eval, *]]
+   * scala> val b: OptionT[StateT[Eval, String, *], Int] = a.mapK(StateT.liftK)
    * scala> b.value.runEmpty.value
    * res0: (String, Option[Int]) = ("",Some(1))
    * }}}
    */
-  def liftK[F[_], S](implicit F: Applicative[F]): F ~> IndexedStateT[F, S, S, ?] =
-    λ[F ~> IndexedStateT[F, S, S, ?]](IndexedStateT.liftF(_))
+  def liftK[F[_], S](implicit F: Applicative[F]): F ~> IndexedStateT[F, S, S, *] =
+    λ[F ~> IndexedStateT[F, S, S, *]](IndexedStateT.liftF(_))
 
   @deprecated("Use liftF instead", "1.0.0-RC2")
   def lift[F[_], S, A](fa: F[A])(implicit F: Applicative[F]): IndexedStateT[F, S, S, A] =
@@ -255,11 +255,11 @@ sealed abstract private[data] class IndexedStateTInstances extends IndexedStateT
   implicit def catsDataAlternativeForIndexedStateT[F[_], S](
     implicit FM: Monad[F],
     FA: Alternative[F]
-  ): Alternative[IndexedStateT[F, S, S, ?]] with Monad[IndexedStateT[F, S, S, ?]] =
+  ): Alternative[IndexedStateT[F, S, S, *]] with Monad[IndexedStateT[F, S, S, *]] =
     new IndexedStateTAlternative[F, S] { implicit def F = FM; implicit def G = FA }
 
-  implicit def catsDataDeferForIndexedStateT[F[_], SA, SB](implicit F: Defer[F]): Defer[IndexedStateT[F, SA, SB, ?]] =
-    new Defer[IndexedStateT[F, SA, SB, ?]] {
+  implicit def catsDataDeferForIndexedStateT[F[_], SA, SB](implicit F: Defer[F]): Defer[IndexedStateT[F, SA, SB, *]] =
+    new Defer[IndexedStateT[F, SA, SB, *]] {
       def defer[A](fa: => IndexedStateT[F, SA, SB, A]): IndexedStateT[F, SA, SB, A] =
         IndexedStateT.applyF(F.defer(fa.runF))
     }
@@ -268,7 +268,7 @@ sealed abstract private[data] class IndexedStateTInstances extends IndexedStateT
     implicit
     ev1: Monad[F],
     ev2: FunctorFilter[F]
-  ): FunctorFilter[IndexedStateT[F, SA, SB, ?]] =
+  ): FunctorFilter[IndexedStateT[F, SA, SB, *]] =
     new IndexedStateTFunctorFilter[F, SA, SB] {
       val F0 = ev1
       val FF = ev2
@@ -278,45 +278,45 @@ sealed abstract private[data] class IndexedStateTInstances extends IndexedStateT
 sealed abstract private[data] class IndexedStateTInstances1 extends IndexedStateTInstances2 {
   implicit def catsDataMonadErrorForIndexedStateT[F[_], S, E](
     implicit F0: MonadError[F, E]
-  ): MonadError[IndexedStateT[F, S, S, ?], E] =
+  ): MonadError[IndexedStateT[F, S, S, *], E] =
     new IndexedStateTMonadError[F, S, E] { implicit def F = F0 }
 
   implicit def catsDataSemigroupKForIndexedStateT[F[_], SA, SB](
     implicit F0: Monad[F],
     G0: SemigroupK[F]
-  ): SemigroupK[IndexedStateT[F, SA, SB, ?]] =
+  ): SemigroupK[IndexedStateT[F, SA, SB, *]] =
     new IndexedStateTSemigroupK[F, SA, SB] { implicit def F = F0; implicit def G = G0 }
 }
 
 sealed abstract private[data] class IndexedStateTInstances2 extends IndexedStateTInstances3 {
-  implicit def catsDataMonadForIndexedStateT[F[_], S](implicit F0: Monad[F]): Monad[IndexedStateT[F, S, S, ?]] =
+  implicit def catsDataMonadForIndexedStateT[F[_], S](implicit F0: Monad[F]): Monad[IndexedStateT[F, S, S, *]] =
     new IndexedStateTMonad[F, S] { implicit def F = F0 }
 }
 
 sealed abstract private[data] class IndexedStateTInstances3 extends IndexedStateTInstances4 {
   implicit def catsDataFunctorForIndexedStateT[F[_], SA, SB](
     implicit F0: Functor[F]
-  ): Functor[IndexedStateT[F, SA, SB, ?]] =
+  ): Functor[IndexedStateT[F, SA, SB, *]] =
     new IndexedStateTFunctor[F, SA, SB] { implicit def F = F0 }
 
   implicit def catsDataContravariantForIndexedStateT[F[_], SB, V](
     implicit F0: Functor[F]
-  ): Contravariant[IndexedStateT[F, ?, SB, V]] =
+  ): Contravariant[IndexedStateT[F, *, SB, V]] =
     new IndexedStateTContravariant[F, SB, V] { implicit def F = F0 }
 
   implicit def catsDataProfunctorForIndexedStateT[F[_], V](
     implicit F0: Functor[F]
-  ): Profunctor[IndexedStateT[F, ?, ?, V]] =
+  ): Profunctor[IndexedStateT[F, *, *, V]] =
     new IndexedStateTProfunctor[F, V] { implicit def F = F0 }
 
   implicit def catsDataBifunctorForIndexedStateT[F[_], SA](
     implicit F0: Functor[F]
-  ): Bifunctor[IndexedStateT[F, SA, ?, ?]] =
+  ): Bifunctor[IndexedStateT[F, SA, *, *]] =
     new IndexedStateTBifunctor[F, SA] { implicit def F = F0 }
 }
 
 sealed abstract private[data] class IndexedStateTInstances4 {
-  implicit def catsDataStrongForIndexedStateT[F[_], V](implicit F0: Monad[F]): Strong[IndexedStateT[F, ?, ?, V]] =
+  implicit def catsDataStrongForIndexedStateT[F[_], V](implicit F0: Monad[F]): Strong[IndexedStateT[F, *, *, V]] =
     new IndexedStateTStrong[F, V] { implicit def F = F0 }
 }
 
@@ -376,7 +376,7 @@ abstract private[data] class StateFunctions {
   def set[S](s: S): State[S, Unit] = State(_ => (s, ()))
 }
 
-sealed abstract private[data] class IndexedStateTFunctor[F[_], SA, SB] extends Functor[IndexedStateT[F, SA, SB, ?]] {
+sealed abstract private[data] class IndexedStateTFunctor[F[_], SA, SB] extends Functor[IndexedStateT[F, SA, SB, *]] {
   implicit def F: Functor[F]
 
   override def map[A, B](fa: IndexedStateT[F, SA, SB, A])(f: A => B): IndexedStateT[F, SA, SB, B] =
@@ -384,21 +384,21 @@ sealed abstract private[data] class IndexedStateTFunctor[F[_], SA, SB] extends F
 }
 
 sealed abstract private[data] class IndexedStateTContravariant[F[_], SB, V]
-    extends Contravariant[IndexedStateT[F, ?, SB, V]] {
+    extends Contravariant[IndexedStateT[F, *, SB, V]] {
   implicit def F: Functor[F]
 
   override def contramap[A, B](fa: IndexedStateT[F, A, SB, V])(f: B => A): IndexedStateT[F, B, SB, V] =
     fa.contramap(f)
 }
 
-sealed abstract private[data] class IndexedStateTBifunctor[F[_], SA] extends Bifunctor[IndexedStateT[F, SA, ?, ?]] {
+sealed abstract private[data] class IndexedStateTBifunctor[F[_], SA] extends Bifunctor[IndexedStateT[F, SA, *, *]] {
   implicit def F: Functor[F]
 
   def bimap[A, B, C, D](fab: IndexedStateT[F, SA, A, B])(f: A => C, g: B => D): IndexedStateT[F, SA, C, D] =
     fab.bimap(f, g)
 }
 
-sealed abstract private[data] class IndexedStateTProfunctor[F[_], V] extends Profunctor[IndexedStateT[F, ?, ?, V]] {
+sealed abstract private[data] class IndexedStateTProfunctor[F[_], V] extends Profunctor[IndexedStateT[F, *, *, V]] {
   implicit def F: Functor[F]
 
   def dimap[A, B, C, D](fab: IndexedStateT[F, A, B, V])(f: C => A)(g: B => D): IndexedStateT[F, C, D, V] =
@@ -407,7 +407,7 @@ sealed abstract private[data] class IndexedStateTProfunctor[F[_], V] extends Pro
 
 sealed abstract private[data] class IndexedStateTStrong[F[_], V]
     extends IndexedStateTProfunctor[F, V]
-    with Strong[IndexedStateT[F, ?, ?, V]] {
+    with Strong[IndexedStateT[F, *, *, V]] {
   implicit def F: Monad[F]
 
   def first[A, B, C](fa: IndexedStateT[F, A, B, V]): IndexedStateT[F, (A, C), (B, C), V] =
@@ -425,7 +425,7 @@ sealed abstract private[data] class IndexedStateTStrong[F[_], V]
 
 sealed abstract private[data] class IndexedStateTMonad[F[_], S]
     extends IndexedStateTFunctor[F, S, S]
-    with Monad[IndexedStateT[F, S, S, ?]] {
+    with Monad[IndexedStateT[F, S, S, *]] {
   implicit def F: Monad[F]
 
   def pure[A](a: A): IndexedStateT[F, S, S, A] =
@@ -444,7 +444,7 @@ sealed abstract private[data] class IndexedStateTMonad[F[_], S]
 }
 
 sealed abstract private[data] class IndexedStateTSemigroupK[F[_], SA, SB]
-    extends SemigroupK[IndexedStateT[F, SA, SB, ?]] {
+    extends SemigroupK[IndexedStateT[F, SA, SB, *]] {
   implicit def F: Monad[F]
   implicit def G: SemigroupK[F]
 
@@ -453,7 +453,7 @@ sealed abstract private[data] class IndexedStateTSemigroupK[F[_], SA, SB]
 }
 
 sealed abstract private[data] class IndexedStateTContravariantMonoidal[F[_], S]
-    extends ContravariantMonoidal[IndexedStateT[F, S, S, ?]] {
+    extends ContravariantMonoidal[IndexedStateT[F, S, S, *]] {
   implicit def F: ContravariantMonoidal[F]
   implicit def G: Applicative[F]
 
@@ -484,7 +484,7 @@ sealed abstract private[data] class IndexedStateTContravariantMonoidal[F[_], S]
 
 sealed abstract private[data] class IndexedStateTAlternative[F[_], S]
     extends IndexedStateTMonad[F, S]
-    with Alternative[IndexedStateT[F, S, S, ?]] {
+    with Alternative[IndexedStateT[F, S, S, *]] {
   def G: Alternative[F]
 
   def combineK[A](x: IndexedStateT[F, S, S, A], y: IndexedStateT[F, S, S, A]): IndexedStateT[F, S, S, A] =
@@ -496,7 +496,7 @@ sealed abstract private[data] class IndexedStateTAlternative[F[_], S]
 
 sealed abstract private[data] class IndexedStateTMonadError[F[_], S, E]
     extends IndexedStateTMonad[F, S]
-    with MonadError[IndexedStateT[F, S, S, ?], E] {
+    with MonadError[IndexedStateT[F, S, S, *], E] {
   implicit def F: MonadError[F, E]
 
   def raiseError[A](e: E): IndexedStateT[F, S, S, A] = IndexedStateT.liftF(F.raiseError(e))
@@ -505,12 +505,12 @@ sealed abstract private[data] class IndexedStateTMonadError[F[_], S, E]
     IndexedStateT(s => F.handleErrorWith(fa.run(s))(e => f(e).run(s)))
 }
 
-private[this] trait IndexedStateTFunctorFilter[F[_], SA, SB] extends FunctorFilter[IndexedStateT[F, SA, SB, ?]] {
+private[this] trait IndexedStateTFunctorFilter[F[_], SA, SB] extends FunctorFilter[IndexedStateT[F, SA, SB, *]] {
 
   implicit def F0: Monad[F]
   def FF: FunctorFilter[F]
 
-  def functor: Functor[IndexedStateT[F, SA, SB, ?]] =
+  def functor: Functor[IndexedStateT[F, SA, SB, *]] =
     IndexedStateT.catsDataFunctorForIndexedStateT(FF.functor)
 
   def mapFilter[A, B](fa: IndexedStateT[F, SA, SB, A])(f: A => Option[B]): IndexedStateT[F, SA, SB, B] =

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -194,8 +194,8 @@ sealed abstract private[data] class IorInstances extends IorInstances0 {
     def combine(x: Ior[A, B], y: Ior[A, B]) = x.combine(y)
   }
 
-  implicit def catsDataMonadErrorForIor[A: Semigroup]: MonadError[Ior[A, ?], A] =
-    new MonadError[Ior[A, ?], A] {
+  implicit def catsDataMonadErrorForIor[A: Semigroup]: MonadError[Ior[A, *], A] =
+    new MonadError[Ior[A, *], A] {
 
       def raiseError[B](e: A): Ior[A, B] = Ior.left(e)
 
@@ -242,15 +242,15 @@ sealed abstract private[data] class IorInstances extends IorInstances0 {
     }
 
   // scalastyle:off cyclomatic.complexity
-  implicit def catsDataParallelForIor[E](implicit E: Semigroup[E]): Parallel[Ior[E, ?], Ior[E, ?]] =
-    new Parallel[Ior[E, ?], Ior[E, ?]] {
+  implicit def catsDataParallelForIor[E](implicit E: Semigroup[E]): Parallel[Ior[E, *], Ior[E, *]] =
+    new Parallel[Ior[E, *], Ior[E, *]] {
 
-      private[this] val identityK: Ior[E, ?] ~> Ior[E, ?] = FunctionK.id
+      private[this] val identityK: Ior[E, *] ~> Ior[E, *] = FunctionK.id
 
-      def parallel: Ior[E, ?] ~> Ior[E, ?] = identityK
-      def sequential: Ior[E, ?] ~> Ior[E, ?] = identityK
+      def parallel: Ior[E, *] ~> Ior[E, *] = identityK
+      def sequential: Ior[E, *] ~> Ior[E, *] = identityK
 
-      val applicative: Applicative[Ior[E, ?]] = new Applicative[Ior[E, ?]] {
+      val applicative: Applicative[Ior[E, *]] = new Applicative[Ior[E, *]] {
         def pure[A](a: A): Ior[E, A] = Ior.right(a)
         def ap[A, B](ff: Ior[E, A => B])(fa: Ior[E, A]): Ior[E, B] =
           fa match {
@@ -275,7 +275,7 @@ sealed abstract private[data] class IorInstances extends IorInstances0 {
           }
       }
 
-      lazy val monad: Monad[Ior[E, ?]] = Monad[Ior[E, ?]]
+      lazy val monad: Monad[Ior[E, *]] = Monad[Ior[E, *]]
     }
   // scalastyle:on cyclomatic.complexity
 
@@ -283,7 +283,7 @@ sealed abstract private[data] class IorInstances extends IorInstances0 {
 
 sealed abstract private[data] class IorInstances0 {
 
-  implicit def catsDataTraverseFunctorForIor[A]: Traverse[A Ior ?] = new Traverse[A Ior ?] {
+  implicit def catsDataTraverseFunctorForIor[A]: Traverse[A Ior *] = new Traverse[A Ior *] {
     def traverse[F[_]: Applicative, B, C](fa: A Ior B)(f: B => F[C]): F[A Ior C] =
       fa.traverse(f)
     def foldLeft[B, C](fa: A Ior B, b: C)(f: (C, B) => C): C =

--- a/core/src/main/scala/cats/data/IorT.scala
+++ b/core/src/main/scala/cats/data/IorT.scala
@@ -37,10 +37,10 @@ final case class IorT[F[_], A, B](value: F[Ior[A, B]]) {
 
   def toEither(implicit F: Functor[F]): EitherT[F, A, B] = EitherT(F.map(value)(_.toEither))
 
-  def toNested: Nested[F, Ior[A, ?], B] = Nested[F, Ior[A, ?], B](value)
+  def toNested: Nested[F, Ior[A, *], B] = Nested[F, Ior[A, *], B](value)
 
-  def toNestedValidated(implicit F: Functor[F]): Nested[F, Validated[A, ?], B] =
-    Nested[F, Validated[A, ?], B](F.map(value)(_.toValidated))
+  def toNestedValidated(implicit F: Functor[F]): Nested[F, Validated[A, *], B] =
+    Nested[F, Validated[A, *], B](F.map(value)(_.toValidated))
 
   def toValidated(implicit F: Functor[F]): F[Validated[A, B]] = F.map(value)(_.toValidated)
 
@@ -82,7 +82,7 @@ final case class IorT[F[_], A, B](value: F[Ior[A, B]]) {
   def transform[C, D](f: Ior[A, B] => Ior[C, D])(implicit F: Functor[F]): IorT[F, C, D] = IorT(F.map(value)(f))
 
   def applyAlt[D](ff: IorT[F, A, B => D])(implicit F: Apply[F], A: Semigroup[A]): IorT[F, A, D] =
-    IorT[F, A, D](F.map2(value, ff.value)((iorb, iorbd) => Apply[Ior[A, ?]].ap(iorbd)(iorb)))
+    IorT[F, A, D](F.map2(value, ff.value)((iorb, iorbd) => Apply[Ior[A, *]].ap(iorbd)(iorb)))
 
   def flatMap[AA >: A, D](f: B => IorT[F, AA, D])(implicit F: Monad[F], AA: Semigroup[AA]): IorT[F, AA, D] =
     IorT(F.flatMap(value) {
@@ -110,7 +110,7 @@ final case class IorT[F[_], A, B](value: F[Ior[A, B]]) {
     })
 
   def traverse[G[_], D](f: B => G[D])(implicit traverseF: Traverse[F], applicativeG: Applicative[G]): G[IorT[F, A, D]] =
-    applicativeG.map(traverseF.traverse(value)(ior => Traverse[Ior[A, ?]].traverse(ior)(f)))(IorT.apply)
+    applicativeG.map(traverseF.traverse(value)(ior => Traverse[Ior[A, *]].traverse(ior)(f)))(IorT.apply)
 
   def foldLeft[C](c: C)(f: (C, B) => C)(implicit F: Foldable[F]): C =
     F.foldLeft(value, c)((c, ior) => ior.foldLeft(c)(f))
@@ -260,14 +260,14 @@ object IorT extends IorTInstances {
    * Same as [[liftF]], but expressed as a FunctionK for use with [[IorT.mapK]]
    * {{{
    * scala> import cats._, data._, implicits._
-   * scala> val a: OptionT[Eval, Int] = 1.pure[OptionT[Eval, ?]]
-   * scala> val b: OptionT[IorT[Eval, String, ?], Int] = a.mapK(IorT.liftK)
+   * scala> val a: OptionT[Eval, Int] = 1.pure[OptionT[Eval, *]]
+   * scala> val b: OptionT[IorT[Eval, String, *], Int] = a.mapK(IorT.liftK)
    * scala> b.value.value.value
    * res0: cats.data.Ior[String,Option[Int]] = Right(Some(1))
    * }}}
    */
-  final def liftK[F[_], A](implicit F: Functor[F]): F ~> IorT[F, A, ?] =
-    new (F ~> IorT[F, A, ?]) {
+  final def liftK[F[_], A](implicit F: Functor[F]): F ~> IorT[F, A, *] =
+    new (F ~> IorT[F, A, *]) {
       def apply[B](fb: F[B]): IorT[F, A, B] = right(fb)
     }
 
@@ -407,12 +407,12 @@ abstract private[data] class IorTInstances extends IorTInstances1 {
   implicit def catsDataShowForIorT[F[_], A, B](implicit sh: Show[F[Ior[A, B]]]): Show[IorT[F, A, B]] =
     Contravariant[Show].contramap(sh)(_.value)
 
-  implicit def catsDataBifunctorForIorT[F[_]](implicit F: Functor[F]): Bifunctor[IorT[F, ?, ?]] =
-    new Bifunctor[IorT[F, ?, ?]] {
+  implicit def catsDataBifunctorForIorT[F[_]](implicit F: Functor[F]): Bifunctor[IorT[F, *, *]] =
+    new Bifunctor[IorT[F, *, *]] {
       override def bimap[A, B, C, D](iort: IorT[F, A, B])(fa: A => C, fb: B => D): IorT[F, C, D] = iort.bimap(fa, fb)
     }
 
-  implicit def catsDataTraverseForIorT[F[_], A](implicit F: Traverse[F]): Traverse[IorT[F, A, ?]] =
+  implicit def catsDataTraverseForIorT[F[_], A](implicit F: Traverse[F]): Traverse[IorT[F, A, *]] =
     new IorTTraverse[F, A] with IorTFunctor[F, A] { val F0: Traverse[F] = F }
 
   implicit def catsDataMonoidForIorT[F[_], A, B](implicit F: Monoid[F[Ior[A, B]]]): Monoid[IorT[F, A, B]] =
@@ -421,30 +421,30 @@ abstract private[data] class IorTInstances extends IorTInstances1 {
   implicit def catsDataParallelForIorTWithParallelEffect[M[_], F[_], E](
     implicit P: Parallel[M, F],
     E: Semigroup[E]
-  ): Parallel[IorT[M, E, ?], IorT[F, E, ?]] { type Dummy } = new Parallel[IorT[M, E, ?], IorT[F, E, ?]] {
+  ): Parallel[IorT[M, E, *], IorT[F, E, *]] { type Dummy } = new Parallel[IorT[M, E, *], IorT[F, E, *]] {
     type Dummy // fix to make this one more specific than the catsDataParallelForIorTWithSequentialEffect, see https://github.com/typelevel/cats/pull/2335#issuecomment-408249775
 
-    val parallel: IorT[M, E, ?] ~> IorT[F, E, ?] = λ[IorT[M, E, ?] ~> IorT[F, E, ?]](fm => IorT(P.parallel(fm.value)))
-    val sequential: IorT[F, E, ?] ~> IorT[M, E, ?] =
-      λ[IorT[F, E, ?] ~> IorT[M, E, ?]](ff => IorT(P.sequential(ff.value)))
+    val parallel: IorT[M, E, *] ~> IorT[F, E, *] = λ[IorT[M, E, *] ~> IorT[F, E, *]](fm => IorT(P.parallel(fm.value)))
+    val sequential: IorT[F, E, *] ~> IorT[M, E, *] =
+      λ[IorT[F, E, *] ~> IorT[M, E, *]](ff => IorT(P.sequential(ff.value)))
 
     private[this] val FA: Applicative[F] = P.applicative
-    private[this] val IorA: Applicative[Ior[E, ?]] = Parallel[Ior[E, ?], Ior[E, ?]].applicative
+    private[this] val IorA: Applicative[Ior[E, *]] = Parallel[Ior[E, *], Ior[E, *]].applicative
 
-    val applicative: Applicative[IorT[F, E, ?]] = new Applicative[IorT[F, E, ?]] {
+    val applicative: Applicative[IorT[F, E, *]] = new Applicative[IorT[F, E, *]] {
       def pure[A](a: A): IorT[F, E, A] = IorT.pure(a)(FA)
       def ap[A, B](ff: IorT[F, E, A => B])(fa: IorT[F, E, A]): IorT[F, E, B] =
         IorT(FA.map2(ff.value, fa.value)((f, a) => IorA.ap(f)(a)))
     }
 
-    lazy val monad: Monad[IorT[M, E, ?]] = {
+    lazy val monad: Monad[IorT[M, E, *]] = {
       implicit def underlyingMonadM: Monad[M] = P.monad
-      Monad[IorT[M, E, ?]]
+      Monad[IorT[M, E, *]]
     }
   }
 
-  implicit def catsDataDeferForIor[F[_], E](implicit F: Defer[F]): Defer[IorT[F, E, ?]] =
-    new Defer[IorT[F, E, ?]] {
+  implicit def catsDataDeferForIor[F[_], E](implicit F: Defer[F]): Defer[IorT[F, E, *]] =
+    new Defer[IorT[F, E, *]] {
       def defer[A](fa: => IorT[F, E, A]): IorT[F, E, A] =
         IorT(F.defer(fa.value))
     }
@@ -454,10 +454,10 @@ abstract private[data] class IorTInstances1 extends IorTInstances2 {
   implicit def catsDataSemigroupForIorT[F[_], A, B](implicit F: Semigroup[F[Ior[A, B]]]): Semigroup[IorT[F, A, B]] =
     new IorTSemigroup[F, A, B] { val F0: Semigroup[F[Ior[A, B]]] = F }
 
-  implicit def catsDataFoldableForIorT[F[_], A](implicit F: Foldable[F]): Foldable[IorT[F, A, ?]] =
+  implicit def catsDataFoldableForIorT[F[_], A](implicit F: Foldable[F]): Foldable[IorT[F, A, *]] =
     new IorTFoldable[F, A] { val F0: Foldable[F] = F }
 
-  implicit def catsDataMonadErrorForIorT[F[_], A](implicit F: Monad[F], A: Semigroup[A]): MonadError[IorT[F, A, ?], A] =
+  implicit def catsDataMonadErrorForIorT[F[_], A](implicit F: Monad[F], A: Semigroup[A]): MonadError[IorT[F, A, *], A] =
     new IorTMonadError[F, A] {
       val A0: Semigroup[A] = A
       val F0: Monad[F] = F
@@ -466,28 +466,28 @@ abstract private[data] class IorTInstances1 extends IorTInstances2 {
   implicit def catsDataParallelForIorTWithSequentialEffect[F[_], E](
     implicit F: Monad[F],
     E: Semigroup[E]
-  ): Parallel[IorT[F, E, ?], IorT[F, E, ?]] = new Parallel[IorT[F, E, ?], IorT[F, E, ?]] {
-    private[this] val identityK: IorT[F, E, ?] ~> IorT[F, E, ?] = FunctionK.id
-    private[this] val underlyingParallel: Parallel[Ior[E, ?], Ior[E, ?]] =
-      Parallel[Ior[E, ?], Ior[E, ?]]
+  ): Parallel[IorT[F, E, *], IorT[F, E, *]] = new Parallel[IorT[F, E, *], IorT[F, E, *]] {
+    private[this] val identityK: IorT[F, E, *] ~> IorT[F, E, *] = FunctionK.id
+    private[this] val underlyingParallel: Parallel[Ior[E, *], Ior[E, *]] =
+      Parallel[Ior[E, *], Ior[E, *]]
 
-    def parallel: IorT[F, E, ?] ~> IorT[F, E, ?] = identityK
-    def sequential: IorT[F, E, ?] ~> IorT[F, E, ?] = identityK
+    def parallel: IorT[F, E, *] ~> IorT[F, E, *] = identityK
+    def sequential: IorT[F, E, *] ~> IorT[F, E, *] = identityK
 
-    val applicative: Applicative[IorT[F, E, ?]] = new Applicative[IorT[F, E, ?]] {
+    val applicative: Applicative[IorT[F, E, *]] = new Applicative[IorT[F, E, *]] {
       def pure[A](a: A): IorT[F, E, A] = IorT.pure(a)
       def ap[A, B](ff: IorT[F, E, A => B])(fa: IorT[F, E, A]): IorT[F, E, B] =
         IorT(F.map2(ff.value, fa.value)((f, a) => underlyingParallel.applicative.ap(f)(a)))
     }
 
-    lazy val monad: Monad[IorT[F, E, ?]] = Monad[IorT[F, E, ?]]
+    lazy val monad: Monad[IorT[F, E, *]] = Monad[IorT[F, E, *]]
   }
 
 }
 
 abstract private[data] class IorTInstances2 extends IorTInstances3 {
   implicit def catsDataMonadErrorFForIorT[F[_], A, E](implicit FE: MonadError[F, E],
-                                                      A: Semigroup[A]): MonadError[IorT[F, A, ?], E] =
+                                                      A: Semigroup[A]): MonadError[IorT[F, A, *], E] =
     new IorTMonadErrorF[F, A, E] {
       val A0: Semigroup[A] = A
       val F0: MonadError[F, E] = FE
@@ -498,11 +498,11 @@ abstract private[data] class IorTInstances2 extends IorTInstances3 {
 }
 
 abstract private[data] class IorTInstances3 {
-  implicit def catsDataFunctorForIorT[F[_], A](implicit F: Functor[F]): Functor[IorT[F, A, ?]] =
+  implicit def catsDataFunctorForIorT[F[_], A](implicit F: Functor[F]): Functor[IorT[F, A, *]] =
     new IorTFunctor[F, A] { val F0: Functor[F] = F }
 }
 
-sealed private[data] trait IorTFunctor[F[_], A] extends Functor[IorT[F, A, ?]] {
+sealed private[data] trait IorTFunctor[F[_], A] extends Functor[IorT[F, A, *]] {
   implicit def F0: Functor[F]
 
   override def map[B, D](iort: IorT[F, A, B])(f: B => D): IorT[F, A, D] = iort.map(f)
@@ -514,7 +514,7 @@ sealed private[data] trait IorTEq[F[_], A, B] extends Eq[IorT[F, A, B]] {
   override def eqv(x: IorT[F, A, B], y: IorT[F, A, B]): Boolean = x === y
 }
 
-sealed private[data] trait IorTMonad[F[_], A] extends Monad[IorT[F, A, ?]] with IorTFunctor[F, A] {
+sealed private[data] trait IorTMonad[F[_], A] extends Monad[IorT[F, A, *]] with IorTFunctor[F, A] {
   implicit def A0: Semigroup[A]
   implicit override def F0: Monad[F]
 
@@ -535,7 +535,7 @@ sealed private[data] trait IorTMonad[F[_], A] extends Monad[IorT[F, A, ?]] with 
     })
 }
 
-sealed private[data] trait IorTMonadError[F[_], A] extends MonadError[IorT[F, A, ?], A] with IorTMonad[F, A] {
+sealed private[data] trait IorTMonadError[F[_], A] extends MonadError[IorT[F, A, *], A] with IorTMonad[F, A] {
   override def raiseError[B](a: A): IorT[F, A, B] = IorT(F0.pure(Ior.left(a)))
 
   override def handleErrorWith[B](iort: IorT[F, A, B])(f: A => IorT[F, A, B]): IorT[F, A, B] =
@@ -545,7 +545,7 @@ sealed private[data] trait IorTMonadError[F[_], A] extends MonadError[IorT[F, A,
     })
 }
 
-sealed private[data] trait IorTMonadErrorF[F[_], A, E] extends MonadError[IorT[F, A, ?], E] with IorTMonad[F, A] {
+sealed private[data] trait IorTMonadErrorF[F[_], A, E] extends MonadError[IorT[F, A, *], E] with IorTMonad[F, A] {
   implicit override def F0: MonadError[F, E]
 
   override def raiseError[B](e: E): IorT[F, A, B] = IorT(F0.raiseError(e))
@@ -567,7 +567,7 @@ sealed private[data] trait IorTMonoid[F[_], A, B] extends Monoid[IorT[F, A, B]] 
   override def empty: IorT[F, A, B] = IorT(F0.empty)
 }
 
-sealed private[data] trait IorTFoldable[F[_], A] extends Foldable[IorT[F, A, ?]] {
+sealed private[data] trait IorTFoldable[F[_], A] extends Foldable[IorT[F, A, *]] {
   implicit def F0: Foldable[F]
 
   override def foldLeft[B, C](iort: IorT[F, A, B], c: C)(f: (C, B) => C): C = iort.foldLeft(c)(f)
@@ -576,7 +576,7 @@ sealed private[data] trait IorTFoldable[F[_], A] extends Foldable[IorT[F, A, ?]]
     iort.foldRight(lc)(f)
 }
 
-sealed private[data] trait IorTTraverse[F[_], A] extends Traverse[IorT[F, A, ?]] with IorTFoldable[F, A] {
+sealed private[data] trait IorTTraverse[F[_], A] extends Traverse[IorT[F, A, *]] with IorTFoldable[F, A] {
   implicit override def F0: Traverse[F]
 
   override def traverse[G[_]: Applicative, B, D](iort: IorT[F, A, B])(f: B => G[D]): G[IorT[F, A, D]] = iort.traverse(f)

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -159,7 +159,7 @@ object Kleisli
    *
    * scala> type KOI[A] = Kleisli[Option, Int, A]
    * scala> val b: KOI[Either[Char, Char]] = Kleisli[Option, Int, Either[Char, Char]](f _)
-   * scala> val nt: Kleisli[Option, Int, ?] ~> Option = Kleisli.applyK[Option, Int](1)
+   * scala> val nt: Kleisli[Option, Int, *] ~> Option = Kleisli.applyK[Option, Int](1)
    * scala> nt(b)
    * res0: Option[Either[Char, Char]] = Some(Right(n))
    *
@@ -173,8 +173,8 @@ object Kleisli
    * res2: Option[Either[Char, Char]] = None
    * }}}
    */
-  def applyK[F[_], A](a: A): Kleisli[F, A, ?] ~> F =
-    λ[Kleisli[F, A, ?] ~> F](_.apply(a))
+  def applyK[F[_], A](a: A): Kleisli[F, A, *] ~> F =
+    λ[Kleisli[F, A, *] ~> F](_.apply(a))
 
 }
 
@@ -197,14 +197,14 @@ sealed private[data] trait KleisliFunctions {
    * Same as [[liftF]], but expressed as a FunctionK for use with mapK
    * {{{
    * scala> import cats._, data._, implicits._
-   * scala> val a: OptionT[Eval, Int] = 1.pure[OptionT[Eval, ?]]
-   * scala> val b: OptionT[Kleisli[Eval, String, ?], Int] = a.mapK(Kleisli.liftK)
+   * scala> val a: OptionT[Eval, Int] = 1.pure[OptionT[Eval, *]]
+   * scala> val b: OptionT[Kleisli[Eval, String, *], Int] = a.mapK(Kleisli.liftK)
    * scala> b.value.run("").value
    * res0: Option[Int] = Some(1)
    * }}}
    */
-  def liftK[F[_], A]: F ~> Kleisli[F, A, ?] =
-    λ[F ~> Kleisli[F, A, ?]](Kleisli.liftF(_))
+  def liftK[F[_], A]: F ~> Kleisli[F, A, *] =
+    λ[F ~> Kleisli[F, A, *]](Kleisli.liftF(_))
 
   @deprecated("Use liftF instead", "1.0.0-RC2")
   def lift[F[_], A, B](x: F[B]): Kleisli[F, A, B] =
@@ -267,28 +267,28 @@ sealed private[data] trait KleisliFunctionsBinCompat {
    * res1: Option[Char] = Some(f)
    * }}}
    * */
-  def liftFunctionK[F[_], G[_], A](f: F ~> G): Kleisli[F, A, ?] ~> Kleisli[G, A, ?] =
-    λ[Kleisli[F, A, ?] ~> Kleisli[G, A, ?]](_.mapK(f))
+  def liftFunctionK[F[_], G[_], A](f: F ~> G): Kleisli[F, A, *] ~> Kleisli[G, A, *] =
+    λ[Kleisli[F, A, *] ~> Kleisli[G, A, *]](_.mapK(f))
 }
 
 sealed private[data] trait KleisliExplicitInstances {
 
   def endoSemigroupK[F[_]](implicit FM: FlatMap[F]): SemigroupK[λ[α => Kleisli[F, α, α]]] =
-    Compose[Kleisli[F, ?, ?]].algebraK
+    Compose[Kleisli[F, *, *]].algebraK
 
   def endoMonoidK[F[_]](implicit M: Monad[F]): MonoidK[λ[α => Kleisli[F, α, α]]] =
-    Category[Kleisli[F, ?, ?]].algebraK
+    Category[Kleisli[F, *, *]].algebraK
 }
 
 sealed abstract private[data] class KleisliInstances extends KleisliInstances0 {
-  implicit def catsDataMonadForKleisliId[A]: CommutativeMonad[Kleisli[Id, A, ?]] =
+  implicit def catsDataMonadForKleisliId[A]: CommutativeMonad[Kleisli[Id, A, *]] =
     catsDataCommutativeMonadForKleisli[Id, A]
 
-  implicit val catsDataCommutativeArrowForKleisliId: CommutativeArrow[Kleisli[Id, ?, ?]] =
+  implicit val catsDataCommutativeArrowForKleisliId: CommutativeArrow[Kleisli[Id, *, *]] =
     catsDataCommutativeArrowForKleisli[Id]
 
-  implicit def catsDataDeferForKleisli[F[_], A](implicit F: Defer[F]): Defer[Kleisli[F, A, ?]] =
-    new Defer[Kleisli[F, A, ?]] {
+  implicit def catsDataDeferForKleisli[F[_], A](implicit F: Defer[F]): Defer[Kleisli[F, A, *]] =
+    new Defer[Kleisli[F, A, *]] {
       def defer[B](fa: => Kleisli[F, A, B]): Kleisli[F, A, B] = {
         lazy val cacheFa = fa
         Kleisli[F, A, B] { a =>
@@ -299,7 +299,7 @@ sealed abstract private[data] class KleisliInstances extends KleisliInstances0 {
 
   implicit def catsDataFunctorFilterForKleisli[F[_], A](
     implicit ev: FunctorFilter[F]
-  ): FunctorFilter[Kleisli[F, A, ?]] =
+  ): FunctorFilter[Kleisli[F, A, *]] =
     new KleisliFunctorFilter[F, A] { val FF = ev }
 }
 
@@ -307,13 +307,13 @@ sealed abstract private[data] class KleisliInstances0 extends KleisliInstances0_
 
   implicit def catsDataCommutativeArrowForKleisli[F[_]](
     implicit M: CommutativeMonad[F]
-  ): CommutativeArrow[Kleisli[F, ?, ?]] with ArrowChoice[Kleisli[F, ?, ?]] =
+  ): CommutativeArrow[Kleisli[F, *, *]] with ArrowChoice[Kleisli[F, *, *]] =
     new KleisliCommutativeArrow[F] { def F: CommutativeMonad[F] = M }
 
   implicit def catsDataCommutativeMonadForKleisli[F[_], A](
     implicit F0: CommutativeMonad[F]
-  ): CommutativeMonad[Kleisli[F, A, ?]] =
-    new KleisliMonad[F, A] with CommutativeMonad[Kleisli[F, A, ?]] {
+  ): CommutativeMonad[Kleisli[F, A, *]] =
+    new KleisliMonad[F, A] with CommutativeMonad[Kleisli[F, A, *]] {
       implicit def F: Monad[F] = F0
     }
 
@@ -325,17 +325,17 @@ sealed abstract private[data] class KleisliInstances0_5 extends KleisliInstances
 
   implicit def catsDataMonadErrorForKleisli[F[_], A, E](
     implicit ME: MonadError[F, E]
-  ): MonadError[Kleisli[F, A, ?], E] =
+  ): MonadError[Kleisli[F, A, *], E] =
     new KleisliMonadError[F, A, E] { def F: MonadError[F, E] = ME }
 
-  implicit def catsDataArrowChoiceForKleisli[F[_]](implicit M: Monad[F]): ArrowChoice[Kleisli[F, ?, ?]] =
+  implicit def catsDataArrowChoiceForKleisli[F[_]](implicit M: Monad[F]): ArrowChoice[Kleisli[F, *, *]] =
     new KleisliArrowChoice[F] {
       def F: Monad[F] = M
     }
 
   implicit def catsDataContravariantMonoidalForKleisli[F[_], A](
     implicit F0: ContravariantMonoidal[F]
-  ): ContravariantMonoidal[Kleisli[F, A, ?]] =
+  ): ContravariantMonoidal[Kleisli[F, A, *]] =
     new KleisliContravariantMonoidal[F, A] { def F: ContravariantMonoidal[F] = F0 }
 
   /**
@@ -345,12 +345,12 @@ sealed abstract private[data] class KleisliInstances0_5 extends KleisliInstances
   implicit def catsDataRepresentableForKleisli[M[_], R, E](
     implicit
     R: Representable.Aux[M, R],
-    FK: Functor[Kleisli[M, E, ?]]
-  ): Representable.Aux[Kleisli[M, E, ?], (E, R)] = new Representable[Kleisli[M, E, ?]] {
+    FK: Functor[Kleisli[M, E, *]]
+  ): Representable.Aux[Kleisli[M, E, *], (E, R)] = new Representable[Kleisli[M, E, *]] {
 
     override type Representation = (E, R)
 
-    override val F: Functor[Kleisli[M, E, ?]] = FK
+    override val F: Functor[Kleisli[M, E, *]] = FK
 
     def index[A](f: Kleisli[M, E, A]): Representation => A = {
       case (e, r) => R.index(f.run(e))(r)
@@ -365,55 +365,55 @@ sealed abstract private[data] class KleisliInstances0_5 extends KleisliInstances
 }
 
 sealed abstract private[data] class KleisliInstances1 extends KleisliInstances2 {
-  implicit def catsDataMonadForKleisli[F[_], A](implicit M: Monad[F]): Monad[Kleisli[F, A, ?]] =
+  implicit def catsDataMonadForKleisli[F[_], A](implicit M: Monad[F]): Monad[Kleisli[F, A, *]] =
     new KleisliMonad[F, A] { def F: Monad[F] = M }
 
   implicit def catsDataParallelForKleisli[F[_], M[_], A](
     implicit P: Parallel[M, F]
-  ): Parallel[Kleisli[M, A, ?], Kleisli[F, A, ?]] = new Parallel[Kleisli[M, A, ?], Kleisli[F, A, ?]] {
+  ): Parallel[Kleisli[M, A, *], Kleisli[F, A, *]] = new Parallel[Kleisli[M, A, *], Kleisli[F, A, *]] {
     implicit val appF = P.applicative
     implicit val monadM = P.monad
-    def applicative: Applicative[Kleisli[F, A, ?]] = catsDataApplicativeForKleisli
-    def monad: Monad[Kleisli[M, A, ?]] = catsDataMonadForKleisli
+    def applicative: Applicative[Kleisli[F, A, *]] = catsDataApplicativeForKleisli
+    def monad: Monad[Kleisli[M, A, *]] = catsDataMonadForKleisli
 
-    def sequential: Kleisli[F, A, ?] ~> Kleisli[M, A, ?] =
-      λ[Kleisli[F, A, ?] ~> Kleisli[M, A, ?]](_.mapK(P.sequential))
+    def sequential: Kleisli[F, A, *] ~> Kleisli[M, A, *] =
+      λ[Kleisli[F, A, *] ~> Kleisli[M, A, *]](_.mapK(P.sequential))
 
-    def parallel: Kleisli[M, A, ?] ~> Kleisli[F, A, ?] =
-      λ[Kleisli[M, A, ?] ~> Kleisli[F, A, ?]](_.mapK(P.parallel))
+    def parallel: Kleisli[M, A, *] ~> Kleisli[F, A, *] =
+      λ[Kleisli[M, A, *] ~> Kleisli[F, A, *]](_.mapK(P.parallel))
   }
 
-  implicit def catsDataContravariantForKleisli[F[_], C]: Contravariant[Kleisli[F, ?, C]] =
-    new Contravariant[Kleisli[F, ?, C]] {
+  implicit def catsDataContravariantForKleisli[F[_], C]: Contravariant[Kleisli[F, *, C]] =
+    new Contravariant[Kleisli[F, *, C]] {
       override def contramap[A, B](fa: Kleisli[F, A, C])(f: B => A): Kleisli[F, B, C] =
         fa.local(f)
     }
 }
 
 sealed abstract private[data] class KleisliInstances2 extends KleisliInstances3 {
-  implicit def catsDataAlternativeForKleisli[F[_], A](implicit F0: Alternative[F]): Alternative[Kleisli[F, A, ?]] =
+  implicit def catsDataAlternativeForKleisli[F[_], A](implicit F0: Alternative[F]): Alternative[Kleisli[F, A, *]] =
     new KleisliAlternative[F, A] { def F: Alternative[F] = F0 }
 }
 
 sealed abstract private[data] class KleisliInstances3 extends KleisliInstances4 {
-  implicit def catsDataMonoidKForKleisli[F[_], A](implicit F0: MonoidK[F]): MonoidK[Kleisli[F, A, ?]] =
+  implicit def catsDataMonoidKForKleisli[F[_], A](implicit F0: MonoidK[F]): MonoidK[Kleisli[F, A, *]] =
     new KleisliMonoidK[F, A] { def F: MonoidK[F] = F0 }
 
   implicit def catsDataCommutativeFlatMapForKleisli[F[_], A](
     implicit F0: CommutativeFlatMap[F]
-  ): CommutativeFlatMap[Kleisli[F, A, ?]] =
-    new KleisliFlatMap[F, A] with CommutativeFlatMap[Kleisli[F, A, ?]] { val F: CommutativeFlatMap[F] = F0 }
+  ): CommutativeFlatMap[Kleisli[F, A, *]] =
+    new KleisliFlatMap[F, A] with CommutativeFlatMap[Kleisli[F, A, *]] { val F: CommutativeFlatMap[F] = F0 }
 
-  implicit def catsDataChoiceForKleisli[F[_]](implicit M: Monad[F]): Choice[Kleisli[F, ?, ?]] =
+  implicit def catsDataChoiceForKleisli[F[_]](implicit M: Monad[F]): Choice[Kleisli[F, *, *]] =
     new KleisliChoice[F] { def F: Monad[F] = M }
 
-  implicit val catsDataChoiceForKleisliId: Choice[Kleisli[Id, ?, ?]] =
+  implicit val catsDataChoiceForKleisliId: Choice[Kleisli[Id, *, *]] =
     catsDataChoiceForKleisli[Id]
 
-  implicit def catsDataComposeForKleisli[F[_]](implicit FM: FlatMap[F]): Compose[Kleisli[F, ?, ?]] =
+  implicit def catsDataComposeForKleisli[F[_]](implicit FM: FlatMap[F]): Compose[Kleisli[F, *, *]] =
     new KleisliCompose[F] { def F: FlatMap[F] = FM }
 
-  implicit def catsDataStrongForKleisli[F[_]](implicit F0: Functor[F]): Strong[Kleisli[F, ?, ?]] =
+  implicit def catsDataStrongForKleisli[F[_]](implicit F0: Functor[F]): Strong[Kleisli[F, *, *]] =
     new KleisliStrong[F] { def F: Functor[F] = F0 }
 
   implicit def catsDataSemigroupForKleisli[F[_], A, B](implicit FB0: Semigroup[F[B]]): Semigroup[Kleisli[F, A, B]] =
@@ -421,10 +421,10 @@ sealed abstract private[data] class KleisliInstances3 extends KleisliInstances4 
 }
 
 sealed abstract private[data] class KleisliInstances4 extends KleisliInstances5 {
-  implicit def catsDataSemigroupKForKleisli[F[_], A](implicit F0: SemigroupK[F]): SemigroupK[Kleisli[F, A, ?]] =
+  implicit def catsDataSemigroupKForKleisli[F[_], A](implicit F0: SemigroupK[F]): SemigroupK[Kleisli[F, A, *]] =
     new KleisliSemigroupK[F, A] { def F: SemigroupK[F] = F0 }
 
-  implicit def catsDataFlatMapForKleisli[F[_], A](implicit FM: FlatMap[F]): FlatMap[Kleisli[F, A, ?]] =
+  implicit def catsDataFlatMapForKleisli[F[_], A](implicit FM: FlatMap[F]): FlatMap[Kleisli[F, A, *]] =
     new KleisliFlatMap[F, A] { def F: FlatMap[F] = FM }
 
 }
@@ -433,38 +433,38 @@ sealed abstract private[data] class KleisliInstances5 extends KleisliInstances6 
 
   implicit def catsDataApplicativeErrorForKleisli[F[_], E, A](
     implicit F0: ApplicativeError[F, E]
-  ): ApplicativeError[Kleisli[F, A, ?], E] =
+  ): ApplicativeError[Kleisli[F, A, *], E] =
     new KleisliApplicativeError[F, A, E] { def F: ApplicativeError[F, E] = F0 }
 }
 
 sealed abstract private[data] class KleisliInstances6 extends KleisliInstances7 {
-  implicit def catsDataApplicativeForKleisli[F[_], A](implicit A: Applicative[F]): Applicative[Kleisli[F, A, ?]] =
+  implicit def catsDataApplicativeForKleisli[F[_], A](implicit A: Applicative[F]): Applicative[Kleisli[F, A, *]] =
     new KleisliApplicative[F, A] { def F: Applicative[F] = A }
 }
 
 sealed abstract private[data] class KleisliInstances7 extends KleisliInstances8 {
-  implicit def catsDataApplyForKleisli[F[_], A](implicit A: Apply[F]): Apply[Kleisli[F, A, ?]] =
+  implicit def catsDataApplyForKleisli[F[_], A](implicit A: Apply[F]): Apply[Kleisli[F, A, *]] =
     new KleisliApply[F, A] { def F: Apply[F] = A }
 }
 
 sealed abstract private[data] class KleisliInstances8 extends KleisliInstances9 {
-  implicit def catsDataDistributiveForKleisli[F[_], R](implicit F0: Distributive[F]): Distributive[Kleisli[F, R, ?]] =
+  implicit def catsDataDistributiveForKleisli[F[_], R](implicit F0: Distributive[F]): Distributive[Kleisli[F, R, *]] =
     new KleisliDistributive[F, R] with KleisliFunctor[F, R] { implicit def F: Distributive[F] = F0 }
 }
 
 sealed abstract private[data] class KleisliInstances9 {
-  implicit def catsDataFunctorForKleisli[F[_], A](implicit F0: Functor[F]): Functor[Kleisli[F, A, ?]] =
+  implicit def catsDataFunctorForKleisli[F[_], A](implicit F0: Functor[F]): Functor[Kleisli[F, A, *]] =
     new KleisliFunctor[F, A] { def F: Functor[F] = F0 }
 }
 
 private[data] trait KleisliCommutativeArrow[F[_]]
-    extends CommutativeArrow[Kleisli[F, ?, ?]]
+    extends CommutativeArrow[Kleisli[F, *, *]]
     with KleisliArrowChoice[F] {
   implicit def F: CommutativeMonad[F]
 }
 
 private[data] trait KleisliArrowChoice[F[_]]
-    extends ArrowChoice[Kleisli[F, ?, ?]]
+    extends ArrowChoice[Kleisli[F, *, *]]
     with KleisliCategory[F]
     with KleisliStrong[F] {
   implicit def F: Monad[F]
@@ -485,7 +485,7 @@ private[data] trait KleisliArrowChoice[F[_]]
     )
 }
 
-private[data] trait KleisliStrong[F[_]] extends Strong[Kleisli[F, ?, ?]] {
+private[data] trait KleisliStrong[F[_]] extends Strong[Kleisli[F, *, *]] {
   implicit def F: Functor[F]
 
   override def lmap[A, B, C](fab: Kleisli[F, A, B])(f: C => A): Kleisli[F, C, B] =
@@ -504,18 +504,18 @@ private[data] trait KleisliStrong[F[_]] extends Strong[Kleisli[F, ?, ?]] {
     fa.second[C]
 }
 
-private[data] trait KleisliChoice[F[_]] extends Choice[Kleisli[F, ?, ?]] with KleisliCategory[F] {
+private[data] trait KleisliChoice[F[_]] extends Choice[Kleisli[F, *, *]] with KleisliCategory[F] {
   def choice[A, B, C](f: Kleisli[F, A, C], g: Kleisli[F, B, C]): Kleisli[F, Either[A, B], C] =
     Kleisli(_.fold(f.run, g.run))
 }
 
-private[data] trait KleisliCategory[F[_]] extends Category[Kleisli[F, ?, ?]] with KleisliCompose[F] {
+private[data] trait KleisliCategory[F[_]] extends Category[Kleisli[F, *, *]] with KleisliCompose[F] {
   implicit def F: Monad[F]
 
   override def id[A]: Kleisli[F, A, A] = Kleisli.ask[F, A]
 }
 
-private[data] trait KleisliCompose[F[_]] extends Compose[Kleisli[F, ?, ?]] {
+private[data] trait KleisliCompose[F[_]] extends Compose[Kleisli[F, *, *]] {
   implicit def F: FlatMap[F]
 
   def compose[A, B, C](f: Kleisli[F, B, C], g: Kleisli[F, A, B]): Kleisli[F, A, C] =
@@ -535,27 +535,27 @@ private[data] trait KleisliMonoid[F[_], A, B] extends Monoid[Kleisli[F, A, B]] w
   override def empty: Kleisli[F, A, B] = Kleisli[F, A, B](_ => FB.empty)
 }
 
-sealed private[data] trait KleisliSemigroupK[F[_], A] extends SemigroupK[Kleisli[F, A, ?]] {
+sealed private[data] trait KleisliSemigroupK[F[_], A] extends SemigroupK[Kleisli[F, A, *]] {
   implicit def F: SemigroupK[F]
 
   override def combineK[B](x: Kleisli[F, A, B], y: Kleisli[F, A, B]): Kleisli[F, A, B] =
     Kleisli(a => F.combineK(x.run(a), y.run(a)))
 }
 
-sealed private[data] trait KleisliMonoidK[F[_], A] extends MonoidK[Kleisli[F, A, ?]] with KleisliSemigroupK[F, A] {
+sealed private[data] trait KleisliMonoidK[F[_], A] extends MonoidK[Kleisli[F, A, *]] with KleisliSemigroupK[F, A] {
   implicit def F: MonoidK[F]
 
   override def empty[B]: Kleisli[F, A, B] = Kleisli.liftF(F.empty[B])
 }
 
 private[data] trait KleisliAlternative[F[_], A]
-    extends Alternative[Kleisli[F, A, ?]]
+    extends Alternative[Kleisli[F, A, *]]
     with KleisliApplicative[F, A]
     with KleisliMonoidK[F, A] {
   implicit def F: Alternative[F]
 }
 
-sealed private[data] trait KleisliContravariantMonoidal[F[_], D] extends ContravariantMonoidal[Kleisli[F, D, ?]] {
+sealed private[data] trait KleisliContravariantMonoidal[F[_], D] extends ContravariantMonoidal[Kleisli[F, D, *]] {
   implicit def F: ContravariantMonoidal[F]
 
   override def unit: Kleisli[F, D, Unit] = Kleisli(Function.const(F.unit))
@@ -568,14 +568,14 @@ sealed private[data] trait KleisliContravariantMonoidal[F[_], D] extends Contrav
 }
 
 private[data] trait KleisliMonadError[F[_], A, E]
-    extends MonadError[Kleisli[F, A, ?], E]
+    extends MonadError[Kleisli[F, A, *], E]
     with KleisliApplicativeError[F, A, E]
     with KleisliMonad[F, A] {
   def F: MonadError[F, E]
 }
 
 private[data] trait KleisliApplicativeError[F[_], A, E]
-    extends ApplicativeError[Kleisli[F, A, ?], E]
+    extends ApplicativeError[Kleisli[F, A, *], E]
     with KleisliApplicative[F, A] {
   type K[T] = Kleisli[F, A, T]
 
@@ -589,13 +589,13 @@ private[data] trait KleisliApplicativeError[F[_], A, E]
 }
 
 private[data] trait KleisliMonad[F[_], A]
-    extends Monad[Kleisli[F, A, ?]]
+    extends Monad[Kleisli[F, A, *]]
     with KleisliFlatMap[F, A]
     with KleisliApplicative[F, A] {
   implicit def F: Monad[F]
 }
 
-private[data] trait KleisliFlatMap[F[_], A] extends FlatMap[Kleisli[F, A, ?]] with KleisliApply[F, A] {
+private[data] trait KleisliFlatMap[F[_], A] extends FlatMap[Kleisli[F, A, *]] with KleisliApply[F, A] {
   implicit def F: FlatMap[F]
 
   def flatMap[B, C](fa: Kleisli[F, A, B])(f: B => Kleisli[F, A, C]): Kleisli[F, A, C] =
@@ -607,14 +607,14 @@ private[data] trait KleisliFlatMap[F[_], A] extends FlatMap[Kleisli[F, A, ?]] wi
     })
 }
 
-private[data] trait KleisliApplicative[F[_], A] extends Applicative[Kleisli[F, A, ?]] with KleisliApply[F, A] {
+private[data] trait KleisliApplicative[F[_], A] extends Applicative[Kleisli[F, A, *]] with KleisliApply[F, A] {
   implicit def F: Applicative[F]
 
   def pure[B](x: B): Kleisli[F, A, B] =
     Kleisli.pure[F, A, B](x)
 }
 
-private[data] trait KleisliApply[F[_], A] extends Apply[Kleisli[F, A, ?]] with KleisliFunctor[F, A] {
+private[data] trait KleisliApply[F[_], A] extends Apply[Kleisli[F, A, *]] with KleisliFunctor[F, A] {
   implicit def F: Apply[F]
 
   override def ap[B, C](f: Kleisli[F, A, B => C])(fa: Kleisli[F, A, B]): Kleisli[F, A, C] =
@@ -624,14 +624,14 @@ private[data] trait KleisliApply[F[_], A] extends Apply[Kleisli[F, A, ?]] with K
     Kleisli(a => F.product(fb.run(a), fc.run(a)))
 }
 
-private[data] trait KleisliFunctor[F[_], A] extends Functor[Kleisli[F, A, ?]] {
+private[data] trait KleisliFunctor[F[_], A] extends Functor[Kleisli[F, A, *]] {
   implicit def F: Functor[F]
 
   override def map[B, C](fa: Kleisli[F, A, B])(f: B => C): Kleisli[F, A, C] =
     fa.map(f)
 }
 
-private trait KleisliDistributive[F[_], R] extends Distributive[Kleisli[F, R, ?]] {
+private trait KleisliDistributive[F[_], R] extends Distributive[Kleisli[F, R, *]] {
   implicit def F: Distributive[F]
 
   override def distribute[G[_]: Functor, A, B](a: G[A])(f: A => Kleisli[F, R, B]): Kleisli[F, R, G[B]] =
@@ -640,11 +640,11 @@ private trait KleisliDistributive[F[_], R] extends Distributive[Kleisli[F, R, ?]
   def map[A, B](fa: Kleisli[F, R, A])(f: A => B): Kleisli[F, R, B] = fa.map(f)
 }
 
-private[this] trait KleisliFunctorFilter[F[_], R] extends FunctorFilter[Kleisli[F, R, ?]] {
+private[this] trait KleisliFunctorFilter[F[_], R] extends FunctorFilter[Kleisli[F, R, *]] {
 
   def FF: FunctorFilter[F]
 
-  def functor: Functor[Kleisli[F, R, ?]] = Kleisli.catsDataFunctorForKleisli(FF.functor)
+  def functor: Functor[Kleisli[F, R, *]] = Kleisli.catsDataFunctorForKleisli(FF.functor)
 
   def mapFilter[A, B](fa: Kleisli[F, R, A])(f: A => Option[B]): Kleisli[F, R, B] =
     Kleisli[F, R, B] { r =>

--- a/core/src/main/scala/cats/data/Nested.scala
+++ b/core/src/main/scala/cats/data/Nested.scala
@@ -5,7 +5,7 @@ package data
  *
  * For instance, since both `List` and `Option` have a `Functor`, then so does
  * `List[Option[_]]`. This is represented by this data type via the instantiation
- * `Nested[List, Option, ?]`.
+ * `Nested[List, Option, *]`.
  *
  * {{{
  * scala> import cats.Functor
@@ -16,7 +16,7 @@ package data
  * scala> Functor[List].map(listOption)(opt => opt.map(f))
  * res0: List[Option[String]] = List(Some(2), None)
  * scala> val nested: Nested[List, Option, Int] = Nested(listOption)
- * scala> val result: Nested[List, Option, String] = Functor[Nested[List, Option, ?]].map(nested)(f)
+ * scala> val result: Nested[List, Option, String] = Functor[Nested[List, Option, *]].map(nested)(f)
  * scala> result.value
  * res1: List[Option[String]] = List(Some(2), None)
  * }}}
@@ -38,25 +38,25 @@ sealed abstract private[data] class NestedInstances extends NestedInstances0 {
     Eq.by[Nested[F, G, A], F[G[A]]](_.value)
 
   implicit def catsDataNonEmptyTraverseForNested[F[_]: NonEmptyTraverse, G[_]: NonEmptyTraverse]
-    : NonEmptyTraverse[Nested[F, G, ?]] =
+    : NonEmptyTraverse[Nested[F, G, *]] =
     new NestedNonEmptyTraverse[F, G] {
       val FG: NonEmptyTraverse[λ[α => F[G[α]]]] = NonEmptyTraverse[F].compose[G]
     }
 
   implicit def catsDataContravariantMonoidalForApplicativeForNested[F[_]: Applicative, G[_]: ContravariantMonoidal]
-    : ContravariantMonoidal[Nested[F, G, ?]] =
+    : ContravariantMonoidal[Nested[F, G, *]] =
     new NestedContravariantMonoidal[F, G] with NestedContravariant[F, G] {
       val FG: ContravariantMonoidal[λ[α => F[G[α]]]] = Applicative[F].composeContravariantMonoidal[G]
     }
 
-  implicit def catsDataDeferForNested[F[_], G[_]](implicit F: Defer[F]): Defer[Nested[F, G, ?]] =
-    new Defer[Nested[F, G, ?]] {
+  implicit def catsDataDeferForNested[F[_], G[_]](implicit F: Defer[F]): Defer[Nested[F, G, *]] =
+    new Defer[Nested[F, G, *]] {
       def defer[A](fa: => Nested[F, G, A]): Nested[F, G, A] =
         Nested(F.defer(fa.value))
     }
 
   implicit def catsDataTraverseFilterForNested[F[_], G[_]](implicit F0: Traverse[F],
-                                                           G0: TraverseFilter[G]): TraverseFilter[Nested[F, G, ?]] =
+                                                           G0: TraverseFilter[G]): TraverseFilter[Nested[F, G, *]] =
     new NestedTraverseFilter[F, G] {
       implicit val F: Traverse[F] = F0
       implicit val G: TraverseFilter[G] = G0
@@ -64,13 +64,13 @@ sealed abstract private[data] class NestedInstances extends NestedInstances0 {
 }
 
 sealed abstract private[data] class NestedInstances0 extends NestedInstances1 {
-  implicit def catsDataTraverseForNested[F[_]: Traverse, G[_]: Traverse]: Traverse[Nested[F, G, ?]] =
+  implicit def catsDataTraverseForNested[F[_]: Traverse, G[_]: Traverse]: Traverse[Nested[F, G, *]] =
     new NestedTraverse[F, G] {
       val FG: Traverse[λ[α => F[G[α]]]] = Traverse[F].compose[G]
     }
 
   implicit def catsDataFunctorFilterForNested[F[_], G[_]](implicit F0: Functor[F],
-                                                          G0: FunctorFilter[G]): FunctorFilter[Nested[F, G, ?]] =
+                                                          G0: FunctorFilter[G]): FunctorFilter[Nested[F, G, *]] =
     new NestedFunctorFilter[F, G] {
       implicit val F: Functor[F] = F0
       implicit val G: FunctorFilter[G] = G0
@@ -78,47 +78,47 @@ sealed abstract private[data] class NestedInstances0 extends NestedInstances1 {
 }
 
 sealed abstract private[data] class NestedInstances1 extends NestedInstances2 {
-  implicit def catsDataReducibleForNested[F[_]: Reducible, G[_]: Reducible]: Reducible[Nested[F, G, ?]] =
+  implicit def catsDataReducibleForNested[F[_]: Reducible, G[_]: Reducible]: Reducible[Nested[F, G, *]] =
     new NestedReducible[F, G] {
       val FG: Reducible[λ[α => F[G[α]]]] = Reducible[F].compose[G]
     }
 
   implicit def catsDataFunctorForContravariantForNested[F[_]: Contravariant, G[_]: Contravariant]
-    : Functor[Nested[F, G, ?]] =
+    : Functor[Nested[F, G, *]] =
     new NestedFunctor[F, G] {
       val FG: Functor[λ[α => F[G[α]]]] = Contravariant[F].compose[G]
     }
 }
 
 sealed abstract private[data] class NestedInstances2 extends NestedInstances3 {
-  implicit def catsDataFoldableForNested[F[_]: Foldable, G[_]: Foldable]: Foldable[Nested[F, G, ?]] =
+  implicit def catsDataFoldableForNested[F[_]: Foldable, G[_]: Foldable]: Foldable[Nested[F, G, *]] =
     new NestedFoldable[F, G] {
       val FG: Foldable[λ[α => F[G[α]]]] = Foldable[F].compose[G]
     }
 
   implicit def catsDataContravariantForCovariantNested[F[_]: Contravariant, G[_]: Functor]
-    : Contravariant[Nested[F, G, ?]] =
+    : Contravariant[Nested[F, G, *]] =
     new NestedContravariant[F, G] {
       val FG: Contravariant[λ[α => F[G[α]]]] = Contravariant[F].composeFunctor[G]
     }
 }
 
 sealed abstract private[data] class NestedInstances3 extends NestedInstances4 {
-  implicit def catsDataAlternativeForNested[F[_]: Alternative, G[_]: Applicative]: Alternative[Nested[F, G, ?]] =
+  implicit def catsDataAlternativeForNested[F[_]: Alternative, G[_]: Applicative]: Alternative[Nested[F, G, *]] =
     new NestedAlternative[F, G] {
       val FG: Alternative[λ[α => F[G[α]]]] = Alternative[F].compose[G]
     }
 
   implicit def catsDataContravariantForContravariantNested[F[_]: Functor, G[_]: Contravariant]
-    : Contravariant[Nested[F, G, ?]] =
+    : Contravariant[Nested[F, G, *]] =
     new NestedContravariant[F, G] {
       val FG: Contravariant[λ[α => F[G[α]]]] = Functor[F].composeContravariant[G]
     }
 }
 
 sealed abstract private[data] class NestedInstances4 extends NestedInstances5 {
-  implicit def catsDataApplicativeErrorForNested[F[_]: ApplicativeError[?[_], E], G[_]: Applicative, E]
-    : ApplicativeError[Nested[F, G, ?], E] =
+  implicit def catsDataApplicativeErrorForNested[F[_]: ApplicativeError[*[_], E], G[_]: Applicative, E]
+    : ApplicativeError[Nested[F, G, *], E] =
     new NestedApplicativeError[F, G, E] {
       val G: Applicative[G] = Applicative[G]
 
@@ -129,12 +129,12 @@ sealed abstract private[data] class NestedInstances4 extends NestedInstances5 {
 
 sealed abstract private[data] class NestedInstances5 extends NestedInstances6 {
   implicit def catsDataCommutativeApplicativeForNestedContravariant[F[_]: CommutativeApplicative, G[_]: CommutativeApplicative]
-    : CommutativeApplicative[Nested[F, G, ?]] =
-    new NestedApplicative[F, G] with CommutativeApplicative[Nested[F, G, ?]] {
+    : CommutativeApplicative[Nested[F, G, *]] =
+    new NestedApplicative[F, G] with CommutativeApplicative[Nested[F, G, *]] {
       val FG: Applicative[λ[α => F[G[α]]]] = Applicative[F].compose[G]
     }
 
-  implicit def catsDataMonoidKForNested[F[_]: MonoidK, G[_]]: MonoidK[Nested[F, G, ?]] =
+  implicit def catsDataMonoidKForNested[F[_]: MonoidK, G[_]]: MonoidK[Nested[F, G, *]] =
     new NestedMonoidK[F, G] {
       val FG: MonoidK[λ[α => F[G[α]]]] = MonoidK[F].compose[G]
     }
@@ -142,31 +142,31 @@ sealed abstract private[data] class NestedInstances5 extends NestedInstances6 {
 
 sealed abstract private[data] class NestedInstances6 extends NestedInstances7 {
   implicit def catsDataCommutativeApplyForNestedContravariant[F[_]: CommutativeApply, G[_]: CommutativeApply]
-    : CommutativeApply[Nested[F, G, ?]] =
-    new NestedApply[F, G] with CommutativeApply[Nested[F, G, ?]] {
+    : CommutativeApply[Nested[F, G, *]] =
+    new NestedApply[F, G] with CommutativeApply[Nested[F, G, *]] {
       val FG: Apply[λ[α => F[G[α]]]] = Apply[F].compose[G]
     }
 
-  implicit def catsDataSemigroupKForNested[F[_]: SemigroupK, G[_]]: SemigroupK[Nested[F, G, ?]] =
+  implicit def catsDataSemigroupKForNested[F[_]: SemigroupK, G[_]]: SemigroupK[Nested[F, G, *]] =
     new NestedSemigroupK[F, G] {
       val FG: SemigroupK[λ[α => F[G[α]]]] = SemigroupK[F].compose[G]
     }
 }
 
 sealed abstract private[data] class NestedInstances7 extends NestedInstances8 {
-  implicit def catsDataApplicativeForNested[F[_]: Applicative, G[_]: Applicative]: Applicative[Nested[F, G, ?]] =
+  implicit def catsDataApplicativeForNested[F[_]: Applicative, G[_]: Applicative]: Applicative[Nested[F, G, *]] =
     new NestedApplicative[F, G] {
       val FG: Applicative[λ[α => F[G[α]]]] = Applicative[F].compose[G]
     }
 }
 
 sealed abstract private[data] class NestedInstances8 extends NestedInstances9 {
-  implicit def catsDataApplyForNested[F[_]: Apply, G[_]: Apply]: Apply[Nested[F, G, ?]] =
+  implicit def catsDataApplyForNested[F[_]: Apply, G[_]: Apply]: Apply[Nested[F, G, *]] =
     new NestedApply[F, G] {
       val FG: Apply[λ[α => F[G[α]]]] = Apply[F].compose[G]
     }
 
-  implicit def catsDataDistributiveForNested[F[_]: Distributive, G[_]: Distributive]: Distributive[Nested[F, G, ?]] =
+  implicit def catsDataDistributiveForNested[F[_]: Distributive, G[_]: Distributive]: Distributive[Nested[F, G, *]] =
     new NestedDistributive[F, G] {
       val FG: Distributive[λ[α => F[G[α]]]] = Distributive[F].compose[G]
     }
@@ -174,28 +174,28 @@ sealed abstract private[data] class NestedInstances8 extends NestedInstances9 {
 
 sealed abstract private[data] class NestedInstances9 extends NestedInstances10 {
   implicit def catsDataInvariantSemigroupalApplyForNested[F[_]: InvariantSemigroupal, G[_]: Apply]
-    : InvariantSemigroupal[Nested[F, G, ?]] =
+    : InvariantSemigroupal[Nested[F, G, *]] =
     new NestedInvariantSemigroupalApply[F, G] {
       val FG: InvariantSemigroupal[λ[α => F[G[α]]]] = InvariantSemigroupal[F].composeApply[G]
     }
 }
 
 sealed abstract private[data] class NestedInstances10 extends NestedInstances11 {
-  implicit def catsDataFunctorForNested[F[_]: Functor, G[_]: Functor]: Functor[Nested[F, G, ?]] =
+  implicit def catsDataFunctorForNested[F[_]: Functor, G[_]: Functor]: Functor[Nested[F, G, *]] =
     new NestedFunctor[F, G] {
       val FG: Functor[λ[α => F[G[α]]]] = Functor[F].compose[G]
     }
 }
 
 sealed abstract private[data] class NestedInstances11 extends NestedInstances12 {
-  implicit def catsDataInvariantForNested[F[_]: Invariant, G[_]: Invariant]: Invariant[Nested[F, G, ?]] =
+  implicit def catsDataInvariantForNested[F[_]: Invariant, G[_]: Invariant]: Invariant[Nested[F, G, *]] =
     new NestedInvariant[F, G] {
       val FG: Invariant[λ[α => F[G[α]]]] = Invariant[F].compose[G]
     }
 }
 
 sealed abstract private[data] class NestedInstances12 extends NestedInstances13 {
-  implicit def catsDataInvariantForCovariantNested[F[_]: Invariant, G[_]: Functor]: Invariant[Nested[F, G, ?]] =
+  implicit def catsDataInvariantForCovariantNested[F[_]: Invariant, G[_]: Functor]: Invariant[Nested[F, G, *]] =
     new NestedInvariant[F, G] {
       val FG: Invariant[λ[α => F[G[α]]]] = Invariant[F].composeFunctor[G]
     }
@@ -203,27 +203,27 @@ sealed abstract private[data] class NestedInstances12 extends NestedInstances13 
 
 sealed abstract private[data] class NestedInstances13 {
   implicit def catsDataInvariantForNestedContravariant[F[_]: Invariant, G[_]: Contravariant]
-    : Invariant[Nested[F, G, ?]] =
+    : Invariant[Nested[F, G, *]] =
     new NestedInvariant[F, G] {
       val FG: Invariant[λ[α => F[G[α]]]] = Invariant[F].composeContravariant[G]
     }
 }
 
-private[data] trait NestedInvariant[F[_], G[_]] extends Invariant[Nested[F, G, ?]] {
+private[data] trait NestedInvariant[F[_], G[_]] extends Invariant[Nested[F, G, *]] {
   def FG: Invariant[λ[α => F[G[α]]]]
 
   override def imap[A, B](fga: Nested[F, G, A])(f: A => B)(g: B => A): Nested[F, G, B] =
     Nested(FG.imap(fga.value)(f)(g))
 }
 
-private[data] trait NestedFunctor[F[_], G[_]] extends Functor[Nested[F, G, ?]] with NestedInvariant[F, G] {
+private[data] trait NestedFunctor[F[_], G[_]] extends Functor[Nested[F, G, *]] with NestedInvariant[F, G] {
   override def FG: Functor[λ[α => F[G[α]]]]
 
   override def map[A, B](fga: Nested[F, G, A])(f: A => B): Nested[F, G, B] =
     Nested(FG.map(fga.value)(f))
 }
 
-private[data] trait NestedApply[F[_], G[_]] extends Apply[Nested[F, G, ?]] with NestedFunctor[F, G] {
+private[data] trait NestedApply[F[_], G[_]] extends Apply[Nested[F, G, *]] with NestedFunctor[F, G] {
   override def FG: Apply[λ[α => F[G[α]]]]
 
   override def ap[A, B](fgf: Nested[F, G, A => B])(fga: Nested[F, G, A]): Nested[F, G, B] =
@@ -233,14 +233,14 @@ private[data] trait NestedApply[F[_], G[_]] extends Apply[Nested[F, G, ?]] with 
     Nested(FG.product(fga.value, fgb.value))
 }
 
-private[data] trait NestedApplicative[F[_], G[_]] extends Applicative[Nested[F, G, ?]] with NestedApply[F, G] {
+private[data] trait NestedApplicative[F[_], G[_]] extends Applicative[Nested[F, G, *]] with NestedApply[F, G] {
   def FG: Applicative[λ[α => F[G[α]]]]
 
   def pure[A](x: A): Nested[F, G, A] = Nested(FG.pure(x))
 }
 
 abstract private[data] class NestedApplicativeError[F[_], G[_], E]
-    extends ApplicativeError[Nested[F, G, ?], E]
+    extends ApplicativeError[Nested[F, G, *], E]
     with NestedApplicative[F, G] {
   def G: Applicative[G]
   def AEF: ApplicativeError[F, E]
@@ -254,26 +254,26 @@ abstract private[data] class NestedApplicativeError[F[_], G[_], E]
 
 }
 
-private[data] trait NestedSemigroupK[F[_], G[_]] extends SemigroupK[Nested[F, G, ?]] {
+private[data] trait NestedSemigroupK[F[_], G[_]] extends SemigroupK[Nested[F, G, *]] {
   def FG: SemigroupK[λ[α => F[G[α]]]]
 
   def combineK[A](x: Nested[F, G, A], y: Nested[F, G, A]): Nested[F, G, A] = Nested(FG.combineK(x.value, y.value))
 }
 
-private[data] trait NestedMonoidK[F[_], G[_]] extends MonoidK[Nested[F, G, ?]] with NestedSemigroupK[F, G] {
+private[data] trait NestedMonoidK[F[_], G[_]] extends MonoidK[Nested[F, G, *]] with NestedSemigroupK[F, G] {
   def FG: MonoidK[λ[α => F[G[α]]]]
 
   def empty[A]: Nested[F, G, A] = Nested(FG.empty[A])
 }
 
 private[data] trait NestedAlternative[F[_], G[_]]
-    extends Alternative[Nested[F, G, ?]]
+    extends Alternative[Nested[F, G, *]]
     with NestedApplicative[F, G]
     with NestedMonoidK[F, G] {
   def FG: Alternative[λ[α => F[G[α]]]]
 }
 
-private[data] trait NestedFoldable[F[_], G[_]] extends Foldable[Nested[F, G, ?]] {
+private[data] trait NestedFoldable[F[_], G[_]] extends Foldable[Nested[F, G, *]] {
   def FG: Foldable[λ[α => F[G[α]]]]
 
   def foldLeft[A, B](fga: Nested[F, G, A], b: B)(f: (B, A) => B): B =
@@ -284,7 +284,7 @@ private[data] trait NestedFoldable[F[_], G[_]] extends Foldable[Nested[F, G, ?]]
 }
 
 private[data] trait NestedTraverse[F[_], G[_]]
-    extends Traverse[Nested[F, G, ?]]
+    extends Traverse[Nested[F, G, *]]
     with NestedFoldable[F, G]
     with NestedFunctor[F, G] {
   def FG: Traverse[λ[α => F[G[α]]]]
@@ -293,7 +293,7 @@ private[data] trait NestedTraverse[F[_], G[_]]
     Applicative[H].map(FG.traverse(fga.value)(f))(Nested(_))
 }
 
-private[data] trait NestedDistributive[F[_], G[_]] extends Distributive[Nested[F, G, ?]] with NestedFunctor[F, G] {
+private[data] trait NestedDistributive[F[_], G[_]] extends Distributive[Nested[F, G, *]] with NestedFunctor[F, G] {
   def FG: Distributive[λ[α => F[G[α]]]]
 
   def distribute[H[_]: Functor, A, B](ha: H[A])(f: A => Nested[F, G, B]): Nested[F, G, H[B]] =
@@ -302,7 +302,7 @@ private[data] trait NestedDistributive[F[_], G[_]] extends Distributive[Nested[F
     })
 }
 
-private[data] trait NestedReducible[F[_], G[_]] extends Reducible[Nested[F, G, ?]] with NestedFoldable[F, G] {
+private[data] trait NestedReducible[F[_], G[_]] extends Reducible[Nested[F, G, *]] with NestedFoldable[F, G] {
   def FG: Reducible[λ[α => F[G[α]]]]
 
   def reduceLeftTo[A, B](fga: Nested[F, G, A])(f: A => B)(g: (B, A) => B): B =
@@ -313,7 +313,7 @@ private[data] trait NestedReducible[F[_], G[_]] extends Reducible[Nested[F, G, ?
 }
 
 private[data] trait NestedNonEmptyTraverse[F[_], G[_]]
-    extends NonEmptyTraverse[Nested[F, G, ?]]
+    extends NonEmptyTraverse[Nested[F, G, *]]
     with NestedTraverse[F, G]
     with NestedReducible[F, G] {
   def FG: NonEmptyTraverse[λ[α => F[G[α]]]]
@@ -322,14 +322,14 @@ private[data] trait NestedNonEmptyTraverse[F[_], G[_]]
     Apply[H].map(FG.nonEmptyTraverse(fga.value)(f))(Nested(_))
 }
 
-private[data] trait NestedContravariant[F[_], G[_]] extends Contravariant[Nested[F, G, ?]] {
+private[data] trait NestedContravariant[F[_], G[_]] extends Contravariant[Nested[F, G, *]] {
   def FG: Contravariant[λ[α => F[G[α]]]]
 
   override def contramap[A, B](fga: Nested[F, G, A])(f: B => A): Nested[F, G, B] =
     Nested(FG.contramap(fga.value)(f))
 }
 
-private[data] trait NestedContravariantMonoidal[F[_], G[_]] extends ContravariantMonoidal[Nested[F, G, ?]] {
+private[data] trait NestedContravariantMonoidal[F[_], G[_]] extends ContravariantMonoidal[Nested[F, G, *]] {
   def FG: ContravariantMonoidal[λ[α => F[G[α]]]]
 
   def unit: Nested[F, G, Unit] = Nested(FG.unit)
@@ -341,7 +341,7 @@ private[data] trait NestedContravariantMonoidal[F[_], G[_]] extends Contravarian
     Nested(FG.product(fa.value, fb.value))
 }
 
-private[data] trait NestedInvariantSemigroupalApply[F[_], G[_]] extends InvariantSemigroupal[Nested[F, G, ?]] {
+private[data] trait NestedInvariantSemigroupalApply[F[_], G[_]] extends InvariantSemigroupal[Nested[F, G, *]] {
   def FG: InvariantSemigroupal[λ[α => F[G[α]]]]
 
   def imap[A, B](fa: Nested[F, G, A])(f: A => B)(g: B => A): Nested[F, G, B] =
@@ -351,12 +351,12 @@ private[data] trait NestedInvariantSemigroupalApply[F[_], G[_]] extends Invarian
     Nested(FG.product(fa.value, fb.value))
 }
 
-abstract private[data] class NestedFunctorFilter[F[_], G[_]] extends FunctorFilter[Nested[F, G, ?]] {
+abstract private[data] class NestedFunctorFilter[F[_], G[_]] extends FunctorFilter[Nested[F, G, *]] {
   implicit val F: Functor[F]
 
   implicit val G: FunctorFilter[G]
 
-  def functor: Functor[Nested[F, G, ?]] = Nested.catsDataFunctorForNested(F, G.functor)
+  def functor: Functor[Nested[F, G, *]] = Nested.catsDataFunctorForNested(F, G.functor)
 
   def mapFilter[A, B](fa: Nested[F, G, A])(f: (A) => Option[B]): Nested[F, G, B] =
     Nested[F, G, B](F.map(fa.value)(G.mapFilter(_)(f)))
@@ -373,12 +373,12 @@ abstract private[data] class NestedFunctorFilter[F[_], G[_]] extends FunctorFilt
 
 abstract private[data] class NestedTraverseFilter[F[_], G[_]]
     extends NestedFunctorFilter[F, G]
-    with TraverseFilter[Nested[F, G, ?]] {
+    with TraverseFilter[Nested[F, G, *]] {
   implicit val F: Traverse[F]
 
   implicit val G: TraverseFilter[G]
 
-  def traverse: Traverse[Nested[F, G, ?]] = Nested.catsDataTraverseForNested(F, G.traverse)
+  def traverse: Traverse[Nested[F, G, *]] = Nested.catsDataTraverseForNested(F, G.traverse)
 
   override def filterA[H[_], A](
     fa: Nested[F, G, A]

--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -86,7 +86,7 @@ sealed class NonEmptyMapOps[K, A](val value: NonEmptyMap[K, A]) {
    * Applies f to all the elements
    */
   def map[B](f: A => B): NonEmptyMap[K, B] =
-    NonEmptyMapImpl.create(Functor[SortedMap[K, ?]].map(toSortedMap)(f))
+    NonEmptyMapImpl.create(Functor[SortedMap[K, *]].map(toSortedMap)(f))
 
   /**
    * Optionally returns the value associated with the given key.
@@ -167,7 +167,7 @@ sealed class NonEmptyMapOps[K, A](val value: NonEmptyMap[K, A]) {
    * Right-associative fold using f.
    */
   def foldRight[B](lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
-    Foldable[SortedMap[K, ?]].foldRight(toSortedMap, lb)(f)
+    Foldable[SortedMap[K, *]].foldRight(toSortedMap, lb)(f)
 
   /**
    * Left-associative reduce using f.
@@ -195,7 +195,7 @@ sealed class NonEmptyMapOps[K, A](val value: NonEmptyMap[K, A]) {
   def reduceRightTo[B](f: A => B)(g: (A, Eval[B]) => Eval[B]): Eval[B] =
     Always((head, tail)).flatMap {
       case ((_, a), ga) =>
-        Foldable[SortedMap[K, ?]].reduceRightToOption(ga)(f)(g).flatMap {
+        Foldable[SortedMap[K, *]].reduceRightToOption(ga)(f)(g).flatMap {
           case Some(b) => g(a, Now(b))
           case None    => Later(f(a))
         }
@@ -268,8 +268,8 @@ sealed class NonEmptyMapOps[K, A](val value: NonEmptyMap[K, A]) {
 sealed abstract private[data] class NonEmptyMapInstances {
 
   implicit def catsDataInstancesForNonEmptyMap[K: Order]
-    : SemigroupK[NonEmptyMap[K, ?]] with NonEmptyTraverse[NonEmptyMap[K, ?]] =
-    new SemigroupK[NonEmptyMap[K, ?]] with NonEmptyTraverse[NonEmptyMap[K, ?]] {
+    : SemigroupK[NonEmptyMap[K, *]] with NonEmptyTraverse[NonEmptyMap[K, *]] =
+    new SemigroupK[NonEmptyMap[K, *]] with NonEmptyTraverse[NonEmptyMap[K, *]] {
 
       override def map[A, B](fa: NonEmptyMap[K, A])(f: A => B): NonEmptyMap[K, B] =
         fa.map(f)

--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -109,17 +109,17 @@ sealed abstract private[data] class OneAndInstances extends OneAndLowPriority0 {
 
   implicit def catsDataParallelForOneAnd[A, M[_]: Alternative, F[_]: Alternative](
     implicit P: Parallel[M, F]
-  ): Parallel[OneAnd[M, ?], OneAnd[F, ?]] =
-    new Parallel[OneAnd[M, ?], OneAnd[F, ?]] {
-      def monad: Monad[OneAnd[M, ?]] = catsDataMonadForOneAnd(P.monad, Alternative[M])
+  ): Parallel[OneAnd[M, *], OneAnd[F, *]] =
+    new Parallel[OneAnd[M, *], OneAnd[F, *]] {
+      def monad: Monad[OneAnd[M, *]] = catsDataMonadForOneAnd(P.monad, Alternative[M])
 
-      def applicative: Applicative[OneAnd[F, ?]] = catsDataApplicativeForOneAnd(Alternative[F])
+      def applicative: Applicative[OneAnd[F, *]] = catsDataApplicativeForOneAnd(Alternative[F])
 
-      def sequential: OneAnd[F, ?] ~> OneAnd[M, ?] =
-        λ[OneAnd[F, ?] ~> OneAnd[M, ?]](ofa => OneAnd(ofa.head, P.sequential(ofa.tail)))
+      def sequential: OneAnd[F, *] ~> OneAnd[M, *] =
+        λ[OneAnd[F, *] ~> OneAnd[M, *]](ofa => OneAnd(ofa.head, P.sequential(ofa.tail)))
 
-      def parallel: OneAnd[M, ?] ~> OneAnd[F, ?] =
-        λ[OneAnd[M, ?] ~> OneAnd[F, ?]](ofa => OneAnd(ofa.head, P.parallel(ofa.tail)))
+      def parallel: OneAnd[M, *] ~> OneAnd[F, *] =
+        λ[OneAnd[M, *] ~> OneAnd[F, *]](ofa => OneAnd(ofa.head, P.parallel(ofa.tail)))
 
     }
 
@@ -131,8 +131,8 @@ sealed abstract private[data] class OneAndInstances extends OneAndLowPriority0 {
   implicit def catsDataShowForOneAnd[A, F[_]](implicit A: Show[A], FA: Show[F[A]]): Show[OneAnd[F, A]] =
     Show.show[OneAnd[F, A]](_.show)
 
-  implicit def catsDataSemigroupKForOneAnd[F[_]: Alternative]: SemigroupK[OneAnd[F, ?]] =
-    new SemigroupK[OneAnd[F, ?]] {
+  implicit def catsDataSemigroupKForOneAnd[F[_]: Alternative]: SemigroupK[OneAnd[F, *]] =
+    new SemigroupK[OneAnd[F, *]] {
       def combineK[A](a: OneAnd[F, A], b: OneAnd[F, A]): OneAnd[F, A] =
         a.combine(b)
     }
@@ -141,8 +141,8 @@ sealed abstract private[data] class OneAndInstances extends OneAndLowPriority0 {
     catsDataSemigroupKForOneAnd[F].algebra
 
   implicit def catsDataMonadForOneAnd[F[_]](implicit monad: Monad[F],
-                                            alternative: Alternative[F]): Monad[OneAnd[F, ?]] =
-    new Monad[OneAnd[F, ?]] {
+                                            alternative: Alternative[F]): Monad[OneAnd[F, *]] =
+    new Monad[OneAnd[F, *]] {
       override def map[A, B](fa: OneAnd[F, A])(f: A => B): OneAnd[F, B] =
         fa.map(f)(monad)
 
@@ -193,8 +193,8 @@ sealed abstract private[data] class OneAndInstances extends OneAndLowPriority0 {
 }
 
 sealed abstract private[data] class OneAndLowPriority4 {
-  implicit val catsDataComonadForNonEmptyStream: Comonad[OneAnd[LazyList, ?]] =
-    new Comonad[OneAnd[LazyList, ?]] {
+  implicit val catsDataComonadForNonEmptyStream: Comonad[OneAnd[LazyList, *]] =
+    new Comonad[OneAnd[LazyList, *]] {
       def coflatMap[A, B](fa: OneAnd[LazyList, A])(f: OneAnd[LazyList, A] => B): OneAnd[LazyList, B] = {
         @tailrec def consume(as: LazyList[A], buf: Builder[B, LazyList[B]]): LazyList[B] =
           if (as.isEmpty) buf.result
@@ -215,8 +215,8 @@ sealed abstract private[data] class OneAndLowPriority4 {
 
 sealed abstract private[data] class OneAndLowPriority3 extends OneAndLowPriority4 {
 
-  implicit def catsDataFunctorForOneAnd[F[_]](implicit F: Functor[F]): Functor[OneAnd[F, ?]] =
-    new Functor[OneAnd[F, ?]] {
+  implicit def catsDataFunctorForOneAnd[F[_]](implicit F: Functor[F]): Functor[OneAnd[F, *]] =
+    new Functor[OneAnd[F, *]] {
       def map[A, B](fa: OneAnd[F, A])(f: A => B): OneAnd[F, B] =
         fa.map(f)
     }
@@ -225,8 +225,8 @@ sealed abstract private[data] class OneAndLowPriority3 extends OneAndLowPriority
 
 sealed abstract private[data] class OneAndLowPriority2 extends OneAndLowPriority3 {
 
-  implicit def catsDataApplicativeForOneAnd[F[_]](implicit F: Alternative[F]): Applicative[OneAnd[F, ?]] =
-    new Applicative[OneAnd[F, ?]] {
+  implicit def catsDataApplicativeForOneAnd[F[_]](implicit F: Alternative[F]): Applicative[OneAnd[F, *]] =
+    new Applicative[OneAnd[F, *]] {
       override def map[A, B](fa: OneAnd[F, A])(f: A => B): OneAnd[F, B] =
         fa.map(f)
 
@@ -245,8 +245,8 @@ sealed abstract private[data] class OneAndLowPriority2 extends OneAndLowPriority
 
 sealed abstract private[data] class OneAndLowPriority1 extends OneAndLowPriority2 {
 
-  implicit def catsDataTraverseForOneAnd[F[_]](implicit F: Traverse[F]): Traverse[OneAnd[F, ?]] =
-    new Traverse[OneAnd[F, ?]] {
+  implicit def catsDataTraverseForOneAnd[F[_]](implicit F: Traverse[F]): Traverse[OneAnd[F, *]] =
+    new Traverse[OneAnd[F, *]] {
       def traverse[G[_], A, B](fa: OneAnd[F, A])(f: (A) => G[B])(implicit G: Applicative[G]): G[OneAnd[F, B]] =
         G.map2Eval(f(fa.head), Always(F.traverse(fa.tail)(f)))(OneAnd(_, _)).value
 
@@ -259,8 +259,8 @@ sealed abstract private[data] class OneAndLowPriority1 extends OneAndLowPriority
 }
 
 sealed abstract private[data] class OneAndLowPriority0_5 extends OneAndLowPriority1 {
-  implicit def catsDataReducibleForOneAnd[F[_]](implicit F: Foldable[F]): Reducible[OneAnd[F, ?]] =
-    new NonEmptyReducible[OneAnd[F, ?], F] {
+  implicit def catsDataReducibleForOneAnd[F[_]](implicit F: Foldable[F]): Reducible[OneAnd[F, *]] =
+    new NonEmptyReducible[OneAnd[F, *], F] {
       override def split[A](fa: OneAnd[F, A]): (A, F[A]) = (fa.head, fa.tail)
 
       override def get[A](fa: OneAnd[F, A])(idx: Long): Option[A] =
@@ -272,8 +272,8 @@ sealed abstract private[data] class OneAndLowPriority0_5 extends OneAndLowPriori
 
 sealed abstract private[data] class OneAndLowPriority0 extends OneAndLowPriority0_5 {
   implicit def catsDataNonEmptyTraverseForOneAnd[F[_]](implicit F: Traverse[F],
-                                                       F2: Alternative[F]): NonEmptyTraverse[OneAnd[F, ?]] =
-    new NonEmptyReducible[OneAnd[F, ?], F] with NonEmptyTraverse[OneAnd[F, ?]] {
+                                                       F2: Alternative[F]): NonEmptyTraverse[OneAnd[F, *]] =
+    new NonEmptyReducible[OneAnd[F, *], F] with NonEmptyTraverse[OneAnd[F, *]] {
       def nonEmptyTraverse[G[_], A, B](fa: OneAnd[F, A])(f: (A) => G[B])(implicit G: Apply[G]): G[OneAnd[F, B]] = {
         import cats.syntax.apply._
 

--- a/core/src/main/scala/cats/data/Op.scala
+++ b/core/src/main/scala/cats/data/Op.scala
@@ -17,7 +17,7 @@ final case class Op[Arr[_, _], A, B](run: Arr[B, A]) {
 object Op extends OpInstances
 
 sealed abstract private[data] class OpInstances extends OpInstances0 {
-  implicit def catsDataCategoryForOp[Arr[_, _]](implicit ArrC: Category[Arr]): Category[Op[Arr, ?, ?]] =
+  implicit def catsDataCategoryForOp[Arr[_, _]](implicit ArrC: Category[Arr]): Category[Op[Arr, *, *]] =
     new OpCategory[Arr] { def Arr: Category[Arr] = ArrC }
 
   implicit def catsKernelEqForOp[Arr[_, _], A, B](implicit ArrEq: Eq[Arr[B, A]]): Eq[Op[Arr, A, B]] =
@@ -25,17 +25,17 @@ sealed abstract private[data] class OpInstances extends OpInstances0 {
 }
 
 sealed abstract private[data] class OpInstances0 {
-  implicit def catsDataComposeForOp[Arr[_, _]](implicit ArrC: Compose[Arr]): Compose[Op[Arr, ?, ?]] =
+  implicit def catsDataComposeForOp[Arr[_, _]](implicit ArrC: Compose[Arr]): Compose[Op[Arr, *, *]] =
     new OpCompose[Arr] { def Arr: Compose[Arr] = ArrC }
 }
 
-private[data] trait OpCategory[Arr[_, _]] extends Category[Op[Arr, ?, ?]] with OpCompose[Arr] {
+private[data] trait OpCategory[Arr[_, _]] extends Category[Op[Arr, *, *]] with OpCompose[Arr] {
   implicit def Arr: Category[Arr]
 
   override def id[A]: Op[Arr, A, A] = Op(Arr.id)
 }
 
-private[data] trait OpCompose[Arr[_, _]] extends Compose[Op[Arr, ?, ?]] {
+private[data] trait OpCompose[Arr[_, _]] extends Compose[Op[Arr, *, *]] {
   implicit def Arr: Compose[Arr]
 
   def compose[A, B, C](f: Op[Arr, B, C], g: Op[Arr, A, B]): Op[Arr, A, C] =

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -215,22 +215,22 @@ object OptionT extends OptionTInstances {
    * Same as [[liftF]], but expressed as a FunctionK for use with mapK
    * {{{
    * scala> import cats._, data._,  implicits._
-   * scala> val a: EitherT[Eval, String, Int] = 1.pure[EitherT[Eval, String, ?]]
-   * scala> val b: EitherT[OptionT[Eval, ?], String, Int] = a.mapK(OptionT.liftK)
+   * scala> val a: EitherT[Eval, String, Int] = 1.pure[EitherT[Eval, String, *]]
+   * scala> val b: EitherT[OptionT[Eval, *], String, Int] = a.mapK(OptionT.liftK)
    * scala> b.value.value.value
    * res0: Option[Either[String,Int]] = Some(Right(1))
    * }}}
    */
-  def liftK[F[_]](implicit F: Functor[F]): F ~> OptionT[F, ?] =
-    λ[F ~> OptionT[F, ?]](OptionT.liftF(_))
+  def liftK[F[_]](implicit F: Functor[F]): F ~> OptionT[F, *] =
+    λ[F ~> OptionT[F, *]](OptionT.liftF(_))
 }
 
 sealed abstract private[data] class OptionTInstances extends OptionTInstances0 {
   // to maintain binary compatibility
-  def catsDataMonadForOptionT[F[_]](implicit F0: Monad[F]): Monad[OptionT[F, ?]] =
+  def catsDataMonadForOptionT[F[_]](implicit F0: Monad[F]): Monad[OptionT[F, *]] =
     new OptionTMonad[F] { implicit val F = F0 }
 
-  implicit def catsDataTraverseForOptionT[F[_]](implicit F0: Traverse[F]): Traverse[OptionT[F, ?]] =
+  implicit def catsDataTraverseForOptionT[F[_]](implicit F0: Traverse[F]): Traverse[OptionT[F, *]] =
     new OptionTTraverse[F] with OptionTFunctor[F] { implicit val F = F0 }
 
   implicit def catsDataOrderForOptionT[F[_], A](implicit F0: Order[F[Option[A]]]): Order[OptionT[F, A]] =
@@ -242,17 +242,17 @@ sealed abstract private[data] class OptionTInstances extends OptionTInstances0 {
   implicit def catsDataShowForOptionT[F[_], A](implicit F: Show[F[Option[A]]]): Show[OptionT[F, A]] =
     Contravariant[Show].contramap(F)(_.value)
 
-  implicit def catsDataDeferForOptionT[F[_]](implicit F: Defer[F]): Defer[OptionT[F, ?]] =
-    new Defer[OptionT[F, ?]] {
+  implicit def catsDataDeferForOptionT[F[_]](implicit F: Defer[F]): Defer[OptionT[F, *]] =
+    new Defer[OptionT[F, *]] {
       def defer[A](fa: => OptionT[F, A]): OptionT[F, A] =
         OptionT(F.defer(fa.value))
     }
 
-  implicit def catsDateTraverseFilterForOptionT[F[_]](implicit F0: Traverse[F]): TraverseFilter[OptionT[F, ?]] =
-    new OptionTFunctorFilter[F] with TraverseFilter[OptionT[F, ?]] {
+  implicit def catsDateTraverseFilterForOptionT[F[_]](implicit F0: Traverse[F]): TraverseFilter[OptionT[F, *]] =
+    new OptionTFunctorFilter[F] with TraverseFilter[OptionT[F, *]] {
       implicit def F: Functor[F] = F0
 
-      val traverse: Traverse[OptionT[F, ?]] = OptionT.catsDataTraverseForOptionT[F]
+      val traverse: Traverse[OptionT[F, *]] = OptionT.catsDataTraverseForOptionT[F]
 
       def traverseFilter[G[_], A, B](
         fa: OptionT[F, A]
@@ -275,7 +275,7 @@ sealed abstract private[data] class OptionTInstances0 extends OptionTInstances1 
   // see https://github.com/typelevel/cats/pull/2335#issuecomment-408249775
   implicit def catsDataMonadErrorForOptionT[F[_], E](
     implicit F0: MonadError[F, E]
-  ): MonadError[OptionT[F, ?], E] { type Dummy } =
+  ): MonadError[OptionT[F, *], E] { type Dummy } =
     new OptionTMonadError[F, E] {
       type Dummy
       implicit val F = F0
@@ -283,10 +283,10 @@ sealed abstract private[data] class OptionTInstances0 extends OptionTInstances1 
 
   implicit def catsDataContravariantMonoidalForOptionT[F[_]](
     implicit F0: ContravariantMonoidal[F]
-  ): ContravariantMonoidal[OptionT[F, ?]] =
+  ): ContravariantMonoidal[OptionT[F, *]] =
     new OptionTContravariantMonoidal[F] { implicit val F = F0 }
 
-  implicit def catsDataMonoidKForOptionT[F[_]](implicit F0: Monad[F]): MonoidK[OptionT[F, ?]] =
+  implicit def catsDataMonoidKForOptionT[F[_]](implicit F0: Monad[F]): MonoidK[OptionT[F, *]] =
     new OptionTMonoidK[F] { implicit val F = F0 }
 
   implicit def catsDataSemigroupForOptionT[F[_], A](implicit F0: Semigroup[F[Option[A]]]): Semigroup[OptionT[F, A]] =
@@ -297,58 +297,58 @@ sealed abstract private[data] class OptionTInstances0 extends OptionTInstances1 
   ): PartialOrder[OptionT[F, A]] =
     new OptionTPartialOrder[F, A] { implicit val F = F0 }
 
-  implicit def catsDateFunctorFilterForOptionT[F[_]](implicit F0: Functor[F]): FunctorFilter[OptionT[F, ?]] =
+  implicit def catsDateFunctorFilterForOptionT[F[_]](implicit F0: Functor[F]): FunctorFilter[OptionT[F, *]] =
     new OptionTFunctorFilter[F] { implicit val F = F0 }
 
-  implicit def catsDataContravariantForOptionT[F[_]](implicit F0: Contravariant[F]): Contravariant[OptionT[F, ?]] =
+  implicit def catsDataContravariantForOptionT[F[_]](implicit F0: Contravariant[F]): Contravariant[OptionT[F, *]] =
     new OptionTContravariant[F] { implicit val F = F0 }
 }
 
 sealed abstract private[data] class OptionTInstances1 extends OptionTInstances2 {
-  implicit def catsDataSemigroupKForOptionT[F[_]](implicit F0: Monad[F]): SemigroupK[OptionT[F, ?]] =
+  implicit def catsDataSemigroupKForOptionT[F[_]](implicit F0: Monad[F]): SemigroupK[OptionT[F, *]] =
     new OptionTSemigroupK[F] { implicit val F = F0 }
 
   implicit def catsDataEqForOptionT[F[_], A](implicit F0: Eq[F[Option[A]]]): Eq[OptionT[F, A]] =
     new OptionTEq[F, A] { implicit val F = F0 }
 
-  implicit def catsDataMonadErrorMonadForOptionT[F[_]](implicit F0: Monad[F]): MonadError[OptionT[F, ?], Unit] =
+  implicit def catsDataMonadErrorMonadForOptionT[F[_]](implicit F0: Monad[F]): MonadError[OptionT[F, *], Unit] =
     new OptionTMonadErrorMonad[F] { implicit val F = F0 }
 }
 
 sealed abstract private[data] class OptionTInstances2 extends OptionTInstances3 {
-  implicit def catsDataFoldableForOptionT[F[_]](implicit F0: Foldable[F]): Foldable[OptionT[F, ?]] =
+  implicit def catsDataFoldableForOptionT[F[_]](implicit F0: Foldable[F]): Foldable[OptionT[F, *]] =
     new OptionTFoldable[F] { implicit val F = F0 }
 
-  implicit def catsDataInvariantForOptionT[F[_]](implicit F0: Invariant[F]): Invariant[OptionT[F, ?]] =
+  implicit def catsDataInvariantForOptionT[F[_]](implicit F0: Invariant[F]): Invariant[OptionT[F, *]] =
     new OptionTInvariant[F] { implicit val F = F0 }
 }
 
 sealed abstract private[data] class OptionTInstances3 {
-  implicit def catsDataFunctorForOptionT[F[_]](implicit F0: Functor[F]): Functor[OptionT[F, ?]] =
+  implicit def catsDataFunctorForOptionT[F[_]](implicit F0: Functor[F]): Functor[OptionT[F, *]] =
     new OptionTFunctor[F] { implicit val F = F0 }
 }
 
-private[data] trait OptionTFunctor[F[_]] extends Functor[OptionT[F, ?]] {
+private[data] trait OptionTFunctor[F[_]] extends Functor[OptionT[F, *]] {
   implicit def F: Functor[F]
 
   override def map[A, B](fa: OptionT[F, A])(f: A => B): OptionT[F, B] = fa.map(f)
 }
 
-sealed private[data] trait OptionTInvariant[F[_]] extends Invariant[OptionT[F, ?]] {
+sealed private[data] trait OptionTInvariant[F[_]] extends Invariant[OptionT[F, *]] {
   implicit def F: Invariant[F]
 
   override def imap[A, B](fa: OptionT[F, A])(f: A => B)(g: B => A): OptionT[F, B] =
     fa.imap(f)(g)
 }
 
-sealed private[data] trait OptionTContravariant[F[_]] extends Contravariant[OptionT[F, ?]] {
+sealed private[data] trait OptionTContravariant[F[_]] extends Contravariant[OptionT[F, *]] {
   implicit def F: Contravariant[F]
 
   override def contramap[A, B](fa: OptionT[F, A])(f: B => A): OptionT[F, B] =
     fa.contramap(f)
 }
 
-private[data] trait OptionTMonad[F[_]] extends Monad[OptionT[F, ?]] {
+private[data] trait OptionTMonad[F[_]] extends Monad[OptionT[F, *]] {
   implicit def F: Monad[F]
 
   def pure[A](a: A): OptionT[F, A] = OptionT.pure(a)
@@ -368,7 +368,7 @@ private[data] trait OptionTMonad[F[_]] extends Monad[OptionT[F, ?]] {
     )
 }
 
-private[data] trait OptionTMonadErrorMonad[F[_]] extends MonadError[OptionT[F, ?], Unit] with OptionTMonad[F] {
+private[data] trait OptionTMonadErrorMonad[F[_]] extends MonadError[OptionT[F, *], Unit] with OptionTMonad[F] {
   implicit def F: Monad[F]
 
   override def raiseError[A](e: Unit): OptionT[F, A] = OptionT.none
@@ -380,7 +380,7 @@ private[data] trait OptionTMonadErrorMonad[F[_]] extends MonadError[OptionT[F, ?
     })
 }
 
-private trait OptionTMonadError[F[_], E] extends MonadError[OptionT[F, ?], E] with OptionTMonad[F] {
+private trait OptionTMonadError[F[_], E] extends MonadError[OptionT[F, *], E] with OptionTMonad[F] {
   override def F: MonadError[F, E]
 
   override def raiseError[A](e: E): OptionT[F, A] =
@@ -390,7 +390,7 @@ private trait OptionTMonadError[F[_], E] extends MonadError[OptionT[F, ?], E] wi
     OptionT(F.handleErrorWith(fa.value)(f(_).value))
 }
 
-private trait OptionTContravariantMonoidal[F[_]] extends ContravariantMonoidal[OptionT[F, ?]] {
+private trait OptionTContravariantMonoidal[F[_]] extends ContravariantMonoidal[OptionT[F, *]] {
   def F: ContravariantMonoidal[F]
 
   override def unit: OptionT[F, Unit] = OptionT(F.trivial)
@@ -410,7 +410,7 @@ private trait OptionTContravariantMonoidal[F[_]] extends ContravariantMonoidal[O
     )
 }
 
-private[data] trait OptionTFoldable[F[_]] extends Foldable[OptionT[F, ?]] {
+private[data] trait OptionTFoldable[F[_]] extends Foldable[OptionT[F, *]] {
   implicit def F: Foldable[F]
 
   def foldLeft[A, B](fa: OptionT[F, A], b: B)(f: (B, A) => B): B =
@@ -420,7 +420,7 @@ private[data] trait OptionTFoldable[F[_]] extends Foldable[OptionT[F, ?]] {
     fa.foldRight(lb)(f)
 }
 
-sealed private[data] trait OptionTTraverse[F[_]] extends Traverse[OptionT[F, ?]] with OptionTFoldable[F] {
+sealed private[data] trait OptionTTraverse[F[_]] extends Traverse[OptionT[F, *]] with OptionTFoldable[F] {
   implicit def F: Traverse[F]
 
   def traverse[G[_]: Applicative, A, B](fa: OptionT[F, A])(f: A => G[B]): G[OptionT[F, B]] =
@@ -440,13 +440,13 @@ private[data] trait OptionTMonoid[F[_], A] extends Monoid[OptionT[F, A]] with Op
   def empty: OptionT[F, A] = OptionT(F.empty)
 }
 
-private[data] trait OptionTSemigroupK[F[_]] extends SemigroupK[OptionT[F, ?]] {
+private[data] trait OptionTSemigroupK[F[_]] extends SemigroupK[OptionT[F, *]] {
   implicit def F: Monad[F]
 
   def combineK[A](x: OptionT[F, A], y: OptionT[F, A]): OptionT[F, A] = x.orElse(y)
 }
 
-private[data] trait OptionTMonoidK[F[_]] extends MonoidK[OptionT[F, ?]] with OptionTSemigroupK[F] {
+private[data] trait OptionTMonoidK[F[_]] extends MonoidK[OptionT[F, *]] with OptionTSemigroupK[F] {
   def empty[A]: OptionT[F, A] = OptionT.none[F, A]
 }
 
@@ -462,10 +462,10 @@ sealed private[data] trait OptionTPartialOrder[F[_], A] extends PartialOrder[Opt
   override def partialCompare(x: OptionT[F, A], y: OptionT[F, A]): Double = x.partialCompare(y)
 }
 
-sealed private[data] trait OptionTFunctorFilter[F[_]] extends FunctorFilter[OptionT[F, ?]] {
+sealed private[data] trait OptionTFunctorFilter[F[_]] extends FunctorFilter[OptionT[F, *]] {
   implicit def F: Functor[F]
 
-  def functor: Functor[OptionT[F, ?]] = OptionT.catsDataFunctorForOptionT[F]
+  def functor: Functor[OptionT[F, *]] = OptionT.catsDataFunctorForOptionT[F]
 
   def mapFilter[A, B](fa: OptionT[F, A])(f: (A) => Option[B]): OptionT[F, B] = fa.subflatMap(f)
 

--- a/core/src/main/scala/cats/data/RepresentableStore.scala
+++ b/core/src/main/scala/cats/data/RepresentableStore.scala
@@ -48,8 +48,8 @@ object RepresentableStore {
 
   implicit def catsDataRepresentableStoreComonad[F[_], S](
     implicit R: Representable[F]
-  ): Comonad[RepresentableStore[F, S, ?]] =
-    new Comonad[RepresentableStore[F, S, ?]] {
+  ): Comonad[RepresentableStore[F, S, *]] =
+    new Comonad[RepresentableStore[F, S, *]] {
       override def extract[B](x: RepresentableStore[F, S, B]): B =
         x.extract
 

--- a/core/src/main/scala/cats/data/Tuple2K.scala
+++ b/core/src/main/scala/cats/data/Tuple2K.scala
@@ -42,8 +42,8 @@ sealed abstract private[data] class Tuple2KInstances extends Tuple2KInstances0 {
       def G: ContravariantMonoidal[G] = GD
     }
 
-  implicit def catsDataDeferForTuple2K[F[_], G[_]](implicit F: Defer[F], G: Defer[G]): Defer[Tuple2K[F, G, ?]] =
-    new Defer[Tuple2K[F, G, ?]] {
+  implicit def catsDataDeferForTuple2K[F[_], G[_]](implicit F: Defer[F], G: Defer[G]): Defer[Tuple2K[F, G, *]] =
+    new Defer[Tuple2K[F, G, *]] {
       def defer[A](fa: => Tuple2K[F, G, A]): Tuple2K[F, G, A] = {
         // Make sure we only evaluate once on both the first and second
         lazy val cacheFa = fa

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -359,8 +359,8 @@ object Validated extends ValidatedInstances with ValidatedFunctions with Validat
 
 sealed abstract private[data] class ValidatedInstances extends ValidatedInstances1 {
 
-  implicit def catsDataSemigroupKForValidated[A](implicit A: Semigroup[A]): SemigroupK[Validated[A, ?]] =
-    new SemigroupK[Validated[A, ?]] {
+  implicit def catsDataSemigroupKForValidated[A](implicit A: Semigroup[A]): SemigroupK[Validated[A, *]] =
+    new SemigroupK[Validated[A, *]] {
       def combineK[B](x: Validated[A, B], y: Validated[A, B]): Validated[A, B] = x match {
         case v @ Valid(_) => v
         case Invalid(ix) =>
@@ -418,8 +418,8 @@ sealed abstract private[data] class ValidatedInstances extends ValidatedInstance
         fab.leftMap(f)
     }
 
-  implicit def catsDataApplicativeErrorForValidated[E](implicit E: Semigroup[E]): ApplicativeError[Validated[E, ?], E] =
-    new ValidatedApplicative[E] with ApplicativeError[Validated[E, ?], E] {
+  implicit def catsDataApplicativeErrorForValidated[E](implicit E: Semigroup[E]): ApplicativeError[Validated[E, *], E] =
+    new ValidatedApplicative[E] with ApplicativeError[Validated[E, *], E] {
 
       def handleErrorWith[A](fa: Validated[E, A])(f: E => Validated[E, A]): Validated[E, A] =
         fa match {
@@ -439,8 +439,8 @@ sealed abstract private[data] class ValidatedInstances1 extends ValidatedInstanc
     }
 
   implicit def catsDataCommutativeApplicativeForValidated[E: CommutativeSemigroup]
-    : CommutativeApplicative[Validated[E, ?]] =
-    new ValidatedApplicative[E] with CommutativeApplicative[Validated[E, ?]]
+    : CommutativeApplicative[Validated[E, *]] =
+    new ValidatedApplicative[E] with CommutativeApplicative[Validated[E, *]]
 
   implicit def catsDataPartialOrderForValidated[A: PartialOrder, B: PartialOrder]: PartialOrder[Validated[A, B]] =
     new PartialOrder[Validated[A, B]] {
@@ -456,8 +456,8 @@ sealed abstract private[data] class ValidatedInstances2 {
     }
 
   // scalastyle:off method.length
-  implicit def catsDataTraverseFunctorForValidated[E]: Traverse[Validated[E, ?]] =
-    new Traverse[Validated[E, ?]] {
+  implicit def catsDataTraverseFunctorForValidated[E]: Traverse[Validated[E, *]] =
+    new Traverse[Validated[E, *]] {
 
       override def traverse[G[_]: Applicative, A, B](fa: Validated[E, A])(f: (A) => G[B]): G[Validated[E, B]] =
         fa.traverse(f)
@@ -517,7 +517,7 @@ sealed abstract private[data] class ValidatedInstances2 {
   // scalastyle:off method.length
 }
 
-private[data] class ValidatedApplicative[E: Semigroup] extends CommutativeApplicative[Validated[E, ?]] {
+private[data] class ValidatedApplicative[E: Semigroup] extends CommutativeApplicative[Validated[E, *]] {
   override def map[A, B](fa: Validated[E, A])(f: A => B): Validated[E, B] =
     fa.map(f)
 

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -98,14 +98,14 @@ object WriterT extends WriterTInstances with WriterTFunctions with WriterTFuncti
    * Same as [[liftF]], but expressed as a FunctionK for use with mapK
    * {{{
    * scala> import cats._, data._, implicits._
-   * scala> val a: OptionT[Eval, Int] = 1.pure[OptionT[Eval, ?]]
-   * scala> val b: OptionT[WriterT[Eval, String, ?], Int] = a.mapK(WriterT.liftK)
+   * scala> val a: OptionT[Eval, Int] = 1.pure[OptionT[Eval, *]]
+   * scala> val b: OptionT[WriterT[Eval, String, *], Int] = a.mapK(WriterT.liftK)
    * scala> b.value.run.value
    * res0: (String, Option[Int]) = ("",Some(1))
    * }}}
    */
-  def liftK[F[_], L](implicit monoidL: Monoid[L], F: Applicative[F]): F ~> WriterT[F, L, ?] =
-    λ[F ~> WriterT[F, L, ?]](WriterT.liftF(_))
+  def liftK[F[_], L](implicit monoidL: Monoid[L], F: Applicative[F]): F ~> WriterT[F, L, *] =
+    λ[F ~> WriterT[F, L, *]](WriterT.liftF(_))
 
   @deprecated("Use liftF instead", "1.0.0-RC2")
   def lift[F[_], L, V](fv: F[V])(implicit monoidL: Monoid[L], F: Applicative[F]): WriterT[F, L, V] =
@@ -117,17 +117,17 @@ sealed abstract private[data] class WriterTInstances extends WriterTInstances0 {
   implicit def catsDataCommutativeMonadForWriterT[F[_], L](
     implicit F: CommutativeMonad[F],
     L: CommutativeMonoid[L]
-  ): CommutativeMonad[WriterT[F, L, ?]] =
-    new WriterTMonad[F, L] with CommutativeMonad[WriterT[F, L, ?]] {
+  ): CommutativeMonad[WriterT[F, L, *]] =
+    new WriterTMonad[F, L] with CommutativeMonad[WriterT[F, L, *]] {
       implicit val F0: Monad[F] = F
       implicit val L0: Monoid[L] = L
     }
 
-  implicit def catsDataTraverseForWriterTId[L](implicit F: Traverse[Id]): Traverse[WriterT[Id, L, ?]] =
+  implicit def catsDataTraverseForWriterTId[L](implicit F: Traverse[Id]): Traverse[WriterT[Id, L, *]] =
     catsDataTraverseForWriterT[Id, L](F)
 
-  implicit def catsDataDeferForWriterT[F[_], L](implicit F: Defer[F]): Defer[WriterT[F, L, ?]] =
-    new Defer[WriterT[F, L, ?]] {
+  implicit def catsDataDeferForWriterT[F[_], L](implicit F: Defer[F]): Defer[WriterT[F, L, *]] =
+    new Defer[WriterT[F, L, *]] {
       def defer[A](fa: => WriterT[F, L, A]): WriterT[F, L, A] =
         WriterT(F.defer(fa.run))
     }
@@ -135,18 +135,18 @@ sealed abstract private[data] class WriterTInstances extends WriterTInstances0 {
 
 sealed abstract private[data] class WriterTInstances0 extends WriterTInstances1 {
 
-  implicit def catsDataTraverseForWriterT[F[_], L](implicit F: Traverse[F]): Traverse[WriterT[F, L, ?]] =
+  implicit def catsDataTraverseForWriterT[F[_], L](implicit F: Traverse[F]): Traverse[WriterT[F, L, *]] =
     new WriterTTraverse[F, L] {
       val F0: Traverse[F] = F
     }
 
-  implicit def catsDataFoldableForWriterTId[L](implicit F: Foldable[Id]): Foldable[WriterT[Id, L, ?]] =
+  implicit def catsDataFoldableForWriterTId[L](implicit F: Foldable[Id]): Foldable[WriterT[Id, L, *]] =
     catsDataFoldableForWriterT[Id, L](F)
 }
 
 sealed abstract private[data] class WriterTInstances1 extends WriterTInstances2 {
   implicit def catsDataMonadErrorForWriterT[F[_], L, E](implicit F: MonadError[F, E],
-                                                        L: Monoid[L]): MonadError[WriterT[F, L, ?], E] =
+                                                        L: Monoid[L]): MonadError[WriterT[F, L, *], E] =
     new WriterTMonadError[F, L, E] {
       implicit val F0: MonadError[F, E] = F
       implicit val L0: Monoid[L] = L
@@ -154,25 +154,25 @@ sealed abstract private[data] class WriterTInstances1 extends WriterTInstances2 
 
   implicit def catsDataParallelForWriterT[F[_], M[_], L: Monoid](
     implicit P: Parallel[M, F]
-  ): Parallel[WriterT[M, L, ?], WriterT[F, L, ?]] = new Parallel[WriterT[M, L, ?], WriterT[F, L, ?]] {
+  ): Parallel[WriterT[M, L, *], WriterT[F, L, *]] = new Parallel[WriterT[M, L, *], WriterT[F, L, *]] {
     implicit val appF = P.applicative
     implicit val monadM = P.monad
 
-    def applicative: Applicative[WriterT[F, L, ?]] = catsDataApplicativeForWriterT
-    def monad: Monad[WriterT[M, L, ?]] = catsDataMonadForWriterT
+    def applicative: Applicative[WriterT[F, L, *]] = catsDataApplicativeForWriterT
+    def monad: Monad[WriterT[M, L, *]] = catsDataMonadForWriterT
 
-    def sequential: WriterT[F, L, ?] ~> WriterT[M, L, ?] =
-      λ[WriterT[F, L, ?] ~> WriterT[M, L, ?]](wfl => WriterT(P.sequential(wfl.run)))
+    def sequential: WriterT[F, L, *] ~> WriterT[M, L, *] =
+      λ[WriterT[F, L, *] ~> WriterT[M, L, *]](wfl => WriterT(P.sequential(wfl.run)))
 
-    def parallel: WriterT[M, L, ?] ~> WriterT[F, L, ?] =
-      λ[WriterT[M, L, ?] ~> WriterT[F, L, ?]](wml => WriterT(P.parallel(wml.run)))
+    def parallel: WriterT[M, L, *] ~> WriterT[F, L, *] =
+      λ[WriterT[M, L, *] ~> WriterT[F, L, *]](wml => WriterT(P.parallel(wml.run)))
   }
 
   implicit def catsDataEqForWriterTId[L: Eq, V: Eq]: Eq[WriterT[Id, L, V]] =
     catsDataEqForWriterT[Id, L, V]
 
-  implicit def catsDataBifunctorForWriterT[F[_]: Functor]: Bifunctor[WriterT[F, ?, ?]] =
-    new Bifunctor[WriterT[F, ?, ?]] {
+  implicit def catsDataBifunctorForWriterT[F[_]: Functor]: Bifunctor[WriterT[F, *, *]] =
+    new Bifunctor[WriterT[F, *, *]] {
       def bimap[A, B, C, D](fab: WriterT[F, A, B])(f: A => C, g: B => D): WriterT[F, C, D] =
         fab.bimap(f, g)
     }
@@ -185,14 +185,14 @@ sealed abstract private[data] class WriterTInstances1 extends WriterTInstances2 
   implicit def catsDataMonoidForWriterTId[L: Monoid, V: Monoid]: Monoid[WriterT[Id, L, V]] =
     catsDataMonoidForWriterT[Id, L, V]
 
-  implicit def catsDataFoldableForWriterT[F[_], L](implicit F: Foldable[F]): Foldable[WriterT[F, L, ?]] =
+  implicit def catsDataFoldableForWriterT[F[_], L](implicit F: Foldable[F]): Foldable[WriterT[F, L, *]] =
     new WriterTFoldable[F, L] {
       val F0: Foldable[F] = F
     }
 }
 
 sealed abstract private[data] class WriterTInstances2 extends WriterTInstances3 {
-  implicit def catsDataMonadForWriterTId[L: Monoid]: Monad[WriterT[Id, L, ?]] =
+  implicit def catsDataMonadForWriterTId[L: Monoid]: Monad[WriterT[Id, L, *]] =
     catsDataMonadForWriterT[Id, L]
 
   implicit def catsDataEqForWriterT[F[_], L, V](implicit F: Eq[F[(L, V)]]): Eq[WriterT[F, L, V]] =
@@ -201,12 +201,12 @@ sealed abstract private[data] class WriterTInstances2 extends WriterTInstances3 
   implicit def catsDataSemigroupForWriterTId[L: Semigroup, V: Semigroup]: Semigroup[WriterT[Id, L, V]] =
     catsDataSemigroupForWriterT[Id, L, V]
 
-  implicit def catsDataComonadForWriterTId[L](implicit F: Comonad[Id]): Comonad[WriterT[Id, L, ?]] =
+  implicit def catsDataComonadForWriterTId[L](implicit F: Comonad[Id]): Comonad[WriterT[Id, L, *]] =
     catsDataComonadForWriterT[Id, L](F)
 }
 
 sealed abstract private[data] class WriterTInstances3 extends WriterTInstances4 {
-  implicit def catsDataMonadForWriterT[F[_], L](implicit F: Monad[F], L: Monoid[L]): Monad[WriterT[F, L, ?]] =
+  implicit def catsDataMonadForWriterT[F[_], L](implicit F: Monad[F], L: Monoid[L]): Monad[WriterT[F, L, *]] =
     new WriterTMonad[F, L] {
       implicit val F0: Monad[F] = F
       implicit val L0: Monoid[L] = L
@@ -217,17 +217,17 @@ sealed abstract private[data] class WriterTInstances3 extends WriterTInstances4 
       implicit val F0: Monoid[F[(L, V)]] = W
     }
 
-  implicit def catsDataCoflatMapForWriterTId[L]: CoflatMap[WriterT[Id, L, ?]] =
+  implicit def catsDataCoflatMapForWriterTId[L]: CoflatMap[WriterT[Id, L, *]] =
     catsDataCoflatMapForWriterT[Id, L]
 }
 
 sealed abstract private[data] class WriterTInstances4 extends WriterTInstances5 {
-  implicit def catsDataFlatMapForWriterTId[L: Semigroup]: FlatMap[WriterT[Id, L, ?]] =
+  implicit def catsDataFlatMapForWriterTId[L: Semigroup]: FlatMap[WriterT[Id, L, *]] =
     catsDataFlatMapForWriterT2[Id, L]
 }
 
 sealed abstract private[data] class WriterTInstances5 extends WriterTInstances6 {
-  implicit def catsDataFlatMapForWriterT1[F[_], L](implicit F: FlatMap[F], L: Monoid[L]): FlatMap[WriterT[F, L, ?]] =
+  implicit def catsDataFlatMapForWriterT1[F[_], L](implicit F: FlatMap[F], L: Monoid[L]): FlatMap[WriterT[F, L, *]] =
     new WriterTFlatMap1[F, L] {
       implicit val F0: FlatMap[F] = F
       implicit val L0: Monoid[L] = L
@@ -241,7 +241,7 @@ sealed abstract private[data] class WriterTInstances5 extends WriterTInstances6 
 
 sealed abstract private[data] class WriterTInstances6 extends WriterTInstances7 {
   implicit def catsDataApplicativeErrorForWriterT[F[_], L, E](implicit F: ApplicativeError[F, E],
-                                                              L: Monoid[L]): ApplicativeError[WriterT[F, L, ?], E] =
+                                                              L: Monoid[L]): ApplicativeError[WriterT[F, L, *], E] =
     new WriterTApplicativeError[F, L, E] {
       implicit val F0: ApplicativeError[F, E] = F
       implicit val L0: Monoid[L] = L
@@ -250,7 +250,7 @@ sealed abstract private[data] class WriterTInstances6 extends WriterTInstances7 
 
 sealed abstract private[data] class WriterTInstances7 extends WriterTInstances8 {
   implicit def catsDataAlternativeForWriterT[F[_], L](implicit F: Alternative[F],
-                                                      L: Monoid[L]): Alternative[WriterT[F, L, ?]] =
+                                                      L: Monoid[L]): Alternative[WriterT[F, L, *]] =
     new WriterTAlternative[F, L] {
       implicit val F0: Alternative[F] = F
       implicit val L0: Monoid[L] = L
@@ -258,49 +258,49 @@ sealed abstract private[data] class WriterTInstances7 extends WriterTInstances8 
 
   implicit def catsDataContravariantMonoidalForWriterT[F[_], L](
     implicit F: ContravariantMonoidal[F]
-  ): ContravariantMonoidal[WriterT[F, L, ?]] =
+  ): ContravariantMonoidal[WriterT[F, L, *]] =
     new WriterTContravariantMonoidal[F, L] {
       implicit val F0: ContravariantMonoidal[F] = F
     }
 }
 
 sealed abstract private[data] class WriterTInstances8 extends WriterTInstances9 {
-  implicit def catsDataMonoidKForWriterT[F[_], L](implicit F: MonoidK[F]): MonoidK[WriterT[F, L, ?]] =
+  implicit def catsDataMonoidKForWriterT[F[_], L](implicit F: MonoidK[F]): MonoidK[WriterT[F, L, *]] =
     new WriterTMonoidK[F, L] {
       implicit val F0: MonoidK[F] = F
     }
 
-  implicit def catsDataFlatMapForWriterT2[F[_], L](implicit F: Monad[F], L: Semigroup[L]): FlatMap[WriterT[F, L, ?]] =
+  implicit def catsDataFlatMapForWriterT2[F[_], L](implicit F: Monad[F], L: Semigroup[L]): FlatMap[WriterT[F, L, *]] =
     new WriterTFlatMap2[F, L] {
       implicit val F0: Monad[F] = F
       implicit val L0: Semigroup[L] = L
     }
 
-  implicit def catsDataContravariantForWriterT[F[_], L](implicit F: Contravariant[F]): Contravariant[WriterT[F, L, ?]] =
+  implicit def catsDataContravariantForWriterT[F[_], L](implicit F: Contravariant[F]): Contravariant[WriterT[F, L, *]] =
     new WriterTContravariant[F, L] {
       implicit val F0: Contravariant[F] = F
     }
 }
 
 sealed abstract private[data] class WriterTInstances9 extends WriterTInstances10 {
-  implicit def catsDataSemigroupKForWriterT[F[_], L](implicit F: SemigroupK[F]): SemigroupK[WriterT[F, L, ?]] =
+  implicit def catsDataSemigroupKForWriterT[F[_], L](implicit F: SemigroupK[F]): SemigroupK[WriterT[F, L, *]] =
     new WriterTSemigroupK[F, L] {
       implicit val F0: SemigroupK[F] = F
     }
 
   implicit def catsDataApplicativeForWriterT[F[_], L](implicit F: Applicative[F],
-                                                      L: Monoid[L]): Applicative[WriterT[F, L, ?]] =
+                                                      L: Monoid[L]): Applicative[WriterT[F, L, *]] =
     new WriterTApplicative[F, L] {
       implicit val F0: Applicative[F] = F
       implicit val L0: Monoid[L] = L
     }
 
-  implicit def catsDataInvariantForWriterT[F[_], L](implicit F0: Invariant[F]): Invariant[WriterT[F, L, ?]] =
+  implicit def catsDataInvariantForWriterT[F[_], L](implicit F0: Invariant[F]): Invariant[WriterT[F, L, *]] =
     new WriterTInvariant[F, L] { implicit val F = F0 }
 }
 
 sealed abstract private[data] class WriterTInstances10 extends WriterTInstances11 {
-  implicit def catsDataApplyForWriterT[F[_], L](implicit F: Apply[F], L: Semigroup[L]): Apply[WriterT[F, L, ?]] =
+  implicit def catsDataApplyForWriterT[F[_], L](implicit F: Apply[F], L: Semigroup[L]): Apply[WriterT[F, L, *]] =
     new WriterTApply[F, L] {
       implicit val F0: Apply[F] = F
       implicit val L0: Semigroup[L] = L
@@ -308,41 +308,41 @@ sealed abstract private[data] class WriterTInstances10 extends WriterTInstances1
 }
 
 sealed abstract private[data] class WriterTInstances11 extends WriterTInstances12 {
-  implicit def catsDataComonadForWriterT[F[_], L](implicit F: Comonad[F]): Comonad[WriterT[F, L, ?]] =
+  implicit def catsDataComonadForWriterT[F[_], L](implicit F: Comonad[F]): Comonad[WriterT[F, L, *]] =
     new WriterTComonad[F, L] {
       implicit val F0: Comonad[F] = F
     }
 }
 
 sealed abstract private[data] class WriterTInstances12 {
-  implicit def catsDataCoflatMapForWriterT[F[_], L](implicit F: Functor[F]): CoflatMap[WriterT[F, L, ?]] =
+  implicit def catsDataCoflatMapForWriterT[F[_], L](implicit F: Functor[F]): CoflatMap[WriterT[F, L, *]] =
     new WriterTCoflatMap[F, L] {
       implicit val F0: Functor[F] = F
     }
 }
 
-sealed private[data] trait WriterTFunctor[F[_], L] extends Functor[WriterT[F, L, ?]] {
+sealed private[data] trait WriterTFunctor[F[_], L] extends Functor[WriterT[F, L, *]] {
   implicit def F0: Functor[F]
 
   override def map[A, B](fa: WriterT[F, L, A])(f: A => B): WriterT[F, L, B] =
     fa.map(f)
 }
 
-sealed private[data] trait WriterTContravariant[F[_], L] extends Contravariant[WriterT[F, L, ?]] {
+sealed private[data] trait WriterTContravariant[F[_], L] extends Contravariant[WriterT[F, L, *]] {
   implicit def F0: Contravariant[F]
 
   override def contramap[A, B](fa: WriterT[F, L, A])(f: B => A): WriterT[F, L, B] =
     fa.contramap(f)
 }
 
-sealed private[data] trait WriterTInvariant[F[_], L] extends Invariant[WriterT[F, L, ?]] {
+sealed private[data] trait WriterTInvariant[F[_], L] extends Invariant[WriterT[F, L, *]] {
   implicit def F: Invariant[F]
 
   override def imap[A, B](fa: WriterT[F, L, A])(f: A => B)(g: B => A): WriterT[F, L, B] =
     fa.imap(f)(g)
 }
 
-sealed private[data] trait WriterTApply[F[_], L] extends WriterTFunctor[F, L] with Apply[WriterT[F, L, ?]] {
+sealed private[data] trait WriterTApply[F[_], L] extends WriterTFunctor[F, L] with Apply[WriterT[F, L, *]] {
   implicit override def F0: Apply[F]
   implicit def L0: Semigroup[L]
 
@@ -358,7 +358,7 @@ sealed private[data] trait WriterTApply[F[_], L] extends WriterTFunctor[F, L] wi
     WriterT(F0.map(F0.product(fa.run, fb.run)) { case ((l1, a), (l2, b)) => (L0.combine(l1, l2), (a, b)) })
 }
 
-sealed private[data] trait WriterTFlatMap1[F[_], L] extends WriterTApply[F, L] with FlatMap[WriterT[F, L, ?]] {
+sealed private[data] trait WriterTFlatMap1[F[_], L] extends WriterTApply[F, L] with FlatMap[WriterT[F, L, *]] {
   implicit override def F0: FlatMap[F]
   implicit def L0: Monoid[L]
 
@@ -386,7 +386,7 @@ sealed private[data] trait WriterTFlatMap1[F[_], L] extends WriterTApply[F, L] w
   }
 }
 
-sealed private[data] trait WriterTFlatMap2[F[_], L] extends WriterTApply[F, L] with FlatMap[WriterT[F, L, ?]] {
+sealed private[data] trait WriterTFlatMap2[F[_], L] extends WriterTApply[F, L] with FlatMap[WriterT[F, L, *]] {
   implicit override def F0: Monad[F]
   implicit def L0: Semigroup[L]
 
@@ -416,7 +416,7 @@ sealed private[data] trait WriterTFlatMap2[F[_], L] extends WriterTApply[F, L] w
   }
 }
 
-sealed private[data] trait WriterTApplicative[F[_], L] extends WriterTApply[F, L] with Applicative[WriterT[F, L, ?]] {
+sealed private[data] trait WriterTApplicative[F[_], L] extends WriterTApply[F, L] with Applicative[WriterT[F, L, *]] {
   implicit override def F0: Applicative[F]
   implicit override def L0: Monoid[L]
 
@@ -427,13 +427,13 @@ sealed private[data] trait WriterTApplicative[F[_], L] extends WriterTApply[F, L
 sealed private[data] trait WriterTMonad[F[_], L]
     extends WriterTApplicative[F, L]
     with WriterTFlatMap1[F, L]
-    with Monad[WriterT[F, L, ?]] {
+    with Monad[WriterT[F, L, *]] {
   implicit override def F0: Monad[F]
   implicit override def L0: Monoid[L]
 }
 
 sealed private[data] trait WriterTApplicativeError[F[_], L, E]
-    extends ApplicativeError[WriterT[F, L, ?], E]
+    extends ApplicativeError[WriterT[F, L, *], E]
     with WriterTApplicative[F, L] {
   implicit override def F0: ApplicativeError[F, E]
 
@@ -444,33 +444,33 @@ sealed private[data] trait WriterTApplicativeError[F[_], L, E]
 }
 
 sealed private[data] trait WriterTMonadError[F[_], L, E]
-    extends MonadError[WriterT[F, L, ?], E]
+    extends MonadError[WriterT[F, L, *], E]
     with WriterTMonad[F, L]
     with WriterTApplicativeError[F, L, E] {
   implicit override def F0: MonadError[F, E]
 }
 
-sealed private[data] trait WriterTSemigroupK[F[_], L] extends SemigroupK[WriterT[F, L, ?]] {
+sealed private[data] trait WriterTSemigroupK[F[_], L] extends SemigroupK[WriterT[F, L, *]] {
   implicit def F0: SemigroupK[F]
 
   def combineK[A](x: WriterT[F, L, A], y: WriterT[F, L, A]): WriterT[F, L, A] =
     WriterT(F0.combineK(x.run, y.run))
 }
 
-sealed private[data] trait WriterTMonoidK[F[_], L] extends MonoidK[WriterT[F, L, ?]] with WriterTSemigroupK[F, L] {
+sealed private[data] trait WriterTMonoidK[F[_], L] extends MonoidK[WriterT[F, L, *]] with WriterTSemigroupK[F, L] {
   implicit override def F0: MonoidK[F]
 
   def empty[A]: WriterT[F, L, A] = WriterT(F0.empty)
 }
 
 sealed private[data] trait WriterTAlternative[F[_], L]
-    extends Alternative[WriterT[F, L, ?]]
+    extends Alternative[WriterT[F, L, *]]
     with WriterTMonoidK[F, L]
     with WriterTApplicative[F, L] {
   implicit override def F0: Alternative[F]
 }
 
-sealed private[data] trait WriterTContravariantMonoidal[F[_], L] extends ContravariantMonoidal[WriterT[F, L, ?]] {
+sealed private[data] trait WriterTContravariantMonoidal[F[_], L] extends ContravariantMonoidal[WriterT[F, L, *]] {
   implicit def F0: ContravariantMonoidal[F]
 
   override def unit: WriterT[F, L, Unit] = WriterT(F0.trivial[(L, Unit)])
@@ -502,12 +502,12 @@ sealed private[data] trait WriterTMonoid[F[_], L, A] extends Monoid[WriterT[F, L
   def empty: WriterT[F, L, A] = WriterT(F0.empty)
 }
 
-sealed private[data] trait WriterTCoflatMap[F[_], L] extends CoflatMap[WriterT[F, L, ?]] with WriterTFunctor[F, L] {
+sealed private[data] trait WriterTCoflatMap[F[_], L] extends CoflatMap[WriterT[F, L, *]] with WriterTFunctor[F, L] {
 
   def coflatMap[A, B](fa: WriterT[F, L, A])(f: WriterT[F, L, A] => B): WriterT[F, L, B] = fa.map(_ => f(fa))
 }
 
-sealed private[data] trait WriterTFoldable[F[_], L] extends Foldable[WriterT[F, L, ?]] {
+sealed private[data] trait WriterTFoldable[F[_], L] extends Foldable[WriterT[F, L, *]] {
 
   implicit def F0: Foldable[F]
 
@@ -516,7 +516,7 @@ sealed private[data] trait WriterTFoldable[F[_], L] extends Foldable[WriterT[F, 
 }
 
 sealed private[data] trait WriterTTraverse[F[_], L]
-    extends Traverse[WriterT[F, L, ?]]
+    extends Traverse[WriterT[F, L, *]]
     with WriterTFoldable[F, L]
     with WriterTFunctor[F, L] {
 
@@ -525,7 +525,7 @@ sealed private[data] trait WriterTTraverse[F[_], L]
   def traverse[G[_]: Applicative, A, B](fa: WriterT[F, L, A])(f: A => G[B]): G[WriterT[F, L, B]] = fa.traverse(f)
 }
 
-sealed private[data] trait WriterTComonad[F[_], L] extends Comonad[WriterT[F, L, ?]] with WriterTCoflatMap[F, L] {
+sealed private[data] trait WriterTComonad[F[_], L] extends Comonad[WriterT[F, L, *]] with WriterTCoflatMap[F, L] {
 
   implicit override def F0: Comonad[F]
 

--- a/core/src/main/scala/cats/data/package.scala
+++ b/core/src/main/scala/cats/data/package.scala
@@ -87,11 +87,11 @@ package object data {
   type RWS[E, L, S, A] = ReaderWriterState[E, L, S, A]
   val RWS = ReaderWriterState
 
-  type Store[S, A] = RepresentableStore[S => ?, S, A]
+  type Store[S, A] = RepresentableStore[S => *, S, A]
   object Store {
     import cats.instances.function._
     def apply[S, A](f: S => A, s: S): Store[S, A] =
-      RepresentableStore[S => ?, S, A](f, s)
+      RepresentableStore[S => *, S, A](f, s)
   }
 
   type ZipLazyList[A] = ZipStream[A]

--- a/core/src/main/scala/cats/evidence/As.scala
+++ b/core/src/main/scala/cats/evidence/As.scala
@@ -69,7 +69,7 @@ object As extends AsInstances {
    * We can witness the relationship by using it to make a substitution *
    */
   implicit def witness[A, B](lt: A As B): A => B =
-    lt.substitute[-? => B](identity)
+    lt.substitute[-* => B](identity)
 
   /**
    * Subtyping is transitive

--- a/core/src/main/scala/cats/evidence/Is.scala
+++ b/core/src/main/scala/cats/evidence/Is.scala
@@ -27,7 +27,7 @@ abstract class Is[A, B] extends Serializable {
    * chain much like functions. See also `compose`.
    */
   @inline final def andThen[C](next: B Is C): A Is C =
-    next.substitute[A Is ?](this)
+    next.substitute[A Is *](this)
 
   /**
    * `Is` is transitive and therefore values of `Is` can be composed in a
@@ -41,7 +41,7 @@ abstract class Is[A, B] extends Serializable {
    * own inverse, so `x.flip.flip == x`.
    */
   @inline final def flip: B Is A =
-    this.substitute[? Is A](Is.refl)
+    this.substitute[* Is A](Is.refl)
 
   /**
    * Sometimes for more complex substitutions it helps the typechecker to
@@ -63,7 +63,7 @@ abstract class Is[A, B] extends Serializable {
    * value.
    */
   @inline final def predefEq: A =:= B =
-    substitute[A =:= ?](implicitly[A =:= A])
+    substitute[A =:= *](implicitly[A =:= A])
 }
 
 sealed abstract class IsInstances {

--- a/core/src/main/scala/cats/instances/either.scala
+++ b/core/src/main/scala/cats/instances/either.scala
@@ -30,8 +30,8 @@ trait EitherInstances extends cats.kernel.instances.EitherInstances {
     }
 
   // scalastyle:off method.length
-  implicit def catsStdInstancesForEither[A]: MonadError[Either[A, ?], A] with Traverse[Either[A, ?]] =
-    new MonadError[Either[A, ?], A] with Traverse[Either[A, ?]] {
+  implicit def catsStdInstancesForEither[A]: MonadError[Either[A, *], A] with Traverse[Either[A, *]] =
+    new MonadError[Either[A, *], A] with Traverse[Either[A, *]] {
       def pure[B](b: B): Either[A, B] = Right(b)
 
       def flatMap[B, C](fa: Either[A, B])(f: B => Either[A, C]): Either[A, C] =
@@ -142,8 +142,8 @@ trait EitherInstances extends cats.kernel.instances.EitherInstances {
     }
   // scalastyle:on method.length
 
-  implicit def catsStdSemigroupKForEither[L]: SemigroupK[Either[L, ?]] =
-    new SemigroupK[Either[L, ?]] {
+  implicit def catsStdSemigroupKForEither[L]: SemigroupK[Either[L, *]] =
+    new SemigroupK[Either[L, *]] {
       def combineK[A](x: Either[L, A], y: Either[L, A]): Either[L, A] = x match {
         case Left(_)  => y
         case Right(_) => x

--- a/core/src/main/scala/cats/instances/function.scala
+++ b/core/src/main/scala/cats/instances/function.scala
@@ -14,10 +14,10 @@ trait FunctionInstancesBinCompat0 {
   /**
    * Witness for: E => A <-> E => A
    */
-  implicit def catsStdRepresentableForFunction1[E](implicit EF: Functor[E => ?]): Representable.Aux[E => ?, E] =
-    new Representable[E => ?] {
+  implicit def catsStdRepresentableForFunction1[E](implicit EF: Functor[E => *]): Representable.Aux[E => *, E] =
+    new Representable[E => *] {
       override type Representation = E
-      override val F: Functor[E => ?] = EF
+      override val F: Functor[E => *] = EF
       override def tabulate[A](f: E => A): E => A = f
       override def index[A](f: E => A): E => A = f
     }
@@ -41,8 +41,8 @@ trait FunctionInstancesBinCompat0 {
       }
     }
 
-  implicit def catsStdDeferForFunction1[A]: Defer[A => ?] =
-    new Defer[A => ?] {
+  implicit def catsStdDeferForFunction1[A]: Defer[A => *] =
+    new Defer[A => *] {
       case class Deferred[B](fa: () => A => B) extends (A => B) {
         def apply(a: A) = {
           @annotation.tailrec
@@ -98,8 +98,8 @@ sealed private[instances] trait Function0Instances0 {
 }
 
 sealed private[instances] trait Function1Instances extends Function1Instances0 {
-  implicit def catsStdContravariantMonoidalForFunction1[R: Monoid]: ContravariantMonoidal[? => R] =
-    new ContravariantMonoidal[? => R] {
+  implicit def catsStdContravariantMonoidalForFunction1[R: Monoid]: ContravariantMonoidal[* => R] =
+    new ContravariantMonoidal[* => R] {
       def unit: Unit => R = Function.const(Monoid[R].empty)
       def contramap[A, B](fa: A => R)(f: B => A): B => R =
         fa.compose(f)
@@ -110,8 +110,8 @@ sealed private[instances] trait Function1Instances extends Function1Instances0 {
           }
     }
 
-  implicit def catsStdMonadForFunction1[T1]: Monad[T1 => ?] =
-    new Monad[T1 => ?] {
+  implicit def catsStdMonadForFunction1[T1]: Monad[T1 => *] =
+    new Monad[T1 => *] {
       def pure[R](r: R): T1 => R = _ => r
 
       def flatMap[R1, R2](fa: T1 => R1)(f: R1 => T1 => R2): T1 => R2 =
@@ -165,13 +165,13 @@ sealed private[instances] trait Function1Instances extends Function1Instances0 {
 }
 
 sealed private[instances] trait Function1Instances0 {
-  implicit def catsStdContravariantForFunction1[R]: Contravariant[? => R] =
-    new Contravariant[? => R] {
+  implicit def catsStdContravariantForFunction1[R]: Contravariant[* => R] =
+    new Contravariant[* => R] {
       def contramap[T1, T0](fa: T1 => R)(f: T0 => T1): T0 => R =
         fa.compose(f)
     }
 
-  implicit def catsStdDistributiveForFunction1[T1]: Distributive[T1 => ?] = new Distributive[T1 => ?] {
+  implicit def catsStdDistributiveForFunction1[T1]: Distributive[T1 => *] = new Distributive[T1 => *] {
     def distribute[F[_]: Functor, A, B](fa: F[A])(f: A => (T1 => B)): T1 => F[B] = { t1 =>
       Functor[F].map(fa)(a => f(a)(t1))
     }

--- a/core/src/main/scala/cats/instances/map.scala
+++ b/core/src/main/scala/cats/instances/map.scala
@@ -17,8 +17,8 @@ trait MapInstances extends cats.kernel.instances.MapInstances {
     }
 
   // scalastyle:off method.length
-  implicit def catsStdInstancesForMap[K]: UnorderedTraverse[Map[K, ?]] with FlatMap[Map[K, ?]] =
-    new UnorderedTraverse[Map[K, ?]] with FlatMap[Map[K, ?]] {
+  implicit def catsStdInstancesForMap[K]: UnorderedTraverse[Map[K, *]] with FlatMap[Map[K, *]] =
+    new UnorderedTraverse[Map[K, *]] with FlatMap[Map[K, *]] {
 
       def unorderedTraverse[G[_], A, B](
         fa: Map[K, A]
@@ -118,10 +118,10 @@ trait MapInstancesBinCompat0 {
       }
   }
 
-  implicit def catsStdFunctorFilterForMap[K]: FunctorFilter[Map[K, ?]] =
-    new FunctorFilter[Map[K, ?]] {
+  implicit def catsStdFunctorFilterForMap[K]: FunctorFilter[Map[K, *]] =
+    new FunctorFilter[Map[K, *]] {
 
-      val functor: Functor[Map[K, ?]] = cats.instances.map.catsStdInstancesForMap[K]
+      val functor: Functor[Map[K, *]] = cats.instances.map.catsStdInstancesForMap[K]
 
       def mapFilter[A, B](fa: Map[K, A])(f: A => Option[B]) =
         fa.collect(scala.Function.unlift(t => f(t._2).map(t._1 -> _)))
@@ -140,7 +140,7 @@ trait MapInstancesBinCompat0 {
 }
 
 trait MapInstancesBinCompat1 {
-  implicit def catsStdMonoidKForMap[K]: MonoidK[Map[K, ?]] = new MonoidK[Map[K, ?]] {
+  implicit def catsStdMonoidKForMap[K]: MonoidK[Map[K, *]] = new MonoidK[Map[K, *]] {
     override def empty[A]: Map[K, A] = Map.empty
 
     override def combineK[A](x: Map[K, A], y: Map[K, A]): Map[K, A] = x ++ y

--- a/core/src/main/scala/cats/instances/parallel.scala
+++ b/core/src/main/scala/cats/instances/parallel.scala
@@ -9,36 +9,36 @@ import kernel.compat.scalaVersionSpecific._
 
 @suppressUnusedImportWarningForScalaVersionSpecific
 trait ParallelInstances extends ParallelInstances1 {
-  implicit def catsParallelForEitherValidated[E: Semigroup]: Parallel[Either[E, ?], Validated[E, ?]] =
-    new Parallel[Either[E, ?], Validated[E, ?]] {
+  implicit def catsParallelForEitherValidated[E: Semigroup]: Parallel[Either[E, *], Validated[E, *]] =
+    new Parallel[Either[E, *], Validated[E, *]] {
 
-      def applicative: Applicative[Validated[E, ?]] = Validated.catsDataApplicativeErrorForValidated
-      def monad: Monad[Either[E, ?]] = cats.instances.either.catsStdInstancesForEither
+      def applicative: Applicative[Validated[E, *]] = Validated.catsDataApplicativeErrorForValidated
+      def monad: Monad[Either[E, *]] = cats.instances.either.catsStdInstancesForEither
 
-      def sequential: Validated[E, ?] ~> Either[E, ?] =
-        λ[Validated[E, ?] ~> Either[E, ?]](_.toEither)
+      def sequential: Validated[E, *] ~> Either[E, *] =
+        λ[Validated[E, *] ~> Either[E, *]](_.toEither)
 
-      def parallel: Either[E, ?] ~> Validated[E, ?] =
-        λ[Either[E, ?] ~> Validated[E, ?]](_.toValidated)
+      def parallel: Either[E, *] ~> Validated[E, *] =
+        λ[Either[E, *] ~> Validated[E, *]](_.toValidated)
     }
 
   implicit def catsParallelForOptionTNestedOption[F[_], M[_]](
     implicit P: Parallel[M, F]
-  ): Parallel[OptionT[M, ?], Nested[F, Option, ?]] = new Parallel[OptionT[M, ?], Nested[F, Option, ?]] {
+  ): Parallel[OptionT[M, *], Nested[F, Option, *]] = new Parallel[OptionT[M, *], Nested[F, Option, *]] {
 
     implicit val appF: Applicative[F] = P.applicative
     implicit val monadM: Monad[M] = P.monad
     implicit val appOption: Applicative[Option] = cats.instances.option.catsStdInstancesForOption
 
-    def applicative: Applicative[Nested[F, Option, ?]] = cats.data.Nested.catsDataApplicativeForNested[F, Option]
+    def applicative: Applicative[Nested[F, Option, *]] = cats.data.Nested.catsDataApplicativeForNested[F, Option]
 
-    def monad: Monad[OptionT[M, ?]] = cats.data.OptionT.catsDataMonadErrorMonadForOptionT[M]
+    def monad: Monad[OptionT[M, *]] = cats.data.OptionT.catsDataMonadErrorMonadForOptionT[M]
 
-    def sequential: Nested[F, Option, ?] ~> OptionT[M, ?] =
-      λ[Nested[F, Option, ?] ~> OptionT[M, ?]](nested => OptionT(P.sequential(nested.value)))
+    def sequential: Nested[F, Option, *] ~> OptionT[M, *] =
+      λ[Nested[F, Option, *] ~> OptionT[M, *]](nested => OptionT(P.sequential(nested.value)))
 
-    def parallel: OptionT[M, ?] ~> Nested[F, Option, ?] =
-      λ[OptionT[M, ?] ~> Nested[F, Option, ?]](optT => Nested(P.parallel(optT.value)))
+    def parallel: OptionT[M, *] ~> Nested[F, Option, *] =
+      λ[OptionT[M, *] ~> Nested[F, Option, *]](optT => Nested(P.parallel(optT.value)))
   }
 
   implicit def catsStdNonEmptyParallelForZipList[A]: NonEmptyParallel[List, ZipList] =
@@ -82,27 +82,27 @@ trait ParallelInstances extends ParallelInstances1 {
 
   implicit def catsParallelForEitherTNestedParallelValidated[F[_], M[_], E: Semigroup](
     implicit P: Parallel[M, F]
-  ): Parallel[EitherT[M, E, ?], Nested[F, Validated[E, ?], ?]] =
-    new Parallel[EitherT[M, E, ?], Nested[F, Validated[E, ?], ?]] {
+  ): Parallel[EitherT[M, E, *], Nested[F, Validated[E, *], *]] =
+    new Parallel[EitherT[M, E, *], Nested[F, Validated[E, *], *]] {
 
       implicit val appF: Applicative[F] = P.applicative
       implicit val monadM: Monad[M] = P.monad
-      implicit val appValidated: Applicative[Validated[E, ?]] = Validated.catsDataApplicativeErrorForValidated
-      implicit val monadEither: Monad[Either[E, ?]] = cats.instances.either.catsStdInstancesForEither
+      implicit val appValidated: Applicative[Validated[E, *]] = Validated.catsDataApplicativeErrorForValidated
+      implicit val monadEither: Monad[Either[E, *]] = cats.instances.either.catsStdInstancesForEither
 
-      def applicative: Applicative[Nested[F, Validated[E, ?], ?]] =
-        cats.data.Nested.catsDataApplicativeForNested[F, Validated[E, ?]]
+      def applicative: Applicative[Nested[F, Validated[E, *], *]] =
+        cats.data.Nested.catsDataApplicativeForNested[F, Validated[E, *]]
 
-      def monad: Monad[EitherT[M, E, ?]] = cats.data.EitherT.catsDataMonadErrorForEitherT
+      def monad: Monad[EitherT[M, E, *]] = cats.data.EitherT.catsDataMonadErrorForEitherT
 
-      def sequential: Nested[F, Validated[E, ?], ?] ~> EitherT[M, E, ?] =
-        λ[Nested[F, Validated[E, ?], ?] ~> EitherT[M, E, ?]] { nested =>
+      def sequential: Nested[F, Validated[E, *], *] ~> EitherT[M, E, *] =
+        λ[Nested[F, Validated[E, *], *] ~> EitherT[M, E, *]] { nested =>
           val mva = P.sequential(nested.value)
           EitherT(Functor[M].map(mva)(_.toEither))
         }
 
-      def parallel: EitherT[M, E, ?] ~> Nested[F, Validated[E, ?], ?] =
-        λ[EitherT[M, E, ?] ~> Nested[F, Validated[E, ?], ?]] { eitherT =>
+      def parallel: EitherT[M, E, *] ~> Nested[F, Validated[E, *], *] =
+        λ[EitherT[M, E, *] ~> Nested[F, Validated[E, *], *]] { eitherT =>
           val fea = P.parallel(eitherT.value)
           Nested(Functor[F].map(fea)(_.toValidated))
         }
@@ -111,24 +111,24 @@ trait ParallelInstances extends ParallelInstances1 {
 
 private[instances] trait ParallelInstances1 {
   implicit def catsParallelForEitherTNestedValidated[M[_]: Monad, E: Semigroup]
-    : Parallel[EitherT[M, E, ?], Nested[M, Validated[E, ?], ?]] =
-    new Parallel[EitherT[M, E, ?], Nested[M, Validated[E, ?], ?]] {
+    : Parallel[EitherT[M, E, *], Nested[M, Validated[E, *], *]] =
+    new Parallel[EitherT[M, E, *], Nested[M, Validated[E, *], *]] {
 
-      implicit val appValidated: Applicative[Validated[E, ?]] = Validated.catsDataApplicativeErrorForValidated
-      implicit val monadEither: Monad[Either[E, ?]] = cats.instances.either.catsStdInstancesForEither
+      implicit val appValidated: Applicative[Validated[E, *]] = Validated.catsDataApplicativeErrorForValidated
+      implicit val monadEither: Monad[Either[E, *]] = cats.instances.either.catsStdInstancesForEither
 
-      def applicative: Applicative[Nested[M, Validated[E, ?], ?]] =
-        cats.data.Nested.catsDataApplicativeForNested[M, Validated[E, ?]]
+      def applicative: Applicative[Nested[M, Validated[E, *], *]] =
+        cats.data.Nested.catsDataApplicativeForNested[M, Validated[E, *]]
 
-      def monad: Monad[EitherT[M, E, ?]] = cats.data.EitherT.catsDataMonadErrorForEitherT
+      def monad: Monad[EitherT[M, E, *]] = cats.data.EitherT.catsDataMonadErrorForEitherT
 
-      def sequential: Nested[M, Validated[E, ?], ?] ~> EitherT[M, E, ?] =
-        λ[Nested[M, Validated[E, ?], ?] ~> EitherT[M, E, ?]] { nested =>
+      def sequential: Nested[M, Validated[E, *], *] ~> EitherT[M, E, *] =
+        λ[Nested[M, Validated[E, *], *] ~> EitherT[M, E, *]] { nested =>
           EitherT(Monad[M].map(nested.value)(_.toEither))
         }
 
-      def parallel: EitherT[M, E, ?] ~> Nested[M, Validated[E, ?], ?] =
-        λ[EitherT[M, E, ?] ~> Nested[M, Validated[E, ?], ?]] { eitherT =>
+      def parallel: EitherT[M, E, *] ~> Nested[M, Validated[E, *], *] =
+        λ[EitherT[M, E, *] ~> Nested[M, Validated[E, *], *]] { eitherT =>
           Nested(Monad[M].map(eitherT.value)(_.toValidated))
         }
     }

--- a/core/src/main/scala/cats/instances/sortedMap.scala
+++ b/core/src/main/scala/cats/instances/sortedMap.scala
@@ -25,8 +25,8 @@ trait SortedMapInstances extends SortedMapInstances2 {
     }
 
   // scalastyle:off method.length
-  implicit def catsStdInstancesForSortedMap[K: Order]: Traverse[SortedMap[K, ?]] with FlatMap[SortedMap[K, ?]] =
-    new Traverse[SortedMap[K, ?]] with FlatMap[SortedMap[K, ?]] {
+  implicit def catsStdInstancesForSortedMap[K: Order]: Traverse[SortedMap[K, *]] with FlatMap[SortedMap[K, *]] =
+    new Traverse[SortedMap[K, *]] with FlatMap[SortedMap[K, *]] {
 
       implicit val orderingK: Ordering[K] = Order[K].toOrdering
 
@@ -185,12 +185,12 @@ class SortedMapMonoid[K, V](implicit V: Semigroup[V], O: Order[K]) extends Monoi
 }
 
 trait SortedMapInstancesBinCompat0 {
-  implicit def catsStdTraverseFilterForSortedMap[K: Order]: TraverseFilter[SortedMap[K, ?]] =
-    new TraverseFilter[SortedMap[K, ?]] {
+  implicit def catsStdTraverseFilterForSortedMap[K: Order]: TraverseFilter[SortedMap[K, *]] =
+    new TraverseFilter[SortedMap[K, *]] {
 
       implicit val ordering: Ordering[K] = Order[K].toOrdering
 
-      val traverse: Traverse[SortedMap[K, ?]] = cats.instances.sortedMap.catsStdInstancesForSortedMap[K]
+      val traverse: Traverse[SortedMap[K, *]] = cats.instances.sortedMap.catsStdInstancesForSortedMap[K]
 
       override def traverseFilter[G[_], A, B](
         fa: SortedMap[K, A]
@@ -225,7 +225,7 @@ trait SortedMapInstancesBinCompat0 {
 }
 
 trait SortedMapInstancesBinCompat1 {
-  implicit def catsStdMonoidKForSortedMap[K: Order]: MonoidK[SortedMap[K, ?]] = new MonoidK[SortedMap[K, ?]] {
+  implicit def catsStdMonoidKForSortedMap[K: Order]: MonoidK[SortedMap[K, *]] = new MonoidK[SortedMap[K, *]] {
     override def empty[A]: SortedMap[K, A] = SortedMap.empty[K, A](Order[K].toOrdering)
 
     override def combineK[A](x: SortedMap[K, A], y: SortedMap[K, A]): SortedMap[K, A] = x ++ y

--- a/core/src/main/scala/cats/instances/tuple.scala
+++ b/core/src/main/scala/cats/instances/tuple.scala
@@ -50,8 +50,8 @@ sealed trait Tuple2Instances extends Tuple2Instances1 {
       s"(${aShow.show(f._1)},${bShow.show(f._2)})"
   }
 
-  implicit def catsStdInstancesForTuple2[X]: Traverse[(X, ?)] with Comonad[(X, ?)] with Reducible[(X, ?)] =
-    new Traverse[(X, ?)] with Comonad[(X, ?)] with Reducible[(X, ?)] {
+  implicit def catsStdInstancesForTuple2[X]: Traverse[(X, *)] with Comonad[(X, *)] with Reducible[(X, *)] =
+    new Traverse[(X, *)] with Comonad[(X, *)] with Reducible[(X, *)] {
       def traverse[G[_], A, B](fa: (X, A))(f: A => G[B])(implicit G: Applicative[G]): G[(X, B)] =
         G.map(f(fa._2))((fa._1, _))
 
@@ -104,30 +104,30 @@ sealed trait Tuple2Instances extends Tuple2Instances1 {
 }
 
 sealed trait Tuple2Instances1 extends Tuple2Instances2 {
-  implicit def catsStdCommutativeMonadForTuple2[X](implicit MX: CommutativeMonoid[X]): CommutativeMonad[(X, ?)] =
-    new FlatMapTuple2[X](MX) with CommutativeMonad[(X, ?)] {
+  implicit def catsStdCommutativeMonadForTuple2[X](implicit MX: CommutativeMonoid[X]): CommutativeMonad[(X, *)] =
+    new FlatMapTuple2[X](MX) with CommutativeMonad[(X, *)] {
       def pure[A](a: A): (X, A) = (MX.empty, a)
     }
 }
 
 sealed trait Tuple2Instances2 extends Tuple2Instances3 {
-  implicit def catsStdCommutativeFlatMapForTuple2[X](implicit MX: CommutativeSemigroup[X]): CommutativeFlatMap[(X, ?)] =
-    new FlatMapTuple2[X](MX) with CommutativeFlatMap[(X, ?)]
+  implicit def catsStdCommutativeFlatMapForTuple2[X](implicit MX: CommutativeSemigroup[X]): CommutativeFlatMap[(X, *)] =
+    new FlatMapTuple2[X](MX) with CommutativeFlatMap[(X, *)]
 }
 
 sealed trait Tuple2Instances3 extends Tuple2Instances4 {
-  implicit def catsStdMonadForTuple2[X](implicit MX: Monoid[X]): Monad[(X, ?)] =
-    new FlatMapTuple2[X](MX) with Monad[(X, ?)] {
+  implicit def catsStdMonadForTuple2[X](implicit MX: Monoid[X]): Monad[(X, *)] =
+    new FlatMapTuple2[X](MX) with Monad[(X, *)] {
       def pure[A](a: A): (X, A) = (MX.empty, a)
     }
 }
 
 sealed trait Tuple2Instances4 {
-  implicit def catsStdFlatMapForTuple2[X](implicit SX: Semigroup[X]): FlatMap[(X, ?)] =
+  implicit def catsStdFlatMapForTuple2[X](implicit SX: Semigroup[X]): FlatMap[(X, *)] =
     new FlatMapTuple2[X](SX)
 }
 
-private[instances] class FlatMapTuple2[X](s: Semigroup[X]) extends FlatMap[(X, ?)] {
+private[instances] class FlatMapTuple2[X](s: Semigroup[X]) extends FlatMap[(X, *)] {
   override def ap[A, B](ff: (X, A => B))(fa: (X, A)): (X, B) = {
     val x = s.combine(ff._1, fa._1)
     val b = ff._2(fa._2)

--- a/core/src/main/scala/cats/syntax/TrySyntax.scala
+++ b/core/src/main/scala/cats/syntax/TrySyntax.scala
@@ -17,11 +17,11 @@ final class TryOps[A](private val self: Try[A]) extends AnyVal {
    * scala> import util.Try
    *
    * scala> val s: Try[Int] = Try(3)
-   * scala> s.liftTo[Either[Throwable, ?]]
+   * scala> s.liftTo[Either[Throwable, *]]
    * res0: Either[Throwable, Int] = Right(3)
    *
    * scala> val f: Try[Int] = Try(throw new Throwable("boo"))
-   * scala> f.liftTo[Either[Throwable, ?]]
+   * scala> f.liftTo[Either[Throwable, *]]
    * res0: Either[Throwable, Int] = Left(java.lang.Throwable: boo)
    * }}}
    */

--- a/core/src/main/scala/cats/syntax/applicativeError.scala
+++ b/core/src/main/scala/cats/syntax/applicativeError.scala
@@ -33,7 +33,7 @@ final class ApplicativeErrorExtensionOps[F[_], E](F: ApplicativeError[F, E]) {
    * {{{
    * scala> import cats.implicits._
    * scala> import cats.ApplicativeError
-   * scala> val F = ApplicativeError[Either[String, ?], String]
+   * scala> val F = ApplicativeError[Either[String, *], String]
    *
    * scala> F.fromOption(Some(1), "Empty")
    * res0: scala.Either[String, Int] = Right(1)

--- a/core/src/main/scala/cats/syntax/either.scala
+++ b/core/src/main/scala/cats/syntax/either.scala
@@ -286,7 +286,7 @@ final class EitherOps[A, B](private val eab: Either[A, B]) extends AnyVal {
    * scala> import cats.implicits._
    * scala> import cats.data.EitherT
    * scala> val e: Either[String, Int] = Right(3)
-   * scala> e.liftTo[EitherT[Option, CharSequence, ?]]
+   * scala> e.liftTo[EitherT[Option, CharSequence, *]]
    * res0: cats.data.EitherT[Option, CharSequence, Int] = EitherT(Some(Right(3)))
    * }}}
    */

--- a/core/src/main/scala/cats/syntax/option.scala
+++ b/core/src/main/scala/cats/syntax/option.scala
@@ -227,10 +227,10 @@ final class OptionOps[A](private val oa: Option[A]) extends AnyVal {
    * Example:
    * {{{
    * scala> import cats.implicits._
-   * scala> Some(1).liftTo[Either[CharSequence, ?]]("Empty")
+   * scala> Some(1).liftTo[Either[CharSequence, *]]("Empty")
    * res0: scala.Either[CharSequence, Int] = Right(1)
    *
-   * scala> Option.empty[Int].liftTo[Either[CharSequence, ?]]("Empty")
+   * scala> Option.empty[Int].liftTo[Either[CharSequence, *]]("Empty")
    * res1: scala.Either[CharSequence, Int] = Left(Empty)
    * }}}
    */

--- a/docs/src/main/tut/datatypes/const.md
+++ b/docs/src/main/tut/datatypes/const.md
@@ -139,8 +139,8 @@ define a `Functor` instance for `Const`, where the first type parameter is fixed
 ```tut:silent
 import cats.data.Const
 
-implicit def constFunctor[X]: Functor[Const[X, ?]] =
-  new Functor[Const[X, ?]] {
+implicit def constFunctor[X]: Functor[Const[X, *]] =
+  new Functor[Const[X, *]] {
     // Recall Const[X, A] ~= X, so the function is not of any use to us
     def map[A, B](fa: Const[X, A])(f: A => B): Const[X, B] =
       Const(fa.getConst)
@@ -158,7 +158,7 @@ trait Lens[S, A] {
   def modify(s: S)(f: A => A): S = modifyF[Id](s)(f)
 
   def get(s: S): A = {
-    val storedValue = modifyF[Const[A, ?]](s)(a => Const(a))
+    val storedValue = modifyF[Const[A, *]](s)(a => Const(a))
     storedValue.getConst
   }
 }
@@ -216,8 +216,8 @@ one.
 ```tut:silent
 import cats.data.Const
 
-implicit def constApplicative[Z]: Applicative[Const[Z, ?]] =
-  new Applicative[Const[Z, ?]] {
+implicit def constApplicative[Z]: Applicative[Const[Z, *]] =
+  new Applicative[Const[Z, *]] {
     def pure[A](a: A): Const[Z, A] = ???
 
     def ap[A, B](f: Const[Z, A => B])(fa: Const[Z, A]): Const[Z, B] = ???
@@ -238,8 +238,8 @@ So now we need a constant `Z` value, and a binary function that takes two `Z`s a
 We want `Z` to have a `Monoid` instance!
 
 ```tut:silent
-implicit def constApplicative[Z : Monoid]: Applicative[Const[Z, ?]] =
-  new Applicative[Const[Z, ?]] {
+implicit def constApplicative[Z : Monoid]: Applicative[Const[Z, *]] =
+  new Applicative[Const[Z, *]] {
     def pure[A](a: A): Const[Z, A] = Const(Monoid[Z].empty)
 
     def ap[A, B](f: Const[Z, A => B])(fa: Const[Z, A]): Const[Z, B] =

--- a/docs/src/main/tut/datatypes/freemonad.md
+++ b/docs/src/main/tut/datatypes/freemonad.md
@@ -218,7 +218,7 @@ behavior, such as:
  - `Future[_]` for asynchronous computation
  - `List[_]` for gathering multiple results
  - `Option[_]` to support optional results
- - `Either[E, ?]` to support failure
+ - `Either[E, *]` to support failure
  - a pseudo-random monad to support non-determinism
  - and so on...
 

--- a/docs/src/main/tut/datatypes/iort.md
+++ b/docs/src/main/tut/datatypes/iort.md
@@ -65,7 +65,7 @@ addressProgram("SW1W", "")
 ```
 
 Suppose `parseNumber`, `parseStreet`, and `numberToString` are rewritten to be
-asynchronous and return `Future[Ior[Logs, ?]]` instead. The for-comprehension
+asynchronous and return `Future[Ior[Logs, *]]` instead. The for-comprehension
 can no longer be used since `addressProgram` must now compose `Future` and
 `Ior` together, which means that the error handling must be performed
 explicitly to ensure that the proper types are returned:

--- a/docs/src/main/tut/datatypes/nested.md
+++ b/docs/src/main/tut/datatypes/nested.md
@@ -30,7 +30,7 @@ x.map(_.map(_.toString))
 ```tut:silent
 import cats.data.Nested
 import cats.implicits._
-val nested: Nested[Option, Validated[String, ?], Int] = Nested(Some(Valid(123)))
+val nested: Nested[Option, Validated[String, *], Int] = Nested(Some(Valid(123)))
 ```
 
 ```tut:book
@@ -49,13 +49,13 @@ final case class Nested[F[_], G[_], A](value: F[G[A]])
 Instead, it provides a set of inference rules based on the properties of `F[_]`
 and `G[_]`. For example:
 
-* If `F[_]` and `G[_]` are both `Functor`s, then `Nested[F, G, ?]` is also a
+* If `F[_]` and `G[_]` are both `Functor`s, then `Nested[F, G, *]` is also a
     `Functor` (we saw this in action in the example above)
-* If `F[_]` and `G[_]` are both `Applicative`s, then `Nested[F, G, ?]` is also an
+* If `F[_]` and `G[_]` are both `Applicative`s, then `Nested[F, G, *]` is also an
     `Applicative`
 * If `F[_]` is an `ApplicativeError` and `G[_]` is an `Applicative`, then
-    `Nested[F, G, ?]` is an `ApplicativeError`
-* If `F[_]` and `G[_]` are both `Traverse`s, then `Nested[F, G, ?]` is also a
+    `Nested[F, G, *]` is an `ApplicativeError`
+* If `F[_]` and `G[_]` are both `Traverse`s, then `Nested[F, G, *]` is also a
     `Traverse`
 
 You can see the full list of these rules in the `Nested` companion object.

--- a/docs/src/main/tut/datatypes/validated.md
+++ b/docs/src/main/tut/datatypes/validated.md
@@ -504,8 +504,8 @@ Can we perhaps define an `Apply` instance for `Validated`? Better yet, can we de
 ```tut:silent
 import cats.Applicative
 
-implicit def validatedApplicative[E : Semigroup]: Applicative[Validated[E, ?]] =
-  new Applicative[Validated[E, ?]] {
+implicit def validatedApplicative[E : Semigroup]: Applicative[Validated[E, *]] =
+  new Applicative[Validated[E, *]] {
     def ap[A, B](f: Validated[E, A => B])(fa: Validated[E, A]): Validated[E, B] =
       (fa, f) match {
         case (Valid(a), Valid(fab)) => Valid(fab(a))
@@ -540,7 +540,7 @@ Thus.
 
 ```tut:book
 val personFromConfig: ValidatedNec[ConfigError, Person] =
-  Apply[ValidatedNec[ConfigError, ?]].map4(config.parse[String]("name").toValidatedNec,
+  Apply[ValidatedNec[ConfigError, *]].map4(config.parse[String]("name").toValidatedNec,
                                            config.parse[Int]("age").toValidatedNec,
                                            config.parse[Int]("house_number").toValidatedNec,
                                            config.parse[String]("street").toValidatedNec) {
@@ -555,8 +555,8 @@ let's implement the `Monad` type class.
 ```tut:silent
 import cats.Monad
 
-implicit def validatedMonad[E]: Monad[Validated[E, ?]] =
-  new Monad[Validated[E, ?]] {
+implicit def validatedMonad[E]: Monad[Validated[E, *]] =
+  new Monad[Validated[E, *]] {
     def flatMap[A, B](fa: Validated[E, A])(f: A => Validated[E, B]): Validated[E, B] =
       fa match {
         case Valid(a)     => f(a)

--- a/docs/src/main/tut/guidelines.md
+++ b/docs/src/main/tut/guidelines.md
@@ -103,11 +103,11 @@ trait Monad[F[_]] extends Functor
 object Kleisli extends KleisliInstance0
 
 abstract class KleisliInstance0 extends KleisliInstance1 {
-  implicit def catsDataMonadForKleisli[F[_], A]: Monad[Kleisli[F, A, ?]] = ...
+  implicit def catsDataMonadForKleisli[F[_], A]: Monad[Kleisli[F, A, *]] = ...
 }
 
 abstract class KleisliInstance1 {
-  implicit def catsDataFunctorForKleisli[F[_], A]: Functor[Kleisli[F, A, ?]] = ...
+  implicit def catsDataFunctorForKleisli[F[_], A]: Functor[Kleisli[F, A, *]] = ...
 }
 ```
 
@@ -118,9 +118,9 @@ We can introduce new type classes for the sake of adding laws that don't apply t
 
 ### <a id="applicative-monad-transformers" href="#applicative-monad-transformers">Applicative instances for monad transformers</a>
 
-We explicitly don't provide an instance of `Applicative` for e.g. `EitherT[F, String, ?]` given an `Applicative[F]`.
+We explicitly don't provide an instance of `Applicative` for e.g. `EitherT[F, String, *]` given an `Applicative[F]`.
 An attempt to construct one without a proper `Monad[F]` instance would be inconsistent in `ap` with the provided `Monad` instance
-for `EitherT[F, String, ?]`. Such an instance will be derived if you use `Nested` instead:
+for `EitherT[F, String, *]`. Such an instance will be derived if you use `Nested` instead:
 
 ```scala
 import cats._, cats.data._, cats.implicits._

--- a/docs/src/main/tut/typeclasses/applicative.md
+++ b/docs/src/main/tut/typeclasses/applicative.md
@@ -34,7 +34,7 @@ trait Applicative[F[_]] extends Functor[F] {
 }
 
 // Example implementation for right-biased Either
-implicit def applicativeForEither[L]: Applicative[Either[L, ?]] = new Applicative[Either[L, ?]] {
+implicit def applicativeForEither[L]: Applicative[Either[L, *]] = new Applicative[Either[L, *]] {
   def product[A, B](fa: Either[L, A], fb: Either[L, B]): Either[L, (A, B)] = (fa, fb) match {
     case (Right(a), Right(b)) => Right((a, b))
     case (Left(l) , _       ) => Left(l)
@@ -120,7 +120,7 @@ val y: Future[Option[Char]] = Future.successful(Some('a'))
 ```tut:book
 val composed = Applicative[Future].compose[Option].map2(x, y)(_ + _)
 
-val nested = Applicative[Nested[Future, Option, ?]].map2(Nested(x), Nested(y))(_ + _)
+val nested = Applicative[Nested[Future, Option, *]].map2(Nested(x), Nested(y))(_ + _)
 ```
 
 ## Traverse
@@ -186,7 +186,7 @@ import cats.implicits._
 def traverseEither[E, A, B](as: List[A])(f: A => Either[E, B]): Either[E, List[B]] =
   as.foldRight(Right(List.empty[B]): Either[E, List[B]]) { (a: A, acc: Either[E, List[B]]) =>
     val eitherB: Either[E, B] = f(a)
-    Applicative[Either[E, ?]].map2(eitherB, acc)(_ :: _)
+    Applicative[Either[E, *]].map2(eitherB, acc)(_ :: _)
   }
 ```
 
@@ -197,7 +197,7 @@ traverseEither(List(1, 2, 3))(i => if (i % 2 != 0) Left(s"${i} is not even") els
 The implementation of `traverseOption` and `traverseEither` are more or less identical, modulo the initial
 "accumulator" to `foldRight`. But even that could be made the same by delegating to `Applicative#pure`!
 Generalizing `Option` and `Either` to any `F[_]: Applicative` gives us the fully polymorphic version.
-Existing data types with `Applicative` instances (`Future`, `Option`, `Either[E, ?]`, `Try`) can call it by fixing `F`
+Existing data types with `Applicative` instances (`Future`, `Option`, `Either[E, *]`, `Try`) can call it by fixing `F`
 appropriately, and new data types need only be concerned with implementing `Applicative` to do so as well.
 
 ```tut:book:silent
@@ -241,11 +241,11 @@ The laws for `Apply` are just the laws of `Applicative` that don't mention `pure
 above, the only law would be associativity.
 
 One of the motivations for `Apply`'s existence is that some types have `Apply` instances but not
-`Applicative` - one example is `Map[K, ?]`. Consider the behavior of `pure` for `Map[K, A]`. Given
+`Applicative` - one example is `Map[K, *]`. Consider the behavior of `pure` for `Map[K, A]`. Given
 a value of type `A`, we need to associate some arbitrary `K` to it but we have no way of doing that.
 
 However, given existing `Map[K, A]` and `Map[K, B]` (or `Map[K, A => B]`), it is straightforward to
-pair up (or apply functions to) values with the same key. Hence `Map[K, ?]` has an `Apply` instance.
+pair up (or apply functions to) values with the same key. Hence `Map[K, *]` has an `Apply` instance.
 
 ## Syntax
 

--- a/docs/src/main/tut/typeclasses/arrow.md
+++ b/docs/src/main/tut/typeclasses/arrow.md
@@ -76,7 +76,7 @@ val lastK = Kleisli((_: List[Int]).lastOption)
 With `headK` and `lastK`, we can obtain the `Kleisli` arrow we want by combining them, and composing it with `_ + _`:
 
 ```tut:book:silent
-val headPlusLast = combine(headK, lastK) >>> Arrow[Kleisli[Option, ?, ?]].lift(((_: Int) + (_: Int)).tupled)
+val headPlusLast = combine(headK, lastK) >>> Arrow[Kleisli[Option, *, *]].lift(((_: Int) + (_: Int)).tupled)
 ```
 
 ```tut:book

--- a/docs/src/main/tut/typeclasses/foldable.md
+++ b/docs/src/main/tut/typeclasses/foldable.md
@@ -79,8 +79,8 @@ Foldable[List].dropWhile_(List[Int](1,2,4,5,6,7))(_ % 2 == 0)
 import cats.data.Nested
 val listOption0 = Nested(List(Option(1), Option(2), Option(3)))
 val listOption1 = Nested(List(Option(1), Option(2), None))
-Foldable[Nested[List, Option, ?]].fold(listOption0)
-Foldable[Nested[List, Option, ?]].fold(listOption1)
+Foldable[Nested[List, Option, *]].fold(listOption0)
+Foldable[Nested[List, Option, *]].fold(listOption1)
 ```
 
 Hence when defining some new data structure, if we can define a `foldLeft` and

--- a/docs/src/main/tut/typeclasses/monad.md
+++ b/docs/src/main/tut/typeclasses/monad.md
@@ -135,7 +135,7 @@ example).
 case class OptionT[F[_], A](value: F[Option[A]])
 
 implicit def optionTMonad[F[_]](implicit F : Monad[F]) = {
-  new Monad[OptionT[F, ?]] {
+  new Monad[OptionT[F, *]] {
     def pure[A](a: A): OptionT[F, A] = OptionT(F.pure(Some(a)))
     def flatMap[A, B](fa: OptionT[F, A])(f: A => OptionT[F, B]): OptionT[F, B] =
       OptionT {
@@ -176,9 +176,9 @@ trait Monad[F[_]] extends FlatMap[F] with Applicative[F]
 The laws for `FlatMap` are just the laws of `Monad` that don't mention `pure`.
 
 One of the motivations for `FlatMap`'s existence is that some types have `FlatMap` instances but not
-`Monad` - one example is `Map[K, ?]`. Consider the behavior of `pure` for `Map[K, A]`. Given
+`Monad` - one example is `Map[K, *]`. Consider the behavior of `pure` for `Map[K, A]`. Given
 a value of type `A`, we need to associate some arbitrary `K` to it but we have no way of doing that.
 
 However, given existing `Map[K, A]` and `Map[K, B]` (or `Map[K, A => B]`), it is straightforward to
-pair up (or apply functions to) values with the same key. Hence `Map[K, ?]` has an `FlatMap` instance.
+pair up (or apply functions to) values with the same key. Hence `Map[K, *]` has an `FlatMap` instance.
 

--- a/docs/src/main/tut/typeclasses/nonemptytraverse.md
+++ b/docs/src/main/tut/typeclasses/nonemptytraverse.md
@@ -19,7 +19,7 @@ def nonEmptySequence[G[_]: Apply, A](fga: F[G[A]]): G[F[A]]
 ```
 
 In the [Applicative tutorial](applicative.html) we learned of `Apply` as a weakened `Applicative` lacking the `pure` method.
-One example type lacking an `Applicative` instance is `Map[K, ?]`, it's impossible to implement a `pure` method for it.
+One example type lacking an `Applicative` instance is `Map[K, *]`, it's impossible to implement a `pure` method for it.
 
 Knowing this, we can make use of `NonEmptyTraverse`, to traverse over a sequence of `Map`s.
 One example application one could think of is, when we have a list of text snippets,

--- a/docs/src/main/tut/typeclasses/semigroup.md
+++ b/docs/src/main/tut/typeclasses/semigroup.md
@@ -132,7 +132,7 @@ val y = mergeMap(ym1, ym2)
 ```
 
 It is interesting to note that the type of `mergeMap` satisfies the type of `Semigroup`
-specialized to `Map[K, ?]` and is associative - indeed the `Semigroup` instance for `Map`
+specialized to `Map[K, *]` and is associative - indeed the `Semigroup` instance for `Map`
 uses the same function for its `combine`.
 
 ```tut:book

--- a/docs/src/main/tut/typeclasses/traverse.md
+++ b/docs/src/main/tut/typeclasses/traverse.md
@@ -157,7 +157,7 @@ import cats.{Applicative, Monoid, Traverse}
 import cats.data.Const
 
 def foldMap[F[_]: Traverse, A, B: Monoid](fa: F[A])(f: A => B): B =
-  Traverse[F].traverse[Const[B, ?], A, B](fa)(a => Const(f(a))).getConst
+  Traverse[F].traverse[Const[B, *], A, B](fa)(a => Const(f(a))).getConst
 ```
 
 ## Further Reading

--- a/free/src/main/scala/cats/free/Cofree.scala
+++ b/free/src/main/scala/cats/free/Cofree.scala
@@ -100,26 +100,26 @@ object Cofree extends CofreeInstances {
 }
 
 sealed abstract private[free] class CofreeInstances2 {
-  implicit def catsReducibleForCofree[F[_]: Foldable]: Reducible[Cofree[F, ?]] =
+  implicit def catsReducibleForCofree[F[_]: Foldable]: Reducible[Cofree[F, *]] =
     new CofreeReducible[F] {
       def F = implicitly
     }
 }
 
 sealed abstract private[free] class CofreeInstances1 extends CofreeInstances2 {
-  implicit def catsTraverseForCofree[F[_]: Traverse]: Traverse[Cofree[F, ?]] =
+  implicit def catsTraverseForCofree[F[_]: Traverse]: Traverse[Cofree[F, *]] =
     new CofreeTraverse[F] {
       def F = implicitly
     }
 }
 
 sealed abstract private[free] class CofreeInstances extends CofreeInstances1 {
-  implicit def catsFreeComonadForCofree[S[_]: Functor]: Comonad[Cofree[S, ?]] = new CofreeComonad[S] {
+  implicit def catsFreeComonadForCofree[S[_]: Functor]: Comonad[Cofree[S, *]] = new CofreeComonad[S] {
     def F = implicitly
   }
 }
 
-private trait CofreeComonad[S[_]] extends Comonad[Cofree[S, ?]] {
+private trait CofreeComonad[S[_]] extends Comonad[Cofree[S, *]] {
   implicit def F: Functor[S]
 
   final override def extract[A](p: Cofree[S, A]): A = p.extract
@@ -131,7 +131,7 @@ private trait CofreeComonad[S[_]] extends Comonad[Cofree[S, ?]] {
   final override def map[A, B](a: Cofree[S, A])(f: A => B): Cofree[S, B] = a.map(f)
 }
 
-private trait CofreeReducible[F[_]] extends Reducible[Cofree[F, ?]] {
+private trait CofreeReducible[F[_]] extends Reducible[Cofree[F, *]] {
   implicit def F: Foldable[F]
 
   final override def foldMap[A, B](fa: Cofree[F, A])(f: A => B)(implicit M: Monoid[B]): B =
@@ -157,7 +157,7 @@ private trait CofreeReducible[F[_]] extends Reducible[Cofree[F, ?]] {
 
 }
 
-private trait CofreeTraverse[F[_]] extends Traverse[Cofree[F, ?]] with CofreeReducible[F] with CofreeComonad[F] {
+private trait CofreeTraverse[F[_]] extends Traverse[Cofree[F, *]] with CofreeReducible[F] with CofreeComonad[F] {
   implicit def F: Traverse[F]
 
   final override def traverse[G[_], A, B](fa: Cofree[F, A])(f: A => G[B])(implicit G: Applicative[G]): G[Cofree[F, B]] =

--- a/free/src/main/scala/cats/free/ContravariantCoyoneda.scala
+++ b/free/src/main/scala/cats/free/ContravariantCoyoneda.scala
@@ -65,9 +65,9 @@ object ContravariantCoyoneda {
       val fi = fa
     }
 
-  /** `ContravariantCoyoneda[F, ?]` provides a contravariant functor for any `F`. */
-  implicit def catsFreeContravariantFunctorForContravariantCoyoneda[F[_]]: Contravariant[ContravariantCoyoneda[F, ?]] =
-    new Contravariant[ContravariantCoyoneda[F, ?]] {
+  /** `ContravariantCoyoneda[F, *]` provides a contravariant functor for any `F`. */
+  implicit def catsFreeContravariantFunctorForContravariantCoyoneda[F[_]]: Contravariant[ContravariantCoyoneda[F, *]] =
+    new Contravariant[ContravariantCoyoneda[F, *]] {
       def contramap[A, B](cfa: ContravariantCoyoneda[F, A])(f: B => A): ContravariantCoyoneda[F, B] =
         cfa.contramap(f)
     }

--- a/free/src/main/scala/cats/free/Coyoneda.scala
+++ b/free/src/main/scala/cats/free/Coyoneda.scala
@@ -83,10 +83,10 @@ object Coyoneda {
     }
 
   /**
-   * As the free functor, `Coyoneda[F, ?]` provides a functor for any `F`.
+   * As the free functor, `Coyoneda[F, *]` provides a functor for any `F`.
    */
-  implicit def catsFreeFunctorForCoyoneda[F[_]]: Functor[Coyoneda[F, ?]] =
-    new Functor[Coyoneda[F, ?]] {
+  implicit def catsFreeFunctorForCoyoneda[F[_]]: Functor[Coyoneda[F, *]] =
+    new Functor[Coyoneda[F, *]] {
       def map[A, B](cfa: Coyoneda[F, A])(f: A => B): Coyoneda[F, B] = cfa.map(f)
     }
 

--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -28,8 +28,8 @@ sealed abstract class Free[S[_], A] extends Product with Serializable {
    * effects will be applied by `mapK`.
    */
   final def mapK[T[_]](f: S ~> T): Free[T, A] =
-    foldMap[Free[T, ?]] { // this is safe because Free is stack safe
-      λ[FunctionK[S, Free[T, ?]]](fa => Suspend(f(fa)))
+    foldMap[Free[T, *]] { // this is safe because Free is stack safe
+      λ[FunctionK[S, Free[T, *]]](fa => Suspend(f(fa)))
     }
 
   /**
@@ -184,7 +184,7 @@ sealed abstract class Free[S[_], A] extends Product with Serializable {
     mapK(λ[S ~> G](ev.inj(_)))
 
   final def toFreeT[G[_]: Applicative]: FreeT[S, G, A] =
-    foldMap[FreeT[S, G, ?]](λ[S ~> FreeT[S, G, ?]](FreeT.liftF(_)))
+    foldMap[FreeT[S, G, *]](λ[S ~> FreeT[S, G, *]](FreeT.liftF(_)))
 
   override def toString: String =
     "Free(...)"
@@ -235,20 +235,20 @@ object Free extends FreeInstances {
   /**
    * a FunctionK, suitable for composition, which calls mapK
    */
-  def mapK[F[_], G[_]](fk: FunctionK[F, G]): FunctionK[Free[F, ?], Free[G, ?]] =
-    λ[FunctionK[Free[F, ?], Free[G, ?]]](f => f.mapK(fk))
+  def mapK[F[_], G[_]](fk: FunctionK[F, G]): FunctionK[Free[F, *], Free[G, *]] =
+    λ[FunctionK[Free[F, *], Free[G, *]]](f => f.mapK(fk))
 
   /**
    * a FunctionK, suitable for composition, which calls compile
    */
-  def compile[F[_], G[_]](fk: FunctionK[F, G]): FunctionK[Free[F, ?], Free[G, ?]] =
+  def compile[F[_], G[_]](fk: FunctionK[F, G]): FunctionK[Free[F, *], Free[G, *]] =
     mapK(fk)
 
   /**
    * a FunctionK, suitable for composition, which calls foldMap
    */
-  def foldMap[F[_], M[_]: Monad](fk: FunctionK[F, M]): FunctionK[Free[F, ?], M] =
-    λ[FunctionK[Free[F, ?], M]](f => f.foldMap(fk))
+  def foldMap[F[_], M[_]: Monad](fk: FunctionK[F, M]): FunctionK[Free[F, *], M] =
+    λ[FunctionK[Free[F, *], M]](f => f.foldMap(fk))
 
   /**
    * This method is used to defer the application of an InjectK[F, G]
@@ -295,12 +295,12 @@ object Free extends FreeInstances {
   def match_[F[_], G[_], A](fa: Free[F, A])(implicit F: Functor[F], I: InjectK[G, F]): Option[G[Free[F, A]]] =
     fa.resume.fold(I.prj(_), _ => None)
 
-  implicit def catsFreeMonadForId: Monad[Free[Id, ?]] = catsFreeMonadForFree[Id]
+  implicit def catsFreeMonadForId: Monad[Free[Id, *]] = catsFreeMonadForFree[Id]
 
-  implicit def catsFreeDeferForId: Defer[Free[Id, ?]] = catsFreeDeferForFree[Id]
+  implicit def catsFreeDeferForId: Defer[Free[Id, *]] = catsFreeDeferForFree[Id]
 }
 
-private trait FreeFoldable[F[_]] extends Foldable[Free[F, ?]] {
+private trait FreeFoldable[F[_]] extends Foldable[Free[F, *]] {
 
   implicit def F: Foldable[F]
 
@@ -319,7 +319,7 @@ private trait FreeFoldable[F[_]] extends Foldable[Free[F, ?]] {
     )
 }
 
-private trait FreeTraverse[F[_]] extends Traverse[Free[F, ?]] with FreeFoldable[F] {
+private trait FreeTraverse[F[_]] extends Traverse[Free[F, *]] with FreeFoldable[F] {
   implicit def TraversableF: Traverse[F]
 
   def F: Foldable[F] = TraversableF
@@ -337,17 +337,17 @@ private trait FreeTraverse[F[_]] extends Traverse[Free[F, ?]] with FreeFoldable[
 sealed abstract private[free] class FreeInstances extends FreeInstances1 {
 
   /**
-   * `Free[S, ?]` has a monad for any type constructor `S[_]`.
+   * `Free[S, *]` has a monad for any type constructor `S[_]`.
    */
-  implicit def catsFreeMonadForFree[S[_]]: Monad[Free[S, ?]] =
-    new Monad[Free[S, ?]] with StackSafeMonad[Free[S, ?]] {
+  implicit def catsFreeMonadForFree[S[_]]: Monad[Free[S, *]] =
+    new Monad[Free[S, *]] with StackSafeMonad[Free[S, *]] {
       def pure[A](a: A): Free[S, A] = Free.pure(a)
       override def map[A, B](fa: Free[S, A])(f: A => B): Free[S, B] = fa.map(f)
       def flatMap[A, B](a: Free[S, A])(f: A => Free[S, B]): Free[S, B] = a.flatMap(f)
     }
 
-  implicit def catsFreeDeferForFree[S[_]]: Defer[Free[S, ?]] =
-    new Defer[Free[S, ?]] {
+  implicit def catsFreeDeferForFree[S[_]]: Defer[Free[S, *]] =
+    new Defer[Free[S, *]] {
       def defer[A](fa: => Free[S, A]): Free[S, A] =
         Free.defer(fa)
     }
@@ -358,7 +358,7 @@ sealed abstract private[free] class FreeInstances1 {
   implicit def catsFreeFoldableForFree[F[_]](
     implicit
     foldableF: Foldable[F]
-  ): Foldable[Free[F, ?]] =
+  ): Foldable[Free[F, *]] =
     new FreeFoldable[F] {
       val F = foldableF
     }
@@ -366,7 +366,7 @@ sealed abstract private[free] class FreeInstances1 {
   implicit def catsFreeTraverseForFree[F[_]](
     implicit
     traversableF: Traverse[F]
-  ): Traverse[Free[F, ?]] =
+  ): Traverse[Free[F, *]] =
     new FreeTraverse[F] {
       val TraversableF = traversableF
     }

--- a/free/src/main/scala/cats/free/FreeApplicative.scala
+++ b/free/src/main/scala/cats/free/FreeApplicative.scala
@@ -139,27 +139,27 @@ sealed abstract class FreeApplicative[F[_], A] extends Product with Serializable
    * Stack-safe.
    */
   final def compile[G[_]](f: F ~> G): FA[G, A] =
-    foldMap[FA[G, ?]] {
-      λ[FunctionK[F, FA[G, ?]]](fa => lift(f(fa)))
+    foldMap[FA[G, *]] {
+      λ[FunctionK[F, FA[G, *]]](fa => lift(f(fa)))
     }
 
   /**
    * Interpret this algebra into a FreeApplicative over another algebra.
    * Stack-safe.
    */
-  def flatCompile[G[_]](f: F ~> FA[G, ?]): FA[G, A] =
+  def flatCompile[G[_]](f: F ~> FA[G, *]): FA[G, A] =
     foldMap(f)
 
   /** Interpret this algebra into a Monoid. */
   final def analyze[M: Monoid](f: FunctionK[F, λ[α => M]]): M =
-    foldMap[Const[M, ?]](
-      λ[FunctionK[F, Const[M, ?]]](x => Const(f(x)))
+    foldMap[Const[M, *]](
+      λ[FunctionK[F, Const[M, *]]](x => Const(f(x)))
     ).getConst
 
   /** Compile this FreeApplicative algebra into a Free algebra. */
   final def monad: Free[F, A] =
-    foldMap[Free[F, ?]] {
-      λ[FunctionK[F, Free[F, ?]]](fa => Free.liftF(fa))
+    foldMap[Free[F, *]] {
+      λ[FunctionK[F, Free[F, *]]](fa => Free.liftF(fa))
     }
 
   override def toString: String = "FreeApplicative(...)"
@@ -197,8 +197,8 @@ object FreeApplicative {
   final def lift[F[_], A](fa: F[A]): FA[F, A] =
     Lift(fa)
 
-  implicit final def freeApplicative[S[_]]: Applicative[FA[S, ?]] =
-    new Applicative[FA[S, ?]] {
+  implicit final def freeApplicative[S[_]]: Applicative[FA[S, *]] =
+    new Applicative[FA[S, *]] {
       override def product[A, B](fa: FA[S, A], fb: FA[S, B]): FA[S, (A, B)] =
         map2(fa, fb)((_, _))
 

--- a/free/src/main/scala/cats/free/FreeInvariantMonoidal.scala
+++ b/free/src/main/scala/cats/free/FreeInvariantMonoidal.scala
@@ -27,14 +27,14 @@ sealed abstract class FreeInvariantMonoidal[F[_], A] extends Product with Serial
 
   /** Interpret this algebra into another InvariantMonoidal */
   final def compile[G[_]](f: FunctionK[F, G]): FA[G, A] =
-    foldMap[FA[G, ?]] {
-      λ[FunctionK[F, FA[G, ?]]](fa => lift(f(fa)))
+    foldMap[FA[G, *]] {
+      λ[FunctionK[F, FA[G, *]]](fa => lift(f(fa)))
     }
 
   /** Interpret this algebra into a Monoid */
   final def analyze[M: Monoid](f: FunctionK[F, λ[α => M]]): M =
-    foldMap[Const[M, ?]](
-      λ[FunctionK[F, Const[M, ?]]](x => Const(f(x)))
+    foldMap[Const[M, *]](
+      λ[FunctionK[F, Const[M, *]]](x => Const(f(x)))
     ).getConst
 }
 
@@ -67,9 +67,9 @@ object FreeInvariantMonoidal {
   def lift[F[_], A](fa: F[A]): FA[F, A] =
     Suspend(fa)
 
-  /** `FreeInvariantMonoidal[S, ?]` has a FreeInvariantMonoidal for any type constructor `S[_]`. */
-  implicit def catsFreeInvariantMonoidal[S[_]]: InvariantMonoidal[FA[S, ?]] =
-    new InvariantMonoidal[FA[S, ?]] {
+  /** `FreeInvariantMonoidal[S, *]` has a FreeInvariantMonoidal for any type constructor `S[_]`. */
+  implicit def catsFreeInvariantMonoidal[S[_]]: InvariantMonoidal[FA[S, *]] =
+    new InvariantMonoidal[FA[S, *]] {
       def unit: FA[S, Unit] = FreeInvariantMonoidal.pure(())
       def imap[A, B](fa: FA[S, A])(f: A => B)(g: B => A): FA[S, B] = fa.imap(f)(g)
       def product[A, B](fa: FA[S, A], fb: FA[S, B]): FA[S, (A, B)] = fa.product(fb)

--- a/free/src/main/scala/cats/free/Yoneda.scala
+++ b/free/src/main/scala/cats/free/Yoneda.scala
@@ -43,8 +43,8 @@ object Yoneda {
   /**
    * `Yoneda[F, _]` is a functor for any `F`.
    */
-  implicit def catsFreeFunctorForYoneda[F[_]]: Functor[Yoneda[F, ?]] =
-    new Functor[Yoneda[F, ?]] {
+  implicit def catsFreeFunctorForYoneda[F[_]]: Functor[Yoneda[F, *]] =
+    new Functor[Yoneda[F, *]] {
       def map[A, B](ya: Yoneda[F, A])(f: A => B): Yoneda[F, B] = ya.map(f)
     }
 

--- a/free/src/test/scala/cats/free/CofreeSuite.scala
+++ b/free/src/test/scala/cats/free/CofreeSuite.scala
@@ -11,20 +11,20 @@ class CofreeSuite extends CatsSuite {
 
   import CofreeSuite._
 
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Cofree[Option, ?]]
+  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Cofree[Option, *]]
 
-  checkAll("Cofree[Option, ?]", ComonadTests[Cofree[Option, ?]].comonad[Int, Int, Int])
+  checkAll("Cofree[Option, *]", ComonadTests[Cofree[Option, *]].comonad[Int, Int, Int])
   locally {
     implicit val instance = Cofree.catsTraverseForCofree[Option]
-    checkAll("Cofree[Option, ?]", TraverseTests[Cofree[Option, ?]].traverse[Int, Int, Int, Int, Option, Option])
-    checkAll("Traverse[Cofree[Option, ?]]", SerializableTests.serializable(Traverse[Cofree[Option, ?]]))
+    checkAll("Cofree[Option, *]", TraverseTests[Cofree[Option, *]].traverse[Int, Int, Int, Int, Option, Option])
+    checkAll("Traverse[Cofree[Option, *]]", SerializableTests.serializable(Traverse[Cofree[Option, *]]))
   }
   locally {
     implicit val instance = Cofree.catsReducibleForCofree[Option]
-    checkAll("Cofree[Option, ?]", ReducibleTests[Cofree[Option, ?]].reducible[Option, Int, Int])
-    checkAll("Reducible[Cofree[Option, ?]]", SerializableTests.serializable(Reducible[Cofree[Option, ?]]))
+    checkAll("Cofree[Option, *]", ReducibleTests[Cofree[Option, *]].reducible[Option, Int, Int])
+    checkAll("Reducible[Cofree[Option, *]]", SerializableTests.serializable(Reducible[Cofree[Option, *]]))
   }
-  checkAll("Comonad[Cofree[Option, ?]]", SerializableTests.serializable(Comonad[Cofree[Option, ?]]))
+  checkAll("Comonad[Cofree[Option, *]]", SerializableTests.serializable(Comonad[Cofree[Option, *]]))
 
   test("Cofree.unfold") {
     val unfoldedHundred: CofreeNel[Int] = Cofree.unfold[Option, Int](0)(i => if (i == 100) None else Some(i + 1))

--- a/free/src/test/scala/cats/free/ContravariantCoyonedaSuite.scala
+++ b/free/src/test/scala/cats/free/ContravariantCoyonedaSuite.scala
@@ -12,40 +12,40 @@ class ContravariantCoyonedaSuite extends CatsSuite {
   // If we can generate functions we can generate an interesting ContravariantCoyoneda.
   implicit def contravariantCoyonedaArbitrary[F[_], A, T](
     implicit F: Arbitrary[A => T]
-  ): Arbitrary[ContravariantCoyoneda[? => T, A]] =
-    Arbitrary(F.arbitrary.map(ContravariantCoyoneda.lift[? => T, A](_)))
+  ): Arbitrary[ContravariantCoyoneda[* => T, A]] =
+    Arbitrary(F.arbitrary.map(ContravariantCoyoneda.lift[* => T, A](_)))
 
   // We can't really test that functions are equal but we can try it with a bunch of test data.
-  implicit def contravariantCoyonedaEq[A: Arbitrary, T](implicit eqft: Eq[T]): Eq[ContravariantCoyoneda[? => T, A]] =
-    new Eq[ContravariantCoyoneda[? => T, A]] {
-      def eqv(cca: ContravariantCoyoneda[? => T, A], ccb: ContravariantCoyoneda[? => T, A]): Boolean =
+  implicit def contravariantCoyonedaEq[A: Arbitrary, T](implicit eqft: Eq[T]): Eq[ContravariantCoyoneda[* => T, A]] =
+    new Eq[ContravariantCoyoneda[* => T, A]] {
+      def eqv(cca: ContravariantCoyoneda[* => T, A], ccb: ContravariantCoyoneda[* => T, A]): Boolean =
         Arbitrary.arbitrary[List[A]].sample.get.forall { a =>
           eqft.eqv(cca.run.apply(a), ccb.run.apply(a))
         }
     }
 
   // This instance cannot be summoned implicitly. This is not specific to contravariant coyoneda;
-  // it doesn't work for Functor[Coyoneda[? => String, ?]] either.
-  implicit val contravariantContravariantCoyonedaToString: Contravariant[ContravariantCoyoneda[? => String, ?]] =
-    ContravariantCoyoneda.catsFreeContravariantFunctorForContravariantCoyoneda[? => String]
+  // it doesn't work for Functor[Coyoneda[* => String, *]] either.
+  implicit val contravariantContravariantCoyonedaToString: Contravariant[ContravariantCoyoneda[* => String, *]] =
+    ContravariantCoyoneda.catsFreeContravariantFunctorForContravariantCoyoneda[* => String]
 
-  checkAll("ContravariantCoyoneda[? => String, Int]",
-           ContravariantTests[ContravariantCoyoneda[? => String, ?]].contravariant[Int, Int, Int])
-  checkAll("Contravariant[ContravariantCoyoneda[Option, ?]]",
-           SerializableTests.serializable(Contravariant[ContravariantCoyoneda[Option, ?]]))
+  checkAll("ContravariantCoyoneda[* => String, Int]",
+           ContravariantTests[ContravariantCoyoneda[* => String, *]].contravariant[Int, Int, Int])
+  checkAll("Contravariant[ContravariantCoyoneda[Option, *]]",
+           SerializableTests.serializable(Contravariant[ContravariantCoyoneda[Option, *]]))
 
   test("mapK and run is same as applying natural trans") {
     forAll { (b: Boolean) =>
-      val nt = λ[(? => String) ~> (? => Int)](f => s => f(s).length)
+      val nt = λ[(* => String) ~> (* => Int)](f => s => f(s).length)
       val o = (b: Boolean) => b.toString
-      val c = ContravariantCoyoneda.lift[? => String, Boolean](o)
-      c.mapK[? => Int](nt).run.apply(b) === nt(o).apply(b)
+      val c = ContravariantCoyoneda.lift[* => String, Boolean](o)
+      c.mapK[* => Int](nt).run.apply(b) === nt(o).apply(b)
     }
   }
 
   test("contramap order") {
     ContravariantCoyoneda
-      .lift[? => Int, String](_.count(_ == 'x'))
+      .lift[* => Int, String](_.count(_ == 'x'))
       .contramap((s: String) => s + "x")
       .contramap((s: String) => s * 3)
       .run
@@ -53,22 +53,22 @@ class ContravariantCoyonedaSuite extends CatsSuite {
   }
 
   test("stack-safe contramapmap") {
-    def loop(n: Int, acc: ContravariantCoyoneda[? => Int, Int]): ContravariantCoyoneda[? => Int, Int] =
+    def loop(n: Int, acc: ContravariantCoyoneda[* => Int, Int]): ContravariantCoyoneda[* => Int, Int] =
       if (n <= 0) acc
       else loop(n - 1, acc.contramap((_: Int) + 1))
-    loop(20000, ContravariantCoyoneda.lift[? => Int, Int](a => a)).run.apply(10)
+    loop(20000, ContravariantCoyoneda.lift[* => Int, Int](a => a)).run.apply(10)
   }
 
   test("run, foldMap consistent") {
     forAll {
       (
-        c: ContravariantCoyoneda[? => Int, String],
+        c: ContravariantCoyoneda[* => Int, String],
         f: Byte => String,
         g: Float => Byte,
         s: Float
       ) =>
         val cʹ = c.contramap(f).contramap(g) // just to ensure there's some structure
-        val h = cʹ.foldMap[? => Int](FunctionK.id[? => Int])
+        val h = cʹ.foldMap[* => Int](FunctionK.id[* => Int])
         cʹ.run.apply(s) === h(s)
     }
   }

--- a/free/src/test/scala/cats/free/CoyonedaSuite.scala
+++ b/free/src/test/scala/cats/free/CoyonedaSuite.scala
@@ -16,8 +16,8 @@ class CoyonedaSuite extends CatsSuite {
       def eqv(a: Coyoneda[F, A], b: Coyoneda[F, A]): Boolean = FA.eqv(a.run, b.run)
     }
 
-  checkAll("Coyoneda[Option, ?]", FunctorTests[Coyoneda[Option, ?]].functor[Int, Int, Int])
-  checkAll("Functor[Coyoneda[Option, ?]]", SerializableTests.serializable(Functor[Coyoneda[Option, ?]]))
+  checkAll("Coyoneda[Option, *]", FunctorTests[Coyoneda[Option, *]].functor[Int, Int, Int])
+  checkAll("Functor[Coyoneda[Option, *]]", SerializableTests.serializable(Functor[Coyoneda[Option, *]]))
 
   test("toYoneda and then toCoyoneda is identity") {
     forAll { (y: Coyoneda[Option, Int]) =>

--- a/free/src/test/scala/cats/free/FreeApplicativeSuite.scala
+++ b/free/src/test/scala/cats/free/FreeApplicativeSuite.scala
@@ -11,11 +11,11 @@ import org.scalacheck.{Arbitrary, Gen}
 class FreeApplicativeSuite extends CatsSuite {
   import FreeApplicativeSuite._
 
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[FreeApplicative[Option, ?]]
+  implicit val iso = SemigroupalTests.Isomorphisms.invariant[FreeApplicative[Option, *]]
 
-  checkAll("FreeApplicative[Option, ?]", ApplicativeTests[FreeApplicative[Option, ?]].applicative[Int, Int, Int])
-  checkAll("Applicative[FreeApplicative[Option, ?]]",
-           SerializableTests.serializable(Applicative[FreeApplicative[Option, ?]]))
+  checkAll("FreeApplicative[Option, *]", ApplicativeTests[FreeApplicative[Option, *]].applicative[Int, Int, Int])
+  checkAll("Applicative[FreeApplicative[Option, *]]",
+           SerializableTests.serializable(Applicative[FreeApplicative[Option, *]]))
 
   test("toString is stack-safe") {
     val r = FreeApplicative.pure[List, Int](333)
@@ -51,9 +51,9 @@ class FreeApplicativeSuite extends CatsSuite {
 
   test("FreeApplicative#flatCompile") {
     forAll { (x: FreeApplicative[Option, Int]) =>
-      val nt = λ[FunctionK[Option, FreeApplicative[Option, ?]]](FreeApplicative.lift(_))
+      val nt = λ[FunctionK[Option, FreeApplicative[Option, *]]](FreeApplicative.lift(_))
 
-      x.foldMap[FreeApplicative[Option, ?]](nt).fold should ===(x.flatCompile[Option](nt).fold)
+      x.foldMap[FreeApplicative[Option, *]](nt).fold should ===(x.flatCompile[Option](nt).fold)
     }
   }
 

--- a/free/src/test/scala/cats/free/FreeInvariantMonoidalSuite.scala
+++ b/free/src/test/scala/cats/free/FreeInvariantMonoidalSuite.scala
@@ -26,12 +26,12 @@ class FreeInvariantMonoidalSuite extends CatsSuite {
       }
     }
 
-  implicit val isoFreeBinCodec = Isomorphisms.invariant[FreeInvariantMonoidal[BinCodec, ?]]
+  implicit val isoFreeBinCodec = Isomorphisms.invariant[FreeInvariantMonoidal[BinCodec, *]]
 
-  checkAll("FreeInvariantMonoidal[BinCodec, ?]",
-           InvariantMonoidalTests[FreeInvariantMonoidal[BinCodec, ?]].invariantMonoidal[MiniInt, Boolean, Boolean])
-  checkAll("InvariantMonoidal[FreeInvariantMonoidal[BinCodec, ?]]",
-           SerializableTests.serializable(InvariantMonoidal[FreeInvariantMonoidal[BinCodec, ?]]))
+  checkAll("FreeInvariantMonoidal[BinCodec, *]",
+           InvariantMonoidalTests[FreeInvariantMonoidal[BinCodec, *]].invariantMonoidal[MiniInt, Boolean, Boolean])
+  checkAll("InvariantMonoidal[FreeInvariantMonoidal[BinCodec, *]]",
+           SerializableTests.serializable(InvariantMonoidal[FreeInvariantMonoidal[BinCodec, *]]))
 
   test("FreeInvariantMonoidal#fold") {
     forAll { i1: BinCodec[MiniInt] =>

--- a/free/src/test/scala/cats/free/FreeSuite.scala
+++ b/free/src/test/scala/cats/free/FreeSuite.scala
@@ -13,30 +13,30 @@ import Arbitrary.arbFunction1
 class FreeSuite extends CatsSuite {
   import FreeSuite._
 
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Free[Option, ?]]
+  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Free[Option, *]]
 
-  Monad[Free[Id, ?]]
-  implicitly[Monad[Free[Id, ?]]]
+  Monad[Free[Id, *]]
+  implicitly[Monad[Free[Id, *]]]
 
-  checkAll("Free[Id, ?]", DeferTests[Free[Id, ?]].defer[Int])
-  checkAll("Free[Id, ?]", MonadTests[Free[Id, ?]].monad[Int, Int, Int])
-  checkAll("Monad[Free[Id, ?]]", SerializableTests.serializable(Monad[Free[Id, ?]]))
+  checkAll("Free[Id, *]", DeferTests[Free[Id, *]].defer[Int])
+  checkAll("Free[Id, *]", MonadTests[Free[Id, *]].monad[Int, Int, Int])
+  checkAll("Monad[Free[Id, *]]", SerializableTests.serializable(Monad[Free[Id, *]]))
 
-  checkAll("Free[Option, ?]", DeferTests[Free[Option, ?]].defer[Int])
-  checkAll("Free[Option, ?]", MonadTests[Free[Option, ?]].monad[Int, Int, Int])
-  checkAll("Monad[Free[Option, ?]]", SerializableTests.serializable(Monad[Free[Option, ?]]))
+  checkAll("Free[Option, *]", DeferTests[Free[Option, *]].defer[Int])
+  checkAll("Free[Option, *]", MonadTests[Free[Option, *]].monad[Int, Int, Int])
+  checkAll("Monad[Free[Option, *]]", SerializableTests.serializable(Monad[Free[Option, *]]))
 
   locally {
     implicit val instance = Free.catsFreeFoldableForFree[Option]
 
-    checkAll("Free[Option, ?]", FoldableTests[Free[Option, ?]].foldable[Int, Int])
-    checkAll("Foldable[Free[Option,?]]", SerializableTests.serializable(Foldable[Free[Option, ?]]))
+    checkAll("Free[Option, *]", FoldableTests[Free[Option, *]].foldable[Int, Int])
+    checkAll("Foldable[Free[Option,*]]", SerializableTests.serializable(Foldable[Free[Option, *]]))
   }
 
   locally {
     implicit val instance = Free.catsFreeTraverseForFree[Option]
-    checkAll("Free[Option,?]", TraverseTests[Free[Option, ?]].traverse[Int, Int, Int, Int, Option, Option])
-    checkAll("Traverse[Free[Option,?]]", SerializableTests.serializable(Traverse[Free[Option, ?]]))
+    checkAll("Free[Option,*]", TraverseTests[Free[Option, *]].traverse[Int, Int, Int, Int, Option, Option])
+    checkAll("Traverse[Free[Option,*]]", SerializableTests.serializable(Traverse[Free[Option, *]]))
   }
 
   test("toString is stack-safe") {
@@ -79,7 +79,7 @@ class FreeSuite extends CatsSuite {
   test("tailRecM is stack safe") {
     val n = 50000
     val fa =
-      Monad[Free[Option, ?]].tailRecM(0)(i => Free.pure[Option, Either[Int, Int]](if (i < n) Left(i + 1) else Right(i)))
+      Monad[Free[Option, *]].tailRecM(0)(i => Free.pure[Option, Either[Int, Int]](if (i < n) Left(i + 1) else Right(i)))
     fa should ===(Free.pure[Option, Int](n))
   }
 

--- a/free/src/test/scala/cats/free/FreeTSuite.scala
+++ b/free/src/test/scala/cats/free/FreeTSuite.scala
@@ -16,31 +16,31 @@ class FreeTSuite extends CatsSuite {
   {
     implicit val freeTFlatMap: FlatMap[FreeTOption] = FreeT.catsFreeFlatMapForFreeT[Option, Option]
     checkAll("FreeT[Option, Option, Int]", FlatMapTests[FreeTOption].flatMap[Int, Int, Int])
-    checkAll("FlatMap[FreeT[Option, Option, ?]]", SerializableTests.serializable(FlatMap[FreeTOption]))
+    checkAll("FlatMap[FreeT[Option, Option, *]]", SerializableTests.serializable(FlatMap[FreeTOption]))
   }
 
   {
     implicit val freeTMonad: Monad[FreeTOption] = FreeT.catsFreeMonadForFreeT[Option, Option]
     checkAll("FreeT[Option, Option, Int]", MonadTests[FreeTOption].monad[Int, Int, Int])
-    checkAll("Monad[FreeT[Option, Option, ?]]", SerializableTests.serializable(Monad[FreeTOption]))
+    checkAll("Monad[FreeT[Option, Option, *]]", SerializableTests.serializable(Monad[FreeTOption]))
   }
 
   {
     implicit val freeTSemigroupK: SemigroupK[FreeTOption] = FreeT.catsFreeSemigroupKForFreeT[Option, Option]
     checkAll("FreeT[Option, Option, Int]", SemigroupKTests[FreeTOption].semigroupK[Int])
-    checkAll("SemigroupK[FreeT[Option, Option, ?]]", SerializableTests.serializable(SemigroupK[FreeTOption]))
+    checkAll("SemigroupK[FreeT[Option, Option, *]]", SerializableTests.serializable(SemigroupK[FreeTOption]))
   }
 
   {
     implicit val freeTAlternative: Alternative[FreeTOption] = FreeT.catsFreeAlternativeForFreeT[Option, Option]
     checkAll("FreeT[Option, Option, Int]", AlternativeTests[FreeTOption].alternative[Int, Int, Int])
-    checkAll("Alternative[FreeT[Option, Option, ?]]", SerializableTests.serializable(Alternative[FreeTOption]))
+    checkAll("Alternative[FreeT[Option, Option, *]]", SerializableTests.serializable(Alternative[FreeTOption]))
   }
 
   {
     implicit val eqEitherTFA: Eq[EitherT[FreeTOption, Unit, Int]] = EitherT.catsDataEqForEitherT[FreeTOption, Unit, Int]
     checkAll("FreeT[Option, Option, Int]", MonadErrorTests[FreeTOption, Unit].monadError[Int, Int, Int])
-    checkAll("MonadError[FreeT[Option, Option, ?], Unit]",
+    checkAll("MonadError[FreeT[Option, Option, *], Unit]",
              SerializableTests.serializable(MonadError[FreeTOption, Unit]))
   }
 
@@ -199,7 +199,7 @@ class FreeTSuite extends CatsSuite {
 
   private[free] def liftTCompilationTests() = {
     val a: Either[String, Int] = Right(42)
-    val b: FreeT[Option, Either[String, ?], Int] = FreeT.liftT(a)
+    val b: FreeT[Option, Either[String, *], Int] = FreeT.liftT(a)
   }
 
 }

--- a/free/src/test/scala/cats/free/YonedaSuite.scala
+++ b/free/src/test/scala/cats/free/YonedaSuite.scala
@@ -15,8 +15,8 @@ class YonedaSuite extends CatsSuite {
       def eqv(a: Yoneda[F, A], b: Yoneda[F, A]): Boolean = FA.eqv(a.run, b.run)
     }
 
-  checkAll("Yoneda[Option, ?]", FunctorTests[Yoneda[Option, ?]].functor[Int, Int, Int])
-  checkAll("Functor[Yoneda[Option, ?]]", SerializableTests.serializable(Functor[Yoneda[Option, ?]]))
+  checkAll("Yoneda[Option, *]", FunctorTests[Yoneda[Option, *]].functor[Int, Int, Int])
+  checkAll("Functor[Yoneda[Option, *]]", SerializableTests.serializable(Functor[Yoneda[Option, *]]))
 
   test("toCoyoneda and then toYoneda is identity") {
     forAll { (y: Yoneda[Option, Int]) =>

--- a/laws/src/main/scala/cats/laws/BitraverseLaws.scala
+++ b/laws/src/main/scala/cats/laws/BitraverseLaws.scala
@@ -21,7 +21,7 @@ trait BitraverseLaws[F[_, _]] extends BifoldableLaws[F] with BifunctorLaws[F] {
     val hi = G.map(fg)(f => F.bitraverse(f)(h, i))
 
     val c =
-      F.bitraverse[Nested[G, G, ?], A, B, E, H](fab)(
+      F.bitraverse[Nested[G, G, *], A, B, E, H](fab)(
         a => Nested(G.map(f(a))(h)),
         b => Nested(G.map(g(b))(i))
       )

--- a/laws/src/main/scala/cats/laws/DistributiveLaws.scala
+++ b/laws/src/main/scala/cats/laws/DistributiveLaws.scala
@@ -26,7 +26,7 @@ trait DistributiveLaws[F[_]] extends FunctorLaws[F] {
   )(implicit
     N: Distributive[N],
     M: Functor[M]): IsEq[Nested[F, N, M[C]]] = {
-    val rhs = ma.distribute[Nested[F, N, ?], C](a => Nested(F.map(f(a))(g)))
+    val rhs = ma.distribute[Nested[F, N, *], C](a => Nested(F.map(f(a))(g)))
     val lhs = Nested(F.map(ma.distribute(f))(fb => fb.distribute(g)))
     lhs <-> rhs
   }

--- a/laws/src/main/scala/cats/laws/FoldableLaws.scala
+++ b/laws/src/main/scala/cats/laws/FoldableLaws.scala
@@ -70,7 +70,7 @@ trait FoldableLaws[F[_]] extends UnorderedFoldableLaws[F] {
   def getRef[A](fa: F[A], idx: Long): IsEq[Option[A]] =
     F.get(fa)(idx) <-> (if (idx < 0L) None
                         else
-                          F.foldM[Either[A, ?], A, Long](fa, 0L) { (i, a) =>
+                          F.foldM[Either[A, *], A, Long](fa, 0L) { (i, a) =>
                             if (i == idx) Left(a) else Right(i + 1L)
                           } match {
                             case Left(a)  => Some(a)

--- a/laws/src/main/scala/cats/laws/NonEmptyTraverseLaws.scala
+++ b/laws/src/main/scala/cats/laws/NonEmptyTraverseLaws.scala
@@ -20,7 +20,7 @@ trait NonEmptyTraverseLaws[F[_]] extends TraverseLaws[F] with ReducibleLaws[F] {
     M: Apply[M]): IsEq[Nested[M, N, F[C]]] = {
 
     val lhs = Nested(M.map(fa.nonEmptyTraverse(f))(fb => fb.nonEmptyTraverse(g)))
-    val rhs = fa.nonEmptyTraverse[Nested[M, N, ?], C](a => Nested(M.map(f(a))(g)))
+    val rhs = fa.nonEmptyTraverse[Nested[M, N, *], C](a => Nested(M.map(f(a))(g)))
     lhs <-> rhs
   }
 
@@ -57,7 +57,7 @@ trait NonEmptyTraverseLaws[F[_]] extends TraverseLaws[F] with ReducibleLaws[F] {
     fa: F[A],
     f: A => B
   )(implicit B: Semigroup[B]): IsEq[B] = {
-    val lhs: B = fa.nonEmptyTraverse[Const[B, ?], B](a => Const(f(a))).getConst
+    val lhs: B = fa.nonEmptyTraverse[Const[B, *], B](a => Const(f(a))).getConst
     val rhs: B = fa.reduceMap(f)
     lhs <-> rhs
   }

--- a/laws/src/main/scala/cats/laws/TraverseFilterLaws.scala
+++ b/laws/src/main/scala/cats/laws/TraverseFilterLaws.scala
@@ -21,7 +21,7 @@ trait TraverseFilterLaws[F[_]] extends FunctorFilterLaws[F] {
   ): IsEq[Nested[M, N, F[C]]] = {
     val lhs = Nested[M, N, F[C]](fa.traverseFilter(f).map(_.traverseFilter(g)))
     val rhs: Nested[M, N, F[C]] =
-      fa.traverseFilter[Nested[M, N, ?], C](a => Nested[M, N, Option[C]](f(a).map(_.traverseFilter(g))))
+      fa.traverseFilter[Nested[M, N, *], C](a => Nested[M, N, Option[C]](f(a).map(_.traverseFilter(g))))
     lhs <-> rhs
   }
 

--- a/laws/src/main/scala/cats/laws/TraverseLaws.scala
+++ b/laws/src/main/scala/cats/laws/TraverseLaws.scala
@@ -21,7 +21,7 @@ trait TraverseLaws[F[_]] extends FunctorLaws[F] with FoldableLaws[F] with Unorde
     M: Applicative[M]): IsEq[Nested[M, N, F[C]]] = {
 
     val lhs = Nested(M.map(fa.traverse(f))(fb => fb.traverse(g)))
-    val rhs = fa.traverse[Nested[M, N, ?], C](a => Nested(M.map(f(a))(g)))
+    val rhs = fa.traverse[Nested[M, N, *], C](a => Nested(M.map(f(a))(g)))
     lhs <-> rhs
   }
 
@@ -59,7 +59,7 @@ trait TraverseLaws[F[_]] extends FunctorLaws[F] with FoldableLaws[F] with Unorde
     fa: F[A],
     f: A => B
   )(implicit B: Monoid[B]): IsEq[B] = {
-    val lhs: B = fa.traverse[Const[B, ?], B](a => Const(f(a))).getConst
+    val lhs: B = fa.traverse[Const[B, *], B](a => Const(f(a))).getConst
     val rhs: B = fa.foldMap(f)
     lhs <-> rhs
   }
@@ -75,9 +75,9 @@ trait TraverseLaws[F[_]] extends FunctorLaws[F] with FoldableLaws[F] with Unorde
     def liftId[T](a: T): Id[T] = a
     def store[T](a: T): Const[FirstOption[T], T] = Const(new FirstOption(Some(a)))
 
-    val first = F.traverse[Const[FirstOption[A], ?], A, A](fa)(store).getConst.o
+    val first = F.traverse[Const[FirstOption[A], *], A, A](fa)(store).getConst.o
     val traverseFirst = F
-      .traverse[Const[FirstOption[A], ?], A, A](
+      .traverse[Const[FirstOption[A], *], A, A](
         F.traverse(fa)(liftId)
       )(store)
       .getConst

--- a/laws/src/main/scala/cats/laws/UnorderedTraverseLaws.scala
+++ b/laws/src/main/scala/cats/laws/UnorderedTraverseLaws.scala
@@ -15,7 +15,7 @@ trait UnorderedTraverseLaws[F[_]] extends UnorderedFoldableLaws[F] {
   ): IsEq[Nested[M, N, F[C]]] = {
 
     val lhs = Nested(M.map(F.unorderedTraverse(fa)(f))(fb => F.unorderedTraverse(fb)(g)))
-    val rhs = F.unorderedTraverse[Nested[M, N, ?], A, C](fa)(a => Nested(M.map(f(a))(g)))
+    val rhs = F.unorderedTraverse[Nested[M, N, *], A, C](fa)(a => Nested(M.map(f(a))(g)))
     lhs <-> rhs
   }
 

--- a/scripts/parse-test-durations.awk
+++ b/scripts/parse-test-durations.awk
@@ -10,8 +10,8 @@
 # gawk -f scripts/parse-test-durations.awk test-output.txt | sort -k 1 -n
 #
 # Example output:
-# 2185 [info] - FreeInvariantMonoidal[CsvCodec, ?].invariantMonoidal.invariant monoidal right identity (2 seconds, 185 milliseconds)
-# 2202 [info] - FreeInvariantMonoidal[CsvCodec, ?].invariantMonoidal.invariant monoidal left identity (2 seconds, 202 milliseconds)
+# 2185 [info] - FreeInvariantMonoidal[CsvCodec, *].invariantMonoidal.invariant monoidal right identity (2 seconds, 185 milliseconds)
+# 2202 [info] - FreeInvariantMonoidal[CsvCodec, *].invariantMonoidal.invariant monoidal left identity (2 seconds, 202 milliseconds)
 # 4778 [info] - Cokleisli[NonEmptyList, Int, Int].arrow.compose associativity (4 seconds, 778 milliseconds)
 # 4781 [info] - Cokleisli[List, Int, Int].semigroupK.semigroupK associative (4 seconds, 781 milliseconds)
 # 4824 [info] - Cokleisli[NonEmptyList, Int, Int].monoidK.semigroupK associative (4 seconds, 824 milliseconds)

--- a/testkit/src/main/scala/cats/tests/ListWrapper.scala
+++ b/testkit/src/main/scala/cats/tests/ListWrapper.scala
@@ -10,13 +10,13 @@ import org.scalacheck.Arbitrary.arbitrary
  * The problem this type solves is to assist in picking up type class
  * instances that have more general constraints.
  *
- * For instance, OneAnd[?, F[_]] has a Monad instance if F[_] does too.
+ * For instance, OneAnd[*, F[_]] has a Monad instance if F[_] does too.
  * By extension, it has an Applicative instance, since Applicative is
  * a superclass of Monad.
  *
  * However, if F[_] doesn't have a Monad instance but does have an
  * Applicative instance (e.g. Validated), you can still get an
- * Applicative instance for OneAnd[?, F[_]]. These two instances
+ * Applicative instance for OneAnd[*, F[_]]. These two instances
  * are different however, and it is a good idea to test to make sure
  * all "variants" of the instances are lawful.
  *

--- a/tests/src/test/scala/cats/tests/AndThenSuite.scala
+++ b/tests/src/test/scala/cats/tests/AndThenSuite.scala
@@ -10,19 +10,19 @@ import cats.laws.discipline.arbitrary._
 import cats.platform.Platform
 
 class AndThenSuite extends CatsSuite {
-  checkAll("AndThen[MiniInt, Int]", SemigroupalTests[AndThen[MiniInt, ?]].semigroupal[Int, Int, Int])
-  checkAll("Semigroupal[AndThen[Int, ?]]", SerializableTests.serializable(Semigroupal[AndThen[Int, ?]]))
+  checkAll("AndThen[MiniInt, Int]", SemigroupalTests[AndThen[MiniInt, *]].semigroupal[Int, Int, Int])
+  checkAll("Semigroupal[AndThen[Int, *]]", SerializableTests.serializable(Semigroupal[AndThen[Int, *]]))
 
   {
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[AndThen[?, Int]]
-    checkAll("AndThen[?, Int]",
-             ContravariantMonoidalTests[AndThen[?, Int]].contravariantMonoidal[MiniInt, Boolean, Boolean])
-    checkAll("ContravariantMonoidal[AndThen[?, Int]]",
-             SerializableTests.serializable(ContravariantMonoidal[AndThen[?, Int]]))
+    implicit val iso = SemigroupalTests.Isomorphisms.invariant[AndThen[*, Int]]
+    checkAll("AndThen[*, Int]",
+             ContravariantMonoidalTests[AndThen[*, Int]].contravariantMonoidal[MiniInt, Boolean, Boolean])
+    checkAll("ContravariantMonoidal[AndThen[*, Int]]",
+             SerializableTests.serializable(ContravariantMonoidal[AndThen[*, Int]]))
   }
 
-  checkAll("AndThen[MiniInt, Int]", MonadTests[AndThen[MiniInt, ?]].monad[Int, Int, Int])
-  checkAll("Monad[AndThen[Int, ?]]", SerializableTests.serializable(Monad[AndThen[Int, ?]]))
+  checkAll("AndThen[MiniInt, Int]", MonadTests[AndThen[MiniInt, *]].monad[Int, Int, Int])
+  checkAll("Monad[AndThen[Int, *]]", SerializableTests.serializable(Monad[AndThen[Int, *]]))
 
   checkAll("AndThen",
            CommutativeArrowTests[AndThen].commutativeArrow[MiniInt, Boolean, Boolean, Boolean, Boolean, Boolean])
@@ -34,8 +34,8 @@ class AndThenSuite extends CatsSuite {
   checkAll("AndThen", ArrowChoiceTests[AndThen].arrowChoice[MiniInt, Boolean, Boolean, Boolean, Boolean, Boolean])
   checkAll("ArrowChoice[AndThen]", SerializableTests.serializable(ArrowChoice[AndThen]))
 
-  checkAll("AndThen[?, Int]", ContravariantTests[AndThen[?, Int]].contravariant[MiniInt, Int, Boolean])
-  checkAll("Contravariant[AndThen[?, Int]]", SerializableTests.serializable(Contravariant[AndThen[?, Int]]))
+  checkAll("AndThen[*, Int]", ContravariantTests[AndThen[*, Int]].contravariant[MiniInt, Int, Boolean])
+  checkAll("Contravariant[AndThen[*, Int]]", SerializableTests.serializable(Contravariant[AndThen[*, Int]]))
 
   test("compose a chain of functions with andThen") {
     check { (i: Int, fs: List[Int => Int]) =>

--- a/tests/src/test/scala/cats/tests/ApplicativeSuite.scala
+++ b/tests/src/test/scala/cats/tests/ApplicativeSuite.scala
@@ -54,11 +54,11 @@ class ApplicativeSuite extends CatsSuite {
     implicit val listwrapperCoflatMap = Applicative.coflatMap[ListWrapper]
     checkAll("Applicative[ListWrapper].coflatMap", CoflatMapTests[ListWrapper].coflatMap[String, String, String])
 
-    implicit val validatedCoflatMap = Applicative.coflatMap[Validated[String, ?]]
-    checkAll("Applicative[Validated].coflatMap", CoflatMapTests[Validated[String, ?]].coflatMap[String, String, String])
+    implicit val validatedCoflatMap = Applicative.coflatMap[Validated[String, *]]
+    checkAll("Applicative[Validated].coflatMap", CoflatMapTests[Validated[String, *]].coflatMap[String, String, String])
 
-    implicit val constCoflatMap = Applicative.coflatMap[Const[String, ?]]
-    checkAll("Applicative[Const].coflatMap", CoflatMapTests[Const[String, ?]].coflatMap[String, String, String])
+    implicit val constCoflatMap = Applicative.coflatMap[Const[String, *]]
+    checkAll("Applicative[Const].coflatMap", CoflatMapTests[Const[String, *]].coflatMap[String, String, String])
   }
 
 }

--- a/tests/src/test/scala/cats/tests/BinestedSuite.scala
+++ b/tests/src/test/scala/cats/tests/BinestedSuite.scala
@@ -19,11 +19,11 @@ class BinestedSuite extends CatsSuite {
     // Bifunctor + Functor + Functor = Bifunctor
     implicit val instance = ListWrapper.functor
     checkAll(
-      "Binested[Either, ListWrapper, Option, ?, ?]",
-      BifunctorTests[Binested[Either, ListWrapper, Option, ?, ?]].bifunctor[Int, Int, Int, String, String, String]
+      "Binested[Either, ListWrapper, Option, *, *]",
+      BifunctorTests[Binested[Either, ListWrapper, Option, *, *]].bifunctor[Int, Int, Int, String, String, String]
     )
-    checkAll("Bifunctor[Binested[Either, ListWrapper, Option, ?, ?]]",
-             SerializableTests.serializable(Bifunctor[Binested[Either, ListWrapper, Option, ?, ?]]))
+    checkAll("Bifunctor[Binested[Either, ListWrapper, Option, *, *]]",
+             SerializableTests.serializable(Bifunctor[Binested[Either, ListWrapper, Option, *, *]]))
   }
 
   {
@@ -31,24 +31,24 @@ class BinestedSuite extends CatsSuite {
     implicit val instance = OptionWrapper.functor
     Eq[OptionWrapper[MiniInt] => Option[Int]]
     checkAll(
-      "Binested[Function1, OptionWrapper, Option, ?, ?]",
-      ProfunctorTests[Binested[Function1, OptionWrapper, Option, ?, ?]]
+      "Binested[Function1, OptionWrapper, Option, *, *]",
+      ProfunctorTests[Binested[Function1, OptionWrapper, Option, *, *]]
         .profunctor[MiniInt, Int, Int, String, String, String]
     )
     checkAll(
-      "Profunctor[Binested[Function1, OptionWrapper, Option, ?, ?]]",
-      SerializableTests.serializable(Profunctor[Binested[Function1, OptionWrapper, Option, ?, ?]])
+      "Profunctor[Binested[Function1, OptionWrapper, Option, *, *]]",
+      SerializableTests.serializable(Profunctor[Binested[Function1, OptionWrapper, Option, *, *]])
     )
   }
 
   {
     // Bifoldable + foldable + foldable = Bifoldable
     implicit val instance = ListWrapper.foldable
-    checkAll("Binested[Either, ListWrapper, ListWrapper, ?, ?]",
-             BifoldableTests[Binested[Either, ListWrapper, ListWrapper, ?, ?]].bifoldable[Int, Int, Int])
+    checkAll("Binested[Either, ListWrapper, ListWrapper, *, *]",
+             BifoldableTests[Binested[Either, ListWrapper, ListWrapper, *, *]].bifoldable[Int, Int, Int])
     checkAll(
-      "Bifoldable[Binested[Either, ListWrapper, ListWrapper, ?, ?]]",
-      SerializableTests.serializable(Bifoldable[Binested[Either, ListWrapper, ListWrapper, ?, ?]])
+      "Bifoldable[Binested[Either, ListWrapper, ListWrapper, *, *]]",
+      SerializableTests.serializable(Bifoldable[Binested[Either, ListWrapper, ListWrapper, *, *]])
     )
   }
 
@@ -56,13 +56,13 @@ class BinestedSuite extends CatsSuite {
     // Bitraverse + traverse + traverse = Bitraverse
     implicit val instance = ListWrapper.traverse
     checkAll(
-      "Binested[Either, ListWrapper, ListWrapper, ?, ?]",
-      BitraverseTests[Binested[Either, ListWrapper, ListWrapper, ?, ?]]
+      "Binested[Either, ListWrapper, ListWrapper, *, *]",
+      BitraverseTests[Binested[Either, ListWrapper, ListWrapper, *, *]]
         .bitraverse[Option, Int, Int, Int, String, String, String]
     )
     checkAll(
-      "Bitraverse[Binested[Either, ListWrapper, ListWrapper, ?, ?]]",
-      SerializableTests.serializable(Bitraverse[Binested[Either, ListWrapper, ListWrapper, ?, ?]])
+      "Bitraverse[Binested[Either, ListWrapper, ListWrapper, *, *]]",
+      SerializableTests.serializable(Bitraverse[Binested[Either, ListWrapper, ListWrapper, *, *]])
     )
   }
 

--- a/tests/src/test/scala/cats/tests/CokleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/CokleisliSuite.scala
@@ -17,27 +17,27 @@ class CokleisliSuite extends SlowCatsSuite {
   implicit def cokleisliEq[F[_], A, B](implicit ev: Eq[F[A] => B]): Eq[Cokleisli[F, A, B]] =
     Eq.by[Cokleisli[F, A, B], F[A] => B](_.run)
 
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Cokleisli[Option, Int, ?]]
+  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Cokleisli[Option, Int, *]]
 
   checkAll("Cokleisli[Option, MiniInt, Int]",
-           SemigroupalTests[Cokleisli[Option, MiniInt, ?]].semigroupal[Int, Int, Int])
-  checkAll("Semigroupal[Cokleisli[Option, Int, ?]]",
-           SerializableTests.serializable(Semigroupal[Cokleisli[Option, Int, ?]]))
+           SemigroupalTests[Cokleisli[Option, MiniInt, *]].semigroupal[Int, Int, Int])
+  checkAll("Semigroupal[Cokleisli[Option, Int, *]]",
+           SerializableTests.serializable(Semigroupal[Cokleisli[Option, Int, *]]))
 
-  checkAll("Cokleisli[Option, MiniInt, Int]", MonadTests[Cokleisli[Option, MiniInt, ?]].monad[Int, Int, Int])
-  checkAll("Monad[Cokleisli[Option, Int, ?]]", SerializableTests.serializable(Monad[Cokleisli[Option, Int, ?]]))
+  checkAll("Cokleisli[Option, MiniInt, Int]", MonadTests[Cokleisli[Option, MiniInt, *]].monad[Int, Int, Int])
+  checkAll("Monad[Cokleisli[Option, Int, *]]", SerializableTests.serializable(Monad[Cokleisli[Option, Int, *]]))
 
   checkAll("Cokleisli[Option, MiniInt, Int]",
-           ProfunctorTests[Cokleisli[Option, ?, ?]].profunctor[MiniInt, Int, Int, Int, Int, Int])
-  checkAll("Profunctor[Cokleisli[Option, ?, ?]]", SerializableTests.serializable(Profunctor[Cokleisli[Option, ?, ?]]))
+           ProfunctorTests[Cokleisli[Option, *, *]].profunctor[MiniInt, Int, Int, Int, Int, Int])
+  checkAll("Profunctor[Cokleisli[Option, *, *]]", SerializableTests.serializable(Profunctor[Cokleisli[Option, *, *]]))
 
   checkAll("Cokleisli[Option, MiniInt, MiniInt]",
-           ContravariantTests[Cokleisli[Option, ?, MiniInt]].contravariant[MiniInt, MiniInt, MiniInt])
-  checkAll("Contravariant[Cokleisli[Option, ?, MiniInt]]",
-           SerializableTests.serializable(Contravariant[Cokleisli[Option, ?, Int]]))
+           ContravariantTests[Cokleisli[Option, *, MiniInt]].contravariant[MiniInt, MiniInt, MiniInt])
+  checkAll("Contravariant[Cokleisli[Option, *, MiniInt]]",
+           SerializableTests.serializable(Contravariant[Cokleisli[Option, *, Int]]))
 
-  checkAll("Cokleisli[(Boolean, ?), MiniInt, MiniInt]",
-           MonoidKTests[λ[α => Cokleisli[(Boolean, ?), α, α]]].monoidK[MiniInt])
+  checkAll("Cokleisli[(Boolean, *), MiniInt, MiniInt]",
+           MonoidKTests[λ[α => Cokleisli[(Boolean, *), α, α]]].monoidK[MiniInt])
   checkAll("MonoidK[λ[α => Cokleisli[NonEmptyList, α, α]]]",
            SerializableTests.serializable(MonoidK[λ[α => Cokleisli[NonEmptyList, α, α]]]))
 
@@ -45,9 +45,9 @@ class CokleisliSuite extends SlowCatsSuite {
   checkAll("SemigroupK[λ[α => Cokleisli[List, α, α]]]",
            SerializableTests.serializable(SemigroupK[λ[α => Cokleisli[List, α, α]]]))
 
-  checkAll("Cokleisli[(Boolean, ?), MiniInt, MiniInt]",
-           ArrowTests[Cokleisli[(Boolean, ?), ?, ?]].arrow[MiniInt, MiniInt, MiniInt, MiniInt, MiniInt, MiniInt])
-  checkAll("Arrow[Cokleisli[NonEmptyList, ?, ?]]", SerializableTests.serializable(Arrow[Cokleisli[NonEmptyList, ?, ?]]))
+  checkAll("Cokleisli[(Boolean, *), MiniInt, MiniInt]",
+           ArrowTests[Cokleisli[(Boolean, *), *, *]].arrow[MiniInt, MiniInt, MiniInt, MiniInt, MiniInt, MiniInt])
+  checkAll("Arrow[Cokleisli[NonEmptyList, *, *]]", SerializableTests.serializable(Arrow[Cokleisli[NonEmptyList, *, *]]))
 
   {
     implicit def cokleisliIdEq[A, B](implicit evidence: Eq[A => B]): Eq[Cokleisli[Id, A, B]] =
@@ -55,10 +55,10 @@ class CokleisliSuite extends SlowCatsSuite {
 
     checkAll(
       "Cokleisli[Id, MiniInt, MiniInt]",
-      CommutativeArrowTests[Cokleisli[Id, ?, ?]].commutativeArrow[MiniInt, MiniInt, MiniInt, MiniInt, MiniInt, MiniInt]
+      CommutativeArrowTests[Cokleisli[Id, *, *]].commutativeArrow[MiniInt, MiniInt, MiniInt, MiniInt, MiniInt, MiniInt]
     )
-    checkAll("CommutativeArrow[Cokleisli[Id, ?, ?]]",
-             SerializableTests.serializable(CommutativeArrow[Cokleisli[Id, ?, ?]]))
+    checkAll("CommutativeArrow[Cokleisli[Id, *, *]]",
+             SerializableTests.serializable(CommutativeArrow[Cokleisli[Id, *, *]]))
   }
 
   test("contramapValue with Id consistent with lmap") {

--- a/tests/src/test/scala/cats/tests/ConstSuite.scala
+++ b/tests/src/test/scala/cats/tests/ConstSuite.scala
@@ -17,29 +17,29 @@ import cats.tests.Helpers.{CMono, CSemi}
 
 class ConstSuite extends CatsSuite {
 
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Const[String, ?]](Const.catsDataTraverseForConst)
+  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Const[String, *]](Const.catsDataTraverseForConst)
 
-  checkAll("Const[String, Int]", SemigroupalTests[Const[String, ?]].semigroupal[Int, Int, Int])
-  checkAll("Semigroupal[Const[String, ?]]", SerializableTests.serializable(Semigroupal[Const[String, ?]]))
+  checkAll("Const[String, Int]", SemigroupalTests[Const[String, *]].semigroupal[Int, Int, Int])
+  checkAll("Semigroupal[Const[String, *]]", SerializableTests.serializable(Semigroupal[Const[String, *]]))
 
-  checkAll("Const[String, Int]", ApplicativeTests[Const[String, ?]].applicative[Int, Int, Int])
-  checkAll("Applicative[Const[String, ?]]", SerializableTests.serializable(Applicative[Const[String, ?]]))
+  checkAll("Const[String, Int]", ApplicativeTests[Const[String, *]].applicative[Int, Int, Int])
+  checkAll("Applicative[Const[String, *]]", SerializableTests.serializable(Applicative[Const[String, *]]))
 
   checkAll("Const[String, Int] with Option",
-           TraverseTests[Const[String, ?]].traverse[Int, Int, Int, Int, Option, Option])
-  checkAll("Traverse[Const[String, ?]]", SerializableTests.serializable(Traverse[Const[String, ?]]))
+           TraverseTests[Const[String, *]].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("Traverse[Const[String, *]]", SerializableTests.serializable(Traverse[Const[String, *]]))
 
-  checkAll("Const[String, Int]", TraverseFilterTests[Const[String, ?]].traverseFilter[Int, Int, Int])
-  checkAll("TraverseFilter[Const[String, ?]]", SerializableTests.serializable(TraverseFilter[Const[String, ?]]))
+  checkAll("Const[String, Int]", TraverseFilterTests[Const[String, *]].traverseFilter[Int, Int, Int])
+  checkAll("TraverseFilter[Const[String, *]]", SerializableTests.serializable(TraverseFilter[Const[String, *]]))
 
-  // Get Apply[Const[C : Semigroup, ?]], not Applicative[Const[C : Monoid, ?]]
+  // Get Apply[Const[C : Semigroup, *]], not Applicative[Const[C : Monoid, *]]
   {
     implicit def nonEmptyListSemigroup[A]: Semigroup[NonEmptyList[A]] = SemigroupK[NonEmptyList].algebra
     implicit val iso =
-      SemigroupalTests.Isomorphisms.invariant[Const[NonEmptyList[String], ?]](Const.catsDataContravariantForConst)
-    checkAll("Apply[Const[NonEmptyList[String], Int]]", ApplyTests[Const[NonEmptyList[String], ?]].apply[Int, Int, Int])
-    checkAll("Apply[Const[NonEmptyList[String], ?]]",
-             SerializableTests.serializable(Apply[Const[NonEmptyList[String], ?]]))
+      SemigroupalTests.Isomorphisms.invariant[Const[NonEmptyList[String], *]](Const.catsDataContravariantForConst)
+    checkAll("Apply[Const[NonEmptyList[String], Int]]", ApplyTests[Const[NonEmptyList[String], *]].apply[Int, Int, Int])
+    checkAll("Apply[Const[NonEmptyList[String], *]]",
+             SerializableTests.serializable(Apply[Const[NonEmptyList[String], *]]))
   }
 
   // Algebra checks for Serializability of instances as part of the laws
@@ -58,26 +58,26 @@ class ConstSuite extends CatsSuite {
   checkAll("UpperBounded[Const[Int, String]]", UpperBoundedTests[Const[Int, String]].upperBounded)
 
   {
-    implicitly[Invariant[Const[String, ?]]]
-    Invariant[Const[String, ?]]
+    implicitly[Invariant[Const[String, *]]]
+    Invariant[Const[String, *]]
 
-    checkAll("Const[String, Int]", InvariantTests[Const[String, ?]].invariant[Int, Int, Int])
-    checkAll("Invariant[Const[String, ?]]", SerializableTests.serializable(Invariant[Const[String, ?]]))
+    checkAll("Const[String, Int]", InvariantTests[Const[String, *]].invariant[Int, Int, Int])
+    checkAll("Invariant[Const[String, *]]", SerializableTests.serializable(Invariant[Const[String, *]]))
   }
 
-  checkAll("Const[String, Int]", ContravariantTests[Const[String, ?]].contravariant[Int, Int, Int])
-  checkAll("Contravariant[Const[String, ?]]", SerializableTests.serializable(Contravariant[Const[String, ?]]))
+  checkAll("Const[String, Int]", ContravariantTests[Const[String, *]].contravariant[Int, Int, Int])
+  checkAll("Contravariant[Const[String, *]]", SerializableTests.serializable(Contravariant[Const[String, *]]))
 
-  checkAll("Const[String, Int]", ContravariantMonoidalTests[Const[String, ?]].contravariantMonoidal[Int, Int, Int])
-  checkAll("ContravariantMonoidal[Const[String, ?]]",
-           SerializableTests.serializable(ContravariantMonoidal[Const[String, ?]]))
+  checkAll("Const[String, Int]", ContravariantMonoidalTests[Const[String, *]].contravariantMonoidal[Int, Int, Int])
+  checkAll("ContravariantMonoidal[Const[String, *]]",
+           SerializableTests.serializable(ContravariantMonoidal[Const[String, *]]))
 
-  checkAll("Const[?, ?]", BifoldableTests[Const].bifoldable[Int, Int, Int])
+  checkAll("Const[*, *]", BifoldableTests[Const].bifoldable[Int, Int, Int])
   checkAll("Bifoldable[Const]", SerializableTests.serializable(Bifoldable[Const]))
 
-  checkAll("InvariantMonoidal[Const[String, ?]]",
-           InvariantMonoidalTests[Const[String, ?]].invariantMonoidal[Int, Int, Int])
-  checkAll("InvariantMonoidal[Const[String, ?]]", SerializableTests.serializable(InvariantMonoidal[Const[String, ?]]))
+  checkAll("InvariantMonoidal[Const[String, *]]",
+           InvariantMonoidalTests[Const[String, *]].invariantMonoidal[Int, Int, Int])
+  checkAll("InvariantMonoidal[Const[String, *]]", SerializableTests.serializable(InvariantMonoidal[Const[String, *]]))
 
   test("show") {
 
@@ -91,16 +91,16 @@ class ConstSuite extends CatsSuite {
     }
   }
 
-  checkAll("Const[String, Int]", FunctorTests[Const[String, ?]].functor[Int, Int, Int])
-  checkAll("Functor[Const[String, ?]]", SerializableTests.serializable(Functor[Const[String, ?]]))
+  checkAll("Const[String, Int]", FunctorTests[Const[String, *]].functor[Int, Int, Int])
+  checkAll("Functor[Const[String, *]]", SerializableTests.serializable(Functor[Const[String, *]]))
 
   {
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[Const[CMono, ?]](Const.catsDataFunctorForConst)
-    checkAll("Const[CMono, Int]", CommutativeApplicativeTests[Const[CMono, ?]].commutativeApplicative[Int, Int, Int])
-    checkAll("CommutativeApplicative[Const[CMono, ?]]",
-             SerializableTests.serializable(CommutativeApplicative[Const[CMono, ?]]))
+    implicit val iso = SemigroupalTests.Isomorphisms.invariant[Const[CMono, *]](Const.catsDataFunctorForConst)
+    checkAll("Const[CMono, Int]", CommutativeApplicativeTests[Const[CMono, *]].commutativeApplicative[Int, Int, Int])
+    checkAll("CommutativeApplicative[Const[CMono, *]]",
+             SerializableTests.serializable(CommutativeApplicative[Const[CMono, *]]))
   }
 
-  checkAll("Const[CSemi, Int]", CommutativeApplyTests[Const[CSemi, ?]].commutativeApply[Int, Int, Int])
-  checkAll("CommutativeApply[Const[CSemi, ?]]", SerializableTests.serializable(CommutativeApply[Const[CSemi, ?]]))
+  checkAll("Const[CSemi, Int]", CommutativeApplyTests[Const[CSemi, *]].commutativeApply[Int, Int, Int])
+  checkAll("CommutativeApply[Const[CSemi, *]]", SerializableTests.serializable(CommutativeApply[Const[CSemi, *]]))
 }

--- a/tests/src/test/scala/cats/tests/ContTSuite.scala
+++ b/tests/src/test/scala/cats/tests/ContTSuite.scala
@@ -22,9 +22,9 @@ class ContTSuite extends CatsSuite {
     }
   }
 
-  checkAll("ContT[Function0, Int, ?]", MonadTests[ContT[Function0, Int, ?]].monad[Int, String, Int])
-  checkAll("ContT[Eval, Int, ?]", MonadTests[ContT[Eval, Int, ?]].monad[Int, String, Int])
-  checkAll("ContT[Function0, Int, ?]", DeferTests[ContT[Function0, Int, ?]].defer[Int])
+  checkAll("ContT[Function0, Int, *]", MonadTests[ContT[Function0, Int, *]].monad[Int, String, Int])
+  checkAll("ContT[Eval, Int, *]", MonadTests[ContT[Eval, Int, *]].monad[Int, String, Int])
+  checkAll("ContT[Function0, Int, *]", DeferTests[ContT[Function0, Int, *]].defer[Int])
 
   /**
    * c.mapCont(f).run(g) == f(c.run(g))

--- a/tests/src/test/scala/cats/tests/EitherKSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherKSuite.scala
@@ -9,32 +9,32 @@ import cats.laws.discipline.eq._
 
 class EitherKSuite extends CatsSuite {
 
-  checkAll("EitherK[Option, Option, ?]",
-           TraverseTests[EitherK[Option, Option, ?]].traverse[Int, Int, Int, Int, Option, Option])
-  checkAll("Traverse[EitherK[Option, Option, ?]]", SerializableTests.serializable(Traverse[EitherK[Option, Option, ?]]))
+  checkAll("EitherK[Option, Option, *]",
+           TraverseTests[EitherK[Option, Option, *]].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("Traverse[EitherK[Option, Option, *]]", SerializableTests.serializable(Traverse[EitherK[Option, Option, *]]))
 
   {
     implicit val foldable = EitherK.catsDataFoldableForEitherK[Option, Option]
-    checkAll("EitherK[Option, Option, ?]", FoldableTests[EitherK[Option, Option, ?]].foldable[Int, Int])
-    checkAll("Foldable[EitherK[Option, Option, ?]]",
-             SerializableTests.serializable(Foldable[EitherK[Option, Option, ?]]))
+    checkAll("EitherK[Option, Option, *]", FoldableTests[EitherK[Option, Option, *]].foldable[Int, Int])
+    checkAll("Foldable[EitherK[Option, Option, *]]",
+             SerializableTests.serializable(Foldable[EitherK[Option, Option, *]]))
   }
 
-  checkAll("EitherK[Eval, Eval, ?]", ComonadTests[EitherK[Eval, Eval, ?]].comonad[Int, Int, Int])
-  checkAll("Comonad[EitherK[Eval, Eval, ?]]", SerializableTests.serializable(Comonad[EitherK[Eval, Eval, ?]]))
+  checkAll("EitherK[Eval, Eval, *]", ComonadTests[EitherK[Eval, Eval, *]].comonad[Int, Int, Int])
+  checkAll("Comonad[EitherK[Eval, Eval, *]]", SerializableTests.serializable(Comonad[EitherK[Eval, Eval, *]]))
 
   {
     implicit val coflatMap = EitherK.catsDataCoflatMapForEitherK[Eval, Eval]
-    checkAll("EitherK[Eval, Eval, ?]", CoflatMapTests[EitherK[Eval, Eval, ?]].coflatMap[Int, Int, Int])
-    checkAll("CoflatMap[EitherK[Eval, Eval, ?]]", SerializableTests.serializable(CoflatMap[EitherK[Eval, Eval, ?]]))
+    checkAll("EitherK[Eval, Eval, *]", CoflatMapTests[EitherK[Eval, Eval, *]].coflatMap[Int, Int, Int])
+    checkAll("CoflatMap[EitherK[Eval, Eval, *]]", SerializableTests.serializable(CoflatMap[EitherK[Eval, Eval, *]]))
   }
 
   checkAll("EitherK[Option, Option, Int]", EqTests[EitherK[Option, Option, Int]].eqv)
   checkAll("Eq[EitherK[Option, Option, Int]]", SerializableTests.serializable(Eq[EitherK[Option, Option, Int]]))
 
-  checkAll("EitherK[Show, Show, ?]", ContravariantTests[EitherK[Show, Show, ?]].contravariant[MiniInt, Int, Boolean])
-  checkAll("Contravariant[EitherK[Show, Show, ?]]",
-           SerializableTests.serializable(Contravariant[EitherK[Show, Show, ?]]))
+  checkAll("EitherK[Show, Show, *]", ContravariantTests[EitherK[Show, Show, *]].contravariant[MiniInt, Int, Boolean])
+  checkAll("Contravariant[EitherK[Show, Show, *]]",
+           SerializableTests.serializable(Contravariant[EitherK[Show, Show, *]]))
 
   test("double swap is identity") {
     forAll { (x: EitherK[Option, Option, Int]) =>

--- a/tests/src/test/scala/cats/tests/EitherSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherSuite.scala
@@ -7,28 +7,28 @@ import cats.kernel.laws.discipline.{EqTests, MonoidTests, OrderTests, PartialOrd
 import scala.util.Try
 
 class EitherSuite extends CatsSuite {
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Either[Int, ?]]
+  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Either[Int, *]]
 
   checkAll("Either[String, Int]", MonoidTests[Either[String, Int]].monoid)
   checkAll("Monoid[Either[String, Int]]", SerializableTests.serializable(Monoid[Either[String, Int]]))
 
-  checkAll("Either[Int, Int]", SemigroupalTests[Either[Int, ?]].semigroupal[Int, Int, Int])
-  checkAll("Semigroupal[Either[Int, ?]]", SerializableTests.serializable(Semigroupal[Either[Int, ?]]))
+  checkAll("Either[Int, Int]", SemigroupalTests[Either[Int, *]].semigroupal[Int, Int, Int])
+  checkAll("Semigroupal[Either[Int, *]]", SerializableTests.serializable(Semigroupal[Either[Int, *]]))
 
-  implicit val eq0 = EitherT.catsDataEqForEitherT[Either[Int, ?], Int, Int]
+  implicit val eq0 = EitherT.catsDataEqForEitherT[Either[Int, *], Int, Int]
 
-  checkAll("Either[Int, Int]", MonadErrorTests[Either[Int, ?], Int].monadError[Int, Int, Int])
-  checkAll("MonadError[Either[Int, ?]]", SerializableTests.serializable(MonadError[Either[Int, ?], Int]))
+  checkAll("Either[Int, Int]", MonadErrorTests[Either[Int, *], Int].monadError[Int, Int, Int])
+  checkAll("MonadError[Either[Int, *]]", SerializableTests.serializable(MonadError[Either[Int, *], Int]))
 
-  checkAll("Either[Int, Int] with Option", TraverseTests[Either[Int, ?]].traverse[Int, Int, Int, Int, Option, Option])
-  checkAll("Traverse[Either[Int, ?]", SerializableTests.serializable(Traverse[Either[Int, ?]]))
+  checkAll("Either[Int, Int] with Option", TraverseTests[Either[Int, *]].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("Traverse[Either[Int, *]", SerializableTests.serializable(Traverse[Either[Int, *]]))
 
-  checkAll("Either[?, ?]", BitraverseTests[Either].bitraverse[Option, Int, Int, Int, String, String, String])
+  checkAll("Either[*, *]", BitraverseTests[Either].bitraverse[Option, Int, Int, Int, String, String, String])
   checkAll("Bitraverse[Either]", SerializableTests.serializable(Bitraverse[Either]))
 
-  checkAll("Either[ListWrapper[String], ?]", SemigroupKTests[Either[ListWrapper[String], ?]].semigroupK[Int])
-  checkAll("SemigroupK[Either[ListWrapper[String], ?]]",
-           SerializableTests.serializable(SemigroupK[Either[ListWrapper[String], ?]]))
+  checkAll("Either[ListWrapper[String], *]", SemigroupKTests[Either[ListWrapper[String], *]].semigroupK[Int])
+  checkAll("SemigroupK[Either[ListWrapper[String], *]]",
+           SerializableTests.serializable(SemigroupK[Either[ListWrapper[String], *]]))
 
   checkAll("Either[ListWrapper[String], Int]", SemigroupTests[Either[ListWrapper[String], Int]].semigroup)
   checkAll("Semigroup[Either[ListWrapper[String], Int]]",
@@ -36,7 +36,7 @@ class EitherSuite extends CatsSuite {
 
   val partialOrder = catsStdPartialOrderForEither[Int, String]
   val order = implicitly[Order[Either[Int, String]]]
-  val monad = implicitly[Monad[Either[Int, ?]]]
+  val monad = implicitly[Monad[Either[Int, *]]]
   val show = implicitly[Show[Either[Int, String]]]
 
   {
@@ -337,16 +337,16 @@ class EitherSuite extends CatsSuite {
   }
 
   test("ap consistent with Applicative") {
-    val fab = implicitly[Applicative[Either[String, ?]]]
+    val fab = implicitly[Applicative[Either[String, *]]]
     forAll { (fa: Either[String, Int], f: Int => String) =>
       fa.ap(Either.right(f)) should ===(fab.map(fa)(f))
     }
   }
 
   test("raiseOrPure syntax consistent with fromEither") {
-    val ev = ApplicativeError[Validated[String, ?], String]
+    val ev = ApplicativeError[Validated[String, *], String]
     forAll { (fa: Either[String, Int]) =>
-      fa.raiseOrPure[Validated[String, ?]] should ===(ev.fromEither(fa))
+      fa.raiseOrPure[Validated[String, *]] should ===(ev.fromEither(fa))
     }
   }
 

--- a/tests/src/test/scala/cats/tests/EitherTSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherTSuite.scala
@@ -11,15 +11,15 @@ import scala.util.{Failure, Success, Try}
 
 class EitherTSuite extends CatsSuite {
   implicit val iso = SemigroupalTests.Isomorphisms
-    .invariant[EitherT[ListWrapper, String, ?]](EitherT.catsDataFunctorForEitherT(ListWrapper.functor))
+    .invariant[EitherT[ListWrapper, String, *]](EitherT.catsDataFunctorForEitherT(ListWrapper.functor))
 
-  checkAll("EitherT[Eval, String, ?]", DeferTests[EitherT[Eval, String, ?]].defer[Int])
+  checkAll("EitherT[Eval, String, *]", DeferTests[EitherT[Eval, String, *]].defer[Int])
 
   {
-    checkAll("EitherT[Option, ListWrapper[String], ?]",
-             SemigroupKTests[EitherT[Option, ListWrapper[String], ?]].semigroupK[Int])
-    checkAll("SemigroupK[EitherT[Option, ListWrapper[String], ?]]",
-             SerializableTests.serializable(SemigroupK[EitherT[Option, ListWrapper[String], ?]]))
+    checkAll("EitherT[Option, ListWrapper[String], *]",
+             SemigroupKTests[EitherT[Option, ListWrapper[String], *]].semigroupK[Int])
+    checkAll("SemigroupK[EitherT[Option, ListWrapper[String], *]]",
+             SerializableTests.serializable(SemigroupK[EitherT[Option, ListWrapper[String], *]]))
   }
 
   {
@@ -34,27 +34,27 @@ class EitherTSuite extends CatsSuite {
     // if a Functor for F is defined
     implicit val F = ListWrapper.functor
 
-    checkAll("EitherT[ListWrapper, ?, ?]",
-             BifunctorTests[EitherT[ListWrapper, ?, ?]].bifunctor[Int, Int, Int, String, String, String])
-    checkAll("Bifunctor[EitherT[ListWrapper, ?, ?]]",
-             SerializableTests.serializable(Bifunctor[EitherT[ListWrapper, ?, ?]]))
-    checkAll("EitherT[ListWrapper, Int, ?]", FunctorTests[EitherT[ListWrapper, Int, ?]].functor[Int, Int, Int])
-    checkAll("Functor[EitherT[ListWrapper, Int, ?]]",
-             SerializableTests.serializable(Functor[EitherT[ListWrapper, Int, ?]]))
+    checkAll("EitherT[ListWrapper, *, *]",
+             BifunctorTests[EitherT[ListWrapper, *, *]].bifunctor[Int, Int, Int, String, String, String])
+    checkAll("Bifunctor[EitherT[ListWrapper, *, *]]",
+             SerializableTests.serializable(Bifunctor[EitherT[ListWrapper, *, *]]))
+    checkAll("EitherT[ListWrapper, Int, *]", FunctorTests[EitherT[ListWrapper, Int, *]].functor[Int, Int, Int])
+    checkAll("Functor[EitherT[ListWrapper, Int, *]]",
+             SerializableTests.serializable(Functor[EitherT[ListWrapper, Int, *]]))
   }
 
   {
     // if a Traverse for F is defined
     implicit val F = ListWrapper.traverse
 
-    checkAll("EitherT[ListWrapper, Int, ?]",
-             TraverseTests[EitherT[ListWrapper, Int, ?]].traverse[Int, Int, Int, Int, Option, Option])
-    checkAll("Traverse[EitherT[ListWrapper, Int, ?]]",
-             SerializableTests.serializable(Traverse[EitherT[ListWrapper, Int, ?]]))
-    checkAll("EitherT[ListWrapper, ?, ?]",
-             BitraverseTests[EitherT[ListWrapper, ?, ?]].bitraverse[Option, Int, Int, Int, String, String, String])
-    checkAll("Bitraverse[EitherT[ListWrapper, ?, ?]]",
-             SerializableTests.serializable(Bitraverse[EitherT[ListWrapper, ?, ?]]))
+    checkAll("EitherT[ListWrapper, Int, *]",
+             TraverseTests[EitherT[ListWrapper, Int, *]].traverse[Int, Int, Int, Int, Option, Option])
+    checkAll("Traverse[EitherT[ListWrapper, Int, *]]",
+             SerializableTests.serializable(Traverse[EitherT[ListWrapper, Int, *]]))
+    checkAll("EitherT[ListWrapper, *, *]",
+             BitraverseTests[EitherT[ListWrapper, *, *]].bitraverse[Option, Int, Int, Int, String, String, String])
+    checkAll("Bitraverse[EitherT[ListWrapper, *, *]]",
+             SerializableTests.serializable(Bitraverse[EitherT[ListWrapper, *, *]]))
 
   }
 
@@ -63,16 +63,16 @@ class EitherTSuite extends CatsSuite {
 
     implicit val F = ListWrapper.monad
     implicit val eq0 = EitherT.catsDataEqForEitherT[ListWrapper, String, Either[String, Int]]
-    implicit val eq1 = EitherT.catsDataEqForEitherT[EitherT[ListWrapper, String, ?], String, Int](eq0)
+    implicit val eq1 = EitherT.catsDataEqForEitherT[EitherT[ListWrapper, String, *], String, Int](eq0)
 
-    Functor[EitherT[ListWrapper, String, ?]]
-    Applicative[EitherT[ListWrapper, String, ?]]
-    Monad[EitherT[ListWrapper, String, ?]]
+    Functor[EitherT[ListWrapper, String, *]]
+    Applicative[EitherT[ListWrapper, String, *]]
+    Monad[EitherT[ListWrapper, String, *]]
 
     checkAll("EitherT[ListWrapper, String, Int]",
-             MonadErrorTests[EitherT[ListWrapper, String, ?], String].monadError[Int, Int, Int])
-    checkAll("MonadError[EitherT[List, ?, ?]]",
-             SerializableTests.serializable(MonadError[EitherT[ListWrapper, String, ?], String]))
+             MonadErrorTests[EitherT[ListWrapper, String, *], String].monadError[Int, Int, Int])
+    checkAll("MonadError[EitherT[List, *, *]]",
+             SerializableTests.serializable(MonadError[EitherT[ListWrapper, String, *], String]))
 
   }
 
@@ -81,39 +81,39 @@ class EitherTSuite extends CatsSuite {
     // Tests for catsDataMonadErrorFForEitherT instance, for recovery on errors of F.
 
     implicit val eq1 = EitherT.catsDataEqForEitherT[Option, String, Either[Unit, String]]
-    implicit val eq2 = EitherT.catsDataEqForEitherT[EitherT[Option, String, ?], Unit, String](eq1)
+    implicit val eq2 = EitherT.catsDataEqForEitherT[EitherT[Option, String, *], Unit, String](eq1)
     implicit val me = EitherT.catsDataMonadErrorFForEitherT[Option, Unit, String](catsStdInstancesForOption)
 
-    Functor[EitherT[Option, String, ?]]
-    Applicative[EitherT[Option, String, ?]]
-    Monad[EitherT[Option, String, ?]]
+    Functor[EitherT[Option, String, *]]
+    Applicative[EitherT[Option, String, *]]
+    Monad[EitherT[Option, String, *]]
 
     checkAll("EitherT[Option, String, String]",
-             MonadErrorTests[EitherT[Option, String, ?], Unit].monadError[String, String, String])
-    checkAll("MonadError[EitherT[Option, ?, ?]]",
-             SerializableTests.serializable(MonadError[EitherT[Option, String, ?], Unit]))
+             MonadErrorTests[EitherT[Option, String, *], Unit].monadError[String, String, String])
+    checkAll("MonadError[EitherT[Option, *, *]]",
+             SerializableTests.serializable(MonadError[EitherT[Option, String, *], Unit]))
   }
 
   {
     // if a Monad is defined
     implicit val F = ListWrapper.monad
 
-    Functor[EitherT[ListWrapper, String, ?]]
-    Applicative[EitherT[ListWrapper, String, ?]]
-    Monad[EitherT[ListWrapper, String, ?]]
+    Functor[EitherT[ListWrapper, String, *]]
+    Applicative[EitherT[ListWrapper, String, *]]
+    Monad[EitherT[ListWrapper, String, *]]
 
-    checkAll("EitherT[ListWrapper, String, Int]", MonadTests[EitherT[ListWrapper, String, ?]].monad[Int, Int, Int])
-    checkAll("Monad[EitherT[ListWrapper, String, ?]]",
-             SerializableTests.serializable(Monad[EitherT[ListWrapper, String, ?]]))
+    checkAll("EitherT[ListWrapper, String, Int]", MonadTests[EitherT[ListWrapper, String, *]].monad[Int, Int, Int])
+    checkAll("Monad[EitherT[ListWrapper, String, *]]",
+             SerializableTests.serializable(Monad[EitherT[ListWrapper, String, *]]))
   }
 
   {
     // if a foldable is defined
     implicit val F = ListWrapper.foldable
 
-    checkAll("EitherT[ListWrapper, Int, ?]", FoldableTests[EitherT[ListWrapper, Int, ?]].foldable[Int, Int])
-    checkAll("Foldable[EitherT[ListWrapper, Int, ?]]",
-             SerializableTests.serializable(Foldable[EitherT[ListWrapper, Int, ?]]))
+    checkAll("EitherT[ListWrapper, Int, *]", FoldableTests[EitherT[ListWrapper, Int, *]].foldable[Int, Int])
+    checkAll("Foldable[EitherT[ListWrapper, Int, *]]",
+             SerializableTests.serializable(Foldable[EitherT[ListWrapper, Int, *]]))
   }
 
   {

--- a/tests/src/test/scala/cats/tests/FoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/FoldableSuite.scala
@@ -350,8 +350,8 @@ class FoldableSuiteAdditional extends CatsSuite {
     checkMonadicFoldsStackSafety[SortedSet](s => SortedSet(s: _*))
   }
 
-  test("Foldable[SortedMap[String, ?]].foldM/existsM/forallM/findM/collectFirstSomeM stack safety") {
-    checkMonadicFoldsStackSafety[SortedMap[String, ?]](
+  test("Foldable[SortedMap[String, *]].foldM/existsM/forallM/findM/collectFirstSomeM stack safety") {
+    checkMonadicFoldsStackSafety[SortedMap[String, *]](
       xs => SortedMap.empty[String, Int] ++ xs.map(x => x.toString -> x).toMap
     )
   }
@@ -413,7 +413,7 @@ class FoldableSuiteAdditional extends CatsSuite {
   test(".foldLeftM short-circuiting") {
     implicit val F = foldableLazyListWithDefaultImpl
     val ns = LazyList.continually(1)
-    val res = F.foldLeftM[Either[Int, ?], Int, Int](ns, 0) { (sum, n) =>
+    val res = F.foldLeftM[Either[Int, *], Int, Int](ns, 0) { (sum, n) =>
       if (sum >= 100000) Left(sum) else Right(sum + n)
     }
     assert(res == Left(100000))
@@ -425,7 +425,7 @@ class FoldableSuiteAdditional extends CatsSuite {
     // test that no more elements are evaluated than absolutely necessary
 
     def concatUntil(ss: LazyList[String], stop: String): Either[String, String] =
-      F.foldLeftM[Either[String, ?], String, String](ss, "") { (acc, s) =>
+      F.foldLeftM[Either[String, *], String, String](ss, "") { (acc, s) =>
         if (s == stop) Left(acc) else Right(acc + s)
       }
 
@@ -469,7 +469,7 @@ class FoldableLazyListSuite extends FoldableSuite[LazyList]("lazyList") {
   def iterator[T](list: LazyList[T]): Iterator[T] = list.iterator
 }
 
-class FoldableSortedMapSuite extends FoldableSuite[SortedMap[Int, ?]]("sortedMap") {
+class FoldableSortedMapSuite extends FoldableSuite[SortedMap[Int, *]]("sortedMap") {
   def iterator[T](map: SortedMap[Int, T]): Iterator[T] = map.valuesIterator
 }
 
@@ -477,11 +477,11 @@ class FoldableOptionSuite extends FoldableSuite[Option]("option") {
   def iterator[T](option: Option[T]): Iterator[T] = option.iterator
 }
 
-class FoldableEitherSuite extends FoldableSuite[Either[Int, ?]]("either") {
+class FoldableEitherSuite extends FoldableSuite[Either[Int, *]]("either") {
   def iterator[T](either: Either[Int, T]): Iterator[T] = either.toOption.iterator
 }
 
-class FoldableValidatedSuite extends FoldableSuite[Validated[String, ?]]("validated") {
+class FoldableValidatedSuite extends FoldableSuite[Validated[String, *]]("validated") {
   def iterator[T](validated: Validated[String, T]): Iterator[T] = validated.toOption.iterator
 }
 
@@ -489,36 +489,36 @@ class FoldableTrySuite extends FoldableSuite[Try]("try") {
   def iterator[T](tryt: Try[T]): Iterator[T] = tryt.toOption.iterator
 }
 
-class FoldableEitherKSuite extends FoldableSuite[EitherK[Option, Option, ?]]("eitherK") {
+class FoldableEitherKSuite extends FoldableSuite[EitherK[Option, Option, *]]("eitherK") {
   def iterator[T](eitherK: EitherK[Option, Option, T]) = eitherK.run.bimap(_.iterator, _.iterator).merge
 }
 
-class FoldableIorSuite extends FoldableSuite[Int Ior ?]("ior") {
+class FoldableIorSuite extends FoldableSuite[Int Ior *]("ior") {
   def iterator[T](ior: Int Ior T) =
     ior.fold(_ => None.iterator, b => Some(b).iterator, (_, b) => Some(b).iterator)
 }
 
-class FoldableIdSuite extends FoldableSuite[Id[?]]("id") {
+class FoldableIdSuite extends FoldableSuite[Id[*]]("id") {
   def iterator[T](id: Id[T]) = Some(id).iterator
 }
 
-class FoldableIdTSuite extends FoldableSuite[IdT[Option, ?]]("idT") {
+class FoldableIdTSuite extends FoldableSuite[IdT[Option, *]]("idT") {
   def iterator[T](idT: IdT[Option, T]) = idT.value.iterator
 }
 
-class FoldableConstSuite extends FoldableSuite[Const[Int, ?]]("const") {
+class FoldableConstSuite extends FoldableSuite[Const[Int, *]]("const") {
   def iterator[T](const: Const[Int, T]) = None.iterator
 }
 
-class FoldableTuple2Suite extends FoldableSuite[(Int, ?)]("tuple2") {
+class FoldableTuple2Suite extends FoldableSuite[(Int, *)]("tuple2") {
   def iterator[T](tuple: (Int, T)) = Some(tuple._2).iterator
 }
 
-class FoldableOneAndSuite extends FoldableSuite[OneAnd[List, ?]]("oneAnd") {
+class FoldableOneAndSuite extends FoldableSuite[OneAnd[List, *]]("oneAnd") {
   def iterator[T](oneAnd: OneAnd[List, T]) = (oneAnd.head :: oneAnd.tail).iterator
 }
 
-class FoldableComposedSuite extends FoldableSuite[Nested[List, Option, ?]]("nested") {
+class FoldableComposedSuite extends FoldableSuite[Nested[List, Option, *]]("nested") {
   def iterator[T](nested: Nested[List, Option, T]) =
     nested.value.collect {
       case Some(t) => t

--- a/tests/src/test/scala/cats/tests/FuncSuite.scala
+++ b/tests/src/test/scala/cats/tests/FuncSuite.scala
@@ -14,43 +14,43 @@ class FuncSuite extends CatsSuite {
   implicit def appFuncEq[F[_], A, B](implicit ev: Eq[A => F[B]]): Eq[AppFunc[F, A, B]] =
     Eq.by[AppFunc[F, A, B], A => F[B]](_.run)
 
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Func[Option, Int, ?]]
+  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Func[Option, Int, *]]
 
-  checkAll("Func[Option, MiniInt, Int]", SemigroupalTests[Func[Option, MiniInt, ?]].semigroupal[Int, Int, Int])
-  checkAll("Semigroupal[Func[Option, Int, ?]]", SerializableTests.serializable(Semigroupal[Func[Option, Int, ?]]))
+  checkAll("Func[Option, MiniInt, Int]", SemigroupalTests[Func[Option, MiniInt, *]].semigroupal[Int, Int, Int])
+  checkAll("Semigroupal[Func[Option, Int, *]]", SerializableTests.serializable(Semigroupal[Func[Option, Int, *]]))
 
   {
     implicit val catsDataApplicativeForFunc = Func.catsDataApplicativeForFunc[Option, Int]
-    checkAll("Func[Option, MiniInt, Int]", ApplicativeTests[Func[Option, MiniInt, ?]].applicative[Int, Int, Int])
-    checkAll("Applicative[Func[Option, Int, ?]]", SerializableTests.serializable(Applicative[Func[Option, Int, ?]]))
+    checkAll("Func[Option, MiniInt, Int]", ApplicativeTests[Func[Option, MiniInt, *]].applicative[Int, Int, Int])
+    checkAll("Applicative[Func[Option, Int, *]]", SerializableTests.serializable(Applicative[Func[Option, Int, *]]))
   }
 
   {
     implicit val catsDataApplyForFunc = Func.catsDataApplyForFunc[Option, MiniInt]
-    checkAll("Func[Option, MiniInt, Int]", ApplyTests[Func[Option, MiniInt, ?]].apply[Int, Int, Int])
-    checkAll("Apply[Func[Option, Int, ?]]", SerializableTests.serializable(Apply[Func[Option, Int, ?]]))
+    checkAll("Func[Option, MiniInt, Int]", ApplyTests[Func[Option, MiniInt, *]].apply[Int, Int, Int])
+    checkAll("Apply[Func[Option, Int, *]]", SerializableTests.serializable(Apply[Func[Option, Int, *]]))
   }
 
   {
     implicit val catsDataFunctorForFunc = Func.catsDataFunctorForFunc[Option, Int]
-    checkAll("Func[Option, MiniInt, Int]", FunctorTests[Func[Option, MiniInt, ?]].functor[Int, Int, Int])
-    checkAll("Functor[Func[Option, Int, ?]]", SerializableTests.serializable(Functor[Func[Option, Int, ?]]))
+    checkAll("Func[Option, MiniInt, Int]", FunctorTests[Func[Option, MiniInt, *]].functor[Int, Int, Int])
+    checkAll("Functor[Func[Option, Int, *]]", SerializableTests.serializable(Functor[Func[Option, Int, *]]))
   }
 
   {
     implicit val funcContravariant = Func.catsDataContravariantForFunc[Show, MiniInt]
     checkAll("Func[Show, MiniInt, MiniInt]",
-             ContravariantTests[Func[Show, ?, MiniInt]].contravariant[MiniInt, MiniInt, MiniInt])
-    checkAll("Contravariant[Func[Show, ?, Int]]", SerializableTests.serializable(Contravariant[Func[Show, ?, Int]]))
+             ContravariantTests[Func[Show, *, MiniInt]].contravariant[MiniInt, MiniInt, MiniInt])
+    checkAll("Contravariant[Func[Show, *, Int]]", SerializableTests.serializable(Contravariant[Func[Show, *, Int]]))
   }
 
   {
     implicit val appFuncApp = AppFunc.appFuncApplicative[Option, Int]
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[AppFunc[Option, Int, ?]]
+    implicit val iso = SemigroupalTests.Isomorphisms.invariant[AppFunc[Option, Int, *]]
     checkAll("AppFunc[Option, MiniInt, MiniInt]",
-             ApplicativeTests[AppFunc[Option, MiniInt, ?]].applicative[MiniInt, MiniInt, MiniInt])
-    checkAll("Applicative[AppFunc[Option, Int, ?]]",
-             SerializableTests.serializable(Applicative[AppFunc[Option, Int, ?]]))
+             ApplicativeTests[AppFunc[Option, MiniInt, *]].applicative[MiniInt, MiniInt, MiniInt])
+    checkAll("Applicative[AppFunc[Option, Int, *]]",
+             SerializableTests.serializable(Applicative[AppFunc[Option, Int, *]]))
   }
 
   test("product") {

--- a/tests/src/test/scala/cats/tests/FunctionSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctionSuite.scala
@@ -34,22 +34,22 @@ class FunctionSuite extends CatsSuite {
   checkAll("Function0[Int]", DeferTests[Function0].defer[Int])
   checkAll("Defer[Function0[Int]]", SerializableTests.serializable(Defer[Function0]))
 
-  checkAll("Function1[MiniInt, Int]", DeferTests[Function1[MiniInt, ?]].defer[Int])
-  checkAll("Defer[Function1[Int, Int]]", SerializableTests.serializable(Defer[Function1[Int, ?]]))
+  checkAll("Function1[MiniInt, Int]", DeferTests[Function1[MiniInt, *]].defer[Int])
+  checkAll("Defer[Function1[Int, Int]]", SerializableTests.serializable(Defer[Function1[Int, *]]))
 
   checkAll("Function0[Int]", BimonadTests[Function0].bimonad[Int, Int, Int])
   checkAll("Bimonad[Function0]", SerializableTests.serializable(Bimonad[Function0]))
 
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Function1[MiniInt, ?]]
-  checkAll("Function1[MiniInt, Int]", SemigroupalTests[Function1[MiniInt, ?]].semigroupal[Int, Int, Int])
+  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Function1[MiniInt, *]]
+  checkAll("Function1[MiniInt, Int]", SemigroupalTests[Function1[MiniInt, *]].semigroupal[Int, Int, Int])
 
   // TODO: make an binary compatible way to do this
-  // checkAll("Function1[Int => ?]", DeferTests[Function1[Int, ?]].defer[Int])
+  // checkAll("Function1[Int => *]", DeferTests[Function1[Int, *]].defer[Int])
 
-  checkAll("Semigroupal[Function1[Int, ?]]", SerializableTests.serializable(Semigroupal[Function1[Int, ?]]))
+  checkAll("Semigroupal[Function1[Int, *]]", SerializableTests.serializable(Semigroupal[Function1[Int, *]]))
 
-  checkAll("Function1[MiniInt, Int]", MonadTests[MiniInt => ?].monad[Int, Int, Int])
-  checkAll("Monad[Int => ?]", SerializableTests.serializable(Monad[Int => ?]))
+  checkAll("Function1[MiniInt, Int]", MonadTests[MiniInt => *].monad[Int, Int, Int])
+  checkAll("Monad[Int => *]", SerializableTests.serializable(Monad[Int => *]))
 
   checkAll("Function1[MiniInt, MiniInt]",
            CommutativeArrowTests[Function1].commutativeArrow[MiniInt, MiniInt, MiniInt, MiniInt, MiniInt, MiniInt])
@@ -61,15 +61,15 @@ class FunctionSuite extends CatsSuite {
   checkAll("Function1", ArrowChoiceTests[Function1].arrowChoice[MiniInt, MiniInt, MiniInt, MiniInt, MiniInt, MiniInt])
   checkAll("ArrowChoice[Function1]", SerializableTests.serializable(ArrowChoice[Function1]))
 
-  checkAll("Function1", ContravariantTests[? => MiniInt].contravariant[MiniInt, MiniInt, MiniInt])
-  checkAll("Contravariant[? => Int]", SerializableTests.serializable(Contravariant[? => Int]))
+  checkAll("Function1", ContravariantTests[* => MiniInt].contravariant[MiniInt, MiniInt, MiniInt])
+  checkAll("Contravariant[* => Int]", SerializableTests.serializable(Contravariant[* => Int]))
 
   checkAll("Function1", MonoidKTests[λ[α => α => α]].monoidK[MiniInt])
   checkAll("MonoidK[λ[α => α => α]", SerializableTests.serializable(catsStdMonoidKForFunction1))
 
-  checkAll("Function1[MiniInt, ?]",
-           DistributiveTests[MiniInt => ?].distributive[Int, Int, Int, Id, Function1[MiniInt, ?]])
-  checkAll("Distributive[Int => ?]", SerializableTests.serializable(Distributive[Int => ?]))
+  checkAll("Function1[MiniInt, *]",
+           DistributiveTests[MiniInt => *].distributive[Int, Int, Int, Id, Function1[MiniInt, *]])
+  checkAll("Distributive[Int => *]", SerializableTests.serializable(Distributive[Int => *]))
 
   // law checks for the various Function0-related instances
   checkAll("Function0[Eqed]", EqTests[Function0[Eqed]].eqv)
@@ -93,9 +93,9 @@ class FunctionSuite extends CatsSuite {
   }
 
   // Test for Arrow applicative
-  Applicative[String => ?]
-  checkAll("Function1[MiniInt, ?]",
-           ApplicativeTests[Function1[MiniInt, ?]](Applicative.catsApplicativeForArrow[Function1, MiniInt])
+  Applicative[String => *]
+  checkAll("Function1[MiniInt, *]",
+           ApplicativeTests[Function1[MiniInt, *]](Applicative.catsApplicativeForArrow[Function1, MiniInt])
              .applicative[Int, Int, Int])
 
   // serialization tests for the various Function0-related instances
@@ -124,9 +124,9 @@ class FunctionSuite extends CatsSuite {
   checkAll("Function1[MiniInt, Grp]", GroupTests[Function1[MiniInt, Grp]].group)
   checkAll("Function1[MiniInt, CGrp]", CommutativeGroupTests[Function1[MiniInt, CGrp]].commutativeGroup)
   // Isos for ContravariantMonoidal
-  implicit val isoCodomain = SemigroupalTests.Isomorphisms.invariant[Function1[?, Long]]
-  checkAll("Function1[?, Monoid]",
-           ContravariantMonoidalTests[Function1[?, Long]].contravariantMonoidal[MiniInt, MiniInt, MiniInt])
+  implicit val isoCodomain = SemigroupalTests.Isomorphisms.invariant[Function1[*, Long]]
+  checkAll("Function1[*, Monoid]",
+           ContravariantMonoidalTests[Function1[*, Long]].contravariantMonoidal[MiniInt, MiniInt, MiniInt])
 
   // serialization tests for the various Function1-related instances
   checkAll("Semigroup[String => Semi]", SerializableTests.serializable(Semigroup[String => Semi]))
@@ -139,8 +139,8 @@ class FunctionSuite extends CatsSuite {
   checkAll("CommutativeMonoid[String => CMono]", SerializableTests.serializable(CommutativeMonoid[String => CMono]))
   checkAll("Group[String => Grp]", SerializableTests.serializable(Group[String => Grp]))
   checkAll("CommutativeGroup[String => CGrp]", SerializableTests.serializable(CommutativeGroup[String => CGrp]))
-  checkAll("ContravariantMonoidal[Function1[?, Monoid]]",
-           SerializableTests.serializable(ContravariantMonoidal[? => Long]))
+  checkAll("ContravariantMonoidal[Function1[*, Monoid]]",
+           SerializableTests.serializable(ContravariantMonoidal[* => Long]))
 
   test("MonoidK[Endo] is stack safe on combineK") {
     def incrementAll(as: Int): Int = as + 1

--- a/tests/src/test/scala/cats/tests/IdTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IdTSuite.scala
@@ -10,14 +10,14 @@ import Helpers.CSemi
 class IdTSuite extends CatsSuite {
 
   implicit val iso =
-    SemigroupalTests.Isomorphisms.invariant[IdT[ListWrapper, ?]](IdT.catsDataFunctorForIdT(ListWrapper.functor))
+    SemigroupalTests.Isomorphisms.invariant[IdT[ListWrapper, *]](IdT.catsDataFunctorForIdT(ListWrapper.functor))
 
-  checkAll("IdT[(CSemi, ?), Int]", CommutativeFlatMapTests[IdT[(CSemi, ?), ?]].commutativeFlatMap[Int, Int, Int])
-  checkAll("CommutativeFlatMap[IdT[(CSemi, ?), ?]]",
-           SerializableTests.serializable(CommutativeFlatMap[IdT[(CSemi, ?), ?]]))
+  checkAll("IdT[(CSemi, *), Int]", CommutativeFlatMapTests[IdT[(CSemi, *), *]].commutativeFlatMap[Int, Int, Int])
+  checkAll("CommutativeFlatMap[IdT[(CSemi, *), *]]",
+           SerializableTests.serializable(CommutativeFlatMap[IdT[(CSemi, *), *]]))
 
-  checkAll("IdT[Option, Int]", CommutativeMonadTests[IdT[Option, ?]].commutativeMonad[Int, Int, Int])
-  checkAll("CommutativeMonad[IdT[Option, ?]]", SerializableTests.serializable(CommutativeMonad[IdT[Option, ?]]))
+  checkAll("IdT[Option, Int]", CommutativeMonadTests[IdT[Option, *]].commutativeMonad[Int, Int, Int])
+  checkAll("CommutativeMonad[IdT[Option, *]]", SerializableTests.serializable(CommutativeMonad[IdT[Option, *]]))
 
   {
     implicit val F = ListWrapper.eqv[Option[Int]]
@@ -36,67 +36,67 @@ class IdTSuite extends CatsSuite {
   {
     implicit val F = ListWrapper.functor
 
-    checkAll("IdT[ListWrapper, Int]", FunctorTests[IdT[ListWrapper, ?]].functor[Int, Int, Int])
-    checkAll("Functor[IdT[ListWrapper, ?]]", SerializableTests.serializable(Functor[IdT[ListWrapper, ?]]))
+    checkAll("IdT[ListWrapper, Int]", FunctorTests[IdT[ListWrapper, *]].functor[Int, Int, Int])
+    checkAll("Functor[IdT[ListWrapper, *]]", SerializableTests.serializable(Functor[IdT[ListWrapper, *]]))
   }
 
   {
     implicit val F = ListWrapper.applyInstance
 
-    checkAll("IdT[ListWrapper, Int]", ApplyTests[IdT[ListWrapper, ?]].apply[Int, Int, Int])
-    checkAll("Apply[IdT[ListWrapper, ?]]", SerializableTests.serializable(Apply[IdT[ListWrapper, ?]]))
+    checkAll("IdT[ListWrapper, Int]", ApplyTests[IdT[ListWrapper, *]].apply[Int, Int, Int])
+    checkAll("Apply[IdT[ListWrapper, *]]", SerializableTests.serializable(Apply[IdT[ListWrapper, *]]))
   }
 
   {
     implicit val F = ListWrapper.applicative
 
-    checkAll("IdT[ListWrapper, Int]", ApplicativeTests[IdT[ListWrapper, ?]].applicative[Int, Int, Int])
-    checkAll("Applicative[IdT[ListWrapper, ?]]", SerializableTests.serializable(Applicative[IdT[ListWrapper, ?]]))
+    checkAll("IdT[ListWrapper, Int]", ApplicativeTests[IdT[ListWrapper, *]].applicative[Int, Int, Int])
+    checkAll("Applicative[IdT[ListWrapper, *]]", SerializableTests.serializable(Applicative[IdT[ListWrapper, *]]))
   }
 
   {
-    checkAll("IdT[Const[String, ?], ?]",
-             ContravariantMonoidalTests[IdT[Const[String, ?], ?]].contravariantMonoidal[Int, Int, Int])
-    checkAll("ContravariantMonoidal[IdT[Const[String, ?], ?]]",
-             SerializableTests.serializable(ContravariantMonoidal[IdT[Const[String, ?], ?]]))
+    checkAll("IdT[Const[String, *], *]",
+             ContravariantMonoidalTests[IdT[Const[String, *], *]].contravariantMonoidal[Int, Int, Int])
+    checkAll("ContravariantMonoidal[IdT[Const[String, *], *]]",
+             SerializableTests.serializable(ContravariantMonoidal[IdT[Const[String, *], *]]))
   }
 
   {
     implicit val F = ListWrapper.flatMap
 
-    checkAll("IdT[ListWrapper, Int]", FlatMapTests[IdT[ListWrapper, ?]].flatMap[Int, Int, Int])
-    checkAll("FlatMap[IdT[ListWrapper, ?]]", SerializableTests.serializable(FlatMap[IdT[ListWrapper, ?]]))
+    checkAll("IdT[ListWrapper, Int]", FlatMapTests[IdT[ListWrapper, *]].flatMap[Int, Int, Int])
+    checkAll("FlatMap[IdT[ListWrapper, *]]", SerializableTests.serializable(FlatMap[IdT[ListWrapper, *]]))
   }
 
   {
     implicit val F = ListWrapper.monad
 
-    checkAll("IdT[ListWrapper, Int]", MonadTests[IdT[ListWrapper, ?]].monad[Int, Int, Int])
-    checkAll("Monad[IdT[ListWrapper, ?]]", SerializableTests.serializable(Monad[IdT[ListWrapper, ?]]))
+    checkAll("IdT[ListWrapper, Int]", MonadTests[IdT[ListWrapper, *]].monad[Int, Int, Int])
+    checkAll("Monad[IdT[ListWrapper, *]]", SerializableTests.serializable(Monad[IdT[ListWrapper, *]]))
   }
 
   {
     implicit val F = ListWrapper.foldable
 
-    checkAll("IdT[ListWrapper, Int]", FoldableTests[IdT[ListWrapper, ?]].foldable[Int, Int])
-    checkAll("Foldable[IdT[ListWrapper, ?]]", SerializableTests.serializable(Foldable[IdT[ListWrapper, ?]]))
+    checkAll("IdT[ListWrapper, Int]", FoldableTests[IdT[ListWrapper, *]].foldable[Int, Int])
+    checkAll("Foldable[IdT[ListWrapper, *]]", SerializableTests.serializable(Foldable[IdT[ListWrapper, *]]))
   }
 
   {
     implicit val F = ListWrapper.traverse
 
     checkAll("IdT[ListWrapper, Int] with Option",
-             TraverseTests[IdT[ListWrapper, ?]].traverse[Int, Int, Int, Int, Option, Option])
-    checkAll("Traverse[IdT[ListWrapper, ?]]", SerializableTests.serializable(Traverse[IdT[ListWrapper, ?]]))
+             TraverseTests[IdT[ListWrapper, *]].traverse[Int, Int, Int, Int, Option, Option])
+    checkAll("Traverse[IdT[ListWrapper, *]]", SerializableTests.serializable(Traverse[IdT[ListWrapper, *]]))
   }
 
   {
     implicit val F = NonEmptyList.catsDataInstancesForNonEmptyList
 
     checkAll("IdT[NonEmptyList, Int]",
-             NonEmptyTraverseTests[IdT[NonEmptyList, ?]].nonEmptyTraverse[Option, Int, Int, Int, Int, Option, Option])
-    checkAll("NonEmptyTraverse[IdT[NonEmptyList, ?]]",
-             SerializableTests.serializable(NonEmptyTraverse[IdT[NonEmptyList, ?]]))
+             NonEmptyTraverseTests[IdT[NonEmptyList, *]].nonEmptyTraverse[Option, Int, Int, Int, Int, Option, Option])
+    checkAll("NonEmptyTraverse[IdT[NonEmptyList, *]]",
+             SerializableTests.serializable(NonEmptyTraverse[IdT[NonEmptyList, *]]))
   }
 
   test("flatMap and flatMapF consistent") {

--- a/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTSuite.scala
@@ -312,65 +312,65 @@ class ReaderWriterStateTSuite extends CatsSuite {
   }
 
   implicit val iso = SemigroupalTests.Isomorphisms
-    .invariant[IndexedReaderWriterStateT[ListWrapper, String, String, Int, String, ?]](
+    .invariant[IndexedReaderWriterStateT[ListWrapper, String, String, Int, String, *]](
       IndexedReaderWriterStateT.catsDataFunctorForIRWST(ListWrapper.functor)
     )
 
   checkAll(
-    "IndexedReaderWriterStateT[Eval, Boolean, String, MiniInt, String, ?]",
-    DeferTests[IndexedReaderWriterStateT[Eval, Boolean, String, MiniInt, String, ?]].defer[Int]
+    "IndexedReaderWriterStateT[Eval, Boolean, String, MiniInt, String, *]",
+    DeferTests[IndexedReaderWriterStateT[Eval, Boolean, String, MiniInt, String, *]].defer[Int]
   )
 
   {
     implicit val F: Monad[ListWrapper] = ListWrapper.monad
 
     checkAll(
-      "IndexedReaderWriterStateT[ListWrapper, Boolean, String, MiniInt, String, ?]",
-      FunctorTests[IndexedReaderWriterStateT[ListWrapper, Boolean, String, MiniInt, String, ?]].functor[Int, Int, Int]
+      "IndexedReaderWriterStateT[ListWrapper, Boolean, String, MiniInt, String, *]",
+      FunctorTests[IndexedReaderWriterStateT[ListWrapper, Boolean, String, MiniInt, String, *]].functor[Int, Int, Int]
     )
     checkAll(
-      "Functor[IndexedReaderWriterStateT[ListWrapper, String, String, Int, String, ?]]",
-      SerializableTests.serializable(Functor[IndexedReaderWriterStateT[ListWrapper, String, String, Int, String, ?]])
+      "Functor[IndexedReaderWriterStateT[ListWrapper, String, String, Int, String, *]]",
+      SerializableTests.serializable(Functor[IndexedReaderWriterStateT[ListWrapper, String, String, Int, String, *]])
     )
 
     checkAll(
-      "IndexedReaderWriterStateT[ListWrapper, String, String, ?, Int, Int]",
-      ContravariantTests[IndexedReaderWriterStateT[ListWrapper, Boolean, String, ?, Int, Int]]
+      "IndexedReaderWriterStateT[ListWrapper, String, String, *, Int, Int]",
+      ContravariantTests[IndexedReaderWriterStateT[ListWrapper, Boolean, String, *, Int, Int]]
         .contravariant[MiniInt, String, Boolean]
     )
     checkAll(
-      "Contravariant[IndexedReaderWriterStateT[ListWrapper, String, String, ?, Int, Int]]",
-      SerializableTests.serializable(Contravariant[IndexedReaderWriterStateT[ListWrapper, String, String, ?, Int, Int]])
+      "Contravariant[IndexedReaderWriterStateT[ListWrapper, String, String, *, Int, Int]]",
+      SerializableTests.serializable(Contravariant[IndexedReaderWriterStateT[ListWrapper, String, String, *, Int, Int]])
     )
 
     checkAll(
-      "IndexedReaderWriterStateT[ListWrapper, String, String, ?, ?, Int]",
-      ProfunctorTests[IndexedReaderWriterStateT[ListWrapper, Boolean, String, ?, ?, Int]]
+      "IndexedReaderWriterStateT[ListWrapper, String, String, *, *, Int]",
+      ProfunctorTests[IndexedReaderWriterStateT[ListWrapper, Boolean, String, *, *, Int]]
         .profunctor[MiniInt, Int, Int, String, String, String]
     )
     checkAll(
-      "Profunctor[IndexedReaderWriterStateT[ListWrapper, String, String, ?, ?, Int]]",
-      SerializableTests.serializable(Profunctor[IndexedReaderWriterStateT[ListWrapper, String, String, ?, ?, Int]])
+      "Profunctor[IndexedReaderWriterStateT[ListWrapper, String, String, *, *, Int]]",
+      SerializableTests.serializable(Profunctor[IndexedReaderWriterStateT[ListWrapper, String, String, *, *, Int]])
     )
 
     checkAll(
-      "IndexedReaderWriterStateT[ListWrapper, Boolean, String, ?, ?, Int]",
-      StrongTests[IndexedReaderWriterStateT[ListWrapper, Boolean, String, ?, ?, Int]]
+      "IndexedReaderWriterStateT[ListWrapper, Boolean, String, *, *, Int]",
+      StrongTests[IndexedReaderWriterStateT[ListWrapper, Boolean, String, *, *, Int]]
         .strong[MiniInt, Int, Boolean, Boolean, Boolean, String]
     )
     checkAll(
-      "Strong[IndexedReaderWriterStateT[ListWrapper, String, String, ?, ?, Int]]",
-      SerializableTests.serializable(Strong[IndexedReaderWriterStateT[ListWrapper, String, String, ?, ?, Int]])
+      "Strong[IndexedReaderWriterStateT[ListWrapper, String, String, *, *, Int]]",
+      SerializableTests.serializable(Strong[IndexedReaderWriterStateT[ListWrapper, String, String, *, *, Int]])
     )
 
     checkAll(
-      "IndexedReaderWriterStateT[ListWrapper, String, String, Int, ?, ?]",
-      BifunctorTests[IndexedReaderWriterStateT[ListWrapper, Boolean, String, MiniInt, ?, ?]]
+      "IndexedReaderWriterStateT[ListWrapper, String, String, Int, *, *]",
+      BifunctorTests[IndexedReaderWriterStateT[ListWrapper, Boolean, String, MiniInt, *, *]]
         .bifunctor[Int, Int, Boolean, String, String, String]
     )
     checkAll(
-      "Bifunctor[IndexedReaderWriterStateT[ListWrapper, String, String, Int, ?, ?]]",
-      SerializableTests.serializable(Bifunctor[IndexedReaderWriterStateT[ListWrapper, String, String, Int, ?, ?]])
+      "Bifunctor[IndexedReaderWriterStateT[ListWrapper, String, String, Int, *, *]]",
+      SerializableTests.serializable(Bifunctor[IndexedReaderWriterStateT[ListWrapper, String, String, Int, *, *]])
     )
   }
 
@@ -382,10 +382,10 @@ class ReaderWriterStateTSuite extends CatsSuite {
                                                                                       Monoid[String])
 
     checkAll(
-      "IndexedReaderWriterStateT[ListWrapper, String, String, Int, Int, ?]",
-      AlternativeTests[IRWST[ListWrapper, Boolean, String, MiniInt, MiniInt, ?]](SA).alternative[Int, Int, Int]
+      "IndexedReaderWriterStateT[ListWrapper, String, String, Int, Int, *]",
+      AlternativeTests[IRWST[ListWrapper, Boolean, String, MiniInt, MiniInt, *]](SA).alternative[Int, Int, Int]
     )
-    checkAll("Alternative[IndexedReaderWriterStateT[ListWrapper, String, String, Int, Int, ?]]",
+    checkAll("Alternative[IndexedReaderWriterStateT[ListWrapper, String, String, Int, Int, *]]",
              SerializableTests.serializable(SA))
   }
 
@@ -393,27 +393,27 @@ class ReaderWriterStateTSuite extends CatsSuite {
     implicit val LWM: Monad[ListWrapper] = ListWrapper.monad
 
     checkAll(
-      "ReaderWriterStateT[ListWrapper, Boolean, String, MiniInt, MiniInt, ?]",
-      MonadTests[ReaderWriterStateT[ListWrapper, Boolean, String, MiniInt, ?]].monad[Int, Int, Int]
+      "ReaderWriterStateT[ListWrapper, Boolean, String, MiniInt, MiniInt, *]",
+      MonadTests[ReaderWriterStateT[ListWrapper, Boolean, String, MiniInt, *]].monad[Int, Int, Int]
     )
     checkAll(
-      "Monad[ReaderWriterStateT[ListWrapper, String, String, Int, ?]]",
-      SerializableTests.serializable(Monad[ReaderWriterStateT[ListWrapper, String, String, Int, ?]])
+      "Monad[ReaderWriterStateT[ListWrapper, String, String, Int, *]]",
+      SerializableTests.serializable(Monad[ReaderWriterStateT[ListWrapper, String, String, Int, *]])
     )
   }
 
   {
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[ReaderWriterStateT[Option, Boolean, String, MiniInt, ?]]
-    implicit val eqEitherTFA: Eq[EitherT[ReaderWriterStateT[Option, Boolean, String, MiniInt, ?], Unit, Int]] =
-      EitherT.catsDataEqForEitherT[ReaderWriterStateT[Option, Boolean, String, MiniInt, ?], Unit, Int]
+    implicit val iso = SemigroupalTests.Isomorphisms.invariant[ReaderWriterStateT[Option, Boolean, String, MiniInt, *]]
+    implicit val eqEitherTFA: Eq[EitherT[ReaderWriterStateT[Option, Boolean, String, MiniInt, *], Unit, Int]] =
+      EitherT.catsDataEqForEitherT[ReaderWriterStateT[Option, Boolean, String, MiniInt, *], Unit, Int]
 
     checkAll(
-      "ReaderWriterStateT[Option, Boolean, String, MiniIntInt, ?]",
-      MonadErrorTests[ReaderWriterStateT[Option, Boolean, String, MiniInt, ?], Unit].monadError[Int, Int, Int]
+      "ReaderWriterStateT[Option, Boolean, String, MiniIntInt, *]",
+      MonadErrorTests[ReaderWriterStateT[Option, Boolean, String, MiniInt, *], Unit].monadError[Int, Int, Int]
     )
     checkAll(
-      "MonadError[ReaderWriterStateT[Option, String, String, Int, ?], Unit]",
-      SerializableTests.serializable(MonadError[ReaderWriterStateT[Option, String, String, Int, ?], Unit])
+      "MonadError[ReaderWriterStateT[Option, String, String, Int, *], Unit]",
+      SerializableTests.serializable(MonadError[ReaderWriterStateT[Option, String, String, Int, *], Unit])
     )
   }
 
@@ -422,12 +422,12 @@ class ReaderWriterStateTSuite extends CatsSuite {
     implicit val S: SemigroupK[ListWrapper] = ListWrapper.semigroupK
 
     checkAll(
-      "ReaderWriterStateT[ListWrapper, Boolean, String, MiniInt, ?]",
-      SemigroupKTests[ReaderWriterStateT[ListWrapper, Boolean, String, MiniInt, ?]].semigroupK[Int]
+      "ReaderWriterStateT[ListWrapper, Boolean, String, MiniInt, *]",
+      SemigroupKTests[ReaderWriterStateT[ListWrapper, Boolean, String, MiniInt, *]].semigroupK[Int]
     )
     checkAll(
-      "SemigroupK[ReaderWriterStateT[ListWrapper, String, String, Int, ?]]",
-      SerializableTests.serializable(SemigroupK[ReaderWriterStateT[ListWrapper, String, String, Int, ?]])
+      "SemigroupK[ReaderWriterStateT[ListWrapper, String, String, Int, *]]",
+      SerializableTests.serializable(SemigroupK[ReaderWriterStateT[ListWrapper, String, String, Int, *]])
     )
   }
 

--- a/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
@@ -291,7 +291,7 @@ class IndexedStateTSuite extends CatsSuite {
   }
 
   test("foreverM works") {
-    val step = StateT[Either[Int, ?], Int, Unit] { i =>
+    val step = StateT[Either[Int, *], Int, Unit] { i =>
       if (i > stackSafeTestSize) Left(i) else Right((i + 1, ()))
     }
     step.foreverM.run(0) match {
@@ -302,7 +302,7 @@ class IndexedStateTSuite extends CatsSuite {
 
   test("iterateForeverM works") {
     val result = 0.iterateForeverM { i =>
-      StateT[Either[Int, ?], Int, Int] { j =>
+      StateT[Either[Int, *], Int, Int] { j =>
         if (j > stackSafeTestSize) Left(j) else Right((j + 1, i + 1))
       }
     }
@@ -312,7 +312,7 @@ class IndexedStateTSuite extends CatsSuite {
     }
   }
 
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[IndexedStateT[ListWrapper, String, Int, ?]](
+  implicit val iso = SemigroupalTests.Isomorphisms.invariant[IndexedStateT[ListWrapper, String, Int, *]](
     IndexedStateT.catsDataFunctorForIndexedStateT(ListWrapper.monad)
   )
 
@@ -320,118 +320,118 @@ class IndexedStateTSuite extends CatsSuite {
     // F has a Functor
     implicit val F: Functor[ListWrapper] = ListWrapper.functor
     // We only need a Functor on F to find a Functor on StateT
-    Functor[IndexedStateT[ListWrapper, String, Int, ?]]
+    Functor[IndexedStateT[ListWrapper, String, Int, *]]
   }
 
   {
     // We only need a Functor to derive a Contravariant for IndexedStateT
     implicit val F: Functor[ListWrapper] = ListWrapper.monad
-    Contravariant[IndexedStateT[ListWrapper, ?, Int, String]]
+    Contravariant[IndexedStateT[ListWrapper, *, Int, String]]
   }
 
   {
     // We only need a Functor to derive a Bifunctor for IndexedStateT
     implicit val F: Functor[ListWrapper] = ListWrapper.monad
-    Bifunctor[IndexedStateT[ListWrapper, Int, ?, ?]]
+    Bifunctor[IndexedStateT[ListWrapper, Int, *, *]]
   }
 
   {
     // We only need a Functor to derive a Profunctor for IndexedStateT
     implicit val F: Functor[ListWrapper] = ListWrapper.monad
-    Profunctor[IndexedStateT[ListWrapper, ?, ?, String]]
+    Profunctor[IndexedStateT[ListWrapper, *, *, String]]
   }
 
-  checkAll("IndexedStateT[Eval, MiniInt, String, ?]", DeferTests[IndexedStateT[Eval, MiniInt, String, ?]].defer[Int])
+  checkAll("IndexedStateT[Eval, MiniInt, String, *]", DeferTests[IndexedStateT[Eval, MiniInt, String, *]].defer[Int])
 
   {
     // F needs a Monad to do Eq on StateT
     implicit val F: Monad[ListWrapper] = ListWrapper.monad
-    implicit val FS: Functor[IndexedStateT[ListWrapper, String, Int, ?]] = IndexedStateT.catsDataFunctorForIndexedStateT
+    implicit val FS: Functor[IndexedStateT[ListWrapper, String, Int, *]] = IndexedStateT.catsDataFunctorForIndexedStateT
 
     checkAll("IndexedStateT[ListWrapper, MiniInt, Int, Int]",
-             FunctorTests[IndexedStateT[ListWrapper, MiniInt, Int, ?]].functor[Int, Int, Int])
-    checkAll("Functor[IndexedStateT[ListWrapper, Int, ?]]",
-             SerializableTests.serializable(Functor[IndexedStateT[ListWrapper, String, Int, ?]]))
+             FunctorTests[IndexedStateT[ListWrapper, MiniInt, Int, *]].functor[Int, Int, Int])
+    checkAll("Functor[IndexedStateT[ListWrapper, Int, *]]",
+             SerializableTests.serializable(Functor[IndexedStateT[ListWrapper, String, Int, *]]))
 
-    Functor[IndexedStateT[ListWrapper, String, Int, ?]]
+    Functor[IndexedStateT[ListWrapper, String, Int, *]]
   }
 
   {
     implicit val F0 = ListWrapper.monad
     implicit val FF = ListWrapper.functorFilter
 
-    checkAll("IndexedStateT[ListWrapper, MiniInt, Int, ?]",
-             FunctorFilterTests[IndexedStateT[ListWrapper, MiniInt, Int, ?]].functorFilter[Int, Int, Int])
-    checkAll("FunctorFilter[IndexedStateT[ListWrapper, MiniInt, Int, ?]]",
-             SerializableTests.serializable(FunctorFilter[IndexedStateT[ListWrapper, MiniInt, Int, ?]]))
+    checkAll("IndexedStateT[ListWrapper, MiniInt, Int, *]",
+             FunctorFilterTests[IndexedStateT[ListWrapper, MiniInt, Int, *]].functorFilter[Int, Int, Int])
+    checkAll("FunctorFilter[IndexedStateT[ListWrapper, MiniInt, Int, *]]",
+             SerializableTests.serializable(FunctorFilter[IndexedStateT[ListWrapper, MiniInt, Int, *]]))
 
-    FunctorFilter[IndexedStateT[ListWrapper, String, Int, ?]]
+    FunctorFilter[IndexedStateT[ListWrapper, String, Int, *]]
   }
 
   {
     implicit val F: Monad[ListWrapper] = ListWrapper.monad
-    implicit val FS: Contravariant[IndexedStateT[ListWrapper, ?, Int, Int]] =
+    implicit val FS: Contravariant[IndexedStateT[ListWrapper, *, Int, Int]] =
       IndexedStateT.catsDataContravariantForIndexedStateT
 
-    checkAll("IndexedStateT[ListWrapper, ?, Int, Boolean]",
-             ContravariantTests[IndexedStateT[ListWrapper, ?, Int, Int]].contravariant[MiniInt, Int, Boolean])
-    checkAll("Contravariant[IndexedStateT[ListWrapper, ?, Int, Int]]",
-             SerializableTests.serializable(Contravariant[IndexedStateT[ListWrapper, ?, Int, Int]]))
+    checkAll("IndexedStateT[ListWrapper, *, Int, Boolean]",
+             ContravariantTests[IndexedStateT[ListWrapper, *, Int, Int]].contravariant[MiniInt, Int, Boolean])
+    checkAll("Contravariant[IndexedStateT[ListWrapper, *, Int, Int]]",
+             SerializableTests.serializable(Contravariant[IndexedStateT[ListWrapper, *, Int, Int]]))
 
-    Contravariant[IndexedStateT[ListWrapper, ?, Int, Int]]
+    Contravariant[IndexedStateT[ListWrapper, *, Int, Int]]
   }
 
   {
     implicit val F: Monad[ListWrapper] = ListWrapper.monad
-    implicit val FS: Bifunctor[IndexedStateT[ListWrapper, Int, ?, ?]] = IndexedStateT.catsDataBifunctorForIndexedStateT
+    implicit val FS: Bifunctor[IndexedStateT[ListWrapper, Int, *, *]] = IndexedStateT.catsDataBifunctorForIndexedStateT
 
     checkAll("IndexedStateT[ListWrapper, MiniInt, String, Int]",
-             BifunctorTests[IndexedStateT[ListWrapper, MiniInt, ?, ?]].bifunctor[String, String, String, Int, Int, Int])
-    checkAll("Bifunctor[IndexedStateT[ListWrapper, Int, ?, ?]]",
-             SerializableTests.serializable(Bifunctor[IndexedStateT[ListWrapper, Int, ?, ?]]))
+             BifunctorTests[IndexedStateT[ListWrapper, MiniInt, *, *]].bifunctor[String, String, String, Int, Int, Int])
+    checkAll("Bifunctor[IndexedStateT[ListWrapper, Int, *, *]]",
+             SerializableTests.serializable(Bifunctor[IndexedStateT[ListWrapper, Int, *, *]]))
 
-    Bifunctor[IndexedStateT[ListWrapper, Int, ?, ?]]
+    Bifunctor[IndexedStateT[ListWrapper, Int, *, *]]
   }
 
   {
     implicit val F: Monad[ListWrapper] = ListWrapper.monad
-    implicit val FS: Profunctor[IndexedStateT[ListWrapper, ?, ?, Int]] =
+    implicit val FS: Profunctor[IndexedStateT[ListWrapper, *, *, Int]] =
       IndexedStateT.catsDataProfunctorForIndexedStateT
 
     checkAll("IndexedStateT[ListWrapper, String, Int, Int]",
-             ProfunctorTests[IndexedStateT[ListWrapper, ?, ?, Int]].profunctor[MiniInt, String, String, Int, Int, Int])
-    checkAll("Profunctor[IndexedStateT[ListWrapper, ?, ?, Int]]",
-             SerializableTests.serializable(Profunctor[IndexedStateT[ListWrapper, ?, ?, Int]]))
+             ProfunctorTests[IndexedStateT[ListWrapper, *, *, Int]].profunctor[MiniInt, String, String, Int, Int, Int])
+    checkAll("Profunctor[IndexedStateT[ListWrapper, *, *, Int]]",
+             SerializableTests.serializable(Profunctor[IndexedStateT[ListWrapper, *, *, Int]]))
 
-    Profunctor[IndexedStateT[ListWrapper, ?, ?, Int]]
+    Profunctor[IndexedStateT[ListWrapper, *, *, Int]]
   }
 
   {
     implicit val F: Monad[ListWrapper] = ListWrapper.monad
-    implicit val FS: Strong[IndexedStateT[ListWrapper, ?, ?, Int]] = IndexedStateT.catsDataStrongForIndexedStateT
+    implicit val FS: Strong[IndexedStateT[ListWrapper, *, *, Int]] = IndexedStateT.catsDataStrongForIndexedStateT
 
-    checkAll("IndexedStateT[ListWrapper, ?, ?, Int]",
-             StrongTests[IndexedStateT[ListWrapper, ?, ?, Int]].strong[MiniInt, Int, Boolean, Boolean, Boolean, String])
-    checkAll("Strong[IndexedStateT[ListWrapper, ?, ?, Int]]",
-             SerializableTests.serializable(Strong[IndexedStateT[ListWrapper, ?, ?, Int]]))
+    checkAll("IndexedStateT[ListWrapper, *, *, Int]",
+             StrongTests[IndexedStateT[ListWrapper, *, *, Int]].strong[MiniInt, Int, Boolean, Boolean, Boolean, String])
+    checkAll("Strong[IndexedStateT[ListWrapper, *, *, Int]]",
+             SerializableTests.serializable(Strong[IndexedStateT[ListWrapper, *, *, Int]]))
 
-    Strong[IndexedStateT[ListWrapper, ?, ?, Int]]
+    Strong[IndexedStateT[ListWrapper, *, *, Int]]
   }
 
   {
     // F has a Monad
     implicit val F = ListWrapper.monad
 
-    checkAll("IndexedStateT[ListWrapper, MiniInt, Int, ?]",
-             MonadTests[IndexedStateT[ListWrapper, MiniInt, MiniInt, ?]].monad[Int, Int, Int])
-    checkAll("Monad[IndexedStateT[ListWrapper, Int, Int, ?]]",
-             SerializableTests.serializable(Monad[IndexedStateT[ListWrapper, Int, Int, ?]]))
+    checkAll("IndexedStateT[ListWrapper, MiniInt, Int, *]",
+             MonadTests[IndexedStateT[ListWrapper, MiniInt, MiniInt, *]].monad[Int, Int, Int])
+    checkAll("Monad[IndexedStateT[ListWrapper, Int, Int, *]]",
+             SerializableTests.serializable(Monad[IndexedStateT[ListWrapper, Int, Int, *]]))
 
-    Monad[IndexedStateT[ListWrapper, Int, Int, ?]]
-    FlatMap[IndexedStateT[ListWrapper, Int, Int, ?]]
-    Applicative[IndexedStateT[ListWrapper, Int, Int, ?]]
-    Apply[IndexedStateT[ListWrapper, Int, Int, ?]]
-    Functor[IndexedStateT[ListWrapper, Int, Int, ?]]
+    Monad[IndexedStateT[ListWrapper, Int, Int, *]]
+    FlatMap[IndexedStateT[ListWrapper, Int, Int, *]]
+    Applicative[IndexedStateT[ListWrapper, Int, Int, *]]
+    Apply[IndexedStateT[ListWrapper, Int, Int, *]]
+    Functor[IndexedStateT[ListWrapper, Int, Int, *]]
   }
 
   {
@@ -439,10 +439,10 @@ class IndexedStateTSuite extends CatsSuite {
     implicit val F = ListWrapper.monad
     implicit val S = ListWrapper.semigroupK
 
-    checkAll("IndexedStateT[ListWrapper, MiniInt, Int, ?]",
-             SemigroupKTests[IndexedStateT[ListWrapper, MiniInt, Int, ?]].semigroupK[Int])
-    checkAll("SemigroupK[IndexedStateT[ListWrapper, Int, ?]]",
-             SerializableTests.serializable(SemigroupK[IndexedStateT[ListWrapper, String, Int, ?]]))
+    checkAll("IndexedStateT[ListWrapper, MiniInt, Int, *]",
+             SemigroupKTests[IndexedStateT[ListWrapper, MiniInt, Int, *]].semigroupK[Int])
+    checkAll("SemigroupK[IndexedStateT[ListWrapper, Int, *]]",
+             SerializableTests.serializable(SemigroupK[IndexedStateT[ListWrapper, String, Int, *]]))
   }
 
   {
@@ -454,36 +454,36 @@ class IndexedStateTSuite extends CatsSuite {
         .catsDataAlternativeForIndexedStateT[ListWrapper, MiniInt](ListWrapper.monad, ListWrapper.alternative)
 
     checkAll("IndexedStateT[ListWrapper, MiniInt, Int, Int]",
-             AlternativeTests[IndexedStateT[ListWrapper, MiniInt, MiniInt, ?]](SA).alternative[Int, Int, Int])
-    checkAll("Alternative[IndexedStateT[ListWrapper, Int, Int, ?]]", SerializableTests.serializable(SA))
+             AlternativeTests[IndexedStateT[ListWrapper, MiniInt, MiniInt, *]](SA).alternative[Int, Int, Int])
+    checkAll("Alternative[IndexedStateT[ListWrapper, Int, Int, *]]", SerializableTests.serializable(SA))
 
-    Monad[IndexedStateT[ListWrapper, Int, Int, ?]]
-    FlatMap[IndexedStateT[ListWrapper, Int, Int, ?]]
-    Alternative[IndexedStateT[ListWrapper, Int, Int, ?]]
-    Applicative[IndexedStateT[ListWrapper, Int, Int, ?]]
-    Apply[IndexedStateT[ListWrapper, Int, Int, ?]]
-    Functor[IndexedStateT[ListWrapper, Int, Int, ?]]
-    MonoidK[IndexedStateT[ListWrapper, Int, Int, ?]]
-    SemigroupK[IndexedStateT[ListWrapper, Int, Int, ?]]
+    Monad[IndexedStateT[ListWrapper, Int, Int, *]]
+    FlatMap[IndexedStateT[ListWrapper, Int, Int, *]]
+    Alternative[IndexedStateT[ListWrapper, Int, Int, *]]
+    Applicative[IndexedStateT[ListWrapper, Int, Int, *]]
+    Apply[IndexedStateT[ListWrapper, Int, Int, *]]
+    Functor[IndexedStateT[ListWrapper, Int, Int, *]]
+    MonoidK[IndexedStateT[ListWrapper, Int, Int, *]]
+    SemigroupK[IndexedStateT[ListWrapper, Int, Int, *]]
   }
 
   {
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[State[MiniInt, ?]]
+    implicit val iso = SemigroupalTests.Isomorphisms.invariant[State[MiniInt, *]]
 
-    checkAll("State[MiniInt, ?]", MonadTests[State[MiniInt, ?]].monad[Int, Int, Int])
-    checkAll("Monad[State[Long, ?]]", SerializableTests.serializable(Monad[State[Long, ?]]))
+    checkAll("State[MiniInt, *]", MonadTests[State[MiniInt, *]].monad[Int, Int, Int])
+    checkAll("Monad[State[Long, *]]", SerializableTests.serializable(Monad[State[Long, *]]))
   }
 
   {
     // F has a MonadError
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[StateT[Option, MiniInt, ?]]
-    implicit val eqEitherTFA: Eq[EitherT[StateT[Option, MiniInt, ?], Unit, Int]] =
-      EitherT.catsDataEqForEitherT[StateT[Option, MiniInt, ?], Unit, Int]
+    implicit val iso = SemigroupalTests.Isomorphisms.invariant[StateT[Option, MiniInt, *]]
+    implicit val eqEitherTFA: Eq[EitherT[StateT[Option, MiniInt, *], Unit, Int]] =
+      EitherT.catsDataEqForEitherT[StateT[Option, MiniInt, *], Unit, Int]
 
     checkAll("StateT[Option, MiniInt, Int]",
-             MonadErrorTests[StateT[Option, MiniInt, ?], Unit].monadError[Int, Int, Int])
-    checkAll("MonadError[StateT[Option, Int, ?], Unit]",
-             SerializableTests.serializable(MonadError[StateT[Option, Int, ?], Unit]))
+             MonadErrorTests[StateT[Option, MiniInt, *], Unit].monadError[Int, Int, Int])
+    checkAll("MonadError[StateT[Option, Int, *], Unit]",
+             SerializableTests.serializable(MonadError[StateT[Option, Int, *], Unit]))
   }
 
 }

--- a/tests/src/test/scala/cats/tests/IorSuite.scala
+++ b/tests/src/test/scala/cats/tests/IorSuite.scala
@@ -16,21 +16,21 @@ import org.scalacheck.Arbitrary._
 
 class IorSuite extends CatsSuite {
 
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Ior[String, ?]]
+  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Ior[String, *]]
 
-  checkAll("Ior[String, Int]", SemigroupalTests[Ior[String, ?]].semigroupal[Int, Int, Int])
-  checkAll("Semigroupal[String Ior ?]]", SerializableTests.serializable(Semigroupal[String Ior ?]))
+  checkAll("Ior[String, Int]", SemigroupalTests[Ior[String, *]].semigroupal[Int, Int, Int])
+  checkAll("Semigroupal[String Ior *]]", SerializableTests.serializable(Semigroupal[String Ior *]))
 
-  implicit val eq0 = EitherT.catsDataEqForEitherT[Ior[String, ?], String, Int]
+  implicit val eq0 = EitherT.catsDataEqForEitherT[Ior[String, *], String, Int]
 
-  checkAll("Ior[String, Int]", MonadErrorTests[String Ior ?, String].monadError[Int, Int, Int])
-  checkAll("MonadError[String Ior ?]", SerializableTests.serializable(MonadError[String Ior ?, String]))
+  checkAll("Ior[String, Int]", MonadErrorTests[String Ior *, String].monadError[Int, Int, Int])
+  checkAll("MonadError[String Ior *]", SerializableTests.serializable(MonadError[String Ior *, String]))
 
-  checkAll("Ior[String, Int] with Option", TraverseTests[String Ior ?].traverse[Int, Int, Int, Int, Option, Option])
-  checkAll("Traverse[String Ior ?]", SerializableTests.serializable(Traverse[String Ior ?]))
-  checkAll("? Ior ?", BifunctorTests[Ior].bifunctor[Int, Int, Int, String, String, String])
+  checkAll("Ior[String, Int] with Option", TraverseTests[String Ior *].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("Traverse[String Ior *]", SerializableTests.serializable(Traverse[String Ior *]))
+  checkAll("* Ior *", BifunctorTests[Ior].bifunctor[Int, Int, Int, String, String, String])
 
-  checkAll("Ior[?, ?]", BitraverseTests[Ior].bitraverse[Option, Int, Int, Int, String, String, String])
+  checkAll("Ior[*, *]", BitraverseTests[Ior].bitraverse[Option, Int, Int, Int, String, String, String])
   checkAll("Bitraverse[Ior]", SerializableTests.serializable(Bitraverse[Ior]))
 
   checkAll("Semigroup[Ior[A: Semigroup, B: Semigroup]]", SemigroupTests[Ior[List[Int], List[Int]]].semigroup)

--- a/tests/src/test/scala/cats/tests/IorTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IorTSuite.scala
@@ -8,50 +8,50 @@ import cats.laws.discipline.arbitrary._
 
 class IorTSuite extends CatsSuite {
 
-  checkAll("IorT[Eval, String, ?]", DeferTests[IorT[Eval, String, ?]].defer[Int])
+  checkAll("IorT[Eval, String, *]", DeferTests[IorT[Eval, String, *]].defer[Int])
 
   {
     implicit val F = ListWrapper.functor
 
-    checkAll("IorT[ListWrapper, ?, ?]",
-             BifunctorTests[IorT[ListWrapper, ?, ?]].bifunctor[Int, Int, Int, String, String, String])
-    checkAll("Bifunctor[IorT[ListWrapper, ?, ?]]", SerializableTests.serializable(Bifunctor[IorT[ListWrapper, ?, ?]]))
+    checkAll("IorT[ListWrapper, *, *]",
+             BifunctorTests[IorT[ListWrapper, *, *]].bifunctor[Int, Int, Int, String, String, String])
+    checkAll("Bifunctor[IorT[ListWrapper, *, *]]", SerializableTests.serializable(Bifunctor[IorT[ListWrapper, *, *]]))
 
-    checkAll("IorT[ListWrapper, Int, ?]", FunctorTests[IorT[ListWrapper, Int, ?]].functor[Int, Int, Int])
-    checkAll("Functor[IorT[ListWrapper, Int, ?]]", SerializableTests.serializable(Functor[IorT[ListWrapper, Int, ?]]))
+    checkAll("IorT[ListWrapper, Int, *]", FunctorTests[IorT[ListWrapper, Int, *]].functor[Int, Int, Int])
+    checkAll("Functor[IorT[ListWrapper, Int, *]]", SerializableTests.serializable(Functor[IorT[ListWrapper, Int, *]]))
   }
 
   {
     implicit val F = ListWrapper.traverse
 
-    checkAll("IorT[ListWrapper, Int, ?]",
-             TraverseTests[IorT[ListWrapper, Int, ?]].traverse[Int, Int, Int, Int, Option, Option])
-    checkAll("Traverse[IorT[ListWrapper, Int, ?]]", SerializableTests.serializable(Traverse[IorT[ListWrapper, Int, ?]]))
+    checkAll("IorT[ListWrapper, Int, *]",
+             TraverseTests[IorT[ListWrapper, Int, *]].traverse[Int, Int, Int, Int, Option, Option])
+    checkAll("Traverse[IorT[ListWrapper, Int, *]]", SerializableTests.serializable(Traverse[IorT[ListWrapper, Int, *]]))
   }
 
   {
     implicit val F = ListWrapper.monad
 
     checkAll("IorT[ListWrapper, String, Int]",
-             MonadErrorTests[IorT[ListWrapper, String, ?], String].monadError[Int, Int, Int])
-    checkAll("MonadError[IorT[List, ?, ?]]",
-             SerializableTests.serializable(MonadError[IorT[ListWrapper, String, ?], String]))
+             MonadErrorTests[IorT[ListWrapper, String, *], String].monadError[Int, Int, Int])
+    checkAll("MonadError[IorT[List, *, *]]",
+             SerializableTests.serializable(MonadError[IorT[ListWrapper, String, *], String]))
   }
 
   {
     implicit val F: MonadError[Option, Unit] = catsStdInstancesForOption
 
     checkAll("IorT[Option, String, String]",
-             MonadErrorTests[IorT[Option, String, ?], Unit].monadError[String, String, String])
-    checkAll("MonadError[IorT[Option, ?, ?]]",
-             SerializableTests.serializable(MonadError[IorT[Option, String, ?], Unit]))
+             MonadErrorTests[IorT[Option, String, *], Unit].monadError[String, String, String])
+    checkAll("MonadError[IorT[Option, *, *]]",
+             SerializableTests.serializable(MonadError[IorT[Option, String, *], Unit]))
   }
 
   {
     implicit val F = ListWrapper.foldable
 
-    checkAll("IorT[ListWrapper, Int, ?]", FoldableTests[IorT[ListWrapper, Int, ?]].foldable[Int, Int])
-    checkAll("Foldable[IorT[ListWrapper, Int, ?]]", SerializableTests.serializable(Foldable[IorT[ListWrapper, Int, ?]]))
+    checkAll("IorT[ListWrapper, Int, *]", FoldableTests[IorT[ListWrapper, Int, *]].foldable[Int, Int])
+    checkAll("Foldable[IorT[ListWrapper, Int, *]]", SerializableTests.serializable(Foldable[IorT[ListWrapper, Int, *]]))
   }
 
   {

--- a/tests/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/KleisliSuite.scala
@@ -19,105 +19,105 @@ class KleisliSuite extends CatsSuite {
   implicit def readerEq[A, B](implicit ev: Eq[A => B]): Eq[Reader[A, B]] =
     kleisliEq
 
-  implicit val eitherTEq = EitherT.catsDataEqForEitherT[Kleisli[Option, MiniInt, ?], Unit, Int]
-  implicit val eitherTEq2 = EitherT.catsDataEqForEitherT[Reader[MiniInt, ?], Unit, Int]
+  implicit val eitherTEq = EitherT.catsDataEqForEitherT[Kleisli[Option, MiniInt, *], Unit, Int]
+  implicit val eitherTEq2 = EitherT.catsDataEqForEitherT[Reader[MiniInt, *], Unit, Int]
 
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Kleisli[Option, Int, ?]]
-  implicit val iso2 = SemigroupalTests.Isomorphisms.invariant[Reader[Int, ?]]
+  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Kleisli[Option, Int, *]]
+  implicit val iso2 = SemigroupalTests.Isomorphisms.invariant[Reader[Int, *]]
 
   {
-    implicit val instance: ApplicativeError[Kleisli[Option, MiniInt, ?], Unit] =
+    implicit val instance: ApplicativeError[Kleisli[Option, MiniInt, *], Unit] =
       Kleisli.catsDataApplicativeErrorForKleisli[Option, Unit, MiniInt](cats.instances.option.catsStdInstancesForOption)
-    checkAll("Kleisli[Option, MinInt, ?] with Unit",
-             ApplicativeErrorTests[Kleisli[Option, MiniInt, ?], Unit](instance).applicativeError[Int, Int, Int])
+    checkAll("Kleisli[Option, MinInt, *] with Unit",
+             ApplicativeErrorTests[Kleisli[Option, MiniInt, *], Unit](instance).applicativeError[Int, Int, Int])
     checkAll("ApplicativeError[Kleisli[Option, Int, Int], Unit]", SerializableTests.serializable(instance))
   }
 
-  checkAll("Kleisli[Eval, MiniInt, ?]", DeferTests[Kleisli[Eval, MiniInt, ?]].defer[Int])
-  checkAll("Kleisli[Option, MiniInt, ?] with Unit",
-           MonadErrorTests[Kleisli[Option, MiniInt, ?], Unit].monadError[Int, Int, Int])
+  checkAll("Kleisli[Eval, MiniInt, *]", DeferTests[Kleisli[Eval, MiniInt, *]].defer[Int])
+  checkAll("Kleisli[Option, MiniInt, *] with Unit",
+           MonadErrorTests[Kleisli[Option, MiniInt, *], Unit].monadError[Int, Int, Int])
   checkAll("MonadError[Kleisli[Option, Int, Int], Unit]",
-           SerializableTests.serializable(MonadError[Kleisli[Option, Int, ?], Unit]))
+           SerializableTests.serializable(MonadError[Kleisli[Option, Int, *], Unit]))
 
-  checkAll("Kleisli[Option, MiniInt, ?]", SemigroupalTests[Kleisli[Option, MiniInt, ?]].semigroupal[Int, Int, Int])
-  checkAll("Semigroupal[Kleisli[Option, Int, ?]]", SerializableTests.serializable(Semigroupal[Kleisli[Option, Int, ?]]))
+  checkAll("Kleisli[Option, MiniInt, *]", SemigroupalTests[Kleisli[Option, MiniInt, *]].semigroupal[Int, Int, Int])
+  checkAll("Semigroupal[Kleisli[Option, Int, *]]", SerializableTests.serializable(Semigroupal[Kleisli[Option, Int, *]]))
 
-  checkAll("Kleisli[(CSemi, ?), MiniInt, ?]",
-           CommutativeFlatMapTests[Kleisli[(CSemi, ?), MiniInt, ?]].commutativeFlatMap[Int, Int, Int])
-  checkAll("CommutativeFlatMap[Kleisli[(CSemi, ?), Int, ?]]",
-           SerializableTests.serializable(CommutativeFlatMap[Kleisli[(CSemi, ?), Int, ?]]))
+  checkAll("Kleisli[(CSemi, *), MiniInt, *]",
+           CommutativeFlatMapTests[Kleisli[(CSemi, *), MiniInt, *]].commutativeFlatMap[Int, Int, Int])
+  checkAll("CommutativeFlatMap[Kleisli[(CSemi, *), Int, *]]",
+           SerializableTests.serializable(CommutativeFlatMap[Kleisli[(CSemi, *), Int, *]]))
 
-  checkAll("Kleisli[Option, MiniInt, ?]",
-           CommutativeMonadTests[Kleisli[Option, MiniInt, ?]].commutativeMonad[Int, Int, Int])
-  checkAll("CommutativeMonad[Kleisli[Option, Int, ?]]",
-           SerializableTests.serializable(CommutativeMonad[Kleisli[Option, Int, ?]]))
+  checkAll("Kleisli[Option, MiniInt, *]",
+           CommutativeMonadTests[Kleisli[Option, MiniInt, *]].commutativeMonad[Int, Int, Int])
+  checkAll("CommutativeMonad[Kleisli[Option, Int, *]]",
+           SerializableTests.serializable(CommutativeMonad[Kleisli[Option, Int, *]]))
 
-  checkAll("Kleisli[Id, MiniInt, ?]", CommutativeMonadTests[Kleisli[Id, MiniInt, ?]].commutativeMonad[Int, Int, Int])
-  checkAll("CommutativeMonad[Kleisli[Id, Int, ?]]",
-           SerializableTests.serializable(CommutativeMonad[Kleisli[Id, Int, ?]]))
+  checkAll("Kleisli[Id, MiniInt, *]", CommutativeMonadTests[Kleisli[Id, MiniInt, *]].commutativeMonad[Int, Int, Int])
+  checkAll("CommutativeMonad[Kleisli[Id, Int, *]]",
+           SerializableTests.serializable(CommutativeMonad[Kleisli[Id, Int, *]]))
 
-  checkAll("Kleisli[List, ?, ?]",
-           ArrowTests[Kleisli[List, ?, ?]].arrow[MiniInt, MiniInt, MiniInt, MiniInt, MiniInt, Boolean])
-  checkAll("Arrow[Kleisli[List, ?, ?]]", SerializableTests.serializable(Arrow[Kleisli[List, ?, ?]]))
+  checkAll("Kleisli[List, *, *]",
+           ArrowTests[Kleisli[List, *, *]].arrow[MiniInt, MiniInt, MiniInt, MiniInt, MiniInt, Boolean])
+  checkAll("Arrow[Kleisli[List, *, *]]", SerializableTests.serializable(Arrow[Kleisli[List, *, *]]))
 
-  checkAll("Kleisli[List, ?, ?]",
-           ArrowChoiceTests[Kleisli[List, ?, ?]].arrowChoice[MiniInt, MiniInt, MiniInt, MiniInt, MiniInt, Boolean])
-  checkAll("ArrowChoice[Kleisli[List, ?, ?]]", SerializableTests.serializable(ArrowChoice[Kleisli[List, ?, ?]]))
+  checkAll("Kleisli[List, *, *]",
+           ArrowChoiceTests[Kleisli[List, *, *]].arrowChoice[MiniInt, MiniInt, MiniInt, MiniInt, MiniInt, Boolean])
+  checkAll("ArrowChoice[Kleisli[List, *, *]]", SerializableTests.serializable(ArrowChoice[Kleisli[List, *, *]]))
 
   checkAll("Kleisli[Option, Int, Int]",
-           CommutativeArrowTests[Kleisli[Option, ?, ?]]
+           CommutativeArrowTests[Kleisli[Option, *, *]]
              .commutativeArrow[MiniInt, MiniInt, MiniInt, MiniInt, MiniInt, Boolean])
-  checkAll("CommutativeArrow[Kleisli[Option, ?, ?]]",
-           SerializableTests.serializable(CommutativeArrow[Kleisli[Option, ?, ?]]))
+  checkAll("CommutativeArrow[Kleisli[Option, *, *]]",
+           SerializableTests.serializable(CommutativeArrow[Kleisli[Option, *, *]]))
 
-  checkAll("Kleisli[Option, ?, ?]", ChoiceTests[Kleisli[Option, ?, ?]].choice[MiniInt, Boolean, Int, Int])
-  checkAll("Choice[Kleisli[Option, ?, ?]]", SerializableTests.serializable(Choice[Kleisli[Option, ?, ?]]))
+  checkAll("Kleisli[Option, *, *]", ChoiceTests[Kleisli[Option, *, *]].choice[MiniInt, Boolean, Int, Int])
+  checkAll("Choice[Kleisli[Option, *, *]]", SerializableTests.serializable(Choice[Kleisli[Option, *, *]]))
 
-  checkAll("Kleisli[Option, MiniInt, ?]", MonadTests[Kleisli[Option, MiniInt, ?]].monad[Int, Int, Int])
-  checkAll("Monad[Kleisli[Option, ?, ?], Int]", SerializableTests.serializable(Monad[Kleisli[Option, Int, ?]]))
+  checkAll("Kleisli[Option, MiniInt, *]", MonadTests[Kleisli[Option, MiniInt, *]].monad[Int, Int, Int])
+  checkAll("Monad[Kleisli[Option, *, *], Int]", SerializableTests.serializable(Monad[Kleisli[Option, Int, *]]))
 
-  checkAll("Reader[MiniInt, ?]", MonadTests[Reader[MiniInt, ?]].monad[Int, Int, Int])
-  checkAll("Monad[Reader[?, ?], Int]", SerializableTests.serializable(Monad[Reader[Int, ?]]))
+  checkAll("Reader[MiniInt, *]", MonadTests[Reader[MiniInt, *]].monad[Int, Int, Int])
+  checkAll("Monad[Reader[*, *], Int]", SerializableTests.serializable(Monad[Reader[Int, *]]))
 
-  checkAll("Kleisli[Option, ?, ?]",
-           StrongTests[Kleisli[Option, ?, ?]].strong[MiniInt, Boolean, Boolean, Boolean, Boolean, Int])
-  checkAll("Strong[Kleisli[Option, ?, ?]]", SerializableTests.serializable(Strong[Kleisli[Option, ?, ?]]))
+  checkAll("Kleisli[Option, *, *]",
+           StrongTests[Kleisli[Option, *, *]].strong[MiniInt, Boolean, Boolean, Boolean, Boolean, Int])
+  checkAll("Strong[Kleisli[Option, *, *]]", SerializableTests.serializable(Strong[Kleisli[Option, *, *]]))
 
-  checkAll("Kleisli[Option, MiniInt, Int]", FlatMapTests[Kleisli[Option, MiniInt, ?]].flatMap[Int, Int, Int])
-  checkAll("FlatMap[Kleisli[Option, Int, ?]]", SerializableTests.serializable(FlatMap[Kleisli[Option, Int, ?]]))
+  checkAll("Kleisli[Option, MiniInt, Int]", FlatMapTests[Kleisli[Option, MiniInt, *]].flatMap[Int, Int, Int])
+  checkAll("FlatMap[Kleisli[Option, Int, *]]", SerializableTests.serializable(FlatMap[Kleisli[Option, Int, *]]))
 
-  checkAll("Kleisli[Option, MiniInt, ?]", AlternativeTests[Kleisli[Option, MiniInt, ?]].alternative[Int, Int, Int])
-  checkAll("Alternative[Kleisli[Option, Int, ?]]", SerializableTests.serializable(Alternative[Kleisli[Option, Int, ?]]))
+  checkAll("Kleisli[Option, MiniInt, *]", AlternativeTests[Kleisli[Option, MiniInt, *]].alternative[Int, Int, Int])
+  checkAll("Alternative[Kleisli[Option, Int, *]]", SerializableTests.serializable(Alternative[Kleisli[Option, Int, *]]))
 
-  checkAll("Kleisli[Const[String, ?], MiniInt, ?]",
-           ContravariantMonoidalTests[Kleisli[Const[String, ?], MiniInt, ?]].contravariantMonoidal[Int, Int, Int])
-  checkAll("ContravariantMonoidal[Kleisli[Option, Int, ?]]",
-           SerializableTests.serializable(ContravariantMonoidal[Kleisli[Const[String, ?], Int, ?]]))
+  checkAll("Kleisli[Const[String, *], MiniInt, *]",
+           ContravariantMonoidalTests[Kleisli[Const[String, *], MiniInt, *]].contravariantMonoidal[Int, Int, Int])
+  checkAll("ContravariantMonoidal[Kleisli[Option, Int, *]]",
+           SerializableTests.serializable(ContravariantMonoidal[Kleisli[Const[String, *], Int, *]]))
 
-  checkAll("Kleisli[Option, MiniInt, Int]", ApplicativeTests[Kleisli[Option, MiniInt, ?]].applicative[Int, Int, Int])
-  checkAll("Applicative[Kleisli[Option, Int, ?]]", SerializableTests.serializable(Applicative[Kleisli[Option, Int, ?]]))
+  checkAll("Kleisli[Option, MiniInt, Int]", ApplicativeTests[Kleisli[Option, MiniInt, *]].applicative[Int, Int, Int])
+  checkAll("Applicative[Kleisli[Option, Int, *]]", SerializableTests.serializable(Applicative[Kleisli[Option, Int, *]]))
 
-  checkAll("Kleisli[Option, MiniInt, Int]", ApplyTests[Kleisli[Option, MiniInt, ?]].apply[Int, Int, Int])
-  checkAll("Apply[Kleisli[Option, Int, ?]]", SerializableTests.serializable(Apply[Kleisli[Option, Int, ?]]))
+  checkAll("Kleisli[Option, MiniInt, Int]", ApplyTests[Kleisli[Option, MiniInt, *]].apply[Int, Int, Int])
+  checkAll("Apply[Kleisli[Option, Int, *]]", SerializableTests.serializable(Apply[Kleisli[Option, Int, *]]))
 
-  checkAll("Kleisli[Option, MiniInt, Int]", FunctorTests[Kleisli[Option, MiniInt, ?]].functor[Int, Int, Int])
-  checkAll("Functor[Kleisli[Option, Int, ?]]", SerializableTests.serializable(Functor[Kleisli[Option, Int, ?]]))
+  checkAll("Kleisli[Option, MiniInt, Int]", FunctorTests[Kleisli[Option, MiniInt, *]].functor[Int, Int, Int])
+  checkAll("Functor[Kleisli[Option, Int, *]]", SerializableTests.serializable(Functor[Kleisli[Option, Int, *]]))
 
   {
     implicit val FF = ListWrapper.functorFilter
 
-    checkAll("Kleisli[ListWrapper, MiniInt, ?]",
-             FunctorFilterTests[Kleisli[ListWrapper, MiniInt, ?]].functorFilter[Int, Int, Int])
-    checkAll("FunctorFilter[Kleisli[ListWrapper, MiniInt, ?]]",
-             SerializableTests.serializable(FunctorFilter[Kleisli[ListWrapper, MiniInt, ?]]))
+    checkAll("Kleisli[ListWrapper, MiniInt, *]",
+             FunctorFilterTests[Kleisli[ListWrapper, MiniInt, *]].functorFilter[Int, Int, Int])
+    checkAll("FunctorFilter[Kleisli[ListWrapper, MiniInt, *]]",
+             SerializableTests.serializable(FunctorFilter[Kleisli[ListWrapper, MiniInt, *]]))
 
-    FunctorFilter[ReaderT[ListWrapper, Int, ?]]
+    FunctorFilter[ReaderT[ListWrapper, Int, *]]
   }
 
-  checkAll("Kleisli[Function0, MiniInt, ?]",
-           DistributiveTests[Kleisli[Function0, MiniInt, ?]].distributive[Int, Int, Int, Option, Id])
-  checkAll("Distributive[Kleisli[Function0, Int, ?]]",
-           SerializableTests.serializable(Distributive[Kleisli[Function0, Int, ?]]))
+  checkAll("Kleisli[Function0, MiniInt, *]",
+           DistributiveTests[Kleisli[Function0, MiniInt, *]].distributive[Int, Int, Int, Option, Id])
+  checkAll("Distributive[Kleisli[Function0, Int, *]]",
+           SerializableTests.serializable(Distributive[Kleisli[Function0, Int, *]]))
 
   checkAll("Kleisli[Option, MiniInt, String]", MonoidTests[Kleisli[Option, MiniInt, String]].monoid)
   checkAll("Monoid[Kleisli[Option, Int, String]]", SerializableTests.serializable(Monoid[Kleisli[Option, Int, String]]))
@@ -139,22 +139,22 @@ class KleisliSuite extends CatsSuite {
              SerializableTests.serializable(SemigroupK[λ[α => Kleisli[Option, α, α]]]))
   }
 
-  checkAll("Kleisli[Option, MiniInt, Int]", SemigroupKTests[Kleisli[Option, MiniInt, ?]].semigroupK[Int])
-  checkAll("SemigroupK[Kleisli[Option, String, ?]]",
-           SerializableTests.serializable(SemigroupK[Kleisli[Option, String, ?]]))
+  checkAll("Kleisli[Option, MiniInt, Int]", SemigroupKTests[Kleisli[Option, MiniInt, *]].semigroupK[Int])
+  checkAll("SemigroupK[Kleisli[Option, String, *]]",
+           SerializableTests.serializable(SemigroupK[Kleisli[Option, String, *]]))
 
-  checkAll("Kleisli[Option, MiniInt, ?]", MonoidKTests[Kleisli[Option, MiniInt, ?]].monoidK[Int])
-  checkAll("MonoidK[Kleisli[Option, String, ?]]", SerializableTests.serializable(MonoidK[Kleisli[Option, String, ?]]))
+  checkAll("Kleisli[Option, MiniInt, *]", MonoidKTests[Kleisli[Option, MiniInt, *]].monoidK[Int])
+  checkAll("MonoidK[Kleisli[Option, String, *]]", SerializableTests.serializable(MonoidK[Kleisli[Option, String, *]]))
 
-  checkAll("Reader[MiniInt, Int]", FunctorTests[Reader[MiniInt, ?]].functor[Int, Int, Int])
+  checkAll("Reader[MiniInt, Int]", FunctorTests[Reader[MiniInt, *]].functor[Int, Int, Int])
 
-  checkAll("Kleisli[Option, ?, Int]", ContravariantTests[Kleisli[Option, ?, Int]].contravariant[MiniInt, Int, Boolean])
-  checkAll("Contravariant[Kleisli[Option, ?, Int]]",
-           SerializableTests.serializable(Contravariant[Kleisli[Option, ?, Int]]))
+  checkAll("Kleisli[Option, *, Int]", ContravariantTests[Kleisli[Option, *, Int]].contravariant[MiniInt, Int, Boolean])
+  checkAll("Contravariant[Kleisli[Option, *, Int]]",
+           SerializableTests.serializable(Contravariant[Kleisli[Option, *, Int]]))
 
-  test("Functor[Kleisli[F, Int, ?]] is not ambiguous when an ApplicativeError and a FlatMap are in scope for F") {
-    def shouldCompile1[F[_]: ApplicativeError[?[_], E]: FlatMap, E]: Functor[Kleisli[F, Int, ?]] =
-      Functor[Kleisli[F, Int, ?]]
+  test("Functor[Kleisli[F, Int, *]] is not ambiguous when an ApplicativeError and a FlatMap are in scope for F") {
+    def shouldCompile1[F[_]: ApplicativeError[*[_], E]: FlatMap, E]: Functor[Kleisli[F, Int, *]] =
+      Functor[Kleisli[F, Int, *]]
   }
 
   test("local composes functions") {
@@ -313,46 +313,46 @@ class KleisliSuite extends CatsSuite {
    */
   object ImplicitResolution {
     // F is List
-    Functor[Kleisli[List, Int, ?]]
-    Apply[Kleisli[List, Int, ?]]
-    Applicative[Kleisli[List, Int, ?]]
-    Alternative[Kleisli[List, Int, ?]]
-    Monad[Kleisli[List, Int, ?]]
+    Functor[Kleisli[List, Int, *]]
+    Apply[Kleisli[List, Int, *]]
+    Applicative[Kleisli[List, Int, *]]
+    Alternative[Kleisli[List, Int, *]]
+    Monad[Kleisli[List, Int, *]]
     Monoid[Kleisli[List, Int, String]]
-    MonoidK[Kleisli[List, Int, ?]]
-    Arrow[Kleisli[List, ?, ?]]
-    Choice[Kleisli[List, ?, ?]]
-    Strong[Kleisli[List, ?, ?]]
-    FlatMap[Kleisli[List, Int, ?]]
+    MonoidK[Kleisli[List, Int, *]]
+    Arrow[Kleisli[List, *, *]]
+    Choice[Kleisli[List, *, *]]
+    Strong[Kleisli[List, *, *]]
+    FlatMap[Kleisli[List, Int, *]]
     Semigroup[Kleisli[List, Int, String]]
-    SemigroupK[Kleisli[List, Int, ?]]
+    SemigroupK[Kleisli[List, Int, *]]
 
     // F is Id
-    Functor[Kleisli[Id, Int, ?]]
-    Apply[Kleisli[Id, Int, ?]]
-    Applicative[Kleisli[Id, Int, ?]]
-    Monad[Kleisli[Id, Int, ?]]
-    CommutativeMonad[Kleisli[Id, Int, ?]]
+    Functor[Kleisli[Id, Int, *]]
+    Apply[Kleisli[Id, Int, *]]
+    Applicative[Kleisli[Id, Int, *]]
+    Monad[Kleisli[Id, Int, *]]
+    CommutativeMonad[Kleisli[Id, Int, *]]
     Monoid[Kleisli[Id, Int, String]]
-    Arrow[Kleisli[Id, ?, ?]]
-    CommutativeArrow[Kleisli[Id, ?, ?]]
-    Choice[Kleisli[Id, ?, ?]]
-    Strong[Kleisli[Id, ?, ?]]
-    CommutativeFlatMap[Kleisli[Id, Int, ?]]
+    Arrow[Kleisli[Id, *, *]]
+    CommutativeArrow[Kleisli[Id, *, *]]
+    Choice[Kleisli[Id, *, *]]
+    Strong[Kleisli[Id, *, *]]
+    CommutativeFlatMap[Kleisli[Id, Int, *]]
     Semigroup[Kleisli[Id, Int, String]]
 
     // using Reader alias instead of Kleisli with Id as F
-    Functor[Reader[Int, ?]]
-    Apply[Reader[Int, ?]]
-    Applicative[Reader[Int, ?]]
-    Monad[Reader[Int, ?]]
-    CommutativeMonad[Reader[Int, ?]]
+    Functor[Reader[Int, *]]
+    Apply[Reader[Int, *]]
+    Applicative[Reader[Int, *]]
+    Monad[Reader[Int, *]]
+    CommutativeMonad[Reader[Int, *]]
     Monoid[Reader[Int, String]]
-    Arrow[Reader[?, ?]]
-    CommutativeArrow[Reader[?, ?]]
-    Choice[Reader[?, ?]]
-    Strong[Reader[?, ?]]
-    CommutativeFlatMap[Reader[Int, ?]]
+    Arrow[Reader[*, *]]
+    CommutativeArrow[Reader[*, *]]
+    Choice[Reader[*, *]]
+    Strong[Reader[*, *]]
+    CommutativeFlatMap[Reader[Int, *]]
     Semigroup[Reader[Int, String]]
 
     // using IntReader alias instead of Kleisli with Id as F and A as Int
@@ -367,10 +367,10 @@ class KleisliSuite extends CatsSuite {
     CommutativeFlatMap[IntReader]
     Semigroup[IntReader[String]]
 
-    ApplicativeError[Kleisli[cats.data.Validated[Unit, ?], Int, ?], Unit]
-    ApplicativeError[Kleisli[Option, Int, ?], Unit]
-    MonadError[Kleisli[Option, Int, ?], Unit]
+    ApplicativeError[Kleisli[cats.data.Validated[Unit, *], Int, *], Unit]
+    ApplicativeError[Kleisli[Option, Int, *], Unit]
+    MonadError[Kleisli[Option, Int, *], Unit]
 
-    Distributive[Kleisli[Function0, Int, ?]]
+    Distributive[Kleisli[Function0, Int, *]]
   }
 }

--- a/tests/src/test/scala/cats/tests/MapSuite.scala
+++ b/tests/src/test/scala/cats/tests/MapSuite.scala
@@ -16,24 +16,24 @@ import cats.kernel.instances.StaticMethods.wrapMutableMap
 
 class MapSuite extends CatsSuite {
 
-  checkAll("Map[Int, Int]", SemigroupalTests[Map[Int, ?]].semigroupal[Int, Int, Int])
-  checkAll("Semigroupal[Map[Int, ?]]", SerializableTests.serializable(Semigroupal[Map[Int, ?]]))
+  checkAll("Map[Int, Int]", SemigroupalTests[Map[Int, *]].semigroupal[Int, Int, Int])
+  checkAll("Semigroupal[Map[Int, *]]", SerializableTests.serializable(Semigroupal[Map[Int, *]]))
 
-  checkAll("Map[Int, Int]", FlatMapTests[Map[Int, ?]].flatMap[Int, Int, Int])
-  checkAll("FlatMap[Map[Int, ?]]", SerializableTests.serializable(FlatMap[Map[Int, ?]]))
+  checkAll("Map[Int, Int]", FlatMapTests[Map[Int, *]].flatMap[Int, Int, Int])
+  checkAll("FlatMap[Map[Int, *]]", SerializableTests.serializable(FlatMap[Map[Int, *]]))
 
   checkAll("Map[Int, Int] with Option",
-           UnorderedTraverseTests[Map[Int, ?]].unorderedTraverse[Int, Int, Int, Option, Option])
-  checkAll("UnorderedTraverse[Map[Int, ?]]", SerializableTests.serializable(UnorderedTraverse[Map[Int, ?]]))
+           UnorderedTraverseTests[Map[Int, *]].unorderedTraverse[Int, Int, Int, Option, Option])
+  checkAll("UnorderedTraverse[Map[Int, *]]", SerializableTests.serializable(UnorderedTraverse[Map[Int, *]]))
 
-  checkAll("Map[Int, Int]", FunctorFilterTests[Map[Int, ?]].functorFilter[Int, Int, Int])
-  checkAll("FunctorFilter[Map[Int, ?]]", SerializableTests.serializable(FunctorFilter[Map[Int, ?]]))
+  checkAll("Map[Int, Int]", FunctorFilterTests[Map[Int, *]].functorFilter[Int, Int, Int])
+  checkAll("FunctorFilter[Map[Int, *]]", SerializableTests.serializable(FunctorFilter[Map[Int, *]]))
 
   checkAll("Map[Int, Long]", ComposeTests[Map].compose[Int, Long, String, Double])
   checkAll("Compose[Map]", SerializableTests.serializable(Compose[Map]))
 
-  checkAll("Map[Int, Int]", MonoidKTests[Map[Int, ?]].monoidK[Int])
-  checkAll("MonoidK[Map[Int, ?]]", SerializableTests.serializable(MonoidK[Map[Int, ?]]))
+  checkAll("Map[Int, Int]", MonoidKTests[Map[Int, *]].monoidK[Int])
+  checkAll("MonoidK[Map[Int, *]]", SerializableTests.serializable(MonoidK[Map[Int, *]]))
 
   test("show isn't empty and is formatted as expected") {
     forAll { (map: Map[Int, String]) =>

--- a/tests/src/test/scala/cats/tests/MonadSuite.scala
+++ b/tests/src/test/scala/cats/tests/MonadSuite.scala
@@ -5,7 +5,7 @@ import cats.data.{IndexedStateT, StateT}
 import org.scalacheck.Gen
 
 class MonadSuite extends CatsSuite {
-  implicit val testInstance: Monad[StateT[Id, Int, ?]] = IndexedStateT.catsDataMonadForIndexedStateT[Id, Int]
+  implicit val testInstance: Monad[StateT[Id, Int, *]] = IndexedStateT.catsDataMonadForIndexedStateT[Id, Int]
 
   val smallPosInt = Gen.choose(1, 5000)
 

--- a/tests/src/test/scala/cats/tests/NestedSuite.scala
+++ b/tests/src/test/scala/cats/tests/NestedSuite.scala
@@ -16,15 +16,15 @@ class NestedSuite extends CatsSuite {
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = 20, sizeRange = 5)
 
-  checkAll("Nested[Eval, List, ?]", DeferTests[Nested[Eval, List, ?]].defer[Int])
+  checkAll("Nested[Eval, List, *]", DeferTests[Nested[Eval, List, *]].defer[Int])
 
   {
     // Invariant composition
     implicit val instance = ListWrapper.invariant
     checkAll("Nested[ListWrapper, ListWrapper]",
-             InvariantTests[Nested[ListWrapper, ListWrapper, ?]].invariant[Int, Int, Int])
-    checkAll("Invariant[Nested[ListWrapper, ListWrapper, ?]]",
-             SerializableTests.serializable(Invariant[Nested[ListWrapper, ListWrapper, ?]]))
+             InvariantTests[Nested[ListWrapper, ListWrapper, *]].invariant[Int, Int, Int])
+    checkAll("Invariant[Nested[ListWrapper, ListWrapper, *]]",
+             SerializableTests.serializable(Invariant[Nested[ListWrapper, ListWrapper, *]]))
   }
 
   {
@@ -32,9 +32,9 @@ class NestedSuite extends CatsSuite {
     implicit val instance = ListWrapper.functorFilter
     implicit val functorInstance = ListWrapper.functor
     checkAll("Nested[ListWrapper, ListWrapper]",
-             FunctorFilterTests[Nested[ListWrapper, ListWrapper, ?]].functorFilter[Int, Int, Int])
-    checkAll("FunctorFilter[Nested[ListWrapper, ListWrapper, ?]]",
-             SerializableTests.serializable(FunctorFilter[Nested[ListWrapper, ListWrapper, ?]]))
+             FunctorFilterTests[Nested[ListWrapper, ListWrapper, *]].functorFilter[Int, Int, Int])
+    checkAll("FunctorFilter[Nested[ListWrapper, ListWrapper, *]]",
+             SerializableTests.serializable(FunctorFilter[Nested[ListWrapper, ListWrapper, *]]))
   }
 
   {
@@ -42,109 +42,109 @@ class NestedSuite extends CatsSuite {
     implicit val instance = ListWrapper.traverseFilter
     implicit val traverseInstance = ListWrapper.traverse
     checkAll("Nested[ListWrapper, ListWrapper]",
-             TraverseFilterTests[Nested[ListWrapper, ListWrapper, ?]].traverseFilter[Int, Int, Int])
-    checkAll("TraverseFilter[Nested[ListWrapper, ListWrapper, ?]]",
-             SerializableTests.serializable(TraverseFilter[Nested[ListWrapper, ListWrapper, ?]]))
+             TraverseFilterTests[Nested[ListWrapper, ListWrapper, *]].traverseFilter[Int, Int, Int])
+    checkAll("TraverseFilter[Nested[ListWrapper, ListWrapper, *]]",
+             SerializableTests.serializable(TraverseFilter[Nested[ListWrapper, ListWrapper, *]]))
   }
 
   {
     // Invariant + Covariant = Invariant
     val instance = Nested.catsDataInvariantForCovariantNested(ListWrapper.invariant, ListWrapper.functor)
     checkAll("Nested[ListWrapper, ListWrapper] - Invariant + Covariant",
-             InvariantTests[Nested[ListWrapper, ListWrapper, ?]](instance).invariant[Int, Int, Int])
-    checkAll("Invariant[Nested[ListWrapper, ListWrapper, ?]] - Invariant + Covariant",
+             InvariantTests[Nested[ListWrapper, ListWrapper, *]](instance).invariant[Int, Int, Int])
+    checkAll("Invariant[Nested[ListWrapper, ListWrapper, *]] - Invariant + Covariant",
              SerializableTests.serializable(instance))
   }
 
   {
     // Invariant + Contravariant = Invariant
     val instance = Nested.catsDataInvariantForNestedContravariant(ListWrapper.invariant, Contravariant[Show])
-    checkAll("Nested[ListWrapper, Show, ?]",
-             InvariantTests[Nested[ListWrapper, Show, ?]](instance).invariant[MiniInt, Int, Boolean])
-    checkAll("Invariant[Nested[ListWrapper, Show, ?]]", SerializableTests.serializable(instance))
+    checkAll("Nested[ListWrapper, Show, *]",
+             InvariantTests[Nested[ListWrapper, Show, *]](instance).invariant[MiniInt, Int, Boolean])
+    checkAll("Invariant[Nested[ListWrapper, Show, *]]", SerializableTests.serializable(instance))
   }
 
   {
     // Functor composition
     implicit val instance = ListWrapper.functor
-    checkAll("Nested[Option, ListWrapper, ?]", FunctorTests[Nested[Option, ListWrapper, ?]].functor[Int, Int, Int])
-    checkAll("Functor[Nested[Option, ListWrapper, ?]]",
-             SerializableTests.serializable(Functor[Nested[Option, ListWrapper, ?]]))
+    checkAll("Nested[Option, ListWrapper, *]", FunctorTests[Nested[Option, ListWrapper, *]].functor[Int, Int, Int])
+    checkAll("Functor[Nested[Option, ListWrapper, *]]",
+             SerializableTests.serializable(Functor[Nested[Option, ListWrapper, *]]))
   }
 
   {
     // Covariant + contravariant functor composition
-    checkAll("Nested[Option, Show, ?]",
-             ContravariantTests[Nested[Option, Show, ?]].contravariant[MiniInt, Int, Boolean])
-    checkAll("Contravariant[Nested[Option, Show, ?]]",
-             SerializableTests.serializable(Contravariant[Nested[Option, Show, ?]]))
+    checkAll("Nested[Option, Show, *]",
+             ContravariantTests[Nested[Option, Show, *]].contravariant[MiniInt, Int, Boolean])
+    checkAll("Contravariant[Nested[Option, Show, *]]",
+             SerializableTests.serializable(Contravariant[Nested[Option, Show, *]]))
   }
 
   {
     // InvariantSemigroupal + Apply functor composition
     implicit val instance = ListWrapper.invariantSemigroupal
-    checkAll("Nested[ListWrapper, Option, ?]",
-             InvariantSemigroupalTests[Nested[ListWrapper, Option, ?]].invariantSemigroupal[Int, Int, Int])
-    checkAll("InvariantSemigroupal[Nested[ListWrapper, Const[String, ?], ?]",
-             SerializableTests.serializable(InvariantSemigroupal[Nested[ListWrapper, Option, ?]]))
+    checkAll("Nested[ListWrapper, Option, *]",
+             InvariantSemigroupalTests[Nested[ListWrapper, Option, *]].invariantSemigroupal[Int, Int, Int])
+    checkAll("InvariantSemigroupal[Nested[ListWrapper, Const[String, *], *]",
+             SerializableTests.serializable(InvariantSemigroupal[Nested[ListWrapper, Option, *]]))
   }
 
   {
     // Applicative + ContravariantMonoidal functor composition
-    checkAll("Nested[Option, Const[String, ?], ?]",
-             ContravariantMonoidalTests[Nested[Option, Const[String, ?], ?]].contravariantMonoidal[Int, Int, Int])
-    checkAll("ContravariantMonoidal[Nested[Option, Const[String, ?], ?]",
-             SerializableTests.serializable(ContravariantMonoidal[Nested[Option, Const[String, ?], ?]]))
+    checkAll("Nested[Option, Const[String, *], *]",
+             ContravariantMonoidalTests[Nested[Option, Const[String, *], *]].contravariantMonoidal[Int, Int, Int])
+    checkAll("ContravariantMonoidal[Nested[Option, Const[String, *], *]",
+             SerializableTests.serializable(ContravariantMonoidal[Nested[Option, Const[String, *], *]]))
   }
 
   {
     // Contravariant + Contravariant = Functor
     type ConstInt[A] = Const[Int, A]
-    checkAll("Nested[Const[Int, ?], Show, ?]", FunctorTests[Nested[ConstInt, Show, ?]].functor[Int, Int, Int])
-    checkAll("Functor[Nested[Const[Int, ?], Show, ?]]",
-             SerializableTests.serializable(Functor[Nested[ConstInt, Show, ?]]))
+    checkAll("Nested[Const[Int, *], Show, *]", FunctorTests[Nested[ConstInt, Show, *]].functor[Int, Int, Int])
+    checkAll("Functor[Nested[Const[Int, *], Show, *]]",
+             SerializableTests.serializable(Functor[Nested[ConstInt, Show, *]]))
   }
 
   {
     // Contravariant + Functor = Contravariant
-    checkAll("Nested[Show, Option, ?]",
-             ContravariantTests[Nested[Show, Option, ?]].contravariant[MiniInt, Int, Boolean])
-    checkAll("Contravariant[Nested[Show, Option, ?]]",
-             SerializableTests.serializable(Contravariant[Nested[Show, Option, ?]]))
+    checkAll("Nested[Show, Option, *]",
+             ContravariantTests[Nested[Show, Option, *]].contravariant[MiniInt, Int, Boolean])
+    checkAll("Contravariant[Nested[Show, Option, *]]",
+             SerializableTests.serializable(Contravariant[Nested[Show, Option, *]]))
   }
 
   {
     // Apply composition
     implicit val instance = ListWrapper.applyInstance
-    checkAll("Nested[List, ListWrapper, ?]", ApplyTests[Nested[List, ListWrapper, ?]].apply[Int, Int, Int])
-    checkAll("Apply[Nested[List, ListWrapper, ?]]", SerializableTests.serializable(Apply[Nested[List, ListWrapper, ?]]))
+    checkAll("Nested[List, ListWrapper, *]", ApplyTests[Nested[List, ListWrapper, *]].apply[Int, Int, Int])
+    checkAll("Apply[Nested[List, ListWrapper, *]]", SerializableTests.serializable(Apply[Nested[List, ListWrapper, *]]))
   }
 
   {
     // CommutativeApply composition
     implicit val optionApply = Apply[Option]
-    implicit val validatedApply = Apply[Validated[Int, ?]]
-    checkAll("Nested[Option, Validated[Int, ?], ?]",
-             CommutativeApplyTests[Nested[Option, Validated[Int, ?], ?]].commutativeApply[Int, Int, Int])
-    checkAll("CommutativeApply[Nested[Option, Validated[Int, ?], ?], ?]]",
-             SerializableTests.serializable(CommutativeApply[Nested[Option, Validated[Int, ?], ?]]))
+    implicit val validatedApply = Apply[Validated[Int, *]]
+    checkAll("Nested[Option, Validated[Int, *], *]",
+             CommutativeApplyTests[Nested[Option, Validated[Int, *], *]].commutativeApply[Int, Int, Int])
+    checkAll("CommutativeApply[Nested[Option, Validated[Int, *], *], *]]",
+             SerializableTests.serializable(CommutativeApply[Nested[Option, Validated[Int, *], *]]))
   }
 
   {
     // Applicative composition
     implicit val instance = ListWrapper.applicative
-    checkAll("Nested[List, ListWrapper, ?]", ApplicativeTests[Nested[List, ListWrapper, ?]].applicative[Int, Int, Int])
-    checkAll("Applicative[Nested[List, ListWrapper, ?]]",
-             SerializableTests.serializable(Applicative[Nested[List, ListWrapper, ?]]))
+    checkAll("Nested[List, ListWrapper, *]", ApplicativeTests[Nested[List, ListWrapper, *]].applicative[Int, Int, Int])
+    checkAll("Applicative[Nested[List, ListWrapper, *]]",
+             SerializableTests.serializable(Applicative[Nested[List, ListWrapper, *]]))
   }
 
   {
     // CommutativeApplicative composition
     implicit val instance = ListWrapper.applicative
-    checkAll("Nested[Option, Validated[Int, ?], ?]",
-             CommutativeApplicativeTests[Nested[Option, Validated[Int, ?], ?]].commutativeApplicative[Int, Int, Int])
-    checkAll("CommutativeApplicative[Nested[List, ListWrapper, ?]]",
-             SerializableTests.serializable(CommutativeApplicative[Nested[Option, Validated[Int, ?], ?]]))
+    checkAll("Nested[Option, Validated[Int, *], *]",
+             CommutativeApplicativeTests[Nested[Option, Validated[Int, *], *]].commutativeApplicative[Int, Int, Int])
+    checkAll("CommutativeApplicative[Nested[List, ListWrapper, *]]",
+             SerializableTests.serializable(CommutativeApplicative[Nested[Option, Validated[Int, *], *]]))
   }
 
   {
@@ -152,84 +152,84 @@ class NestedSuite extends CatsSuite {
     implicit val instance = ListWrapper.applicative
 
     checkAll(
-      "Nested[Validated[String, ?], ListWrapper, ?]",
-      ApplicativeErrorTests[Nested[Validated[String, ?], ListWrapper, ?], String].applicativeError[Int, Int, Int]
+      "Nested[Validated[String, *], ListWrapper, *]",
+      ApplicativeErrorTests[Nested[Validated[String, *], ListWrapper, *], String].applicativeError[Int, Int, Int]
     )
     checkAll(
-      "ApplicativeError[Nested[Validated[String, ?], ListWrapper, ?]]",
-      SerializableTests.serializable(ApplicativeError[Nested[Validated[String, ?], ListWrapper, ?], String])
+      "ApplicativeError[Nested[Validated[String, *], ListWrapper, *]]",
+      SerializableTests.serializable(ApplicativeError[Nested[Validated[String, *], ListWrapper, *], String])
     )
   }
 
   {
     // Alternative composition
     implicit val instance = ListWrapper.alternative
-    checkAll("Nested[List, ListWrapper, ?]", AlternativeTests[Nested[List, ListWrapper, ?]].alternative[Int, Int, Int])
-    checkAll("Alternative[Nested[List, ListWrapper, ?]]",
-             SerializableTests.serializable(Alternative[Nested[List, ListWrapper, ?]]))
+    checkAll("Nested[List, ListWrapper, *]", AlternativeTests[Nested[List, ListWrapper, *]].alternative[Int, Int, Int])
+    checkAll("Alternative[Nested[List, ListWrapper, *]]",
+             SerializableTests.serializable(Alternative[Nested[List, ListWrapper, *]]))
   }
 
   {
     // Foldable composition
     implicit val instance = ListWrapper.foldable
-    checkAll("Nested[List, ListWrapper, ?]", FoldableTests[Nested[List, ListWrapper, ?]].foldable[Int, Int])
-    checkAll("Foldable[Nested[List, ListWrapper, ?]]",
-             SerializableTests.serializable(Foldable[Nested[List, ListWrapper, ?]]))
+    checkAll("Nested[List, ListWrapper, *]", FoldableTests[Nested[List, ListWrapper, *]].foldable[Int, Int])
+    checkAll("Foldable[Nested[List, ListWrapper, *]]",
+             SerializableTests.serializable(Foldable[Nested[List, ListWrapper, *]]))
   }
 
   {
     // Traverse composition
     implicit val instance = ListWrapper.traverse
-    checkAll("Nested[List, ListWrapper, ?]",
-             TraverseTests[Nested[List, ListWrapper, ?]].traverse[Int, Int, Int, Set[Int], Option, Option])
-    checkAll("Traverse[Nested[List, ListWrapper, ?]]",
-             SerializableTests.serializable(Traverse[Nested[List, ListWrapper, ?]]))
+    checkAll("Nested[List, ListWrapper, *]",
+             TraverseTests[Nested[List, ListWrapper, *]].traverse[Int, Int, Int, Set[Int], Option, Option])
+    checkAll("Traverse[Nested[List, ListWrapper, *]]",
+             SerializableTests.serializable(Traverse[Nested[List, ListWrapper, *]]))
   }
 
   {
     // Reducible composition
     implicit val instance = ListWrapper.foldable
-    checkAll("Nested[NonEmptyList, OneAnd[ListWrapper, ?], ?]",
-             ReducibleTests[Nested[NonEmptyList, OneAnd[ListWrapper, ?], ?]].reducible[Option, Int, Int])
-    checkAll("Reducible[Nested[NonEmptyList, OneAnd[ListWrapper, ?], ?]]",
-             SerializableTests.serializable(Reducible[Nested[NonEmptyList, OneAnd[ListWrapper, ?], ?]]))
+    checkAll("Nested[NonEmptyList, OneAnd[ListWrapper, *], *]",
+             ReducibleTests[Nested[NonEmptyList, OneAnd[ListWrapper, *], *]].reducible[Option, Int, Int])
+    checkAll("Reducible[Nested[NonEmptyList, OneAnd[ListWrapper, *], *]]",
+             SerializableTests.serializable(Reducible[Nested[NonEmptyList, OneAnd[ListWrapper, *], *]]))
   }
 
   {
     // NonEmptyTraverse composition
     checkAll(
-      "Nested[NonEmptyList, NonEmptyVector, ?]",
-      NonEmptyTraverseTests[Nested[NonEmptyList, NonEmptyVector, ?]]
+      "Nested[NonEmptyList, NonEmptyVector, *]",
+      NonEmptyTraverseTests[Nested[NonEmptyList, NonEmptyVector, *]]
         .nonEmptyTraverse[Option, Int, Int, Int, Int, Option, Option]
     )
-    checkAll("NonEmptyTraverse[Nested[NonEmptyList, NonEmptyVector, ?]]",
-             SerializableTests.serializable(NonEmptyTraverse[Nested[NonEmptyList, NonEmptyVector, ?]]))
+    checkAll("NonEmptyTraverse[Nested[NonEmptyList, NonEmptyVector, *]]",
+             SerializableTests.serializable(NonEmptyTraverse[Nested[NonEmptyList, NonEmptyVector, *]]))
   }
 
   {
     // SemigroupK composition
     implicit val instance = ListWrapper.semigroupK
-    checkAll("Nested[ListWrapper, Option, ?]", SemigroupKTests[Nested[ListWrapper, Option, ?]].semigroupK[Int])
-    checkAll("SemigroupK[Nested[ListWrapper, Option, ?]]",
-             SerializableTests.serializable(SemigroupK[Nested[ListWrapper, Option, ?]]))
+    checkAll("Nested[ListWrapper, Option, *]", SemigroupKTests[Nested[ListWrapper, Option, *]].semigroupK[Int])
+    checkAll("SemigroupK[Nested[ListWrapper, Option, *]]",
+             SerializableTests.serializable(SemigroupK[Nested[ListWrapper, Option, *]]))
   }
 
   {
     // MonoidK composition
     implicit val instance = ListWrapper.monoidK
-    checkAll("Nested[ListWrapper, Option, ?]", MonoidKTests[Nested[ListWrapper, Option, ?]].monoidK[Int])
-    checkAll("MonoidK[Nested[ListWrapper, Option, ?]]",
-             SerializableTests.serializable(MonoidK[Nested[ListWrapper, Option, ?]]))
+    checkAll("Nested[ListWrapper, Option, *]", MonoidKTests[Nested[ListWrapper, Option, *]].monoidK[Int])
+    checkAll("MonoidK[Nested[ListWrapper, Option, *]]",
+             SerializableTests.serializable(MonoidK[Nested[ListWrapper, Option, *]]))
   }
 
   {
     import cats.laws.discipline.eq._
     // Distributive composition
     checkAll(
-      "Nested[Function1[MiniInt, ?], Function0, ?]",
-      DistributiveTests[Nested[Function1[MiniInt, ?], Function0, ?]].distributive[Int, Int, Int, Option, Function0]
+      "Nested[Function1[MiniInt, *], Function0, *]",
+      DistributiveTests[Nested[Function1[MiniInt, *], Function0, *]].distributive[Int, Int, Int, Option, Function0]
     )
-    checkAll("Distributive[Nested[Function1[Int,?], Function0, ?]]",
-             SerializableTests.serializable(Distributive[Nested[Function1[Int, ?], Function0, ?]]))
+    checkAll("Distributive[Nested[Function1[Int,*], Function0, *]]",
+             SerializableTests.serializable(Distributive[Nested[Function1[Int, *], Function0, *]]))
   }
 }

--- a/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
@@ -26,10 +26,10 @@ import scala.collection.immutable.SortedMap
 
 class NonEmptyMapSuite extends CatsSuite {
 
-  checkAll("NonEmptyMap[String, Int]", SemigroupKTests[NonEmptyMap[String, ?]].semigroupK[Int])
+  checkAll("NonEmptyMap[String, Int]", SemigroupKTests[NonEmptyMap[String, *]].semigroupK[Int])
   checkAll(
     "NonEmptyMap[String, Int]",
-    NonEmptyTraverseTests[NonEmptyMap[String, ?]].nonEmptyTraverse[Option, Int, Int, Double, Int, Option, Option]
+    NonEmptyTraverseTests[NonEmptyMap[String, *]].nonEmptyTraverse[Option, Int, Int, Double, Int, Option, Option]
   )
   checkAll("NonEmptyMap[String, Int]", BandTests[NonEmptyMap[String, Int]].band)
   checkAll("NonEmptyMap[String, Int]", EqTests[NonEmptyMap[String, Int]].eqv)
@@ -104,7 +104,7 @@ class NonEmptyMapSuite extends CatsSuite {
 
   test("reduceLeft consistent with foldLeft") {
     forAll { (nem: NonEmptyMap[String, Int], f: (Int, Int) => Int) =>
-      nem.reduceLeft(f) should ===(Foldable[SortedMap[String, ?]].foldLeft(nem.tail, nem.head._2)(f))
+      nem.reduceLeft(f) should ===(Foldable[SortedMap[String, *]].foldLeft(nem.tail, nem.head._2)(f))
     }
   }
 
@@ -113,7 +113,7 @@ class NonEmptyMapSuite extends CatsSuite {
       val got = nem.reduceRight(f).value
       val last = nem.last
       val rev = nem - last._1
-      val expected = Foldable[SortedMap[String, ?]]
+      val expected = Foldable[SortedMap[String, *]]
         .foldRight(rev, Now(last._2))((a, b) => f(a, b))
         .value
       got should ===(expected)

--- a/tests/src/test/scala/cats/tests/OneAndSuite.scala
+++ b/tests/src/test/scala/cats/tests/OneAndSuite.scala
@@ -31,54 +31,54 @@ class OneAndSuite extends CatsSuite {
   checkAll("OneAnd[Stream, Int]", EqTests[OneAnd[LazyList, Int]].eqv)
 
   checkAll("OneAnd[Stream, Int] with Option",
-           NonEmptyTraverseTests[OneAnd[LazyList, ?]].nonEmptyTraverse[Option, Int, Int, Int, Int, Option, Option])
-  checkAll("NonEmptyTraverse[OneAnd[Stream, A]]", SerializableTests.serializable(NonEmptyTraverse[OneAnd[LazyList, ?]]))
+           NonEmptyTraverseTests[OneAnd[LazyList, *]].nonEmptyTraverse[Option, Int, Int, Int, Int, Option, Option])
+  checkAll("NonEmptyTraverse[OneAnd[Stream, A]]", SerializableTests.serializable(NonEmptyTraverse[OneAnd[LazyList, *]]))
 
   {
     implicit val traverse = OneAnd.catsDataTraverseForOneAnd(ListWrapper.traverse)
     checkAll("OneAnd[ListWrapper, Int] with Option",
-             TraverseTests[OneAnd[ListWrapper, ?]].traverse[Int, Int, Int, Int, Option, Option])
-    checkAll("Traverse[OneAnd[ListWrapper, A]]", SerializableTests.serializable(Traverse[OneAnd[ListWrapper, ?]]))
+             TraverseTests[OneAnd[ListWrapper, *]].traverse[Int, Int, Int, Int, Option, Option])
+    checkAll("Traverse[OneAnd[ListWrapper, A]]", SerializableTests.serializable(Traverse[OneAnd[ListWrapper, *]]))
   }
 
-  checkAll("OneAnd[Stream, Int]", ReducibleTests[OneAnd[LazyList, ?]].reducible[Option, Int, Int])
-  checkAll("Reducible[OneAnd[Stream, ?]]", SerializableTests.serializable(Reducible[OneAnd[LazyList, ?]]))
+  checkAll("OneAnd[Stream, Int]", ReducibleTests[OneAnd[LazyList, *]].reducible[Option, Int, Int])
+  checkAll("Reducible[OneAnd[Stream, *]]", SerializableTests.serializable(Reducible[OneAnd[LazyList, *]]))
 
   implicit val iso = SemigroupalTests.Isomorphisms
-    .invariant[OneAnd[ListWrapper, ?]](OneAnd.catsDataFunctorForOneAnd(ListWrapper.functor))
+    .invariant[OneAnd[ListWrapper, *]](OneAnd.catsDataFunctorForOneAnd(ListWrapper.functor))
 
   // Test instances that have more general constraints
   {
     implicit val monad = ListWrapper.monad
     implicit val alt = ListWrapper.alternative
-    checkAll("OneAnd[ListWrapper, Int]", MonadTests[OneAnd[ListWrapper, ?]].monad[Int, Int, Int])
-    checkAll("MonadTests[OneAnd[ListWrapper, A]]", SerializableTests.serializable(Monad[OneAnd[ListWrapper, ?]]))
+    checkAll("OneAnd[ListWrapper, Int]", MonadTests[OneAnd[ListWrapper, *]].monad[Int, Int, Int])
+    checkAll("MonadTests[OneAnd[ListWrapper, A]]", SerializableTests.serializable(Monad[OneAnd[ListWrapper, *]]))
   }
 
   {
     implicit val alternative = ListWrapper.alternative
-    checkAll("OneAnd[ListWrapper, Int]", ApplicativeTests[OneAnd[ListWrapper, ?]].applicative[Int, Int, Int])
-    checkAll("Applicative[OneAnd[ListWrapper, A]]", SerializableTests.serializable(Applicative[OneAnd[ListWrapper, ?]]))
+    checkAll("OneAnd[ListWrapper, Int]", ApplicativeTests[OneAnd[ListWrapper, *]].applicative[Int, Int, Int])
+    checkAll("Applicative[OneAnd[ListWrapper, A]]", SerializableTests.serializable(Applicative[OneAnd[ListWrapper, *]]))
   }
 
   {
     implicit val functor = ListWrapper.functor
-    checkAll("OneAnd[ListWrapper, Int]", FunctorTests[OneAnd[ListWrapper, ?]].functor[Int, Int, Int])
-    checkAll("Functor[OneAnd[ListWrapper, A]]", SerializableTests.serializable(Functor[OneAnd[ListWrapper, ?]]))
+    checkAll("OneAnd[ListWrapper, Int]", FunctorTests[OneAnd[ListWrapper, *]].functor[Int, Int, Int])
+    checkAll("Functor[OneAnd[ListWrapper, A]]", SerializableTests.serializable(Functor[OneAnd[ListWrapper, *]]))
   }
 
   {
     implicit val alternative = ListWrapper.alternative
-    checkAll("OneAnd[ListWrapper, Int]", SemigroupKTests[OneAnd[ListWrapper, ?]].semigroupK[Int])
+    checkAll("OneAnd[ListWrapper, Int]", SemigroupKTests[OneAnd[ListWrapper, *]].semigroupK[Int])
     checkAll("OneAnd[Stream, Int]", SemigroupTests[OneAnd[LazyList, Int]].semigroup)
-    checkAll("SemigroupK[OneAnd[ListWrapper, A]]", SerializableTests.serializable(SemigroupK[OneAnd[ListWrapper, ?]]))
+    checkAll("SemigroupK[OneAnd[ListWrapper, A]]", SerializableTests.serializable(SemigroupK[OneAnd[ListWrapper, *]]))
     checkAll("Semigroup[NonEmptyStream[Int]]", SerializableTests.serializable(Semigroup[OneAnd[LazyList, Int]]))
   }
 
   {
     implicit val foldable = ListWrapper.foldable
-    checkAll("OneAnd[ListWrapper, Int]", FoldableTests[OneAnd[ListWrapper, ?]].foldable[Int, Int])
-    checkAll("Foldable[OneAnd[ListWrapper, A]]", SerializableTests.serializable(Foldable[OneAnd[ListWrapper, ?]]))
+    checkAll("OneAnd[ListWrapper, Int]", FoldableTests[OneAnd[ListWrapper, *]].foldable[Int, Int])
+    checkAll("Foldable[OneAnd[ListWrapper, A]]", SerializableTests.serializable(Foldable[OneAnd[ListWrapper, *]]))
   }
 
   {
@@ -88,7 +88,7 @@ class OneAndSuite extends CatsSuite {
     implicitly[Comonad[NonEmptyStream]]
   }
 
-  implicit val iso2 = SemigroupalTests.Isomorphisms.invariant[OneAnd[LazyList, ?]]
+  implicit val iso2 = SemigroupalTests.Isomorphisms.invariant[OneAnd[LazyList, *]]
 
   //OneAnd's tailRecM fails on LazyList due to the fact that. todo: replace NonEmptyStream with NonEmptyLazyList using newtype https://github.com/typelevel/cats/issues/2903
   checkAll("NonEmptyStream[Int]", MonadTests[NonEmptyStream].stackUnsafeMonad[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/OpSuite.scala
+++ b/tests/src/test/scala/cats/tests/OpSuite.scala
@@ -17,8 +17,8 @@ class OpSuite extends CatsSuite {
 
   {
     implicit val catsDataCategoryForOp = Op.catsDataCategoryForOp[Function1]
-    checkAll("Op[Function1, ?, ?]", CategoryTests[Op[Function1, ?, ?]].category[Char, MiniInt, Char, Boolean])
-    checkAll("Category[Op[Function1, ?, ?]]", SerializableTests.serializable(Category[Op[Function1, ?, ?]]))
+    checkAll("Op[Function1, *, *]", CategoryTests[Op[Function1, *, *]].category[Char, MiniInt, Char, Boolean])
+    checkAll("Category[Op[Function1, *, *]]", SerializableTests.serializable(Category[Op[Function1, *, *]]))
   }
 
   /**
@@ -26,12 +26,12 @@ class OpSuite extends CatsSuite {
    */
   object ImplicitResolution {
     // Arr is Function1
-    Category[Op[Function1, ?, ?]]
-    Compose[Op[Function1, ?, ?]]
+    Category[Op[Function1, *, *]]
+    Compose[Op[Function1, *, *]]
     Eq[Op[Function1, Char, MiniInt]]
 
-    // Arr is Kleisli[Option, ?, ?]
-    Category[Op[Kleisli[Option, ?, ?], ?, ?]]
-    Compose[Op[Kleisli[Option, ?, ?], ?, ?]]
+    // Arr is Kleisli[Option, *, *]
+    Category[Op[Kleisli[Option, *, *], *, *]]
+    Compose[Op[Kleisli[Option, *, *], *, *]]
   }
 }

--- a/tests/src/test/scala/cats/tests/OptionTSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionTSuite.scala
@@ -10,18 +10,18 @@ import cats.laws.discipline.eq._
 
 class OptionTSuite extends CatsSuite {
   implicit val iso = SemigroupalTests.Isomorphisms
-    .invariant[OptionT[ListWrapper, ?]](OptionT.catsDataFunctorForOptionT(ListWrapper.functor))
+    .invariant[OptionT[ListWrapper, *]](OptionT.catsDataFunctorForOptionT(ListWrapper.functor))
 
-  checkAll("OptionT[Eval, ?]", DeferTests[OptionT[Eval, ?]].defer[Int])
-  checkAll("OptionT[Eval, ?]", FunctorFilterTests[OptionT[Eval, ?]].functorFilter[Int, Int, Int])
+  checkAll("OptionT[Eval, *]", DeferTests[OptionT[Eval, *]].defer[Int])
+  checkAll("OptionT[Eval, *]", FunctorFilterTests[OptionT[Eval, *]].functorFilter[Int, Int, Int])
 
   {
     // if a Functor for F is defined
     implicit val F = ListWrapper.functor
 
-    checkAll("OptionT[ListWrapper, ?]", FunctorFilterTests[OptionT[ListWrapper, ?]].functorFilter[Int, Int, Int])
-    checkAll("FunctorFilter[OptionT[ListWrapper, ?]]",
-             SerializableTests.serializable(FunctorFilter[OptionT[ListWrapper, ?]]))
+    checkAll("OptionT[ListWrapper, *]", FunctorFilterTests[OptionT[ListWrapper, *]].functorFilter[Int, Int, Int])
+    checkAll("FunctorFilter[OptionT[ListWrapper, *]]",
+             SerializableTests.serializable(FunctorFilter[OptionT[ListWrapper, *]]))
 
   }
 
@@ -29,9 +29,9 @@ class OptionTSuite extends CatsSuite {
     // if a Traverse for F is defined
     implicit val F = ListWrapper.traverse
 
-    checkAll("OptionT[ListWrapper, ?]", TraverseFilterTests[OptionT[ListWrapper, ?]].traverseFilter[Int, Int, Int])
-    checkAll("TraverseFilter[OptionT[ListWrapper, ?]]",
-             SerializableTests.serializable(TraverseFilter[OptionT[ListWrapper, ?]]))
+    checkAll("OptionT[ListWrapper, *]", TraverseFilterTests[OptionT[ListWrapper, *]].traverseFilter[Int, Int, Int])
+    checkAll("TraverseFilter[OptionT[ListWrapper, *]]",
+             SerializableTests.serializable(TraverseFilter[OptionT[ListWrapper, *]]))
 
   }
 
@@ -66,59 +66,59 @@ class OptionTSuite extends CatsSuite {
     // F has a Functor
     implicit val F = ListWrapper.functor
 
-    checkAll("OptionT[ListWrapper, Int]", FunctorTests[OptionT[ListWrapper, ?]].functor[Int, Int, Int])
-    checkAll("Functor[OptionT[ListWrapper, ?]]", SerializableTests.serializable(Functor[OptionT[ListWrapper, ?]]))
+    checkAll("OptionT[ListWrapper, Int]", FunctorTests[OptionT[ListWrapper, *]].functor[Int, Int, Int])
+    checkAll("Functor[OptionT[ListWrapper, *]]", SerializableTests.serializable(Functor[OptionT[ListWrapper, *]]))
   }
 
   {
     // F has an Invariant
     implicit val evidence = ListWrapper.invariant
     Invariant[ListWrapper]
-    Invariant[OptionT[ListWrapper, ?]]
+    Invariant[OptionT[ListWrapper, *]]
 
-    checkAll("OptionT[ListWrapper, ?]", InvariantTests[OptionT[ListWrapper, ?]].invariant[Int, Int, Int])
-    checkAll("Invariant[OptionT[ListWrapper, ?]]", SerializableTests.serializable(Invariant[OptionT[ListWrapper, ?]]))
+    checkAll("OptionT[ListWrapper, *]", InvariantTests[OptionT[ListWrapper, *]].invariant[Int, Int, Int])
+    checkAll("Invariant[OptionT[ListWrapper, *]]", SerializableTests.serializable(Invariant[OptionT[ListWrapper, *]]))
   }
 
   {
     // F has a Contravariant
     Contravariant[Show]
-    Contravariant[OptionT[Show, ?]]
+    Contravariant[OptionT[Show, *]]
 
-    checkAll("OptionT[Show, ?]", ContravariantTests[OptionT[Show, ?]].contravariant[MiniInt, Int, Boolean])
-    checkAll("Contravariant[OptionT[Show, ?]]", SerializableTests.serializable(Contravariant[OptionT[Show, ?]]))
+    checkAll("OptionT[Show, *]", ContravariantTests[OptionT[Show, *]].contravariant[MiniInt, Int, Boolean])
+    checkAll("Contravariant[OptionT[Show, *]]", SerializableTests.serializable(Contravariant[OptionT[Show, *]]))
   }
 
   {
     // F has a ContravariantMonoidal
-    checkAll("OptionT[Const[String, ?], Int]",
-             ContravariantMonoidalTests[OptionT[Const[String, ?], ?]].contravariantMonoidal[Int, Int, Int])
-    checkAll("ContravariantMonoidal[OptionT[Const[String, ?], Int]]",
-             SerializableTests.serializable(ContravariantMonoidal[OptionT[Const[String, ?], ?]]))
+    checkAll("OptionT[Const[String, *], Int]",
+             ContravariantMonoidalTests[OptionT[Const[String, *], *]].contravariantMonoidal[Int, Int, Int])
+    checkAll("ContravariantMonoidal[OptionT[Const[String, *], Int]]",
+             SerializableTests.serializable(ContravariantMonoidal[OptionT[Const[String, *], *]]))
   }
 
   {
     // F has a Monad
     implicit val F = ListWrapper.monad
     implicit val eq0 = OptionT.catsDataEqForOptionT[ListWrapper, Option[Int]]
-    implicit val eq1 = OptionT.catsDataEqForOptionT[OptionT[ListWrapper, ?], Int](eq0)
+    implicit val eq1 = OptionT.catsDataEqForOptionT[OptionT[ListWrapper, *], Int](eq0)
 
-    checkAll("OptionT[ListWrapper, Int]", MonadTests[OptionT[ListWrapper, ?]].monad[Int, Int, Int])
-    checkAll("Monad[OptionT[ListWrapper, ?]]", SerializableTests.serializable(Monad[OptionT[ListWrapper, ?]]))
+    checkAll("OptionT[ListWrapper, Int]", MonadTests[OptionT[ListWrapper, *]].monad[Int, Int, Int])
+    checkAll("Monad[OptionT[ListWrapper, *]]", SerializableTests.serializable(Monad[OptionT[ListWrapper, *]]))
 
-    checkAll("OptionT[ListWrapper, Int]", SemigroupKTests[OptionT[ListWrapper, ?]].semigroupK[Int])
-    checkAll("SemigroupK[OptionT[ListWrapper, ?]]", SerializableTests.serializable(SemigroupK[OptionT[ListWrapper, ?]]))
+    checkAll("OptionT[ListWrapper, Int]", SemigroupKTests[OptionT[ListWrapper, *]].semigroupK[Int])
+    checkAll("SemigroupK[OptionT[ListWrapper, *]]", SerializableTests.serializable(SemigroupK[OptionT[ListWrapper, *]]))
 
-    checkAll("OptionT[ListWrapper, Int]", MonoidKTests[OptionT[ListWrapper, ?]].monoidK[Int])
-    checkAll("MonoidK[OptionT[ListWrapper, ?]]", SerializableTests.serializable(MonoidK[OptionT[ListWrapper, ?]]))
+    checkAll("OptionT[ListWrapper, Int]", MonoidKTests[OptionT[ListWrapper, *]].monoidK[Int])
+    checkAll("MonoidK[OptionT[ListWrapper, *]]", SerializableTests.serializable(MonoidK[OptionT[ListWrapper, *]]))
 
-    Monad[OptionT[ListWrapper, ?]]
-    FlatMap[OptionT[ListWrapper, ?]]
-    Applicative[OptionT[ListWrapper, ?]]
-    Apply[OptionT[ListWrapper, ?]]
-    Functor[OptionT[ListWrapper, ?]]
-    MonoidK[OptionT[ListWrapper, ?]]
-    SemigroupK[OptionT[ListWrapper, ?]]
+    Monad[OptionT[ListWrapper, *]]
+    FlatMap[OptionT[ListWrapper, *]]
+    Applicative[OptionT[ListWrapper, *]]
+    Apply[OptionT[ListWrapper, *]]
+    Functor[OptionT[ListWrapper, *]]
+    MonoidK[OptionT[ListWrapper, *]]
+    SemigroupK[OptionT[ListWrapper, *]]
   }
 
   {
@@ -127,22 +127,22 @@ class OptionTSuite extends CatsSuite {
 
     implicit val monadError = OptionT.catsDataMonadErrorForOptionT[SEither, String]
 
-    checkAll("OptionT[Either[String, ?], Int]", MonadErrorTests[OptionT[SEither, ?], String].monadError[Int, Int, Int])
-    checkAll("MonadError[OptionT[Either[String, ?], ?]]", SerializableTests.serializable(monadError))
+    checkAll("OptionT[Either[String, *], Int]", MonadErrorTests[OptionT[SEither, *], String].monadError[Int, Int, Int])
+    checkAll("MonadError[OptionT[Either[String, *], *]]", SerializableTests.serializable(monadError))
 
-    Monad[OptionT[SEither, ?]]
-    FlatMap[OptionT[SEither, ?]]
-    Applicative[OptionT[SEither, ?]]
-    Apply[OptionT[SEither, ?]]
-    Functor[OptionT[SEither, ?]]
+    Monad[OptionT[SEither, *]]
+    FlatMap[OptionT[SEither, *]]
+    Applicative[OptionT[SEither, *]]
+    Apply[OptionT[SEither, *]]
+    Functor[OptionT[SEither, *]]
   }
 
   {
     // F has a Foldable
     implicit val F = ListWrapper.foldable
 
-    checkAll("OptionT[ListWrapper, Int]", FoldableTests[OptionT[ListWrapper, ?]].foldable[Int, Int])
-    checkAll("Foldable[OptionT[ListWrapper, ?]]", SerializableTests.serializable(Foldable[OptionT[ListWrapper, ?]]))
+    checkAll("OptionT[ListWrapper, Int]", FoldableTests[OptionT[ListWrapper, *]].foldable[Int, Int])
+    checkAll("Foldable[OptionT[ListWrapper, *]]", SerializableTests.serializable(Foldable[OptionT[ListWrapper, *]]))
   }
 
   {
@@ -150,12 +150,12 @@ class OptionTSuite extends CatsSuite {
     implicit val F = ListWrapper.traverse
 
     checkAll("OptionT[ListWrapper, Int] with Option",
-             TraverseTests[OptionT[ListWrapper, ?]].traverse[Int, Int, Int, Int, Option, Option])
-    checkAll("Traverse[OptionT[ListWrapper, ?]]", SerializableTests.serializable(Traverse[OptionT[ListWrapper, ?]]))
+             TraverseTests[OptionT[ListWrapper, *]].traverse[Int, Int, Int, Int, Option, Option])
+    checkAll("Traverse[OptionT[ListWrapper, *]]", SerializableTests.serializable(Traverse[OptionT[ListWrapper, *]]))
 
-    Foldable[OptionT[ListWrapper, ?]]
-    Functor[OptionT[ListWrapper, ?]]
-    Traverse[OptionT[ListWrapper, ?]]
+    Foldable[OptionT[ListWrapper, *]]
+    Functor[OptionT[ListWrapper, *]]
+    Traverse[OptionT[ListWrapper, *]]
   }
 
   {
@@ -180,13 +180,13 @@ class OptionTSuite extends CatsSuite {
   {
     // MonadError instance where F has a Monad
     implicit val F = ListWrapper.monad
-    checkAll("OptionT[ListWrapper, Int]", MonadErrorTests[OptionT[ListWrapper, ?], Unit].monadError[Int, Int, Int])
-    checkAll("MonadError[OptionT[List, ?]]", SerializableTests.serializable(MonadError[OptionT[ListWrapper, ?], Unit]))
+    checkAll("OptionT[ListWrapper, Int]", MonadErrorTests[OptionT[ListWrapper, *], Unit].monadError[Int, Int, Int])
+    checkAll("MonadError[OptionT[List, *]]", SerializableTests.serializable(MonadError[OptionT[ListWrapper, *], Unit]))
   }
 
-  test("MonadError[OptionT[F, ?], E] instance has higher priority than MonadError[OptionT[F, ?], Unit]") {
+  test("MonadError[OptionT[F, *], E] instance has higher priority than MonadError[OptionT[F, *], Unit]") {
 
-    def shouldCompile[F[_]: MonadError[?[_], E], E](x: OptionT[F, Int], e: E): OptionT[F, Int] =
+    def shouldCompile[F[_]: MonadError[*[_], E], E](x: OptionT[F, Int], e: E): OptionT[F, Int] =
       x.ensure(e)(_ => true)
   }
 
@@ -328,7 +328,7 @@ class OptionTSuite extends CatsSuite {
 
   test("show") {
     val either: Either[String, Option[Int]] = Either.right(Some(1))
-    OptionT[Either[String, ?], Int](either).show should ===("Right(Some(1))")
+    OptionT[Either[String, *], Int](either).show should ===("Right(Some(1))")
   }
 
   test("none") {
@@ -392,23 +392,23 @@ class OptionTSuite extends CatsSuite {
     Semigroup[OptionT[List, Int]]
     Monoid[OptionT[List, Int]]
 
-    SemigroupK[OptionT[List, ?]]
-    MonoidK[OptionT[List, ?]]
+    SemigroupK[OptionT[List, *]]
+    MonoidK[OptionT[List, *]]
 
-    Functor[OptionT[List, ?]]
-    Monad[OptionT[List, ?]]
+    Functor[OptionT[List, *]]
+    Monad[OptionT[List, *]]
 
     import scala.util.Try
-    Functor[OptionT[Try, ?]]
-    Monad[OptionT[Try, ?]]
-    MonadError[OptionT[Try, ?], Throwable]
+    Functor[OptionT[Try, *]]
+    Monad[OptionT[Try, *]]
+    MonadError[OptionT[Try, *], Throwable]
 
-    Foldable[OptionT[List, ?]]
-    Traverse[OptionT[List, ?]]
+    Foldable[OptionT[List, *]]
+    Traverse[OptionT[List, *]]
 
     implicit val T = ListWrapper.traverse
     implicit val M = ListWrapper.monad
-    Functor[OptionT[ListWrapper, ?]]
+    Functor[OptionT[ListWrapper, *]]
   }
 
 }

--- a/tests/src/test/scala/cats/tests/ParallelSuite.scala
+++ b/tests/src/test/scala/cats/tests/ParallelSuite.scala
@@ -243,17 +243,17 @@ class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest {
   }
 
   test("Kleisli with Either should accumulate errors") {
-    val k1: Kleisli[Either[String, ?], String, Int] = Kleisli(s => Right(s.length))
-    val k2: Kleisli[Either[String, ?], String, Int] = Kleisli(s => Left("Boo"))
-    val k3: Kleisli[Either[String, ?], String, Int] = Kleisli(s => Left("Nope"))
+    val k1: Kleisli[Either[String, *], String, Int] = Kleisli(s => Right(s.length))
+    val k2: Kleisli[Either[String, *], String, Int] = Kleisli(s => Left("Boo"))
+    val k3: Kleisli[Either[String, *], String, Int] = Kleisli(s => Left("Nope"))
 
     (List(k1, k2, k3).parSequence.run("Hello")) should ===(Left("BooNope"))
 
   }
 
   test("WriterT with Either should accumulate errors") {
-    val w1: WriterT[Either[String, ?], String, Int] = WriterT.liftF(Left("Too "))
-    val w2: WriterT[Either[String, ?], String, Int] = WriterT.liftF(Left("bad."))
+    val w1: WriterT[Either[String, *], String, Int] = WriterT.liftF(Left("Too "))
+    val w2: WriterT[Either[String, *], String, Int] = WriterT.liftF(Left("bad."))
 
     ((w1, w2).parMapN(_ + _).value) should ===(Left("Too bad."))
 
@@ -415,32 +415,32 @@ class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest {
     resultWithInstance should ===("parallel".some)
   }
 
-  checkAll("Parallel[Either[String, ?], Validated[String, ?]]",
-           ParallelTests[Either[String, ?], Validated[String, ?]].parallel[Int, String])
-  checkAll("Parallel[Ior[String, ?], Ior[String, ?]]",
-           ParallelTests[Ior[String, ?], Ior[String, ?]].parallel[Int, String])
+  checkAll("Parallel[Either[String, *], Validated[String, *]]",
+           ParallelTests[Either[String, *], Validated[String, *]].parallel[Int, String])
+  checkAll("Parallel[Ior[String, *], Ior[String, *]]",
+           ParallelTests[Ior[String, *], Ior[String, *]].parallel[Int, String])
   checkAll(
-    "Parallel[IorT[F, String, ?], IorT[F, String, ?]] with parallel effect",
-    ParallelTests[IorT[Either[String, ?], String, ?], IorT[Validated[String, ?], String, ?]].parallel[Int, String]
+    "Parallel[IorT[F, String, *], IorT[F, String, *]] with parallel effect",
+    ParallelTests[IorT[Either[String, *], String, *], IorT[Validated[String, *], String, *]].parallel[Int, String]
   )
   checkAll(
-    "Parallel[IorT[F, String, ?], IorT[F, String, ?]] with sequential effect",
-    ParallelTests[IorT[Option, String, ?], IorT[Option, String, ?]].parallel[Int, String]
+    "Parallel[IorT[F, String, *], IorT[F, String, *]] with sequential effect",
+    ParallelTests[IorT[Option, String, *], IorT[Option, String, *]].parallel[Int, String]
   )
-  checkAll("Parallel[OptionT[M, ?], Nested[F, Option, ?]]",
-           ParallelTests[OptionT[Either[String, ?], ?], Nested[Validated[String, ?], Option, ?]].parallel[Int, String])
+  checkAll("Parallel[OptionT[M, *], Nested[F, Option, *]]",
+           ParallelTests[OptionT[Either[String, *], *], Nested[Validated[String, *], Option, *]].parallel[Int, String])
   checkAll(
-    "Parallel[EitherT[M, String, ?], Nested[F, Validated[String, ?], ?]]",
-    ParallelTests[EitherT[Either[String, ?], String, ?], Nested[Validated[String, ?], Validated[String, ?], ?]]
+    "Parallel[EitherT[M, String, *], Nested[F, Validated[String, *], *]]",
+    ParallelTests[EitherT[Either[String, *], String, *], Nested[Validated[String, *], Validated[String, *], *]]
       .parallel[Int, String]
   )
   checkAll(
-    "Parallel[EitherT[Option, String, ?], Nested[Option, Validated[String, ?], ?]]",
-    ParallelTests[EitherT[Option, String, ?], Nested[Option, Validated[String, ?], ?]].parallel[Int, String]
+    "Parallel[EitherT[Option, String, *], Nested[Option, Validated[String, *], *]]",
+    ParallelTests[EitherT[Option, String, *], Nested[Option, Validated[String, *], *]].parallel[Int, String]
   )
   checkAll(
-    "Parallel[WriterT[M, Int, ?], WriterT[F, Int, ?]]",
-    ParallelTests[WriterT[Either[String, ?], Int, ?], WriterT[Validated[String, ?], Int, ?]].parallel[Int, String]
+    "Parallel[WriterT[M, Int, *], WriterT[F, Int, *]]",
+    ParallelTests[WriterT[Either[String, *], Int, *], WriterT[Validated[String, *], Int, *]].parallel[Int, String]
   )
   checkAll("NonEmptyParallel[Vector, ZipVector]",
            NonEmptyParallelTests[Vector, ZipVector].nonEmptyParallel[Int, String])
@@ -451,24 +451,24 @@ class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest {
            NonEmptyParallelTests[NonEmptyVector, ZipNonEmptyVector].nonEmptyParallel[Int, String])
   checkAll("NonEmptyParallel[NonEmptyList, ZipNonEmptyList]",
            NonEmptyParallelTests[NonEmptyList, ZipNonEmptyList].nonEmptyParallel[Int, String])
-  checkAll("Parallel[NonEmptyStream, OneAnd[ZipStream, ?]",
-           ParallelTests[NonEmptyStream, OneAnd[ZipStream, ?]].parallel[Int, String])
+  checkAll("Parallel[NonEmptyStream, OneAnd[ZipStream, *]",
+           ParallelTests[NonEmptyStream, OneAnd[ZipStream, *]].parallel[Int, String])
 
   checkAll("Parallel[Id, Id]", ParallelTests[Id, Id].parallel[Int, String])
 
   checkAll("NonEmptyParallel[NonEmptyList, ZipNonEmptyList]",
            SerializableTests.serializable(NonEmptyParallel[NonEmptyList, ZipNonEmptyList]))
 
-  checkAll("Parallel[Either[String, ?], Validated[String, ?]]",
-           SerializableTests.serializable(Parallel[Either[String, ?], Validated[String, ?]]))
+  checkAll("Parallel[Either[String, *], Validated[String, *]]",
+           SerializableTests.serializable(Parallel[Either[String, *], Validated[String, *]]))
 
   {
     implicit def kleisliEq[F[_], A, B](implicit ev: Eq[A => F[B]]): Eq[Kleisli[F, A, B]] =
       Eq.by[Kleisli[F, A, B], A => F[B]](_.run)
 
     checkAll(
-      "Parallel[KlesliT[M, A, ?], Kleisli[F, A, ?]]",
-      ParallelTests[Kleisli[Either[String, ?], MiniInt, ?], Kleisli[Validated[String, ?], MiniInt, ?]]
+      "Parallel[KlesliT[M, A, *], Kleisli[F, A, *]]",
+      ParallelTests[Kleisli[Either[String, *], MiniInt, *], Kleisli[Validated[String, *], MiniInt, *]]
         .parallel[Int, String]
     )
   }
@@ -487,9 +487,9 @@ trait ApplicativeErrorForEitherTest extends AnyFunSuiteLike with Discipline {
   implicit def eqV[A: Eq, B: Eq]: Eq[Validated[A, B]] = cats.data.Validated.catsDataEqForValidated
 
   {
-    implicit val parVal = Parallel.applicativeError[Either[String, ?], Validated[String, ?], String]
+    implicit val parVal = Parallel.applicativeError[Either[String, *], Validated[String, *], String]
 
     checkAll("ApplicativeError[Validated[String, Int]]",
-             ApplicativeErrorTests[Validated[String, ?], String].applicativeError[Int, Int, Int])
+             ApplicativeErrorTests[Validated[String, *], String].applicativeError[Int, Int, Int])
   }
 }

--- a/tests/src/test/scala/cats/tests/RegressionSuite.scala
+++ b/tests/src/test/scala/cats/tests/RegressionSuite.scala
@@ -23,7 +23,7 @@ class RegressionSuite extends CatsSuite {
   }
 
   object State {
-    implicit def instance[S]: Monad[State[S, ?]] = new Monad[State[S, ?]] with StackSafeMonad[State[S, ?]] { // lies!
+    implicit def instance[S]: Monad[State[S, *]] = new Monad[State[S, *]] with StackSafeMonad[State[S, *]] { // lies!
       def pure[A](a: A): State[S, A] = State(s => (a, s))
       def flatMap[A, B](sa: State[S, A])(f: A => State[S, B]): State[S, B] = sa.flatMap(f)
     }
@@ -50,7 +50,7 @@ class RegressionSuite extends CatsSuite {
     // test order of effects using a contrived, unsafe state monad.
     val names = List("Alice", "Bob", "Claire")
     val allocated = names.map(alloc)
-    val state = Traverse[List].sequence[State[Int, ?], Person](allocated)
+    val state = Traverse[List].sequence[State[Int, *], Person](allocated)
     val (people, counter) = state.run(0)
     people should ===(List(Person(0, "Alice"), Person(1, "Bob"), Person(2, "Claire")))
     counter should ===(3)
@@ -60,7 +60,7 @@ class RegressionSuite extends CatsSuite {
   }
 
   test("#167: confirm ap2 order") {
-    val twelve = Apply[State[String, ?]]
+    val twelve = Apply[State[String, *]]
       .ap2(State.instance[String].pure((_: Unit, _: Unit) => ()))(
         State[String, Unit](s => ((), s + "1")),
         State[String, Unit](s => ((), s + "2"))
@@ -71,7 +71,7 @@ class RegressionSuite extends CatsSuite {
   }
 
   test("#167: confirm map2 order") {
-    val twelve = Apply[State[String, ?]]
+    val twelve = Apply[State[String, *]]
       .map2(
         State[String, Unit](s => ((), s + "1")),
         State[String, Unit](s => ((), s + "2"))
@@ -82,7 +82,7 @@ class RegressionSuite extends CatsSuite {
   }
 
   test("#167: confirm map3 order") {
-    val oneTwoThree = Apply[State[String, ?]]
+    val oneTwoThree = Apply[State[String, *]]
       .map3(
         State[String, Unit](s => ((), s + "1")),
         State[String, Unit](s => ((), s + "2")),
@@ -154,14 +154,14 @@ class RegressionSuite extends CatsSuite {
     EitherT.right[String](Option(1)).handleErrorWith((_: String) => EitherT.pure(2))
 
     {
-      implicit val me = MonadError[EitherT[Option, String, ?], Unit]
+      implicit val me = MonadError[EitherT[Option, String, *], Unit]
       EitherT.right[String](Option(1)).handleErrorWith((_: Unit) => EitherT.pure(2))
     }
 
   }
 
   test("#2809 MonadErrorOps.reject runs effects only once") {
-    val program = StateT.modify[Either[Throwable, ?], Int](_ + 1).reject { case _ if false => new Throwable }
+    val program = StateT.modify[Either[Throwable, *], Int](_ + 1).reject { case _ if false => new Throwable }
     program.runS(0).toOption should ===(Some(1))
   }
 }

--- a/tests/src/test/scala/cats/tests/RepresentableStoreSuite.scala
+++ b/tests/src/test/scala/cats/tests/RepresentableStoreSuite.scala
@@ -9,7 +9,7 @@ import cats.data.Store
 class RepresentableStoreSuite extends CatsSuite {
 
   // Note: The Eq instance for Function1 causes this to run excessively long, and timeout the travis build
-  // checkAll("Comonad[Store[String, ?]]", ComonadTests[Store[String, ?]].comonad[Int, Int, Int])
+  // checkAll("Comonad[Store[String, *]]", ComonadTests[Store[String, *]].comonad[Int, Int, Int])
 
   {
     implicit val pairComonad = RepresentableStore.catsDataRepresentableStoreComonad[λ[P => (P, P)], Boolean]
@@ -22,11 +22,11 @@ class RepresentableStoreSuite extends CatsSuite {
       cats.laws.discipline.eq.catsLawsEqForRepresentableStore[λ[P => (P, P)], Boolean, RepresentableStore[λ[
         P => (P, P)
       ], Boolean, RepresentableStore[λ[P => (P, P)], Boolean, Int]]]
-    checkAll("Comonad[RepresentableStore[λ[P => (P, P)], Boolean, ?]]",
-             ComonadTests[RepresentableStore[λ[P => (P, P)], Boolean, ?]].comonad[Int, Int, Int])
+    checkAll("Comonad[RepresentableStore[λ[P => (P, P)], Boolean, *]]",
+             ComonadTests[RepresentableStore[λ[P => (P, P)], Boolean, *]].comonad[Int, Int, Int])
 
-    checkAll("Comonad[RepresentableStore[λ[P => (P, P)], Boolean, ?]]",
-             SerializableTests.serializable(Comonad[RepresentableStore[λ[P => (P, P)], Boolean, ?]]))
+    checkAll("Comonad[RepresentableStore[λ[P => (P, P)], Boolean, *]]",
+             SerializableTests.serializable(Comonad[RepresentableStore[λ[P => (P, P)], Boolean, *]]))
   }
 
   test("extract and peek are consistent") {

--- a/tests/src/test/scala/cats/tests/RepresentableSuite.scala
+++ b/tests/src/test/scala/cats/tests/RepresentableSuite.scala
@@ -22,8 +22,8 @@ class RepresentableSuite extends CatsSuite {
   checkAll("Id[String] <-> Unit => String", RepresentableTests[Id, Unit].representable[String])
   checkAll("Representable[Id]", SerializableTests.serializable(Representable[Id]))
 
-  checkAll("MiniInt => Int <-> MiniInt => Int", RepresentableTests[MiniInt => ?, MiniInt].representable[Int])
-  checkAll("Representable[String => ?]", SerializableTests.serializable(Representable[String => ?]))
+  checkAll("MiniInt => Int <-> MiniInt => Int", RepresentableTests[MiniInt => *, MiniInt].representable[Int])
+  checkAll("Representable[String => *]", SerializableTests.serializable(Representable[String => *]))
 
   checkAll("Pair[String, String] <-> Boolean => String", RepresentableTests[Pair, Boolean].representable[String])
   checkAll("Representable[Pair]", SerializableTests.serializable(Representable[Pair]))
@@ -40,7 +40,7 @@ class RepresentableSuite extends CatsSuite {
     checkAll(
       "Kleisli[Pair, MiniInt, Int] <-> (MiniInt, Boolean) => Int",
       // Have to summon all implicits using 'implicitly' otherwise we get a diverging implicits error
-      RepresentableTests[Kleisli[Pair, MiniInt, ?], (MiniInt, Boolean)].representable[Int](
+      RepresentableTests[Kleisli[Pair, MiniInt, *], (MiniInt, Boolean)].representable[Int](
         implicitly[Arbitrary[Int]],
         implicitly[Arbitrary[Kleisli[Pair, MiniInt, Int]]],
         implicitly[Arbitrary[(MiniInt, Boolean)]],
@@ -50,8 +50,8 @@ class RepresentableSuite extends CatsSuite {
       )
     )
 
-    checkAll("Representable[Kleisli[Pair, MiniInt, ?]]",
-             SerializableTests.serializable(Representable[Kleisli[Pair, MiniInt, ?]]))
+    checkAll("Representable[Kleisli[Pair, MiniInt, *]]",
+             SerializableTests.serializable(Representable[Kleisli[Pair, MiniInt, *]]))
   }
 
   {
@@ -68,16 +68,16 @@ class RepresentableSuite extends CatsSuite {
 
   {
     // the monadInstance below made a conflict to resolve this one.
-    // TODO: ceedubs is this needed?
-    implicit val isoFun1: Isomorphisms[MiniInt => ?] = Isomorphisms.invariant[MiniInt => ?]
+    // TODO: ceedubs is this needed*
+    implicit val isoFun1: Isomorphisms[MiniInt => *] = Isomorphisms.invariant[MiniInt => *]
 
-    implicit val monadInstance = Representable.monad[MiniInt => ?]
-    checkAll("MiniInt => ?", MonadTests[MiniInt => ?].monad[String, String, String])
+    implicit val monadInstance = Representable.monad[MiniInt => *]
+    checkAll("MiniInt => *", MonadTests[MiniInt => *].monad[String, String, String])
   }
 
   {
     implicit val distributiveInstance = Representable.distributive[Pair]
-    checkAll("Pair[Int]", DistributiveTests[Pair].distributive[Int, Int, Int, Option, MiniInt => ?])
+    checkAll("Pair[Int]", DistributiveTests[Pair].distributive[Int, Int, Int, Option, MiniInt => *])
   }
 
   // Syntax tests. If it compiles is "passes"

--- a/tests/src/test/scala/cats/tests/SetSuite.scala
+++ b/tests/src/test/scala/cats/tests/SetSuite.scala
@@ -12,7 +12,7 @@ class SetSuite extends CatsSuite {
   checkAll("Set[Int]", MonoidKTests[Set].monoidK[Int])
   checkAll("MonoidK[Set]", SerializableTests.serializable(MonoidK[Set]))
 
-  checkAll("Set[Int]", UnorderedTraverseTests[Set].unorderedTraverse[Int, Int, Int, Validated[Int, ?], Option])
+  checkAll("Set[Int]", UnorderedTraverseTests[Set].unorderedTraverse[Int, Int, Int, Validated[Int, *], Option])
   checkAll("UnorderedTraverse[Set]", SerializableTests.serializable(UnorderedTraverse[Set]))
 
   test("show") {

--- a/tests/src/test/scala/cats/tests/SortedMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/SortedMapSuite.scala
@@ -16,20 +16,20 @@ import cats.laws.discipline.arbitrary._
 import scala.collection.immutable.SortedMap
 
 class SortedMapSuite extends CatsSuite {
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[SortedMap[Int, ?]]
+  implicit val iso = SemigroupalTests.Isomorphisms.invariant[SortedMap[Int, *]]
 
-  checkAll("SortedMap[Int, Int]", SemigroupalTests[SortedMap[Int, ?]].semigroupal[Int, Int, Int])
-  checkAll("Semigroupal[SortedMap[Int, ?]]", SerializableTests.serializable(Semigroupal[SortedMap[Int, ?]]))
+  checkAll("SortedMap[Int, Int]", SemigroupalTests[SortedMap[Int, *]].semigroupal[Int, Int, Int])
+  checkAll("Semigroupal[SortedMap[Int, *]]", SerializableTests.serializable(Semigroupal[SortedMap[Int, *]]))
 
-  checkAll("SortedMap[Int, Int]", FlatMapTests[SortedMap[Int, ?]].flatMap[Int, Int, Int])
-  checkAll("FlatMap[SortedMap[Int, ?]]", SerializableTests.serializable(FlatMap[SortedMap[Int, ?]]))
+  checkAll("SortedMap[Int, Int]", FlatMapTests[SortedMap[Int, *]].flatMap[Int, Int, Int])
+  checkAll("FlatMap[SortedMap[Int, *]]", SerializableTests.serializable(FlatMap[SortedMap[Int, *]]))
 
   checkAll("SortedMap[Int, Int] with Option",
-           TraverseTests[SortedMap[Int, ?]].traverse[Int, Int, Int, Int, Option, Option])
-  checkAll("Traverse[SortedMap[Int, ?]]", SerializableTests.serializable(Traverse[SortedMap[Int, ?]]))
+           TraverseTests[SortedMap[Int, *]].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("Traverse[SortedMap[Int, *]]", SerializableTests.serializable(Traverse[SortedMap[Int, *]]))
 
-  checkAll("SortedMap[Int, Int]", TraverseFilterTests[SortedMap[Int, ?]].traverseFilter[Int, Int, Int])
-  checkAll("TraverseFilter[SortedMap[Int, ?]]", SerializableTests.serializable(TraverseFilter[SortedMap[Int, ?]]))
+  checkAll("SortedMap[Int, Int]", TraverseFilterTests[SortedMap[Int, *]].traverseFilter[Int, Int, Int])
+  checkAll("TraverseFilter[SortedMap[Int, *]]", SerializableTests.serializable(TraverseFilter[SortedMap[Int, *]]))
 
   test("show isn't empty and is formatted as expected") {
     forAll { (map: SortedMap[Int, String]) =>
@@ -47,6 +47,6 @@ class SortedMapSuite extends CatsSuite {
   checkAll("Monoid[SortedMap[String, String]]", MonoidTests[SortedMap[String, String]].monoid)
   checkAll("Monoid[SortedMap[String, String]]", SerializableTests.serializable(Monoid[SortedMap[String, String]]))
 
-  checkAll("SortedMap[String, String]", MonoidKTests[SortedMap[String, ?]].monoidK[String])
-  checkAll("MonoidK[SortedMap[String, ?]]", SerializableTests.serializable(MonoidK[SortedMap[String, ?]]))
+  checkAll("SortedMap[String, String]", MonoidKTests[SortedMap[String, *]].monoidK[String])
+  checkAll("MonoidK[SortedMap[String, *]]", SerializableTests.serializable(MonoidK[SortedMap[String, *]]))
 }

--- a/tests/src/test/scala/cats/tests/SyntaxSuite.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxSuite.scala
@@ -349,7 +349,7 @@ object SyntaxSuite
     val done = a.tailRecM[F, B](a => returnValue)
   }
 
-  def testApplicativeError[F[_, _], E, A](implicit F: ApplicativeError[F[E, ?], E]): Unit = {
+  def testApplicativeError[F[_, _], E, A](implicit F: ApplicativeError[F[E, *], E]): Unit = {
     type G[X] = F[E, X]
 
     val e = mock[E]

--- a/tests/src/test/scala/cats/tests/Tuple2KSuite.scala
+++ b/tests/src/test/scala/cats/tests/Tuple2KSuite.scala
@@ -9,8 +9,8 @@ import cats.laws.discipline.eq._
 import cats.kernel.laws.discipline.{EqTests, OrderTests, PartialOrderTests}
 
 class Tuple2KSuite extends CatsSuite {
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Tuple2K[Option, List, ?]]
-  checkAll("Tuple2K[Eval, Eval, ?]", DeferTests[Tuple2K[Eval, Eval, ?]].defer[Int])
+  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Tuple2K[Option, List, *]]
+  checkAll("Tuple2K[Eval, Eval, *]", DeferTests[Tuple2K[Eval, Eval, *]].defer[Int])
   checkAll("Tuple2K[Option, List, Int]", SemigroupalTests[λ[α => Tuple2K[Option, List, α]]].semigroupal[Int, Int, Int])
   checkAll("Semigroupal[Tuple2K[Option, List, Int]]",
            SerializableTests.serializable(Semigroupal[λ[α => Tuple2K[Option, List, α]]]))
@@ -25,96 +25,96 @@ class Tuple2KSuite extends CatsSuite {
            SerializableTests.serializable(Contravariant[λ[α => Tuple2K[Show, Order, α]]]))
 
   checkAll(
-    "Tuple2K[Const[String, ?], Const[Int, ?], Int]",
-    ContravariantMonoidalTests[λ[α => Tuple2K[Const[String, ?], Const[Int, ?], α]]].contravariantMonoidal[Int, Int, Int]
+    "Tuple2K[Const[String, *], Const[Int, *], Int]",
+    ContravariantMonoidalTests[λ[α => Tuple2K[Const[String, *], Const[Int, *], α]]].contravariantMonoidal[Int, Int, Int]
   )
   checkAll(
-    "ContravariantMonoidal[Tuple2K[Const[String, ?], Const[Int, ?], Int]]",
-    SerializableTests.serializable(ContravariantMonoidal[λ[α => Tuple2K[Const[String, ?], Const[Int, ?], α]]])
+    "ContravariantMonoidal[Tuple2K[Const[String, *], Const[Int, *], Int]]",
+    SerializableTests.serializable(ContravariantMonoidal[λ[α => Tuple2K[Const[String, *], Const[Int, *], α]]])
   )
 
   checkAll("Show[Tuple2K[Option, Option, Int]]", SerializableTests.serializable(Show[Tuple2K[Option, Option, Int]]))
 
   {
     implicit val monoidK = ListWrapper.monoidK
-    checkAll("Tuple2K[ListWrapper, ListWrapper, ?]", MonoidKTests[Tuple2K[ListWrapper, ListWrapper, ?]].monoidK[Int])
-    checkAll("MonoidK[Tuple2K[ListWrapper, ListWrapper, ?]]",
-             SerializableTests.serializable(MonoidK[Tuple2K[ListWrapper, ListWrapper, ?]]))
+    checkAll("Tuple2K[ListWrapper, ListWrapper, *]", MonoidKTests[Tuple2K[ListWrapper, ListWrapper, *]].monoidK[Int])
+    checkAll("MonoidK[Tuple2K[ListWrapper, ListWrapper, *]]",
+             SerializableTests.serializable(MonoidK[Tuple2K[ListWrapper, ListWrapper, *]]))
   }
 
   {
     implicit val semigroupK = ListWrapper.semigroupK
-    checkAll("Tuple2K[ListWrapper, ListWrapper, ?]",
-             SemigroupKTests[Tuple2K[ListWrapper, ListWrapper, ?]].semigroupK[Int])
-    checkAll("SemigroupK[Tuple2K[ListWrapper, ListWrapper, ?]]",
-             SerializableTests.serializable(SemigroupK[Tuple2K[ListWrapper, ListWrapper, ?]]))
+    checkAll("Tuple2K[ListWrapper, ListWrapper, *]",
+             SemigroupKTests[Tuple2K[ListWrapper, ListWrapper, *]].semigroupK[Int])
+    checkAll("SemigroupK[Tuple2K[ListWrapper, ListWrapper, *]]",
+             SerializableTests.serializable(SemigroupK[Tuple2K[ListWrapper, ListWrapper, *]]))
   }
 
   {
     implicit val apply = ListWrapper.applyInstance
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[Tuple2K[ListWrapper, ListWrapper, ?]]
-    checkAll("Tuple2K[ListWrapper, ListWrapper, ?]",
-             ApplyTests[Tuple2K[ListWrapper, ListWrapper, ?]].apply[Int, Int, Int])
-    checkAll("Apply[Tuple2K[ListWrapper, ListWrapper, ?]]",
-             SerializableTests.serializable(Apply[Tuple2K[ListWrapper, ListWrapper, ?]]))
+    implicit val iso = SemigroupalTests.Isomorphisms.invariant[Tuple2K[ListWrapper, ListWrapper, *]]
+    checkAll("Tuple2K[ListWrapper, ListWrapper, *]",
+             ApplyTests[Tuple2K[ListWrapper, ListWrapper, *]].apply[Int, Int, Int])
+    checkAll("Apply[Tuple2K[ListWrapper, ListWrapper, *]]",
+             SerializableTests.serializable(Apply[Tuple2K[ListWrapper, ListWrapper, *]]))
   }
 
   {
     implicit val optionApply = Apply[Option]
-    implicit val validatedApply = Apply[Validated[Int, ?]]
-    checkAll("Tuple2K[Option, Validated[Int, ?], ?]",
-             CommutativeApplyTests[Tuple2K[Option, Validated[Int, ?], ?]].commutativeApply[Int, Int, Int])
-    checkAll("Apply[Tuple2K[Option, Validated[Int, ?], ?]]",
-             SerializableTests.serializable(CommutativeApply[Tuple2K[Option, Validated[Int, ?], ?]]))
+    implicit val validatedApply = Apply[Validated[Int, *]]
+    checkAll("Tuple2K[Option, Validated[Int, *], *]",
+             CommutativeApplyTests[Tuple2K[Option, Validated[Int, *], *]].commutativeApply[Int, Int, Int])
+    checkAll("Apply[Tuple2K[Option, Validated[Int, *], *]]",
+             SerializableTests.serializable(CommutativeApply[Tuple2K[Option, Validated[Int, *], *]]))
   }
 
   {
-    checkAll("Tuple2K[Option, Validated[Int, ?], ?]",
-             CommutativeApplicativeTests[Tuple2K[Option, Validated[Int, ?], ?]].commutativeApplicative[Int, Int, Int])
-    checkAll("Applicative[Tuple2K[Option, Validated[Int, ?], ?]]",
-             SerializableTests.serializable(CommutativeApplicative[Tuple2K[Option, Validated[Int, ?], ?]]))
+    checkAll("Tuple2K[Option, Validated[Int, *], *]",
+             CommutativeApplicativeTests[Tuple2K[Option, Validated[Int, *], *]].commutativeApplicative[Int, Int, Int])
+    checkAll("Applicative[Tuple2K[Option, Validated[Int, *], *]]",
+             SerializableTests.serializable(CommutativeApplicative[Tuple2K[Option, Validated[Int, *], *]]))
   }
 
   {
     implicit val functor = ListWrapper.functor
-    checkAll("Tuple2K[ListWrapper, ListWrapper, ?]",
-             FunctorTests[Tuple2K[ListWrapper, ListWrapper, ?]].functor[Int, Int, Int])
-    checkAll("Functor[Tuple2K[ListWrapper, ListWrapper, ?]]",
-             SerializableTests.serializable(Functor[Tuple2K[ListWrapper, ListWrapper, ?]]))
+    checkAll("Tuple2K[ListWrapper, ListWrapper, *]",
+             FunctorTests[Tuple2K[ListWrapper, ListWrapper, *]].functor[Int, Int, Int])
+    checkAll("Functor[Tuple2K[ListWrapper, ListWrapper, *]]",
+             SerializableTests.serializable(Functor[Tuple2K[ListWrapper, ListWrapper, *]]))
   }
 
   {
     implicit val monad = ListWrapper.monad
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[Tuple2K[ListWrapper, ListWrapper, ?]]
-    checkAll("Tuple2K[ListWrapper, ListWrapper, ?]",
-             MonadTests[Tuple2K[ListWrapper, ListWrapper, ?]].monad[Int, Int, Int])
-    checkAll("Monad[Tuple2K[ListWrapper, ListWrapper, ?]]",
-             SerializableTests.serializable(Monad[Tuple2K[ListWrapper, ListWrapper, ?]]))
+    implicit val iso = SemigroupalTests.Isomorphisms.invariant[Tuple2K[ListWrapper, ListWrapper, *]]
+    checkAll("Tuple2K[ListWrapper, ListWrapper, *]",
+             MonadTests[Tuple2K[ListWrapper, ListWrapper, *]].monad[Int, Int, Int])
+    checkAll("Monad[Tuple2K[ListWrapper, ListWrapper, *]]",
+             SerializableTests.serializable(Monad[Tuple2K[ListWrapper, ListWrapper, *]]))
   }
 
   {
     implicit val foldable = ListWrapper.foldable
-    checkAll("Tuple2K[ListWrapper, ListWrapper, ?]",
-             FoldableTests[Tuple2K[ListWrapper, ListWrapper, ?]].foldable[Int, Int])
-    checkAll("Foldable[Tuple2K[ListWrapper, ListWrapper, ?]]",
-             SerializableTests.serializable(Foldable[Tuple2K[ListWrapper, ListWrapper, ?]]))
+    checkAll("Tuple2K[ListWrapper, ListWrapper, *]",
+             FoldableTests[Tuple2K[ListWrapper, ListWrapper, *]].foldable[Int, Int])
+    checkAll("Foldable[Tuple2K[ListWrapper, ListWrapper, *]]",
+             SerializableTests.serializable(Foldable[Tuple2K[ListWrapper, ListWrapper, *]]))
   }
 
   {
     implicit val traverse = ListWrapper.traverse
-    checkAll("Tuple2K[ListWrapper, ListWrapper, ?]",
-             TraverseTests[Tuple2K[ListWrapper, ListWrapper, ?]].traverse[Int, Int, Int, Int, Option, Option])
-    checkAll("Traverse[Tuple2K[ListWrapper, ListWrapper, ?]]",
-             SerializableTests.serializable(Traverse[Tuple2K[ListWrapper, ListWrapper, ?]]))
+    checkAll("Tuple2K[ListWrapper, ListWrapper, *]",
+             TraverseTests[Tuple2K[ListWrapper, ListWrapper, *]].traverse[Int, Int, Int, Int, Option, Option])
+    checkAll("Traverse[Tuple2K[ListWrapper, ListWrapper, *]]",
+             SerializableTests.serializable(Traverse[Tuple2K[ListWrapper, ListWrapper, *]]))
   }
 
   {
     implicit val alternative = ListWrapper.alternative
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[Tuple2K[ListWrapper, ListWrapper, ?]]
-    checkAll("Tuple2K[ListWrapper, ListWrapper, ?]",
-             AlternativeTests[Tuple2K[ListWrapper, ListWrapper, ?]].alternative[Int, Int, Int])
-    checkAll("Alternative[Tuple2K[ListWrapper, ListWrapper, ?]]",
-             SerializableTests.serializable(Alternative[Tuple2K[ListWrapper, ListWrapper, ?]]))
+    implicit val iso = SemigroupalTests.Isomorphisms.invariant[Tuple2K[ListWrapper, ListWrapper, *]]
+    checkAll("Tuple2K[ListWrapper, ListWrapper, *]",
+             AlternativeTests[Tuple2K[ListWrapper, ListWrapper, *]].alternative[Int, Int, Int])
+    checkAll("Alternative[Tuple2K[ListWrapper, ListWrapper, *]]",
+             SerializableTests.serializable(Alternative[Tuple2K[ListWrapper, ListWrapper, *]]))
   }
 
   {
@@ -129,10 +129,10 @@ class Tuple2KSuite extends CatsSuite {
   }
 
   {
-    checkAll("Tuple2K[Function0, Function0, ?]",
-             DistributiveTests[Tuple2K[Function0, Function0, ?]].distributive[Int, Int, Int, Option, Function0])
-    checkAll("Distributive[Tuple2K[Function0, Function0, ?]]",
-             SerializableTests.serializable(Distributive[Tuple2K[Function0, Function0, ?]]))
+    checkAll("Tuple2K[Function0, Function0, *]",
+             DistributiveTests[Tuple2K[Function0, Function0, *]].distributive[Int, Int, Int, Option, Function0])
+    checkAll("Distributive[Tuple2K[Function0, Function0, *]]",
+             SerializableTests.serializable(Distributive[Tuple2K[Function0, Function0, *]]))
   }
 
   test("show") {

--- a/tests/src/test/scala/cats/tests/TupleSuite.scala
+++ b/tests/src/test/scala/cats/tests/TupleSuite.scala
@@ -9,38 +9,38 @@ import Helpers.CSemi
 
 class TupleSuite extends CatsSuite {
 
-  implicit val iso1 = SemigroupalTests.Isomorphisms.invariant[(NonEmptyList[Int], ?)]
-  implicit val iso2 = SemigroupalTests.Isomorphisms.invariant[(String, ?)]
+  implicit val iso1 = SemigroupalTests.Isomorphisms.invariant[(NonEmptyList[Int], *)]
+  implicit val iso2 = SemigroupalTests.Isomorphisms.invariant[(String, *)]
 
   checkAll("Tuple2", BitraverseTests[Tuple2].bitraverse[Option, Int, Int, Int, String, String, String])
   checkAll("Bitraverse[Tuple2]", SerializableTests.serializable(Bitraverse[Tuple2]))
 
-  checkAll("Tuple2[String, Int] with Option", TraverseTests[(String, ?)].traverse[Int, Int, Int, Int, Option, Option])
-  checkAll("Traverse[(String, ?)]", SerializableTests.serializable(Traverse[(String, ?)]))
+  checkAll("Tuple2[String, Int] with Option", TraverseTests[(String, *)].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("Traverse[(String, *)]", SerializableTests.serializable(Traverse[(String, *)]))
 
-  checkAll("Tuple2[String, Int]", ComonadTests[(String, ?)].comonad[Int, Int, Int])
-  checkAll("Comonad[(String, ?)]", SerializableTests.serializable(Comonad[(String, ?)]))
+  checkAll("Tuple2[String, Int]", ComonadTests[(String, *)].comonad[Int, Int, Int])
+  checkAll("Comonad[(String, *)]", SerializableTests.serializable(Comonad[(String, *)]))
 
   // Note that NonEmptyList has no Monoid, so we can make a FlatMap, but not a Monad
-  checkAll("FlatMap[(NonEmptyList[Int], ?)]", FlatMapTests[(NonEmptyList[Int], ?)].flatMap[String, Long, String])
-  checkAll("FlatMap[(String, ?)] serializable", SerializableTests.serializable(FlatMap[(String, ?)]))
+  checkAll("FlatMap[(NonEmptyList[Int], *)]", FlatMapTests[(NonEmptyList[Int], *)].flatMap[String, Long, String])
+  checkAll("FlatMap[(String, *)] serializable", SerializableTests.serializable(FlatMap[(String, *)]))
 
-  checkAll("Monad[(String, ?)]", MonadTests[(String, ?)].monad[Int, Int, String])
-  checkAll("Monad[(String, ?)] serializable", SerializableTests.serializable(Monad[(String, ?)]))
+  checkAll("Monad[(String, *)]", MonadTests[(String, *)].monad[Int, Int, String])
+  checkAll("Monad[(String, *)] serializable", SerializableTests.serializable(Monad[(String, *)]))
 
-  checkAll("CommutativeFlatMap[(CSemi, ?)]",
-           CommutativeFlatMapTests[(CSemi, ?)].commutativeFlatMap[CSemi, CSemi, CSemi])
-  checkAll("CommutativeFlatMap[(CSemi, ?)] serializable",
-           SerializableTests.serializable(CommutativeFlatMap[(CSemi, ?)]))
+  checkAll("CommutativeFlatMap[(CSemi, *)]",
+           CommutativeFlatMapTests[(CSemi, *)].commutativeFlatMap[CSemi, CSemi, CSemi])
+  checkAll("CommutativeFlatMap[(CSemi, *)] serializable",
+           SerializableTests.serializable(CommutativeFlatMap[(CSemi, *)]))
 
-  checkAll("CommutativeMonad[(Int, ?)]", CommutativeMonadTests[(Int, ?)].commutativeMonad[Int, Int, Int])
-  checkAll("CommutativeMonad[(Int, ?)] serializable", SerializableTests.serializable(CommutativeMonad[(Int, ?)]))
+  checkAll("CommutativeMonad[(Int, *)]", CommutativeMonadTests[(Int, *)].commutativeMonad[Int, Int, Int])
+  checkAll("CommutativeMonad[(Int, *)] serializable", SerializableTests.serializable(CommutativeMonad[(Int, *)]))
 
-  checkAll("Tuple2[String, Int]", ReducibleTests[(String, ?)].reducible[Option, Int, Int])
-  checkAll("Reducible[(String, ?)]", SerializableTests.serializable(Reducible[(String, ?)]))
+  checkAll("Tuple2[String, Int]", ReducibleTests[(String, *)].reducible[Option, Int, Int])
+  checkAll("Reducible[(String, *)]", SerializableTests.serializable(Reducible[(String, *)]))
 
   test("Semigroupal composition") {
-    val cart = ContravariantSemigroupal[Eq].composeFunctor[(Int, ?)]
+    val cart = ContravariantSemigroupal[Eq].composeFunctor[(Int, *)]
     val eq = cart.product(Eq[(Int, String)], Eq[(Int, Int)])
     forAll { (a: (Int, (String, Int)), b: (Int, (String, Int))) =>
       (a == b) should ===(eq.eqv(a, b))

--- a/tests/src/test/scala/cats/tests/UnorderedFoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/UnorderedFoldableSuite.scala
@@ -53,7 +53,7 @@ final class UnorderedFoldableSetSuite extends UnorderedFoldableSuite[Set]("set")
     catsStdInstancesForSet.unorderedFoldMap(fa)(f)
 }
 
-final class UnorderedFoldableMapSuite extends UnorderedFoldableSuite[Map[String, ?]]("map") {
+final class UnorderedFoldableMapSuite extends UnorderedFoldableSuite[Map[String, *]]("map") {
   def iterator[T](map: Map[String, T]): Iterator[T] = map.valuesIterator
   def specializedUnorderedFoldMap[A, B: CommutativeMonoid](fa: Map[String, A])(f: A => B): B =
     catsStdInstancesForMap[String].unorderedFoldMap(fa)(f)
@@ -76,6 +76,6 @@ final class SpecializedUnorderedFoldableSetSuite extends SpecializedUnorderedFol
   def iterator[T](set: Set[T]): Iterator[T] = set.iterator
 }
 
-final class SpecializedUnorderedFoldableMapSuite extends SpecializedUnorderedFoldableSuite[Map[String, ?]]("map") {
+final class SpecializedUnorderedFoldableMapSuite extends SpecializedUnorderedFoldableSuite[Map[String, *]]("map") {
   def iterator[T](map: Map[String, T]): Iterator[T] = map.valuesIterator
 }

--- a/tests/src/test/scala/cats/tests/ValidatedSuite.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedSuite.scala
@@ -12,23 +12,23 @@ import cats.kernel.laws.discipline.{EqTests, MonoidTests, OrderTests, PartialOrd
 import scala.util.Try
 
 class ValidatedSuite extends CatsSuite {
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Validated[String, ?]]
-  checkAll("Validated[String, Int]", SemigroupalTests[Validated[String, ?]].semigroupal[Int, Int, Int])
-  checkAll("Semigroupal[Validated[String,?]]", SerializableTests.serializable(Semigroupal[Validated[String, ?]]))
+  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Validated[String, *]]
+  checkAll("Validated[String, Int]", SemigroupalTests[Validated[String, *]].semigroupal[Int, Int, Int])
+  checkAll("Semigroupal[Validated[String,*]]", SerializableTests.serializable(Semigroupal[Validated[String, *]]))
 
-  checkAll("Validated[?, ?]", BitraverseTests[Validated].bitraverse[Option, Int, Int, Int, String, String, String])
+  checkAll("Validated[*, *]", BitraverseTests[Validated].bitraverse[Option, Int, Int, Int, String, String, String])
   checkAll("Bitraverse[Validated]", SerializableTests.serializable(Bitraverse[Validated]))
 
-  implicit val eq0 = EitherT.catsDataEqForEitherT[Validated[String, ?], String, Int]
+  implicit val eq0 = EitherT.catsDataEqForEitherT[Validated[String, *], String, Int]
 
   checkAll("Validated[String, Int]",
-           ApplicativeErrorTests[Validated[String, ?], String].applicativeError[Int, Int, Int])
+           ApplicativeErrorTests[Validated[String, *], String].applicativeError[Int, Int, Int])
   checkAll("ApplicativeError[Validated, String]",
-           SerializableTests.serializable(ApplicativeError[Validated[String, ?], String]))
+           SerializableTests.serializable(ApplicativeError[Validated[String, *], String]))
 
   checkAll("Validated[String, Int] with Option",
-           TraverseTests[Validated[String, ?]].traverse[Int, Int, Int, Int, Option, Option])
-  checkAll("Traverse[Validated[String, ?]]", SerializableTests.serializable(Traverse[Validated[String, ?]]))
+           TraverseTests[Validated[String, *]].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("Traverse[Validated[String, *]]", SerializableTests.serializable(Traverse[Validated[String, *]]))
 
   checkAll("Validated[String, Int]", OrderTests[Validated[String, Int]].order)
   checkAll("Order[Validated[String, Int]]", SerializableTests.serializable(Order[Validated[String, Int]]))
@@ -37,15 +37,15 @@ class ValidatedSuite extends CatsSuite {
 
   checkAll("Validated[String, NonEmptyList[Int]]", SemigroupTests[Validated[String, NonEmptyList[Int]]].semigroup)
 
-  checkAll("Validated[Int, Int]", CommutativeApplicativeTests[Validated[Int, ?]].commutativeApplicative[Int, Int, Int])
-  checkAll("CommutativeApplicative[Validated[Int, ?]]",
-           SerializableTests.serializable(CommutativeApplicative[Validated[Int, ?]]))
+  checkAll("Validated[Int, Int]", CommutativeApplicativeTests[Validated[Int, *]].commutativeApplicative[Int, Int, Int])
+  checkAll("CommutativeApplicative[Validated[Int, *]]",
+           SerializableTests.serializable(CommutativeApplicative[Validated[Int, *]]))
 
   {
     implicit val L = ListWrapper.semigroup[String]
-    checkAll("Validated[ListWrapper[String], ?]", SemigroupKTests[Validated[ListWrapper[String], ?]].semigroupK[Int])
-    checkAll("SemigroupK[Validated[ListWrapper[String], ?]]",
-             SerializableTests.serializable(SemigroupK[Validated[ListWrapper[String], ?]]))
+    checkAll("Validated[ListWrapper[String], *]", SemigroupKTests[Validated[ListWrapper[String], *]].semigroupK[Int])
+    checkAll("SemigroupK[Validated[ListWrapper[String], *]]",
+             SerializableTests.serializable(SemigroupK[Validated[ListWrapper[String], *]]))
   }
 
   {
@@ -70,7 +70,7 @@ class ValidatedSuite extends CatsSuite {
 
   test("ap2 combines failures in order") {
     val plus = (_: Int) + (_: Int)
-    Applicative[Validated[String, ?]].ap2(Valid(plus))(Invalid("1"), Invalid("2")) should ===(Invalid("12"))
+    Applicative[Validated[String, *]].ap2(Valid(plus))(Invalid("1"), Invalid("2")) should ===(Invalid("12"))
   }
 
   test("catchOnly catches matching exceptions") {

--- a/tests/src/test/scala/cats/tests/WriterTSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterTSuite.scala
@@ -17,14 +17,14 @@ class WriterTSuite extends CatsSuite {
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     checkConfiguration.copy(sizeRange = 5)
 
-  checkAll("WriterT[Eval, Int, ?]", DeferTests[WriterT[Eval, Int, ?]].defer[Int])
+  checkAll("WriterT[Eval, Int, *]", DeferTests[WriterT[Eval, Int, *]].defer[Int])
   checkAll("WriterT[List, Int, Int]", EqTests[WriterT[List, Int, Int]].eqv)
   checkAll("Eq[WriterT[List, Int, Int]]", SerializableTests.serializable(Eq[WriterT[List, Int, Int]]))
 
-  checkAll("WriterT[Show, MiniInt, ?]",
-           ContravariantTests[WriterT[Show, MiniInt, ?]].contravariant[MiniInt, Int, Boolean])
+  checkAll("WriterT[Show, MiniInt, *]",
+           ContravariantTests[WriterT[Show, MiniInt, *]].contravariant[MiniInt, Int, Boolean])
   checkAll("Contravariant[WriterT[Show, Int, Int]]",
-           SerializableTests.serializable(Contravariant[WriterT[Show, Int, ?]]))
+           SerializableTests.serializable(Contravariant[WriterT[Show, Int, *]]))
 
   // check that this resolves
   Eq[Writer[Int, Int]]
@@ -37,7 +37,7 @@ class WriterTSuite extends CatsSuite {
 
   test("reset on pure is a noop") {
     forAll { i: Int =>
-      val w = Monad[WriterT[List, Int, ?]].pure(i)
+      val w = Monad[WriterT[List, Int, *]].pure(i)
       w should ===(w.reset)
     }
   }
@@ -119,51 +119,51 @@ class WriterTSuite extends CatsSuite {
     // F has a SemigroupK
     implicit val F: SemigroupK[ListWrapper] = ListWrapper.semigroupK
 
-    checkAll("WriterT[ListWrapper, ListWrapper[Int], ?]",
-             SemigroupKTests[WriterT[ListWrapper, ListWrapper[Int], ?]].semigroupK[Int])
-    checkAll("SemigroupK[WriterT[ListWrapper, ListWrapper[Int], ?]]",
-             SerializableTests.serializable(SemigroupK[WriterT[ListWrapper, ListWrapper[Int], ?]]))
+    checkAll("WriterT[ListWrapper, ListWrapper[Int], *]",
+             SemigroupKTests[WriterT[ListWrapper, ListWrapper[Int], *]].semigroupK[Int])
+    checkAll("SemigroupK[WriterT[ListWrapper, ListWrapper[Int], *]]",
+             SerializableTests.serializable(SemigroupK[WriterT[ListWrapper, ListWrapper[Int], *]]))
   }
 
   {
     // F has a MonoidK
     implicit val F: MonoidK[ListWrapper] = ListWrapper.monoidK
 
-    SemigroupK[WriterT[ListWrapper, ListWrapper[Int], ?]]
+    SemigroupK[WriterT[ListWrapper, ListWrapper[Int], *]]
 
-    checkAll("WriterT[ListWrapper, ListWrapper[Int], ?]",
-             MonoidKTests[WriterT[ListWrapper, ListWrapper[Int], ?]].monoidK[Int])
-    checkAll("MonoidK[WriterT[ListWrapper, ListWrapper[Int], ?]]",
-             SerializableTests.serializable(MonoidK[WriterT[ListWrapper, ListWrapper[Int], ?]]))
+    checkAll("WriterT[ListWrapper, ListWrapper[Int], *]",
+             MonoidKTests[WriterT[ListWrapper, ListWrapper[Int], *]].monoidK[Int])
+    checkAll("MonoidK[WriterT[ListWrapper, ListWrapper[Int], *]]",
+             SerializableTests.serializable(MonoidK[WriterT[ListWrapper, ListWrapper[Int], *]]))
   }
 
   {
     // F has a Functor and L has no Semigroup
     implicit val F: Functor[ListWrapper] = ListWrapper.functor
 
-    checkAll("WriterT[ListWrapper, ListWrapper[Int], ?]",
-             FunctorTests[WriterT[ListWrapper, ListWrapper[Int], ?]].functor[Int, Int, Int])
-    checkAll("Functor[WriterT[ListWrapper, ListWrapper[Int], ?]]",
-             SerializableTests.serializable(Functor[WriterT[ListWrapper, ListWrapper[Int], ?]]))
+    checkAll("WriterT[ListWrapper, ListWrapper[Int], *]",
+             FunctorTests[WriterT[ListWrapper, ListWrapper[Int], *]].functor[Int, Int, Int])
+    checkAll("Functor[WriterT[ListWrapper, ListWrapper[Int], *]]",
+             SerializableTests.serializable(Functor[WriterT[ListWrapper, ListWrapper[Int], *]]))
 
-    checkAll("WriterT[Listwrapper, Int, ?]", CoflatMapTests[WriterT[ListWrapper, Int, ?]].coflatMap[Int, Int, Int])
-    checkAll("WriterT[ListWrapper, Int, ?]", SerializableTests.serializable(CoflatMap[WriterT[ListWrapper, Int, ?]]))
+    checkAll("WriterT[Listwrapper, Int, *]", CoflatMapTests[WriterT[ListWrapper, Int, *]].coflatMap[Int, Int, Int])
+    checkAll("WriterT[ListWrapper, Int, *]", SerializableTests.serializable(CoflatMap[WriterT[ListWrapper, Int, *]]))
 
     // just making sure this resolves; it's tested above
-    Functor[WriterT[Id, ListWrapper[Int], ?]]
+    Functor[WriterT[Id, ListWrapper[Int], *]]
 
-    Functor[Writer[ListWrapper[Int], ?]]
+    Functor[Writer[ListWrapper[Int], *]]
 
     Functor[Logged]
 
-    checkAll("WriterT[ListWrapper, ?, ?]",
-             BifunctorTests[WriterT[ListWrapper, ?, ?]].bifunctor[Int, Int, Int, Int, Int, Int])
-    checkAll("Bifunctor[WriterT[ListWrapper, ?, ?]]",
-             SerializableTests.serializable(Bifunctor[WriterT[ListWrapper, ?, ?]]))
+    checkAll("WriterT[ListWrapper, *, *]",
+             BifunctorTests[WriterT[ListWrapper, *, *]].bifunctor[Int, Int, Int, Int, Int, Int])
+    checkAll("Bifunctor[WriterT[ListWrapper, *, *]]",
+             SerializableTests.serializable(Bifunctor[WriterT[ListWrapper, *, *]]))
   }
 
   implicit val iso = SemigroupalTests.Isomorphisms
-    .invariant[WriterT[ListWrapper, ListWrapper[Int], ?]](WriterT.catsDataCoflatMapForWriterT(ListWrapper.functor))
+    .invariant[WriterT[ListWrapper, ListWrapper[Int], *]](WriterT.catsDataCoflatMapForWriterT(ListWrapper.functor))
 
   // We have varying instances available depending on `F` and `L`.
   // We also battle some inference issues with `Id`.
@@ -174,19 +174,19 @@ class WriterTSuite extends CatsSuite {
     implicit val F: Apply[ListWrapper] = ListWrapper.applyInstance
     implicit val L: Semigroup[ListWrapper[Int]] = ListWrapper.semigroup[Int]
 
-    Functor[WriterT[ListWrapper, ListWrapper[Int], ?]]
-    checkAll("WriterT[ListWrapper, ListWrapper[Int], ?]",
-             ApplyTests[WriterT[ListWrapper, ListWrapper[Int], ?]].apply[Int, Int, Int])
-    checkAll("Apply[WriterT[ListWrapper, ListWrapper[Int], ?]]",
-             SerializableTests.serializable(Apply[WriterT[ListWrapper, ListWrapper[Int], ?]]))
+    Functor[WriterT[ListWrapper, ListWrapper[Int], *]]
+    checkAll("WriterT[ListWrapper, ListWrapper[Int], *]",
+             ApplyTests[WriterT[ListWrapper, ListWrapper[Int], *]].apply[Int, Int, Int])
+    checkAll("Apply[WriterT[ListWrapper, ListWrapper[Int], *]]",
+             SerializableTests.serializable(Apply[WriterT[ListWrapper, ListWrapper[Int], *]]))
 
-    Functor[WriterT[Id, ListWrapper[Int], ?]]
-    Apply[WriterT[Id, ListWrapper[Int], ?]]
-    CoflatMap[WriterT[Id, ListWrapper[Int], ?]]
+    Functor[WriterT[Id, ListWrapper[Int], *]]
+    Apply[WriterT[Id, ListWrapper[Int], *]]
+    CoflatMap[WriterT[Id, ListWrapper[Int], *]]
 
-    Functor[Writer[ListWrapper[Int], ?]]
-    Apply[Writer[ListWrapper[Int], ?]]
-    CoflatMap[Writer[ListWrapper[Int], ?]]
+    Functor[Writer[ListWrapper[Int], *]]
+    Apply[Writer[ListWrapper[Int], *]]
+    CoflatMap[Writer[ListWrapper[Int], *]]
 
     Functor[Logged]
     Apply[Logged]
@@ -198,23 +198,23 @@ class WriterTSuite extends CatsSuite {
     implicit val F: Monad[ListWrapper] = ListWrapper.monad
     implicit val L: Semigroup[ListWrapper[Int]] = ListWrapper.semigroup[Int]
 
-    Functor[WriterT[ListWrapper, ListWrapper[Int], ?]]
-    Apply[WriterT[ListWrapper, ListWrapper[Int], ?]]
-    CoflatMap[WriterT[ListWrapper, ListWrapper[Int], ?]]
-    checkAll("WriterT[ListWrapper, ListWrapper[Int], ?] 1",
-             FlatMapTests[WriterT[ListWrapper, ListWrapper[Int], ?]].flatMap[Int, Int, Int])
-    checkAll("FlatMap[WriterT[ListWrapper, ListWrapper[Int], ?]] 1",
-             SerializableTests.serializable(FlatMap[WriterT[ListWrapper, ListWrapper[Int], ?]]))
+    Functor[WriterT[ListWrapper, ListWrapper[Int], *]]
+    Apply[WriterT[ListWrapper, ListWrapper[Int], *]]
+    CoflatMap[WriterT[ListWrapper, ListWrapper[Int], *]]
+    checkAll("WriterT[ListWrapper, ListWrapper[Int], *] 1",
+             FlatMapTests[WriterT[ListWrapper, ListWrapper[Int], *]].flatMap[Int, Int, Int])
+    checkAll("FlatMap[WriterT[ListWrapper, ListWrapper[Int], *]] 1",
+             SerializableTests.serializable(FlatMap[WriterT[ListWrapper, ListWrapper[Int], *]]))
 
-    Functor[WriterT[Id, ListWrapper[Int], ?]]
-    Apply[WriterT[Id, ListWrapper[Int], ?]]
-    FlatMap[WriterT[Id, ListWrapper[Int], ?]]
-    CoflatMap[WriterT[Id, ListWrapper[Int], ?]]
+    Functor[WriterT[Id, ListWrapper[Int], *]]
+    Apply[WriterT[Id, ListWrapper[Int], *]]
+    FlatMap[WriterT[Id, ListWrapper[Int], *]]
+    CoflatMap[WriterT[Id, ListWrapper[Int], *]]
 
-    Functor[Writer[ListWrapper[Int], ?]]
-    Apply[Writer[ListWrapper[Int], ?]]
-    FlatMap[Writer[ListWrapper[Int], ?]]
-    CoflatMap[Writer[ListWrapper[Int], ?]]
+    Functor[Writer[ListWrapper[Int], *]]
+    Apply[Writer[ListWrapper[Int], *]]
+    FlatMap[Writer[ListWrapper[Int], *]]
+    CoflatMap[Writer[ListWrapper[Int], *]]
 
     Functor[Logged]
     Apply[Logged]
@@ -226,23 +226,23 @@ class WriterTSuite extends CatsSuite {
     implicit val F: FlatMap[ListWrapper] = ListWrapper.flatMap
     implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
 
-    Functor[WriterT[ListWrapper, ListWrapper[Int], ?]]
-    Apply[WriterT[ListWrapper, ListWrapper[Int], ?]]
-    CoflatMap[WriterT[ListWrapper, ListWrapper[Int], ?]]
-    checkAll("WriterT[ListWrapper, ListWrapper[Int], ?] 2",
-             FlatMapTests[WriterT[ListWrapper, ListWrapper[Int], ?]].flatMap[Int, Int, Int])
-    checkAll("FlatMap[WriterT[ListWrapper, ListWrapper[Int], ?]] 2",
-             SerializableTests.serializable(FlatMap[WriterT[ListWrapper, ListWrapper[Int], ?]]))
+    Functor[WriterT[ListWrapper, ListWrapper[Int], *]]
+    Apply[WriterT[ListWrapper, ListWrapper[Int], *]]
+    CoflatMap[WriterT[ListWrapper, ListWrapper[Int], *]]
+    checkAll("WriterT[ListWrapper, ListWrapper[Int], *] 2",
+             FlatMapTests[WriterT[ListWrapper, ListWrapper[Int], *]].flatMap[Int, Int, Int])
+    checkAll("FlatMap[WriterT[ListWrapper, ListWrapper[Int], *]] 2",
+             SerializableTests.serializable(FlatMap[WriterT[ListWrapper, ListWrapper[Int], *]]))
 
-    Functor[WriterT[Id, ListWrapper[Int], ?]]
-    Apply[WriterT[Id, ListWrapper[Int], ?]]
-    FlatMap[WriterT[Id, ListWrapper[Int], ?]]
-    CoflatMap[WriterT[Id, ListWrapper[Int], ?]]
+    Functor[WriterT[Id, ListWrapper[Int], *]]
+    Apply[WriterT[Id, ListWrapper[Int], *]]
+    FlatMap[WriterT[Id, ListWrapper[Int], *]]
+    CoflatMap[WriterT[Id, ListWrapper[Int], *]]
 
-    Functor[Writer[ListWrapper[Int], ?]]
-    Apply[Writer[ListWrapper[Int], ?]]
-    FlatMap[Writer[ListWrapper[Int], ?]]
-    CoflatMap[Writer[ListWrapper[Int], ?]]
+    Functor[Writer[ListWrapper[Int], *]]
+    Apply[Writer[ListWrapper[Int], *]]
+    FlatMap[Writer[ListWrapper[Int], *]]
+    CoflatMap[Writer[ListWrapper[Int], *]]
 
     Functor[Logged]
     Apply[Logged]
@@ -255,23 +255,23 @@ class WriterTSuite extends CatsSuite {
     implicit val F: Applicative[ListWrapper] = ListWrapper.applicative
     implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
 
-    Functor[WriterT[ListWrapper, ListWrapper[Int], ?]]
-    Apply[WriterT[ListWrapper, ListWrapper[Int], ?]]
-    CoflatMap[WriterT[ListWrapper, ListWrapper[Int], ?]]
-    checkAll("WriterT[ListWrapper, ListWrapper[Int], ?]",
-             ApplicativeTests[WriterT[ListWrapper, ListWrapper[Int], ?]].applicative[Int, Int, Int])
-    checkAll("Applicative[WriterT[ListWrapper, ListWrapper[Int], ?]]",
-             SerializableTests.serializable(Applicative[WriterT[ListWrapper, ListWrapper[Int], ?]]))
+    Functor[WriterT[ListWrapper, ListWrapper[Int], *]]
+    Apply[WriterT[ListWrapper, ListWrapper[Int], *]]
+    CoflatMap[WriterT[ListWrapper, ListWrapper[Int], *]]
+    checkAll("WriterT[ListWrapper, ListWrapper[Int], *]",
+             ApplicativeTests[WriterT[ListWrapper, ListWrapper[Int], *]].applicative[Int, Int, Int])
+    checkAll("Applicative[WriterT[ListWrapper, ListWrapper[Int], *]]",
+             SerializableTests.serializable(Applicative[WriterT[ListWrapper, ListWrapper[Int], *]]))
 
-    Functor[WriterT[Id, ListWrapper[Int], ?]]
-    Apply[WriterT[Id, ListWrapper[Int], ?]]
-    Applicative[WriterT[Id, ListWrapper[Int], ?]]
-    CoflatMap[WriterT[Id, ListWrapper[Int], ?]]
+    Functor[WriterT[Id, ListWrapper[Int], *]]
+    Apply[WriterT[Id, ListWrapper[Int], *]]
+    Applicative[WriterT[Id, ListWrapper[Int], *]]
+    CoflatMap[WriterT[Id, ListWrapper[Int], *]]
 
-    Functor[Writer[ListWrapper[Int], ?]]
-    Apply[Writer[ListWrapper[Int], ?]]
-    Applicative[Writer[ListWrapper[Int], ?]]
-    CoflatMap[Writer[ListWrapper[Int], ?]]
+    Functor[Writer[ListWrapper[Int], *]]
+    Apply[Writer[ListWrapper[Int], *]]
+    Applicative[Writer[ListWrapper[Int], *]]
+    CoflatMap[Writer[ListWrapper[Int], *]]
 
     Functor[Logged]
     Apply[Logged]
@@ -284,29 +284,29 @@ class WriterTSuite extends CatsSuite {
     implicit val F: Monad[ListWrapper] = ListWrapper.monad
     implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
 
-    Functor[WriterT[ListWrapper, ListWrapper[Int], ?]]
-    Apply[WriterT[ListWrapper, ListWrapper[Int], ?]]
-    Applicative[WriterT[ListWrapper, ListWrapper[Int], ?]]
-    FlatMap[WriterT[ListWrapper, ListWrapper[Int], ?]]
-    CoflatMap[WriterT[ListWrapper, ListWrapper[Int], ?]]
-    checkAll("WriterT[ListWrapper, ListWrapper[Int], ?]",
-             MonadTests[WriterT[ListWrapper, ListWrapper[Int], ?]].monad[Int, Int, Int])
-    checkAll("Monad[WriterT[ListWrapper, ListWrapper[Int], ?], List[String]]",
-             SerializableTests.serializable(Monad[WriterT[ListWrapper, ListWrapper[Int], ?]]))
+    Functor[WriterT[ListWrapper, ListWrapper[Int], *]]
+    Apply[WriterT[ListWrapper, ListWrapper[Int], *]]
+    Applicative[WriterT[ListWrapper, ListWrapper[Int], *]]
+    FlatMap[WriterT[ListWrapper, ListWrapper[Int], *]]
+    CoflatMap[WriterT[ListWrapper, ListWrapper[Int], *]]
+    checkAll("WriterT[ListWrapper, ListWrapper[Int], *]",
+             MonadTests[WriterT[ListWrapper, ListWrapper[Int], *]].monad[Int, Int, Int])
+    checkAll("Monad[WriterT[ListWrapper, ListWrapper[Int], *], List[String]]",
+             SerializableTests.serializable(Monad[WriterT[ListWrapper, ListWrapper[Int], *]]))
 
-    Functor[WriterT[Id, ListWrapper[Int], ?]]
-    Apply[WriterT[Id, ListWrapper[Int], ?]]
-    Applicative[WriterT[Id, ListWrapper[Int], ?]]
-    FlatMap[WriterT[Id, ListWrapper[Int], ?]]
-    CoflatMap[WriterT[Id, ListWrapper[Int], ?]]
-    Monad[WriterT[Id, ListWrapper[Int], ?]]
+    Functor[WriterT[Id, ListWrapper[Int], *]]
+    Apply[WriterT[Id, ListWrapper[Int], *]]
+    Applicative[WriterT[Id, ListWrapper[Int], *]]
+    FlatMap[WriterT[Id, ListWrapper[Int], *]]
+    CoflatMap[WriterT[Id, ListWrapper[Int], *]]
+    Monad[WriterT[Id, ListWrapper[Int], *]]
 
-    Functor[Writer[ListWrapper[Int], ?]]
-    Apply[Writer[ListWrapper[Int], ?]]
-    Applicative[Writer[ListWrapper[Int], ?]]
-    FlatMap[Writer[ListWrapper[Int], ?]]
-    CoflatMap[Writer[ListWrapper[Int], ?]]
-    Monad[Writer[ListWrapper[Int], ?]]
+    Functor[Writer[ListWrapper[Int], *]]
+    Apply[Writer[ListWrapper[Int], *]]
+    Applicative[Writer[ListWrapper[Int], *]]
+    FlatMap[Writer[ListWrapper[Int], *]]
+    CoflatMap[Writer[ListWrapper[Int], *]]
+    Monad[Writer[ListWrapper[Int], *]]
 
     Functor[Logged]
     Apply[Logged]
@@ -321,15 +321,15 @@ class WriterTSuite extends CatsSuite {
     implicit val F: Alternative[ListWrapper] = ListWrapper.alternative
     implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
 
-    Functor[WriterT[ListWrapper, ListWrapper[Int], ?]]
-    Apply[WriterT[ListWrapper, ListWrapper[Int], ?]]
-    Applicative[WriterT[ListWrapper, ListWrapper[Int], ?]]
-    Alternative[WriterT[ListWrapper, ListWrapper[Int], ?]]
-    CoflatMap[WriterT[ListWrapper, ListWrapper[Int], ?]]
-    checkAll("WriterT[ListWrapper, ListWrapper[Int], ?]",
-             AlternativeTests[WriterT[ListWrapper, ListWrapper[Int], ?]].alternative[Int, Int, Int])
-    checkAll("Alternative[WriterT[ListWrapper, ListWrapper[Int], ?]]",
-             SerializableTests.serializable(Alternative[WriterT[ListWrapper, ListWrapper[Int], ?]]))
+    Functor[WriterT[ListWrapper, ListWrapper[Int], *]]
+    Apply[WriterT[ListWrapper, ListWrapper[Int], *]]
+    Applicative[WriterT[ListWrapper, ListWrapper[Int], *]]
+    Alternative[WriterT[ListWrapper, ListWrapper[Int], *]]
+    CoflatMap[WriterT[ListWrapper, ListWrapper[Int], *]]
+    checkAll("WriterT[ListWrapper, ListWrapper[Int], *]",
+             AlternativeTests[WriterT[ListWrapper, ListWrapper[Int], *]].alternative[Int, Int, Int])
+    checkAll("Alternative[WriterT[ListWrapper, ListWrapper[Int], *]]",
+             SerializableTests.serializable(Alternative[WriterT[ListWrapper, ListWrapper[Int], *]]))
   }
 
   {
@@ -361,136 +361,136 @@ class WriterTSuite extends CatsSuite {
   {
     // F has an Applicative and L has a Monoid
     implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
-    implicit val app = WriterT.catsDataApplicativeForWriterT[Validated[String, ?], ListWrapper[Int]]
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[WriterT[Validated[String, ?], ListWrapper[Int], ?]]
-    implicit def eq1[A: Eq]: Eq[WriterT[Validated[String, ?], ListWrapper[Int], A]] =
-      WriterT.catsDataEqForWriterT[Validated[String, ?], ListWrapper[Int], A]
-    implicit val eq2: Eq[EitherT[WriterT[Validated[String, ?], ListWrapper[Int], ?], String, Int]] =
-      EitherT.catsDataEqForEitherT[WriterT[Validated[String, ?], ListWrapper[Int], ?], String, Int]
+    implicit val app = WriterT.catsDataApplicativeForWriterT[Validated[String, *], ListWrapper[Int]]
+    implicit val iso = SemigroupalTests.Isomorphisms.invariant[WriterT[Validated[String, *], ListWrapper[Int], *]]
+    implicit def eq1[A: Eq]: Eq[WriterT[Validated[String, *], ListWrapper[Int], A]] =
+      WriterT.catsDataEqForWriterT[Validated[String, *], ListWrapper[Int], A]
+    implicit val eq2: Eq[EitherT[WriterT[Validated[String, *], ListWrapper[Int], *], String, Int]] =
+      EitherT.catsDataEqForEitherT[WriterT[Validated[String, *], ListWrapper[Int], *], String, Int]
 
-    Functor[WriterT[Validated[String, ?], ListWrapper[Int], ?]]
-    Apply[WriterT[Validated[String, ?], ListWrapper[Int], ?]]
-    Applicative[WriterT[Validated[String, ?], ListWrapper[Int], ?]]
+    Functor[WriterT[Validated[String, *], ListWrapper[Int], *]]
+    Apply[WriterT[Validated[String, *], ListWrapper[Int], *]]
+    Applicative[WriterT[Validated[String, *], ListWrapper[Int], *]]
 
-    checkAll("WriterT[Validated[String, ?], ListWrapper[Int], ?]",
-             ApplicativeTests[WriterT[Validated[String, ?], ListWrapper[Int], ?]].applicative[Int, Int, Int])
+    checkAll("WriterT[Validated[String, *], ListWrapper[Int], *]",
+             ApplicativeTests[WriterT[Validated[String, *], ListWrapper[Int], *]].applicative[Int, Int, Int])
     checkAll(
-      "Applicative[WriterT[Validated[String, ?], ListWrapper[Int], ?]]",
-      SerializableTests.serializable(Applicative[WriterT[Validated[String, ?], ListWrapper[Int], ?]])
+      "Applicative[WriterT[Validated[String, *], ListWrapper[Int], *]]",
+      SerializableTests.serializable(Applicative[WriterT[Validated[String, *], ListWrapper[Int], *]])
     )
   }
 
   {
     // F has an ApplicativeError and L has a Monoid
     implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
-    implicit val appErr = WriterT.catsDataApplicativeErrorForWriterT[Validated[String, ?], ListWrapper[Int], String]
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[WriterT[Validated[String, ?], ListWrapper[Int], ?]]
+    implicit val appErr = WriterT.catsDataApplicativeErrorForWriterT[Validated[String, *], ListWrapper[Int], String]
+    implicit val iso = SemigroupalTests.Isomorphisms.invariant[WriterT[Validated[String, *], ListWrapper[Int], *]]
     checkAll(
-      "WriterT[Validated[String, ?], ListWrapper[Int], ?]",
-      ApplicativeErrorTests[WriterT[Validated[String, ?], ListWrapper[Int], ?], String].applicativeError[Int, Int, Int]
+      "WriterT[Validated[String, *], ListWrapper[Int], *]",
+      ApplicativeErrorTests[WriterT[Validated[String, *], ListWrapper[Int], *], String].applicativeError[Int, Int, Int]
     )
     checkAll(
-      "ApplicativeError[WriterT[Validated[String, ?], ListWrapper[Int], ?], Unit]",
-      SerializableTests.serializable(ApplicativeError[WriterT[Validated[String, ?], ListWrapper[Int], ?], String])
+      "ApplicativeError[WriterT[Validated[String, *], ListWrapper[Int], *], Unit]",
+      SerializableTests.serializable(ApplicativeError[WriterT[Validated[String, *], ListWrapper[Int], *], String])
     )
   }
 
   {
     // F has a MonadError and L has a Monoid
     implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[WriterT[Option, ListWrapper[Int], ?]]
-    implicit val eq0: Eq[EitherT[WriterT[Option, ListWrapper[Int], ?], Unit, Int]] =
-      EitherT.catsDataEqForEitherT[WriterT[Option, ListWrapper[Int], ?], Unit, Int]
+    implicit val iso = SemigroupalTests.Isomorphisms.invariant[WriterT[Option, ListWrapper[Int], *]]
+    implicit val eq0: Eq[EitherT[WriterT[Option, ListWrapper[Int], *], Unit, Int]] =
+      EitherT.catsDataEqForEitherT[WriterT[Option, ListWrapper[Int], *], Unit, Int]
 
-    Functor[WriterT[Option, ListWrapper[Int], ?]]
-    Apply[WriterT[Option, ListWrapper[Int], ?]]
-    Applicative[WriterT[Option, ListWrapper[Int], ?]]
-    FlatMap[WriterT[Option, ListWrapper[Int], ?]]
-    CoflatMap[WriterT[Option, ListWrapper[Int], ?]]
-    Monad[WriterT[Option, ListWrapper[Int], ?]]
-    ApplicativeError[WriterT[Option, ListWrapper[Int], ?], Unit]
+    Functor[WriterT[Option, ListWrapper[Int], *]]
+    Apply[WriterT[Option, ListWrapper[Int], *]]
+    Applicative[WriterT[Option, ListWrapper[Int], *]]
+    FlatMap[WriterT[Option, ListWrapper[Int], *]]
+    CoflatMap[WriterT[Option, ListWrapper[Int], *]]
+    Monad[WriterT[Option, ListWrapper[Int], *]]
+    ApplicativeError[WriterT[Option, ListWrapper[Int], *], Unit]
 
-    checkAll("WriterT[Option, ListWrapper[Int], ?]",
-             MonadErrorTests[WriterT[Option, ListWrapper[Int], ?], Unit].monadError[Int, Int, Int])
-    checkAll("MonadError[WriterT[Option, ListWrapper[Int], ?], Unit]",
-             SerializableTests.serializable(MonadError[WriterT[Option, ListWrapper[Int], ?], Unit]))
+    checkAll("WriterT[Option, ListWrapper[Int], *]",
+             MonadErrorTests[WriterT[Option, ListWrapper[Int], *], Unit].monadError[Int, Int, Int])
+    checkAll("MonadError[WriterT[Option, ListWrapper[Int], *], Unit]",
+             SerializableTests.serializable(MonadError[WriterT[Option, ListWrapper[Int], *], Unit]))
   }
 
   {
     // F has a ContravariantMonoidal
-    ContravariantMonoidal[WriterT[Const[String, ?], Int, ?]]
+    ContravariantMonoidal[WriterT[Const[String, *], Int, *]]
 
-    checkAll("WriterT[Const[String, ?], Int, ?]",
-             ContravariantMonoidalTests[WriterT[Const[String, ?], Int, ?]].contravariantMonoidal[Int, Int, Int])
-    checkAll("ContravariantMonoidal[WriterT[Const[String, ?], Int, ?]]",
-             SerializableTests.serializable(ContravariantMonoidal[WriterT[Const[String, ?], Int, ?]]))
+    checkAll("WriterT[Const[String, *], Int, *]",
+             ContravariantMonoidalTests[WriterT[Const[String, *], Int, *]].contravariantMonoidal[Int, Int, Int])
+    checkAll("ContravariantMonoidal[WriterT[Const[String, *], Int, *]]",
+             SerializableTests.serializable(ContravariantMonoidal[WriterT[Const[String, *], Int, *]]))
   }
 
   {
     // F has an Invariant
     implicit val evidence = ListWrapper.invariant
     Invariant[ListWrapper]
-    Invariant[WriterT[ListWrapper, Int, ?]]
+    Invariant[WriterT[ListWrapper, Int, *]]
 
-    checkAll("WriterT[ListWrapper, Int, ?]", InvariantTests[WriterT[ListWrapper, Int, ?]].invariant[Int, Int, Int])
-    checkAll("Invariant[WriterT[ListWrapper, Int, ?]]",
-             SerializableTests.serializable(Invariant[WriterT[ListWrapper, Int, ?]]))
+    checkAll("WriterT[ListWrapper, Int, *]", InvariantTests[WriterT[ListWrapper, Int, *]].invariant[Int, Int, Int])
+    checkAll("Invariant[WriterT[ListWrapper, Int, *]]",
+             SerializableTests.serializable(Invariant[WriterT[ListWrapper, Int, *]]))
   }
 
   {
     // F has a Foldable and L has a Monoid
     implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
-    Foldable[Const[String, ?]]
-    Foldable[WriterT[Const[String, ?], ListWrapper[Int], ?]]
+    Foldable[Const[String, *]]
+    Foldable[WriterT[Const[String, *], ListWrapper[Int], *]]
 
-    checkAll("WriterT[Const[String, ?], ListWrapper[Int], ?]",
-             FoldableTests[WriterT[Const[String, ?], ListWrapper[Int], ?]].foldable[Int, Int])
-    checkAll("Foldable[WriterT[Const[String, ?], ListWrapper[Int], ?]]",
-             SerializableTests.serializable(Foldable[WriterT[Const[String, ?], ListWrapper[Int], ?]]))
+    checkAll("WriterT[Const[String, *], ListWrapper[Int], *]",
+             FoldableTests[WriterT[Const[String, *], ListWrapper[Int], *]].foldable[Int, Int])
+    checkAll("Foldable[WriterT[Const[String, *], ListWrapper[Int], *]]",
+             SerializableTests.serializable(Foldable[WriterT[Const[String, *], ListWrapper[Int], *]]))
 
     Foldable[Id]
-    Foldable[WriterT[Id, ListWrapper[Int], ?]]
-    Foldable[Writer[ListWrapper[Int], ?]]
+    Foldable[WriterT[Id, ListWrapper[Int], *]]
+    Foldable[Writer[ListWrapper[Int], *]]
 
-    checkAll("WriterT[Id, ListWrapper[Int], ?]", FoldableTests[WriterT[Id, ListWrapper[Int], ?]].foldable[Int, Int])
+    checkAll("WriterT[Id, ListWrapper[Int], *]", FoldableTests[WriterT[Id, ListWrapper[Int], *]].foldable[Int, Int])
   }
 
   {
     // F has a Traverse and L has a Monoid
     implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
-    Traverse[Const[String, ?]]
-    Traverse[WriterT[Const[String, ?], ListWrapper[Int], ?]]
+    Traverse[Const[String, *]]
+    Traverse[WriterT[Const[String, *], ListWrapper[Int], *]]
 
-    checkAll("WriterT[Const[String, ?], ListWrapper[Int], ?]",
-             TraverseTests[WriterT[Const[String, ?], ListWrapper[Int], ?]].traverse[Int, Int, Int, Int, Option, Option])
-    checkAll("Traverse[WriterT[Const[String, ?], ListWrapper[Int], ?]]",
-             SerializableTests.serializable(Traverse[WriterT[Const[String, ?], ListWrapper[Int], ?]]))
+    checkAll("WriterT[Const[String, *], ListWrapper[Int], *]",
+             TraverseTests[WriterT[Const[String, *], ListWrapper[Int], *]].traverse[Int, Int, Int, Int, Option, Option])
+    checkAll("Traverse[WriterT[Const[String, *], ListWrapper[Int], *]]",
+             SerializableTests.serializable(Traverse[WriterT[Const[String, *], ListWrapper[Int], *]]))
 
     Traverse[Id]
-    Traverse[WriterT[Id, ListWrapper[Int], ?]]
-    Traverse[Writer[ListWrapper[Int], ?]]
+    Traverse[WriterT[Id, ListWrapper[Int], *]]
+    Traverse[Writer[ListWrapper[Int], *]]
 
-    checkAll("WriterT[Id, ListWrapper[Int], ?]",
-             TraverseTests[WriterT[Id, ListWrapper[Int], ?]].traverse[Int, Int, Int, Int, Option, Option])
+    checkAll("WriterT[Id, ListWrapper[Int], *]",
+             TraverseTests[WriterT[Id, ListWrapper[Int], *]].traverse[Int, Int, Int, Int, Option, Option])
   }
 
   {
     // F has a Comonad and L has a Monoid
-    Comonad[WriterT[(String, ?), ListWrapper[Int], ?]]
+    Comonad[WriterT[(String, *), ListWrapper[Int], *]]
 
-    checkAll("WriterT[(String, ?), ListWrapper[Int], ?]",
-             ComonadTests[WriterT[(String, ?), ListWrapper[Int], ?]].comonad[Int, Int, Int])
-    checkAll("Comonad[WriterT[(String, ?), ListWrapper[Int], ?]]",
-             SerializableTests.serializable(Comonad[WriterT[(String, ?), ListWrapper[Int], ?]]))
+    checkAll("WriterT[(String, *), ListWrapper[Int], *]",
+             ComonadTests[WriterT[(String, *), ListWrapper[Int], *]].comonad[Int, Int, Int])
+    checkAll("Comonad[WriterT[(String, *), ListWrapper[Int], *]]",
+             SerializableTests.serializable(Comonad[WriterT[(String, *), ListWrapper[Int], *]]))
 
     Comonad[Id]
-    Comonad[WriterT[Id, ListWrapper[Int], ?]]
-    Comonad[Writer[ListWrapper[Int], ?]]
+    Comonad[WriterT[Id, ListWrapper[Int], *]]
+    Comonad[Writer[ListWrapper[Int], *]]
 
-    checkAll("WriterT[Id, ListWrapper[Int], ?]", ComonadTests[WriterT[Id, ListWrapper[Int], ?]].comonad[Int, Int, Int])
+    checkAll("WriterT[Id, ListWrapper[Int], *]", ComonadTests[WriterT[Id, ListWrapper[Int], *]].comonad[Int, Int, Int])
   }
 
-  checkAll("WriterT[Option, Int, ?]", CommutativeMonadTests[WriterT[Option, Int, ?]].commutativeMonad[Int, Int, Int])
-  checkAll("CommutativeMonad[WriterT[Option, Int, ?]]",
-           SerializableTests.serializable(CommutativeMonad[WriterT[Option, Int, ?]]))
+  checkAll("WriterT[Option, Int, *]", CommutativeMonadTests[WriterT[Option, Int, *]].commutativeMonad[Int, Int, Int])
+  checkAll("CommutativeMonad[WriterT[Option, Int, *]]",
+           SerializableTests.serializable(CommutativeMonad[WriterT[Option, Int, *]]))
 }


### PR DESCRIPTION
We're going to deprecate the use of `?` soon and we have `*` as a replacement for now. See this issue: https://github.com/typelevel/kind-projector/issues/108

See here for the overall migration strategy: http://dotty.epfl.ch/docs/reference/changed-features/wildcards.html