### PR TITLE
add unordered parallel variants of (flat)traverse and (flat)sequence

### DIFF
--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -9,6 +9,7 @@ abstract class AllSyntaxBinCompat
     with AllSyntaxBinCompat3
     with AllSyntaxBinCompat4
     with AllSyntaxBinCompat5
+    with AllSyntaxBinCompat6
 
 trait AllSyntax
     extends AlternativeSyntax
@@ -90,3 +91,5 @@ trait AllSyntaxBinCompat4
     with BitraverseSyntaxBinCompat0
 
 trait AllSyntaxBinCompat5 extends ParallelBitraverseSyntax
+
+trait AllSyntaxBinCompat6 extends ParallelUnorderedTraverseSyntax

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -45,6 +45,7 @@ package object syntax {
       with ParallelFlatSyntax
       with ParallelApplySyntax
       with ParallelBitraverseSyntax
+      with ParallelUnorderedTraverseSyntax
   object partialOrder extends PartialOrderSyntax
   object profunctor extends ProfunctorSyntax
   object reducible extends ReducibleSyntax with ReducibleSyntaxBinCompat0

--- a/core/src/main/scala/cats/syntax/parallel.scala
+++ b/core/src/main/scala/cats/syntax/parallel.scala
@@ -118,29 +118,34 @@ final class ParallelFlatSequenceOps[T[_], M[_], A](private val tmta: T[M[T[A]]])
 }
 
 final class ParallelUnorderedSequenceOps[T[_], M[_], A](private val tmta: T[M[A]]) extends AnyVal {
-  def parUnorderedFlatSequence[F[_]: CommutativeApplicative](implicit P: Parallel[M, F],
-                                                             Tutraverse: UnorderedTraverse[T]): M[T[A]] =
+  def parUnorderedSequence[F[_]](implicit P: Parallel[M, F],
+                                 F: CommutativeApplicative[F],
+                                 Tutraverse: UnorderedTraverse[T]): M[T[A]] =
     Parallel.parUnorderedSequence(tmta)
 }
 
 final class ParallelUnorderedTraverseOps[T[_], A](private val ta: T[A]) extends AnyVal {
-  def parUnorderedFlatTraverse[M[_], F[_]: CommutativeApplicative, B](
+  def parUnorderedTraverse[M[_], F[_], B](
     f: A => M[B]
-  )(implicit P: Parallel[M, F], Tutraverse: UnorderedTraverse[T]): M[T[B]] =
+  )(implicit P: Parallel[M, F], F: CommutativeApplicative[F], Tutraverse: UnorderedTraverse[T]): M[T[B]] =
     Parallel.parUnorderedTraverse(ta)(f)
 }
 
 final class ParallelUnorderedFlatSequenceOps[T[_], M[_], A](private val tmta: T[M[T[A]]]) extends AnyVal {
-  def parUnorderedFlatSequence[F[_]: CommutativeApplicative](implicit P: Parallel[M, F],
-                                                             Tflatmap: FlatMap[T],
-                                                             Tutraverse: UnorderedTraverse[T]): M[T[A]] =
+  def parUnorderedFlatSequence[F[_]](implicit P: Parallel[M, F],
+                                     Tflatmap: FlatMap[T],
+                                     F: CommutativeApplicative[F],
+                                     Tutraverse: UnorderedTraverse[T]): M[T[A]] =
     Parallel.parUnorderedFlatSequence(tmta)
 }
 
 final class ParallelUnorderedFlatTraverseOps[T[_], A](private val ta: T[A]) extends AnyVal {
-  def parUnorderedFlatTraverse[M[_], F[_]: CommutativeApplicative, B](
+  def parUnorderedFlatTraverse[M[_], F[_], B](
     f: A => M[T[B]]
-  )(implicit P: Parallel[M, F], Tflatmap: FlatMap[T], Tutraverse: UnorderedTraverse[T]): M[T[B]] =
+  )(implicit P: Parallel[M, F],
+    F: CommutativeApplicative[F],
+    Tflatmap: FlatMap[T],
+    Tutraverse: UnorderedTraverse[T]): M[T[B]] =
     Parallel.parUnorderedFlatTraverse(ta)(f)
 }
 

--- a/core/src/main/scala/cats/syntax/parallel.scala
+++ b/core/src/main/scala/cats/syntax/parallel.scala
@@ -72,11 +72,6 @@ trait ParallelUnorderedTraverseSyntax {
   ): ParallelUnorderedSequenceOps[T, M, A] =
     new ParallelUnorderedSequenceOps[T, M, A](tma)
 
-  implicit final def catsSyntaxParallelUnorderedFlatTraverse[T[_], A](
-    ta: T[A]
-  ): ParallelUnorderedFlatTraverseOps[T, A] =
-    new ParallelUnorderedFlatTraverseOps[T, A](ta)
-
   implicit final def catsSyntaxParallelUnorderedFlatSequence[T[_], M[_], A](
     tmta: T[M[T[A]]]
   ): ParallelUnorderedFlatSequenceOps[T, M, A] =
@@ -129,6 +124,14 @@ final class ParallelUnorderedTraverseOps[T[_], A](private val ta: T[A]) extends 
     f: A => M[B]
   )(implicit P: Parallel[M, F], F: CommutativeApplicative[F], Tutraverse: UnorderedTraverse[T]): M[T[B]] =
     Parallel.parUnorderedTraverse(ta)(f)
+
+  def parUnorderedFlatTraverse[M[_], F[_], B](
+    f: A => M[T[B]]
+  )(implicit P: Parallel[M, F],
+    F: CommutativeApplicative[F],
+    Tflatmap: FlatMap[T],
+    Tutraverse: UnorderedTraverse[T]): M[T[B]] =
+    Parallel.parUnorderedFlatTraverse(ta)(f)
 }
 
 final class ParallelUnorderedFlatSequenceOps[T[_], M[_], A](private val tmta: T[M[T[A]]]) extends AnyVal {
@@ -137,16 +140,6 @@ final class ParallelUnorderedFlatSequenceOps[T[_], M[_], A](private val tmta: T[
                                      F: CommutativeApplicative[F],
                                      Tutraverse: UnorderedTraverse[T]): M[T[A]] =
     Parallel.parUnorderedFlatSequence(tmta)
-}
-
-final class ParallelUnorderedFlatTraverseOps[T[_], A](private val ta: T[A]) extends AnyVal {
-  def parUnorderedFlatTraverse[M[_], F[_], B](
-    f: A => M[T[B]]
-  )(implicit P: Parallel[M, F],
-    F: CommutativeApplicative[F],
-    Tflatmap: FlatMap[T],
-    Tutraverse: UnorderedTraverse[T]): M[T[B]] =
-    Parallel.parUnorderedFlatTraverse(ta)(f)
 }
 
 final class ParallelApOps[M[_], A](private val ma: M[A]) extends AnyVal {

--- a/core/src/main/scala/cats/syntax/parallel.scala
+++ b/core/src/main/scala/cats/syntax/parallel.scala
@@ -1,6 +1,6 @@
 package cats.syntax
 
-import cats.{Bitraverse, FlatMap, Foldable, Monad, Parallel, Traverse}
+import cats.{Bitraverse, CommutativeApplicative, FlatMap, Foldable, Monad, Parallel, Traverse, UnorderedTraverse}
 
 trait ParallelSyntax extends TupleParallelSyntax {
 
@@ -61,6 +61,29 @@ trait ParallelBitraverseSyntax {
     new ParallelLeftSequenceOps[T, M, A, B](tmab)
 }
 
+trait ParallelUnorderedTraverseSyntax {
+  implicit final def catsSyntaxParallelUnorderedTraverse[T[_], A](
+    ta: T[A]
+  ): ParallelUnorderedTraverseOps[T, A] =
+    new ParallelUnorderedTraverseOps[T, A](ta)
+
+  implicit final def catsSyntaxParallelUnorderedSequence[T[_], M[_], A](
+    tma: T[M[A]]
+  ): ParallelUnorderedSequenceOps[T, M, A] =
+    new ParallelUnorderedSequenceOps[T, M, A](tma)
+
+  implicit final def catsSyntaxParallelUnorderedFlatTraverse[T[_], A](
+    ta: T[A]
+  ): ParallelUnorderedFlatTraverseOps[T, A] =
+    new ParallelUnorderedFlatTraverseOps[T, A](ta)
+
+  implicit final def catsSyntaxParallelUnorderedFlatSequence[T[_], M[_], A](
+    tmta: T[M[T[A]]]
+  ): ParallelUnorderedFlatSequenceOps[T, M, A] =
+    new ParallelUnorderedFlatSequenceOps[T, M, A](tmta)
+
+}
+
 final class ParallelTraversableOps[T[_], A](private val ta: T[A]) extends AnyVal {
   def parTraverse[M[_]: Monad, F[_], B](f: A => M[B])(implicit T: Traverse[T], P: Parallel[M, F]): M[T[B]] =
     Parallel.parTraverse(ta)(f)
@@ -92,6 +115,33 @@ final class ParallelSequence_Ops[T[_], M[_], A](private val tma: T[M[A]]) extend
 final class ParallelFlatSequenceOps[T[_], M[_], A](private val tmta: T[M[T[A]]]) extends AnyVal {
   def parFlatSequence[F[_]](implicit M: Monad[M], T0: Traverse[T], T1: FlatMap[T], P: Parallel[M, F]): M[T[A]] =
     Parallel.parFlatSequence(tmta)
+}
+
+final class ParallelUnorderedSequenceOps[T[_], M[_], A](private val tmta: T[M[A]]) extends AnyVal {
+  def parUnorderedFlatSequence[F[_]: CommutativeApplicative](implicit P: Parallel[M, F],
+                                                             Tutraverse: UnorderedTraverse[T]): M[T[A]] =
+    Parallel.parUnorderedSequence(tmta)
+}
+
+final class ParallelUnorderedTraverseOps[T[_], A](private val ta: T[A]) extends AnyVal {
+  def parUnorderedFlatTraverse[M[_], F[_]: CommutativeApplicative, B](
+    f: A => M[B]
+  )(implicit P: Parallel[M, F], Tutraverse: UnorderedTraverse[T]): M[T[B]] =
+    Parallel.parUnorderedTraverse(ta)(f)
+}
+
+final class ParallelUnorderedFlatSequenceOps[T[_], M[_], A](private val tmta: T[M[T[A]]]) extends AnyVal {
+  def parUnorderedFlatSequence[F[_]: CommutativeApplicative](implicit P: Parallel[M, F],
+                                                             Tflatmap: FlatMap[T],
+                                                             Tutraverse: UnorderedTraverse[T]): M[T[A]] =
+    Parallel.parUnorderedFlatSequence(tmta)
+}
+
+final class ParallelUnorderedFlatTraverseOps[T[_], A](private val ta: T[A]) extends AnyVal {
+  def parUnorderedFlatTraverse[M[_], F[_]: CommutativeApplicative, B](
+    f: A => M[T[B]]
+  )(implicit P: Parallel[M, F], Tflatmap: FlatMap[T], Tutraverse: UnorderedTraverse[T]): M[T[B]] =
+    Parallel.parUnorderedFlatTraverse(ta)(f)
 }
 
 final class ParallelApOps[M[_], A](private val ma: M[A]) extends AnyVal {

--- a/tests/src/test/scala/cats/tests/SyntaxSuite.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxSuite.scala
@@ -188,6 +188,23 @@ object SyntaxSuite
     val mb3: M[B] = mab <&> ma
   }
 
+  def testParallelUnorderedTraverse[M[_]: Monad, F[_]: CommutativeApplicative, T[_]: UnorderedTraverse: FlatMap, A, B](
+    implicit P: Parallel[M, F]
+  ): Unit = {
+    val ta = mock[T[A]]
+    val f = mock[A => M[B]]
+    val mtb = ta.parUnorderedTraverse(f)
+
+    val tma = mock[T[M[A]]]
+    val mta = tma.parUnorderedSequence
+
+    val tmta = mock[T[M[T[A]]]]
+    val mta2 = tmta.parUnorderedFlatSequence
+
+    val g = mock[A => M[T[B]]]
+    val mtb2 = ta.parUnorderedFlatTraverse(g)
+  }
+
   def testParallelFlat[M[_]: Monad, F[_], T[_]: Traverse: FlatMap, A, B](implicit P: Parallel[M, F]): Unit = {
     val ta = mock[T[A]]
     val f = mock[A => M[T[B]]]


### PR DESCRIPTION
Hi,

There currently doesn't seem to be a convenient way to traverse a `Set` with `IO`. `traverse` doesn't work because there's no `Traverse` instance for `Set`, and `unorderedTraverse` doesn't work because there is no `CommutativeApplicative` instance for `IO`. So I've added `parUnorderedTraverse` and `parUnorderedSequence` for that purpose.

I also added `parUnorderedFlatTraverse` and `parUnorderedFlatSequence` for symmetry, but given that the non-par versions of these don't exist I'm not really sure we need these.

Another logical set of operations would be `parUnorderedTraverse_`  and `parUnorderedSequence_`. But again, there is no `unorderedTraverse_` or `unorderedSequence_` in `UnorderedFoldable`, so it's not going to be any more efficient than the non-_ variants, and given that it's easy to just discard the return value I haven't added them.

So overall I think that `parUnorderedTraverse` and `parUnorderedSequence` should be pretty uncontroversial. Which of the other ones do you think we want? I think they all make sense for symmetry, but then I'm not sure how useful they are in practice.

Oh, and one more question: is `FlatMap` actually the right typeclass to use for the `flat` variants, or should it be `CommutativeFlatMap`?