### PR TITLE
fix typo for `Data` in traverseFilter for OptionT

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -394,8 +394,7 @@ def mimaSettings(moduleName: String) =
           exclude[DirectMissingMethodProblem]("cats.syntax.ValidatedIdOpsBinCompat0.a"),
           exclude[DirectMissingMethodProblem]("cats.syntax.ValidatedIdSyntax.a"),
           exclude[DirectMissingMethodProblem]("cats.syntax.VectorOps.va"),
-          exclude[DirectMissingMethodProblem]("cats.syntax.WriterIdSyntax.a"),
-          exclude[DirectMissingMethodProblem]("cats.data.OptionTInstances.catsDateTraverseFilterForOptionT")
+          exclude[DirectMissingMethodProblem]("cats.syntax.WriterIdSyntax.a")
         ) ++ // Only compile-time abstractions (macros) allowed here
         Seq(
           exclude[IncompatibleMethTypeProblem]("cats.arrow.FunctionKMacros.lift"),

--- a/build.sbt
+++ b/build.sbt
@@ -394,7 +394,8 @@ def mimaSettings(moduleName: String) =
           exclude[DirectMissingMethodProblem]("cats.syntax.ValidatedIdOpsBinCompat0.a"),
           exclude[DirectMissingMethodProblem]("cats.syntax.ValidatedIdSyntax.a"),
           exclude[DirectMissingMethodProblem]("cats.syntax.VectorOps.va"),
-          exclude[DirectMissingMethodProblem]("cats.syntax.WriterIdSyntax.a")
+          exclude[DirectMissingMethodProblem]("cats.syntax.WriterIdSyntax.a"),
+          exclude[DirectMissingMethodProblem]("cats.data.OptionTInstances.catsDateTraverseFilterForOptionT")
         ) ++ // Only compile-time abstractions (macros) allowed here
         Seq(
           exclude[IncompatibleMethTypeProblem]("cats.arrow.FunctionKMacros.lift"),

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -248,7 +248,7 @@ sealed abstract private[data] class OptionTInstances extends OptionTInstances0 {
         OptionT(F.defer(fa.value))
     }
 
-  implicit def catsDateTraverseFilterForOptionT[F[_]](implicit F0: Traverse[F]): TraverseFilter[OptionT[F, *]] =
+  implicit def catsDataTraverseFilterForOptionT[F[_]](implicit F0: Traverse[F]): TraverseFilter[OptionT[F, *]] =
     new OptionTFunctorFilter[F] with TraverseFilter[OptionT[F, *]] {
       implicit def F: Functor[F] = F0
 

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -267,6 +267,27 @@ sealed abstract private[data] class OptionTInstances extends OptionTInstances0 {
         G.map(Traverse[F].traverse(fa.value)(TraverseFilter[Option].filterA[G, A](_)(f)))(OptionT[F, A])
 
     }
+
+  @deprecated("renamed to catsDataTraverseFilterForOptionT", "2.0.0")
+  def catsDateTraverseFilterForOptionT[F[_]](implicit F0: Traverse[F]): TraverseFilter[OptionT[F, *]] =
+    new OptionTFunctorFilter[F] with TraverseFilter[OptionT[F, *]] {
+      implicit def F: Functor[F] = F0
+
+      val traverse: Traverse[OptionT[F, *]] = OptionT.catsDataTraverseForOptionT[F]
+
+      def traverseFilter[G[_], A, B](
+        fa: OptionT[F, A]
+      )(f: A => G[Option[B]])(implicit G: Applicative[G]): G[OptionT[F, B]] =
+        G.map(Traverse[F].traverse[G, Option[A], Option[B]](fa.value) { oa =>
+          TraverseFilter[Option].traverseFilter(oa)(f)
+        })(OptionT[F, B])
+
+      override def filterA[G[_], A](
+        fa: OptionT[F, A]
+      )(f: A => G[Boolean])(implicit G: Applicative[G]): G[OptionT[F, A]] =
+        G.map(Traverse[F].traverse(fa.value)(TraverseFilter[Option].filterA[G, A](_)(f)))(OptionT[F, A])
+
+    }
 }
 
 sealed abstract private[data] class OptionTInstances0 extends OptionTInstances1 {

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -270,24 +270,7 @@ sealed abstract private[data] class OptionTInstances extends OptionTInstances0 {
 
   @deprecated("renamed to catsDataTraverseFilterForOptionT", "2.0.0")
   def catsDateTraverseFilterForOptionT[F[_]](implicit F0: Traverse[F]): TraverseFilter[OptionT[F, *]] =
-    new OptionTFunctorFilter[F] with TraverseFilter[OptionT[F, *]] {
-      implicit def F: Functor[F] = F0
-
-      val traverse: Traverse[OptionT[F, *]] = OptionT.catsDataTraverseForOptionT[F]
-
-      def traverseFilter[G[_], A, B](
-        fa: OptionT[F, A]
-      )(f: A => G[Option[B]])(implicit G: Applicative[G]): G[OptionT[F, B]] =
-        G.map(Traverse[F].traverse[G, Option[A], Option[B]](fa.value) { oa =>
-          TraverseFilter[Option].traverseFilter(oa)(f)
-        })(OptionT[F, B])
-
-      override def filterA[G[_], A](
-        fa: OptionT[F, A]
-      )(f: A => G[Boolean])(implicit G: Applicative[G]): G[OptionT[F, A]] =
-        G.map(Traverse[F].traverse(fa.value)(TraverseFilter[Option].filterA[G, A](_)(f)))(OptionT[F, A])
-
-    }
+    catsDataTraverseFilterForOptionT
 }
 
 sealed abstract private[data] class OptionTInstances0 extends OptionTInstances1 {


### PR DESCRIPTION
stumbled across this minor typo when I was looking for specific `traverseFilter` instance for `OptionT`
