### PR TITLE
Remove redundant type annotation.

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -506,10 +506,8 @@ object NonEmptyList extends NonEmptyListInstances {
 
 sealed abstract private[data] class NonEmptyListInstances extends NonEmptyListInstances0 {
 
-  implicit val catsDataInstancesForNonEmptyList: SemigroupK[NonEmptyList]
-    with Reducible[NonEmptyList]
-    with Bimonad[NonEmptyList]
-    with NonEmptyTraverse[NonEmptyList] =
+  implicit val catsDataInstancesForNonEmptyList
+    : SemigroupK[NonEmptyList] with Bimonad[NonEmptyList] with NonEmptyTraverse[NonEmptyList] =
     new NonEmptyReducible[NonEmptyList, List] with SemigroupK[NonEmptyList] with Bimonad[NonEmptyList]
     with NonEmptyTraverse[NonEmptyList] {
 

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -238,10 +238,8 @@ final class NonEmptyVector[+A] private (val toVector: Vector[A]) extends AnyVal 
 @suppressUnusedImportWarningForScalaVersionSpecific
 sealed abstract private[data] class NonEmptyVectorInstances {
 
-  implicit val catsDataInstancesForNonEmptyVector: SemigroupK[NonEmptyVector]
-    with Reducible[NonEmptyVector]
-    with Bimonad[NonEmptyVector]
-    with NonEmptyTraverse[NonEmptyVector] =
+  implicit val catsDataInstancesForNonEmptyVector
+    : SemigroupK[NonEmptyVector] with Bimonad[NonEmptyVector] with NonEmptyTraverse[NonEmptyVector] =
     new NonEmptyReducible[NonEmptyVector, Vector] with SemigroupK[NonEmptyVector] with Bimonad[NonEmptyVector]
     with NonEmptyTraverse[NonEmptyVector] {
 


### PR DESCRIPTION
NonEmptyTraverse already inherits Reduceable.