### PR TITLE
unapplySeq in Chain (issue #2960)

### DIFF
--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -531,6 +531,14 @@ object Chain extends ChainInstances {
       false // b/c `fromSeq` constructor doesn't allow either branch to be empty
   }
 
+  def unapplySeq[A](chain: Chain[A]): Option[Seq[A]] =
+    Some(chain.toList)
+
+  object ==: {
+    def unapply[T](c: Chain[T]): Option[(T, Chain[T])] =
+      c.uncons
+  }
+
   /** Empty Chain. */
   val nil: Chain[Nothing] = Empty
 

--- a/tests/src/test/scala/cats/tests/ChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/ChainSuite.scala
@@ -2,6 +2,7 @@ package cats
 package tests
 
 import cats.data.Chain
+import cats.data.Chain.==:
 import cats.laws.discipline.{
   AlternativeTests,
   CoflatMapTests,
@@ -72,6 +73,17 @@ class ChainSuite extends CatsSuite {
     forAll { (c: Chain[Int]) =>
       c.lastOption should ===(c.toList.lastOption)
     }
+  }
+
+  test("list-like pattern match") {
+    Chain(1, 2, 3) match {
+      case Chain(a, b, c) => (a, b, c) should ===((1, 2, 3))
+    }
+
+    Chain(1, 2, 3) match {
+      case h ==: t => (h, t) should ===(1 -> Chain(2, 3))
+    }
+
   }
 
   test("size is consistent with toList.size") {


### PR DESCRIPTION
Added unapplySeq to Chain and ==: object to allow pattern match Chain in list like manner:
```scala
Chain(1, 2, 3) match {
      case Chain(a, b, c) => 
}

Chain(1, 2, 3) match {
      case h ==: t => 
}

```

