### PR TITLE
Add guarded syntax for Alternative

### DIFF
--- a/core/src/main/scala/cats/implicits.scala
+++ b/core/src/main/scala/cats/implicits.scala
@@ -7,6 +7,9 @@ object implicits
     with syntax.AllSyntaxBinCompat2
     with syntax.AllSyntaxBinCompat3
     with syntax.AllSyntaxBinCompat4
+    with syntax.AllSyntaxBinCompat5
+    with syntax.AllSyntaxBinCompat6
+    with syntax.AllSyntaxBinCompat7
     with instances.AllInstances
     with instances.AllInstancesBinCompat0
     with instances.AllInstancesBinCompat1

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -10,6 +10,7 @@ abstract class AllSyntaxBinCompat
     with AllSyntaxBinCompat4
     with AllSyntaxBinCompat5
     with AllSyntaxBinCompat6
+    with AllSyntaxBinCompat7
 
 trait AllSyntax
     extends AlternativeSyntax
@@ -93,3 +94,5 @@ trait AllSyntaxBinCompat4
 trait AllSyntaxBinCompat5 extends ParallelBitraverseSyntax
 
 trait AllSyntaxBinCompat6 extends ParallelUnorderedTraverseSyntax
+
+trait AllSyntaxBinCompat7 extends AlternativeSyntaxBinCompat0

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -2,7 +2,7 @@ package cats
 
 package object syntax {
   object all extends AllSyntaxBinCompat
-  object alternative extends AlternativeSyntax
+  object alternative extends AlternativeSyntax with AlternativeSyntaxBinCompat0
   object applicative extends ApplicativeSyntax
   object applicativeError extends ApplicativeErrorSyntax
   object apply extends ApplySyntax


### PR DESCRIPTION
This add a `.guarded` syntax for any `A`, allowing to lift this value into a `F[_]` with an `Alternative` instance based on whether some test on the value holds or not: `a.guarded[F](f)`. 

Does the same as `f(a).guard[F].as(a)`, but is very helpful when a is not a simple value, but something more expensive to compute, as the `guard` version would compute `a` twice unless it's extracted in to a variable which is ugly in nested calls, example:

```scala
(0 to 100).toList.flatMap(factorial(_).guarded[List](_ % 10 === 7))
```
Calculates all factorials which end with 7, avoiding duplicate calls to the (expensive) `factorial` function as well as the need to assign it.