### PR TITLE
More consistency

### DIFF
--- a/core/src/main/scala-2.12-/cats/instances/all.scala
+++ b/core/src/main/scala-2.12-/cats/instances/all.scala
@@ -56,3 +56,4 @@ private[cats] trait AllInstancesBinCompat6
     with SortedMapInstancesBinCompat2
     with FunctionInstancesBinCompat1
     with cats.kernel.instances.EitherInstancesBinCompat0
+    with cats.kernel.instances.FunctionInstancesBinCompat0

--- a/core/src/main/scala-2.12-/cats/instances/all.scala
+++ b/core/src/main/scala-2.12-/cats/instances/all.scala
@@ -55,3 +55,4 @@ private[cats] trait AllInstancesBinCompat6
     extends SortedSetInstancesBinCompat1
     with SortedMapInstancesBinCompat2
     with FunctionInstancesBinCompat1
+    with cats.kernel.instances.EitherInstancesBinCompat0

--- a/core/src/main/scala-2.12-/cats/instances/all.scala
+++ b/core/src/main/scala-2.12-/cats/instances/all.scala
@@ -33,9 +33,9 @@ trait AllInstances
     with UUIDInstances
     with VectorInstances
 
-trait AllInstancesBinCompat0 extends FunctionInstancesBinCompat0 with Tuple2InstancesBinCompat0
+private[cats] trait AllInstancesBinCompat0 extends FunctionInstancesBinCompat0 with Tuple2InstancesBinCompat0
 
-trait AllInstancesBinCompat1
+private[cats] trait AllInstancesBinCompat1
     extends OptionInstancesBinCompat0
     with ListInstancesBinCompat0
     with VectorInstancesBinCompat0
@@ -43,12 +43,15 @@ trait AllInstancesBinCompat1
     with MapInstancesBinCompat0
     with SortedMapInstancesBinCompat0
 
-trait AllInstancesBinCompat2 extends DurationInstances with FiniteDurationInstances
+private[cats] trait AllInstancesBinCompat2 extends DurationInstances with FiniteDurationInstances
 
-trait AllInstancesBinCompat3 extends AllCoreDurationInstances
+private[cats] trait AllInstancesBinCompat3 extends AllCoreDurationInstances
 
-trait AllInstancesBinCompat4 extends SortedMapInstancesBinCompat1 with MapInstancesBinCompat1
+private[cats] trait AllInstancesBinCompat4 extends SortedMapInstancesBinCompat1 with MapInstancesBinCompat1
 
-trait AllInstancesBinCompat5 extends SortedSetInstancesBinCompat0
+private[cats] trait AllInstancesBinCompat5 extends SortedSetInstancesBinCompat0
 
-trait AllInstancesBinCompat6 extends SortedSetInstancesBinCompat1 with SortedMapInstancesBinCompat2 with FunctionInstancesBinCompat1
+private[cats] trait AllInstancesBinCompat6
+    extends SortedSetInstancesBinCompat1
+    with SortedMapInstancesBinCompat2
+    with FunctionInstancesBinCompat1

--- a/core/src/main/scala-2.12-/cats/instances/all.scala
+++ b/core/src/main/scala-2.12-/cats/instances/all.scala
@@ -50,3 +50,5 @@ trait AllInstancesBinCompat3 extends AllCoreDurationInstances
 trait AllInstancesBinCompat4 extends SortedMapInstancesBinCompat1 with MapInstancesBinCompat1
 
 trait AllInstancesBinCompat5 extends SortedSetInstancesBinCompat0
+
+trait AllInstancesBinCompat6 extends SortedSetInstancesBinCompat1 with SortedMapInstancesBinCompat2

--- a/core/src/main/scala-2.12-/cats/instances/all.scala
+++ b/core/src/main/scala-2.12-/cats/instances/all.scala
@@ -51,4 +51,4 @@ trait AllInstancesBinCompat4 extends SortedMapInstancesBinCompat1 with MapInstan
 
 trait AllInstancesBinCompat5 extends SortedSetInstancesBinCompat0
 
-trait AllInstancesBinCompat6 extends SortedSetInstancesBinCompat1 with SortedMapInstancesBinCompat2
+trait AllInstancesBinCompat6 extends SortedSetInstancesBinCompat1 with SortedMapInstancesBinCompat2 with FunctionInstancesBinCompat1

--- a/core/src/main/scala-2.12-/cats/instances/package.scala
+++ b/core/src/main/scala-2.12-/cats/instances/package.scala
@@ -18,7 +18,7 @@ package object instances {
   object char extends CharInstances
   object double extends DoubleInstances
   object duration extends CoreDurationInstances with DurationInstances
-  object either extends EitherInstances
+  object either extends EitherInstances with cats.kernel.instances.EitherInstancesBinCompat0
   object eq extends EqInstances
   object equiv extends EquivInstances
   object float extends FloatInstances

--- a/core/src/main/scala-2.12-/cats/instances/package.scala
+++ b/core/src/main/scala-2.12-/cats/instances/package.scala
@@ -23,7 +23,11 @@ package object instances {
   object equiv extends EquivInstances
   object float extends FloatInstances
   object finiteDuration extends CoreFiniteDurationInstances with FiniteDurationInstances
-  object function extends FunctionInstances with FunctionInstancesBinCompat0 with FunctionInstancesBinCompat1
+  object function
+      extends FunctionInstances
+      with FunctionInstancesBinCompat0
+      with FunctionInstancesBinCompat1
+      with cats.kernel.instances.FunctionInstancesBinCompat0
   object future extends FutureInstances
   object int extends IntInstances
   object invariant extends InvariantMonoidalInstances

--- a/core/src/main/scala-2.12-/cats/instances/package.scala
+++ b/core/src/main/scala-2.12-/cats/instances/package.scala
@@ -23,7 +23,7 @@ package object instances {
   object equiv extends EquivInstances
   object float extends FloatInstances
   object finiteDuration extends CoreFiniteDurationInstances with FiniteDurationInstances
-  object function extends FunctionInstances with FunctionInstancesBinCompat0
+  object function extends FunctionInstances with FunctionInstancesBinCompat0 with FunctionInstancesBinCompat1
   object future extends FutureInstances
   object int extends IntInstances
   object invariant extends InvariantMonoidalInstances

--- a/core/src/main/scala-2.12-/cats/instances/package.scala
+++ b/core/src/main/scala-2.12-/cats/instances/package.scala
@@ -9,6 +9,7 @@ package object instances {
       with AllInstancesBinCompat3
       with AllInstancesBinCompat4
       with AllInstancesBinCompat5
+      with AllInstancesBinCompat6
   object bigInt extends BigIntInstances
   object bigDecimal extends BigDecimalInstances
   object bitSet extends BitSetInstances
@@ -38,8 +39,12 @@ package object instances {
   object queue extends QueueInstances
   object set extends SetInstances
   object short extends ShortInstances
-  object sortedMap extends SortedMapInstances with SortedMapInstancesBinCompat0 with SortedMapInstancesBinCompat1
-  object sortedSet extends SortedSetInstances with SortedSetInstancesBinCompat0
+  object sortedMap
+      extends SortedMapInstances
+      with SortedMapInstancesBinCompat0
+      with SortedMapInstancesBinCompat1
+      with SortedMapInstancesBinCompat2
+  object sortedSet extends SortedSetInstances with SortedSetInstancesBinCompat0 with SortedSetInstancesBinCompat1
   object stream extends StreamInstances with StreamInstancesBinCompat0
   object string extends StringInstances
   object try_ extends TryInstances

--- a/core/src/main/scala-2.12-/cats/instances/stream.scala
+++ b/core/src/main/scala-2.12-/cats/instances/stream.scala
@@ -159,7 +159,7 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
 
 }
 
-trait StreamInstancesBinCompat0 {
+private[instances] trait StreamInstancesBinCompat0 {
   implicit val catsStdTraverseFilterForStream: TraverseFilter[Stream] = new TraverseFilter[Stream] {
     val traverse: Traverse[Stream] = cats.instances.stream.catsStdInstancesForStream
 

--- a/core/src/main/scala-2.13+/cats/instances/all.scala
+++ b/core/src/main/scala-2.13+/cats/instances/all.scala
@@ -34,9 +34,9 @@ trait AllInstances
     with UUIDInstances
     with VectorInstances
 
-trait AllInstancesBinCompat0 extends FunctionInstancesBinCompat0 with Tuple2InstancesBinCompat0
+private[cats] trait AllInstancesBinCompat0 extends FunctionInstancesBinCompat0 with Tuple2InstancesBinCompat0
 
-trait AllInstancesBinCompat1
+private[cats] trait AllInstancesBinCompat1
     extends OptionInstancesBinCompat0
     with ListInstancesBinCompat0
     with VectorInstancesBinCompat0
@@ -44,12 +44,15 @@ trait AllInstancesBinCompat1
     with MapInstancesBinCompat0
     with SortedMapInstancesBinCompat0
 
-trait AllInstancesBinCompat2 extends DurationInstances with FiniteDurationInstances
+private[cats] trait AllInstancesBinCompat2 extends DurationInstances with FiniteDurationInstances
 
-trait AllInstancesBinCompat3 extends AllCoreDurationInstances
+private[cats] trait AllInstancesBinCompat3 extends AllCoreDurationInstances
 
-trait AllInstancesBinCompat4 extends SortedMapInstancesBinCompat1 with MapInstancesBinCompat1
+private[cats] trait AllInstancesBinCompat4 extends SortedMapInstancesBinCompat1 with MapInstancesBinCompat1
 
-trait AllInstancesBinCompat5 extends SortedSetInstancesBinCompat0
+private[cats] trait AllInstancesBinCompat5 extends SortedSetInstancesBinCompat0
 
-trait AllInstancesBinCompat6 extends SortedSetInstancesBinCompat1 with SortedMapInstancesBinCompat2 with FunctionInstancesBinCompat1
+private[cats] trait AllInstancesBinCompat6
+    extends SortedSetInstancesBinCompat1
+    with SortedMapInstancesBinCompat2
+    with FunctionInstancesBinCompat1

--- a/core/src/main/scala-2.13+/cats/instances/all.scala
+++ b/core/src/main/scala-2.13+/cats/instances/all.scala
@@ -51,3 +51,5 @@ trait AllInstancesBinCompat3 extends AllCoreDurationInstances
 trait AllInstancesBinCompat4 extends SortedMapInstancesBinCompat1 with MapInstancesBinCompat1
 
 trait AllInstancesBinCompat5 extends SortedSetInstancesBinCompat0
+
+trait AllInstancesBinCompat6 extends SortedSetInstancesBinCompat1 with SortedMapInstancesBinCompat2

--- a/core/src/main/scala-2.13+/cats/instances/all.scala
+++ b/core/src/main/scala-2.13+/cats/instances/all.scala
@@ -52,4 +52,4 @@ trait AllInstancesBinCompat4 extends SortedMapInstancesBinCompat1 with MapInstan
 
 trait AllInstancesBinCompat5 extends SortedSetInstancesBinCompat0
 
-trait AllInstancesBinCompat6 extends SortedSetInstancesBinCompat1 with SortedMapInstancesBinCompat2
+trait AllInstancesBinCompat6 extends SortedSetInstancesBinCompat1 with SortedMapInstancesBinCompat2 with FunctionInstancesBinCompat1

--- a/core/src/main/scala-2.13+/cats/instances/all.scala
+++ b/core/src/main/scala-2.13+/cats/instances/all.scala
@@ -57,3 +57,4 @@ private[cats] trait AllInstancesBinCompat6
     with SortedMapInstancesBinCompat2
     with FunctionInstancesBinCompat1
     with cats.kernel.instances.EitherInstancesBinCompat0
+    with cats.kernel.instances.FunctionInstancesBinCompat0

--- a/core/src/main/scala-2.13+/cats/instances/all.scala
+++ b/core/src/main/scala-2.13+/cats/instances/all.scala
@@ -56,3 +56,4 @@ private[cats] trait AllInstancesBinCompat6
     extends SortedSetInstancesBinCompat1
     with SortedMapInstancesBinCompat2
     with FunctionInstancesBinCompat1
+    with cats.kernel.instances.EitherInstancesBinCompat0

--- a/core/src/main/scala-2.13+/cats/instances/package.scala
+++ b/core/src/main/scala-2.13+/cats/instances/package.scala
@@ -18,7 +18,7 @@ package object instances {
   object char extends CharInstances
   object double extends DoubleInstances
   object duration extends CoreDurationInstances with DurationInstances
-  object either extends EitherInstances
+  object either extends EitherInstances with cats.kernel.instances.EitherInstancesBinCompat0
   object eq extends EqInstances
   object equiv extends EquivInstances
   object float extends FloatInstances

--- a/core/src/main/scala-2.13+/cats/instances/package.scala
+++ b/core/src/main/scala-2.13+/cats/instances/package.scala
@@ -23,7 +23,11 @@ package object instances {
   object equiv extends EquivInstances
   object float extends FloatInstances
   object finiteDuration extends CoreFiniteDurationInstances with FiniteDurationInstances
-  object function extends FunctionInstances with FunctionInstancesBinCompat0 with FunctionInstancesBinCompat1
+  object function
+      extends FunctionInstances
+      with FunctionInstancesBinCompat0
+      with FunctionInstancesBinCompat1
+      with cats.kernel.instances.FunctionInstancesBinCompat0
   object future extends FutureInstances
   object int extends IntInstances
   object invariant extends InvariantMonoidalInstances

--- a/core/src/main/scala-2.13+/cats/instances/package.scala
+++ b/core/src/main/scala-2.13+/cats/instances/package.scala
@@ -44,10 +44,7 @@ package object instances {
       with SortedMapInstancesBinCompat0
       with SortedMapInstancesBinCompat1
       with SortedMapInstancesBinCompat2
-  object sortedSet
-      extends SortedSetInstances
-      with SortedSetInstancesBinCompat0
-      with SortedSetInstancesBinCompat1
+  object sortedSet extends SortedSetInstances with SortedSetInstancesBinCompat0 with SortedSetInstancesBinCompat1
 
   @deprecated("2.0.0-RC2", "Use cats.instances.lazyList")
   object stream extends StreamInstances with StreamInstancesBinCompat0

--- a/core/src/main/scala-2.13+/cats/instances/package.scala
+++ b/core/src/main/scala-2.13+/cats/instances/package.scala
@@ -9,6 +9,7 @@ package object instances {
       with AllInstancesBinCompat3
       with AllInstancesBinCompat4
       with AllInstancesBinCompat5
+      with AllInstancesBinCompat6
   object bigInt extends BigIntInstances
   object bigDecimal extends BigDecimalInstances
   object bitSet extends BitSetInstances
@@ -38,8 +39,15 @@ package object instances {
   object queue extends QueueInstances
   object set extends SetInstances
   object short extends ShortInstances
-  object sortedMap extends SortedMapInstances with SortedMapInstancesBinCompat0 with SortedMapInstancesBinCompat1
-  object sortedSet extends SortedSetInstances with SortedSetInstancesBinCompat0
+  object sortedMap
+      extends SortedMapInstances
+      with SortedMapInstancesBinCompat0
+      with SortedMapInstancesBinCompat1
+      with SortedMapInstancesBinCompat2
+  object sortedSet
+      extends SortedSetInstances
+      with SortedSetInstancesBinCompat0
+      with SortedSetInstancesBinCompat1
 
   @deprecated("2.0.0-RC2", "Use cats.instances.lazyList")
   object stream extends StreamInstances with StreamInstancesBinCompat0

--- a/core/src/main/scala-2.13+/cats/instances/package.scala
+++ b/core/src/main/scala-2.13+/cats/instances/package.scala
@@ -23,7 +23,7 @@ package object instances {
   object equiv extends EquivInstances
   object float extends FloatInstances
   object finiteDuration extends CoreFiniteDurationInstances with FiniteDurationInstances
-  object function extends FunctionInstances with FunctionInstancesBinCompat0
+  object function extends FunctionInstances with FunctionInstancesBinCompat0 with FunctionInstancesBinCompat1
   object future extends FutureInstances
   object int extends IntInstances
   object invariant extends InvariantMonoidalInstances

--- a/core/src/main/scala-2.13+/cats/instances/stream.scala
+++ b/core/src/main/scala-2.13+/cats/instances/stream.scala
@@ -161,7 +161,7 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
 
 }
 
-trait StreamInstancesBinCompat0 {
+private[instances] trait StreamInstancesBinCompat0 {
   @deprecated("2.0.0-RC2", "Use cats.instances.lazyList")
   implicit val catsStdTraverseFilterForStream: TraverseFilter[Stream] = new TraverseFilter[Stream] {
     val traverse: Traverse[Stream] = cats.instances.stream.catsStdInstancesForStream

--- a/core/src/main/scala/cats/data/Binested.scala
+++ b/core/src/main/scala/cats/data/Binested.scala
@@ -51,7 +51,7 @@ trait BinestedInstances extends BinestedInstances0 {
     }
 }
 
-trait BinestedInstances0 {
+private[data] trait BinestedInstances0 {
   implicit def catsDataBifoldableForBinested[F[_, _], G[_], H[_]](
     implicit F0: Bifoldable[F],
     G0: Foldable[G],

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -500,7 +500,10 @@ object NonEmptyList extends NonEmptyListInstances {
           ZipNonEmptyList(fa.value.zipWith(fb.value) { case (a, b) => (a, b) })
       }
 
-    implicit def zipNelEq[A: Eq]: Eq[ZipNonEmptyList[A]] = Eq.by(_.value)
+    @deprecated("2.0.0-RC2", "Use catsDataEqForZipNonEmptyList")
+    private[data] def zipNelEq[A: Eq]: Eq[ZipNonEmptyList[A]] = catsDataEqForZipNonEmptyList[A]
+
+    implicit def catsDataEqForZipNonEmptyList[A: Eq]: Eq[ZipNonEmptyList[A]] = Eq.by(_.value)
   }
 }
 

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -428,6 +428,9 @@ object NonEmptyVector extends NonEmptyVectorInstances with Serializable {
           ZipNonEmptyVector(fa.value.zipWith(fb.value) { case (a, b) => (a, b) })
       }
 
-    implicit def zipNevEq[A: Eq]: Eq[ZipNonEmptyVector[A]] = Eq.by(_.value)
+    @deprecated("2.0.0-RC2", "Use catsDataEqForZipNonEmptyVector")
+    private[data] def zipNevEq[A: Eq]: Eq[ZipNonEmptyVector[A]] = catsDataEqForZipNonEmptyVector[A]
+
+    implicit def catsDataEqForZipNonEmptyVector[A: Eq]: Eq[ZipNonEmptyVector[A]] = Eq.by(_.value)
   }
 }

--- a/core/src/main/scala/cats/data/Op.scala
+++ b/core/src/main/scala/cats/data/Op.scala
@@ -20,8 +20,12 @@ sealed abstract private[data] class OpInstances extends OpInstances0 {
   implicit def catsDataCategoryForOp[Arr[_, _]](implicit ArrC: Category[Arr]): Category[Op[Arr, *, *]] =
     new OpCategory[Arr] { def Arr: Category[Arr] = ArrC }
 
-  implicit def catsKernelEqForOp[Arr[_, _], A, B](implicit ArrEq: Eq[Arr[B, A]]): Eq[Op[Arr, A, B]] =
+  implicit def catsDataEqForOp[Arr[_, _], A, B](implicit ArrEq: Eq[Arr[B, A]]): Eq[Op[Arr, A, B]] =
     new OpEq[Arr, A, B] { def Arr: Eq[Arr[B, A]] = ArrEq }
+
+  @deprecated("2.0.0-RC2", "Use catsDataEqForOp")
+  private[data] def catsKernelEqForOp[Arr[_, _], A, B](implicit ArrEq: Eq[Arr[B, A]]): Eq[Op[Arr, A, B]] =
+    catsDataEqForOp[Arr, A, B]
 }
 
 sealed abstract private[data] class OpInstances0 {

--- a/core/src/main/scala/cats/instances/function.scala
+++ b/core/src/main/scala/cats/instances/function.scala
@@ -22,24 +22,8 @@ trait FunctionInstancesBinCompat0 {
       override def index[A](f: E => A): E => A = f
     }
 
-  implicit val catsSddDeferForFunction0: Defer[Function0] =
-    new Defer[Function0] {
-      case class Deferred[A](fa: () => Function0[A]) extends Function0[A] {
-        def apply() = {
-          @annotation.tailrec
-          def loop(f: () => Function0[A]): A =
-            f() match {
-              case Deferred(f) => loop(f)
-              case next        => next()
-            }
-          loop(fa)
-        }
-      }
-      def defer[A](fa: => Function0[A]): Function0[A] = {
-        lazy val cachedFa = fa
-        Deferred(() => cachedFa)
-      }
-    }
+  @deprecated("2.0.0-RC2", "Use cats.instances.function.catsStdDeferForFunction0")
+  private[instances] def catsSddDeferForFunction0: Defer[Function0] = cats.instances.function.catsStdDeferForFunction0
 
   implicit def catsStdDeferForFunction1[A]: Defer[A => *] =
     new Defer[A => *] {
@@ -55,6 +39,27 @@ trait FunctionInstancesBinCompat0 {
         }
       }
       def defer[B](fa: => A => B): A => B = {
+        lazy val cachedFa = fa
+        Deferred(() => cachedFa)
+      }
+    }
+}
+
+private[instances] trait FunctionInstancesBinCompat1 {
+  implicit val catsStdDeferForFunction0: Defer[Function0] =
+    new Defer[Function0] {
+      case class Deferred[A](fa: () => Function0[A]) extends Function0[A] {
+        def apply() = {
+          @annotation.tailrec
+          def loop(f: () => Function0[A]): A =
+            f() match {
+              case Deferred(f) => loop(f)
+              case next        => next()
+            }
+          loop(fa)
+        }
+      }
+      def defer[A](fa: => Function0[A]): Function0[A] = {
         lazy val cachedFa = fa
         Deferred(() => cachedFa)
       }

--- a/core/src/main/scala/cats/instances/function.scala
+++ b/core/src/main/scala/cats/instances/function.scala
@@ -9,7 +9,7 @@ import annotation.tailrec
 
 trait FunctionInstances extends cats.kernel.instances.FunctionInstances with Function0Instances with Function1Instances
 
-trait FunctionInstancesBinCompat0 {
+private[instances] trait FunctionInstancesBinCompat0 {
 
   /**
    * Witness for: E => A <-> E => A

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -152,7 +152,7 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
     }
 }
 
-trait ListInstancesBinCompat0 {
+private[instances] trait ListInstancesBinCompat0 {
   implicit val catsStdTraverseFilterForList: TraverseFilter[List] = new TraverseFilter[List] {
     val traverse: Traverse[List] = cats.instances.list.catsStdInstancesForList
 

--- a/core/src/main/scala/cats/instances/map.scala
+++ b/core/src/main/scala/cats/instances/map.scala
@@ -93,7 +93,7 @@ trait MapInstances extends cats.kernel.instances.MapInstances {
 
 }
 
-trait MapInstancesBinCompat0 {
+private[instances] trait MapInstancesBinCompat0 {
 
   implicit val catsStdComposeForMap: Compose[Map] = new Compose[Map] {
 
@@ -139,7 +139,7 @@ trait MapInstancesBinCompat0 {
 
 }
 
-trait MapInstancesBinCompat1 {
+private[instances] trait MapInstancesBinCompat1 {
   implicit def catsStdMonoidKForMap[K]: MonoidK[Map[K, *]] = new MonoidK[Map[K, *]] {
     override def empty[A]: Map[K, A] = Map.empty
 

--- a/core/src/main/scala/cats/instances/option.scala
+++ b/core/src/main/scala/cats/instances/option.scala
@@ -127,7 +127,7 @@ trait OptionInstances extends cats.kernel.instances.OptionInstances {
     }
 }
 
-trait OptionInstancesBinCompat0 {
+private[instances] trait OptionInstancesBinCompat0 {
   implicit val catsStdTraverseFilterForOption: TraverseFilter[Option] = new TraverseFilter[Option] {
     val traverse: Traverse[Option] = cats.instances.option.catsStdInstancesForOption
 

--- a/core/src/main/scala/cats/instances/sortedMap.scala
+++ b/core/src/main/scala/cats/instances/sortedMap.scala
@@ -147,7 +147,7 @@ class SortedMapCommutativeMonoid[K, V](implicit V: CommutativeSemigroup[V], O: O
 @deprecated("2.0.0-RC2", "Use cats.kernel.instances.SortedMapMonoid")
 class SortedMapMonoid[K, V](implicit V: Semigroup[V], O: Order[K]) extends cats.kernel.instances.SortedMapMonoid[K, V]
 
-trait SortedMapInstancesBinCompat0 {
+private[instances] trait SortedMapInstancesBinCompat0 {
   implicit def catsStdTraverseFilterForSortedMap[K: Order]: TraverseFilter[SortedMap[K, *]] =
     new TraverseFilter[SortedMap[K, *]] {
 
@@ -187,7 +187,7 @@ trait SortedMapInstancesBinCompat0 {
     }
 }
 
-trait SortedMapInstancesBinCompat1 {
+private[instances] trait SortedMapInstancesBinCompat1 {
   implicit def catsStdMonoidKForSortedMap[K: Order]: MonoidK[SortedMap[K, *]] = new MonoidK[SortedMap[K, *]] {
     override def empty[A]: SortedMap[K, A] = SortedMap.empty[K, A](Order[K].toOrdering)
 
@@ -195,4 +195,4 @@ trait SortedMapInstancesBinCompat1 {
   }
 }
 
-trait SortedMapInstancesBinCompat2 extends cats.kernel.instances.SortedMapInstances
+private[instances] trait SortedMapInstancesBinCompat2 extends cats.kernel.instances.SortedMapInstances

--- a/core/src/main/scala/cats/instances/sortedMap.scala
+++ b/core/src/main/scala/cats/instances/sortedMap.scala
@@ -2,19 +2,19 @@ package cats.instances
 
 import cats.{Always, Applicative, Eval, FlatMap, Foldable, Monoid, MonoidK, Order, Show, Traverse, TraverseFilter}
 import cats.kernel._
-import cats.kernel.instances.StaticMethods
 
 import scala.annotation.tailrec
 import scala.collection.immutable.SortedMap
 
 trait SortedMapInstances extends SortedMapInstances2 {
 
-  implicit def catsStdHashForSortedMap[K: Hash: Order, V: Hash]: Hash[SortedMap[K, V]] =
-    new SortedMapHash[K, V]
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedMap.catsKernelStdHashForSortedMap")
+  private[instances] def catsStdHashForSortedMap[K: Hash: Order, V: Hash]: Hash[SortedMap[K, V]] =
+    cats.kernel.instances.sortedMap.catsKernelStdHashForSortedMap[K, V]
 
-  implicit def catsStdCommutativeMonoidForSortedMap[K: Order, V: CommutativeSemigroup]
-    : CommutativeMonoid[SortedMap[K, V]] =
-    new SortedMapCommutativeMonoid[K, V]
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedMap.catsKernelStdCommutativeMonoidForSortedMap")
+  private[instances] def catsStdCommutativeMonoidForSortedMap[K: Order, V: CommutativeSemigroup] =
+    cats.kernel.instances.sortedMap.catsKernelStdCommutativeMonoidForSortedMap[K, V]
 
   implicit def catsStdShowForSortedMap[A: Order, B](implicit showA: Show[A], showB: Show[B]): Show[SortedMap[A, B]] =
     new Show[SortedMap[A, B]] {
@@ -114,75 +114,38 @@ trait SortedMapInstances extends SortedMapInstances2 {
 }
 
 trait SortedMapInstances1 {
-  implicit def catsStdEqForSortedMap[K: Order, V: Eq]: Eq[SortedMap[K, V]] =
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedMap.catsKernelStdEqForSortedMap")
+  private[instances] def catsStdEqForSortedMap[K: Order, V: Eq]: Eq[SortedMap[K, V]] =
     new SortedMapEq[K, V]
 }
 
 trait SortedMapInstances2 extends SortedMapInstances1 {
-  implicit def catsStdMonoidForSortedMap[K: Order, V: Semigroup]: Monoid[SortedMap[K, V]] =
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedMap.catsKernelStdMonoidForSortedMap")
+  private[instances] def catsStdMonoidForSortedMap[K: Order, V: Semigroup]: Monoid[SortedMap[K, V]] =
     new SortedMapMonoid[K, V]
 }
 
+@deprecated("2.0.0-RC2", "Use cats.kernel.instances.SortedMapHash")
 class SortedMapHash[K, V](implicit V: Hash[V], O: Order[K], K: Hash[K])
-    extends SortedMapEq[K, V]()(V, O)
+    extends SortedMapEq[K, V]
     with Hash[SortedMap[K, V]] {
-  // adapted from [[scala.util.hashing.MurmurHash3]],
-  // but modified standard `Any#hashCode` to `ev.hash`.
-  import scala.util.hashing.MurmurHash3._
-  def hash(x: SortedMap[K, V]): Int = {
-    var a, b, n = 0
-    var c = 1
-    x.foreach {
-      case (k, v) =>
-        val h = StaticMethods.product2HashWithPrefix(K.hash(k), V.hash(v), "Tuple2")
-        a += h
-        b ^= h
-        c = StaticMethods.updateUnorderedHashC(c, h)
-        n += 1
-    }
-    var h = mapSeed
-    h = mix(h, a)
-    h = mix(h, b)
-    h = mixLast(h, c)
-    finalizeHash(h, n)
-  }
+  private[this] val underlying: Hash[SortedMap[K, V]] = new cats.kernel.instances.SortedMapHash[K, V]
+  def hash(x: SortedMap[K, V]): Int = underlying.hash(x)
 }
 
-class SortedMapEq[K, V](implicit V: Eq[V], O: Order[K]) extends Eq[SortedMap[K, V]] {
-  def eqv(x: SortedMap[K, V], y: SortedMap[K, V]): Boolean =
-    if (x eq y) true
-    else
-      x.size == y.size && x.forall {
-        case (k, v1) =>
-          y.get(k) match {
-            case Some(v2) => V.eqv(v1, v2)
-            case None     => false
-          }
-      }
-}
+@deprecated("2.0.0-RC2", "Use cats.kernel.instances.SortedMapEq")
+class SortedMapEq[K, V](implicit V: Eq[V], O: Order[K]) extends cats.kernel.instances.SortedMapEq[K, V]
 
+@deprecated("2.0.0-RC2", "Use cats.kernel.instances.SortedMapCommutativeMonoid")
 class SortedMapCommutativeMonoid[K, V](implicit V: CommutativeSemigroup[V], O: Order[K])
     extends SortedMapMonoid[K, V]
-    with CommutativeMonoid[SortedMap[K, V]]
-
-class SortedMapMonoid[K, V](implicit V: Semigroup[V], O: Order[K]) extends Monoid[SortedMap[K, V]] {
-
-  def empty: SortedMap[K, V] = SortedMap.empty(O.toOrdering)
-
-  def combine(xs: SortedMap[K, V], ys: SortedMap[K, V]): SortedMap[K, V] =
-    if (xs.size <= ys.size) {
-      xs.foldLeft(ys) {
-        case (my, (k, x)) =>
-          my.updated(k, Semigroup.maybeCombine(x, my.get(k)))
-      }
-    } else {
-      ys.foldLeft(xs) {
-        case (mx, (k, y)) =>
-          mx.updated(k, Semigroup.maybeCombine(mx.get(k), y))
-      }
-    }
-
+    with CommutativeMonoid[SortedMap[K, V]] {
+  private[this] val underlying: CommutativeMonoid[SortedMap[K, V]] =
+    new cats.kernel.instances.SortedMapCommutativeMonoid[K, V]
 }
+
+@deprecated("2.0.0-RC2", "Use cats.kernel.instances.SortedMapMonoid")
+class SortedMapMonoid[K, V](implicit V: Semigroup[V], O: Order[K]) extends cats.kernel.instances.SortedMapMonoid[K, V]
 
 trait SortedMapInstancesBinCompat0 {
   implicit def catsStdTraverseFilterForSortedMap[K: Order]: TraverseFilter[SortedMap[K, *]] =
@@ -231,3 +194,5 @@ trait SortedMapInstancesBinCompat1 {
     override def combineK[A](x: SortedMap[K, A], y: SortedMap[K, A]): SortedMap[K, A] = x ++ y
   }
 }
+
+trait SortedMapInstancesBinCompat2 extends cats.kernel.instances.SortedMapInstances

--- a/core/src/main/scala/cats/instances/sortedSet.scala
+++ b/core/src/main/scala/cats/instances/sortedSet.scala
@@ -70,7 +70,7 @@ trait SortedSetInstances extends SortedSetInstances1 {
     cats.kernel.instances.sortedSet.catsKernelStdOrderForSortedSet[A]
 }
 
-trait SortedSetInstances1 {
+private[instances] trait SortedSetInstances1 {
   @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet")
   private[instances] def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
     cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A]
@@ -80,7 +80,7 @@ trait SortedSetInstances1 {
     cats.kernel.instances.sortedSet.catsKernelStdBoundedSemilatticeForSortedSet[A]
 }
 
-trait SortedSetInstancesBinCompat0 {
+private[instances] trait SortedSetInstancesBinCompat0 {
   implicit val catsStdSemigroupalForSortedSet: Semigroupal[SortedSet] = new Semigroupal[SortedSet] {
     override def product[A, B](fa: SortedSet[A], fb: SortedSet[B]): SortedSet[(A, B)] = {
       implicit val orderingA = fa.ordering
@@ -91,7 +91,7 @@ trait SortedSetInstancesBinCompat0 {
   }
 }
 
-trait SortedSetInstancesBinCompat1 extends LowPrioritySortedSetInstancesBinCompat1 {
+private[instances] trait SortedSetInstancesBinCompat1 extends LowPrioritySortedSetInstancesBinCompat1 {
   // TODO: Remove when this is no longer necessary for binary compatibility.
   implicit override def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
     cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A]

--- a/core/src/main/scala/cats/instances/sortedSet.scala
+++ b/core/src/main/scala/cats/instances/sortedSet.scala
@@ -2,10 +2,8 @@ package cats
 package instances
 
 import cats.kernel.{BoundedSemilattice, Hash, Order}
-import cats.kernel.instances.StaticMethods
 import scala.collection.immutable.SortedSet
 import scala.annotation.tailrec
-import cats.implicits._
 
 trait SortedSetInstances extends SortedSetInstances1 {
 
@@ -64,19 +62,22 @@ trait SortedSetInstances extends SortedSetInstances1 {
 
   implicit def catsStdShowForSortedSet[A: Show]: Show[SortedSet[A]] = new Show[SortedSet[A]] {
     def show(fa: SortedSet[A]): String =
-      fa.iterator.map(_.show).mkString("SortedSet(", ", ", ")")
+      fa.iterator.map(Show[A].show).mkString("SortedSet(", ", ", ")")
   }
 
-  implicit def catsKernelStdOrderForSortedSet[A: Order]: Order[SortedSet[A]] =
-    new SortedSetOrder[A]
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedSet.catsKernelStdOrderForSortedSet")
+  private[instances] def catsKernelStdOrderForSortedSet[A: Order]: Order[SortedSet[A]] =
+    cats.kernel.instances.sortedSet.catsKernelStdOrderForSortedSet[A]
 }
 
 trait SortedSetInstances1 {
-  implicit def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
-    new SortedSetHash[A]
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet")
+  private[instances] def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
+    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A]
 
-  implicit def catsKernelStdSemilatticeForSortedSet[A: Order]: BoundedSemilattice[SortedSet[A]] =
-    new SortedSetSemilattice[A]
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedSet.catsKernelStdSemilatticeForSortedSet")
+  private[instances] def catsKernelStdSemilatticeForSortedSet[A: Order]: BoundedSemilattice[SortedSet[A]] =
+    cats.kernel.instances.sortedSet.catsKernelStdBoundedSemilatticeForSortedSet[A]
 }
 
 trait SortedSetInstancesBinCompat0 {
@@ -90,43 +91,27 @@ trait SortedSetInstancesBinCompat0 {
   }
 }
 
-class SortedSetOrder[A: Order] extends Order[SortedSet[A]] {
-  def compare(a1: SortedSet[A], a2: SortedSet[A]): Int =
-    Order[Int].compare(a1.size, a2.size) match {
-      case 0 => StaticMethods.iteratorCompare(a1.iterator, a2.iterator)
-      case x => x
-    }
-
-  override def eqv(s1: SortedSet[A], s2: SortedSet[A]): Boolean =
-    StaticMethods.iteratorEq(s1.iterator, s2.iterator)
+trait SortedSetInstancesBinCompat1 extends LowPrioritySortedSetInstancesBinCompat1 {
+  // TODO: Remove when this is no longer necessary for binary compatibility.
+  implicit override def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
+    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A]
 }
 
-class SortedSetHash[A: Order: Hash] extends Hash[SortedSet[A]] {
-  import scala.util.hashing.MurmurHash3._
+private[instances] trait LowPrioritySortedSetInstancesBinCompat1
+    extends cats.kernel.instances.SortedSetInstances
+    with SortedSetInstances {
+  implicit override def catsKernelStdOrderForSortedSet[A: Order]: Order[SortedSet[A]] =
+    cats.kernel.instances.sortedSet.catsKernelStdOrderForSortedSet[A]
 
-  // adapted from [[scala.util.hashing.MurmurHash3]],
-  // but modified standard `Any#hashCode` to `ev.hash`.
-  def hash(xs: SortedSet[A]): Int = {
-    var a, b, n = 0
-    var c = 1
-    xs.foreach { x =>
-      val h = Hash[A].hash(x)
-      a += h
-      b ^= h
-      c = cats.kernel.instances.StaticMethods.updateUnorderedHashC(c, h)
-      n += 1
-    }
-    var h = setSeed
-    h = mix(h, a)
-    h = mix(h, b)
-    h = mixLast(h, c)
-    finalizeHash(h, n)
-  }
-  override def eqv(s1: SortedSet[A], s2: SortedSet[A]): Boolean =
-    StaticMethods.iteratorEq(s1.iterator, s2.iterator)(Order[A])
+  override def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
+    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A]
 }
 
-class SortedSetSemilattice[A: Order] extends BoundedSemilattice[SortedSet[A]] {
-  def empty: SortedSet[A] = SortedSet.empty(implicitly[Order[A]].toOrdering)
-  def combine(x: SortedSet[A], y: SortedSet[A]): SortedSet[A] = x | y
-}
+@deprecated("2.0.0-RC2", "Use cats.kernel.instances.SortedSetHash")
+class SortedSetHash[A: Order: Hash] extends cats.kernel.instances.SortedSetHash[A]
+
+@deprecated("2.0.0-RC2", "Use cats.kernel.instances.SortedSetOrder")
+class SortedSetOrder[A: Order] extends cats.kernel.instances.SortedSetOrder[A]
+
+@deprecated("2.0.0-RC2", "Use cats.kernel.instances.SortedSetSemilattice")
+class SortedSetSemilattice[A: Order] extends cats.kernel.instances.SortedSetSemilattice[A]

--- a/core/src/main/scala/cats/instances/tuple.scala
+++ b/core/src/main/scala/cats/instances/tuple.scala
@@ -7,7 +7,7 @@ import scala.annotation.tailrec
 
 trait TupleInstances extends Tuple2Instances with cats.kernel.instances.TupleInstances
 
-trait Tuple2InstancesBinCompat0 {
+private[instances] trait Tuple2InstancesBinCompat0 {
 
   /**
    * Witness for: (A, A) <-> Boolean => A
@@ -31,7 +31,7 @@ trait Tuple2InstancesBinCompat0 {
   }
 }
 
-sealed trait Tuple2Instances extends Tuple2Instances1 {
+sealed private[instances] trait Tuple2Instances extends Tuple2Instances1 {
   implicit val catsStdBitraverseForTuple2: Bitraverse[Tuple2] =
     new Bitraverse[Tuple2] {
       def bitraverse[G[_]: Applicative, A, B, C, D](fab: (A, B))(f: A => G[C], g: B => G[D]): G[(C, D)] =
@@ -103,26 +103,26 @@ sealed trait Tuple2Instances extends Tuple2Instances1 {
     }
 }
 
-sealed trait Tuple2Instances1 extends Tuple2Instances2 {
+sealed private[instances] trait Tuple2Instances1 extends Tuple2Instances2 {
   implicit def catsStdCommutativeMonadForTuple2[X](implicit MX: CommutativeMonoid[X]): CommutativeMonad[(X, *)] =
     new FlatMapTuple2[X](MX) with CommutativeMonad[(X, *)] {
       def pure[A](a: A): (X, A) = (MX.empty, a)
     }
 }
 
-sealed trait Tuple2Instances2 extends Tuple2Instances3 {
+sealed private[instances] trait Tuple2Instances2 extends Tuple2Instances3 {
   implicit def catsStdCommutativeFlatMapForTuple2[X](implicit MX: CommutativeSemigroup[X]): CommutativeFlatMap[(X, *)] =
     new FlatMapTuple2[X](MX) with CommutativeFlatMap[(X, *)]
 }
 
-sealed trait Tuple2Instances3 extends Tuple2Instances4 {
+sealed private[instances] trait Tuple2Instances3 extends Tuple2Instances4 {
   implicit def catsStdMonadForTuple2[X](implicit MX: Monoid[X]): Monad[(X, *)] =
     new FlatMapTuple2[X](MX) with Monad[(X, *)] {
       def pure[A](a: A): (X, A) = (MX.empty, a)
     }
 }
 
-sealed trait Tuple2Instances4 {
+sealed private[instances] trait Tuple2Instances4 {
   implicit def catsStdFlatMapForTuple2[X](implicit SX: Semigroup[X]): FlatMap[(X, *)] =
     new FlatMapTuple2[X](SX)
 }

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -122,7 +122,7 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
     }
 }
 
-trait VectorInstancesBinCompat0 {
+private[instances] trait VectorInstancesBinCompat0 {
   implicit val catsStdTraverseFilterForVector: TraverseFilter[Vector] = new TraverseFilter[Vector] {
     val traverse: Traverse[Vector] = cats.instances.vector.catsStdInstancesForVector
 

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -1,7 +1,7 @@
 package cats
 package syntax
 
-abstract class AllSyntaxBinCompat
+abstract private[syntax] class AllSyntaxBinCompat
     extends AllSyntax
     with AllSyntaxBinCompat0
     with AllSyntaxBinCompat1
@@ -59,9 +59,9 @@ trait AllSyntax
     with VectorSyntax
     with WriterSyntax
 
-trait AllSyntaxBinCompat0 extends UnorderedTraverseSyntax with ApplicativeErrorExtension with TrySyntax
+private[cats] trait AllSyntaxBinCompat0 extends UnorderedTraverseSyntax with ApplicativeErrorExtension with TrySyntax
 
-trait AllSyntaxBinCompat1
+private[cats] trait AllSyntaxBinCompat1
     extends FlatMapOptionSyntax
     with ChoiceSyntax
     with NestedSyntax
@@ -71,7 +71,7 @@ trait AllSyntaxBinCompat1
     with ValidatedExtensionSyntax
     with RepresentableSyntax
 
-trait AllSyntaxBinCompat2
+private[cats] trait AllSyntaxBinCompat2
     extends ParallelTraverseSyntax
     with TraverseFilterSyntax
     with FunctorFilterSyntax
@@ -79,9 +79,9 @@ trait AllSyntaxBinCompat2
     with ListSyntaxBinCompat0
     with ValidatedSyntaxBincompat0
 
-trait AllSyntaxBinCompat3 extends UnorderedFoldableSyntax with Function1Syntax
+private[cats] trait AllSyntaxBinCompat3 extends UnorderedFoldableSyntax with Function1Syntax
 
-trait AllSyntaxBinCompat4
+private[cats] trait AllSyntaxBinCompat4
     extends TraverseFilterSyntaxBinCompat0
     with ApplySyntaxBinCompat0
     with ParallelApplySyntax
@@ -90,6 +90,6 @@ trait AllSyntaxBinCompat4
     with FoldableSyntaxBinCompat1
     with BitraverseSyntaxBinCompat0
 
-trait AllSyntaxBinCompat5 extends ParallelBitraverseSyntax
+private[cats] trait AllSyntaxBinCompat5 extends ParallelBitraverseSyntax
 
-trait AllSyntaxBinCompat6 extends ParallelUnorderedTraverseSyntax
+private[cats] trait AllSyntaxBinCompat6 extends ParallelUnorderedTraverseSyntax

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -1,7 +1,7 @@
 package cats
 package syntax
 
-abstract private[syntax] class AllSyntaxBinCompat
+abstract private[cats] class AllSyntaxBinCompat
     extends AllSyntax
     with AllSyntaxBinCompat0
     with AllSyntaxBinCompat1

--- a/core/src/main/scala/cats/syntax/apply.scala
+++ b/core/src/main/scala/cats/syntax/apply.scala
@@ -14,7 +14,7 @@ trait ApplySyntax extends TupleSemigroupalSyntax {
     new ApplyOps(fa)
 }
 
-trait ApplySyntaxBinCompat0 {
+private[syntax] trait ApplySyntaxBinCompat0 {
   implicit final def catsSyntaxIfApplyOps[F[_]](fa: F[Boolean]): IfApplyOps[F] =
     new IfApplyOps[F](fa)
 }

--- a/core/src/main/scala/cats/syntax/bitraverse.scala
+++ b/core/src/main/scala/cats/syntax/bitraverse.scala
@@ -23,7 +23,7 @@ final class NestedBitraverseOps[F[_, _], G[_], A, B](private val fgagb: F[G[A], 
     F.bisequence(fgagb)
 }
 
-trait BitraverseSyntaxBinCompat0 {
+private[syntax] trait BitraverseSyntaxBinCompat0 {
   implicit final def catsSyntaxBitraverseBinCompat0[F[_, _]: Bitraverse, A, B](
     fab: F[A, B]
   ): BitraverseOpsBinCompat0[F, A, B] =
@@ -34,7 +34,7 @@ trait BitraverseSyntaxBinCompat0 {
     new LeftNestedBitraverseOps[F, G, A, B](fgab)
 }
 
-final class BitraverseOpsBinCompat0[F[_, _], A, B](val fab: F[A, B]) extends AnyVal {
+final private[syntax] class BitraverseOpsBinCompat0[F[_, _], A, B](val fab: F[A, B]) extends AnyVal {
 
   /**
    *  Traverse over the left side of the structure.

--- a/core/src/main/scala/cats/syntax/either.scala
+++ b/core/src/main/scala/cats/syntax/either.scala
@@ -397,7 +397,7 @@ final class EitherIdOps[A](private val obj: A) extends AnyVal {
 
 }
 
-trait EitherSyntaxBinCompat0 {
+private[syntax] trait EitherSyntaxBinCompat0 {
   implicit final def catsSyntaxEitherBinCompat0[A, B](eab: Either[A, B]): EitherOpsBinCompat0[A, B] =
     new EitherOpsBinCompat0(eab)
 
@@ -432,7 +432,7 @@ final class EitherIdOpsBinCompat0[A](private val value: A) extends AnyVal {
   def rightNec[B]: Either[NonEmptyChain[B], A] = Right(value)
 }
 
-final class EitherOpsBinCompat0[A, B](private val value: Either[A, B]) extends AnyVal {
+final private[syntax] class EitherOpsBinCompat0[A, B](private val value: Either[A, B]) extends AnyVal {
 
   /** Returns a [[cats.data.ValidatedNec]] representation of this disjunction with the `Left` value
    * as a single element on the `Invalid` side of the [[cats.data.NonEmptyList]]. */

--- a/core/src/main/scala/cats/syntax/foldable.scala
+++ b/core/src/main/scala/cats/syntax/foldable.scala
@@ -9,12 +9,12 @@ trait FoldableSyntax extends Foldable.ToFoldableOps with UnorderedFoldable.ToUno
     new FoldableOps[F, A](fa)
 }
 
-trait FoldableSyntaxBinCompat0 {
+private[syntax] trait FoldableSyntaxBinCompat0 {
   implicit final def catsSyntaxFoldableOps0[F[_], A](fa: F[A]): FoldableOps0[F, A] =
     new FoldableOps0[F, A](fa)
 }
 
-trait FoldableSyntaxBinCompat1 {
+private[syntax] trait FoldableSyntaxBinCompat1 {
   implicit final def catsSyntaxFoldableBinCompat0[F[_]](fa: Foldable[F]): FoldableOps1[F] =
     new FoldableOps1(fa)
 }
@@ -305,7 +305,7 @@ final class FoldableOps0[F[_], A](private val fa: F[A]) extends AnyVal {
   }
 }
 
-final class FoldableOps1[F[_]](private val F: Foldable[F]) extends AnyVal {
+final private[syntax] class FoldableOps1[F[_]](private val F: Foldable[F]) extends AnyVal {
 
   /**
    * Separate this Foldable into a Tuple by a separating function `A => H[B, C]` for some `Bifoldable[H]`

--- a/core/src/main/scala/cats/syntax/list.scala
+++ b/core/src/main/scala/cats/syntax/list.scala
@@ -50,11 +50,11 @@ final class ListOps[A](private val la: List[A]) extends AnyVal {
   }
 }
 
-trait ListSyntaxBinCompat0 {
+private[syntax] trait ListSyntaxBinCompat0 {
   implicit final def catsSyntaxListBinCompat0[A](la: List[A]): ListOpsBinCompat0[A] = new ListOpsBinCompat0(la)
 }
 
-final class ListOpsBinCompat0[A](private val la: List[A]) extends AnyVal {
+final private[syntax] class ListOpsBinCompat0[A](private val la: List[A]) extends AnyVal {
 
   /**
    * Groups elements inside this `List` according to the `Order` of the keys

--- a/core/src/main/scala/cats/syntax/reducible.scala
+++ b/core/src/main/scala/cats/syntax/reducible.scala
@@ -10,7 +10,7 @@ final class NestedReducibleOps[F[_], G[_], A](private val fga: F[G[A]]) extends 
   def reduceK(implicit F: Reducible[F], G: SemigroupK[G]): G[A] = F.reduceK(fga)
 }
 
-trait ReducibleSyntaxBinCompat0 {
+private[syntax] trait ReducibleSyntaxBinCompat0 {
   implicit final def catsSyntaxReducibleOps0[F[_], A](fa: F[A]): ReducibleOps0[F, A] =
     new ReducibleOps0[F, A](fa)
 }

--- a/core/src/main/scala/cats/syntax/traverseFilter.scala
+++ b/core/src/main/scala/cats/syntax/traverseFilter.scala
@@ -3,7 +3,7 @@ package syntax
 
 trait TraverseFilterSyntax extends TraverseFilter.ToTraverseFilterOps
 
-trait TraverseFilterSyntaxBinCompat0 {
+private[syntax] trait TraverseFilterSyntaxBinCompat0 {
   implicit def toSequenceFilterOps[F[_], G[_], A](fgoa: F[G[Option[A]]]): SequenceFilterOps[F, G, A] =
     new SequenceFilterOps(fgoa)
 }

--- a/core/src/main/scala/cats/syntax/validated.scala
+++ b/core/src/main/scala/cats/syntax/validated.scala
@@ -24,7 +24,7 @@ final class ValidatedExtension[E, A](private val self: Validated[E, A]) extends 
     new ApplicativeErrorExtensionOps(F).fromValidated(self)
 }
 
-trait ValidatedSyntaxBincompat0 {
+private[syntax] trait ValidatedSyntaxBincompat0 {
   implicit final def catsSyntaxValidatedIdBinCompat0[A](a: A): ValidatedIdOpsBinCompat0[A] =
     new ValidatedIdOpsBinCompat0(a)
 }

--- a/docs/src/main/tut/guidelines.md
+++ b/docs/src/main/tut/guidelines.md
@@ -80,7 +80,7 @@ therefore name our implicits according to the following rules:
 - If the instance is for multiple type classes, use `InstancesFor` instead of a type class name.
 - If the instance is for a standard library type add `Std` after the package. i.e. `catsStdShowForVector` and `catsKernelStdGroupForTuple`.
 
-As an example, an implicit instance of `Monoid` for `List` defined in the package `Kernel` should be named `catsKernelMonoidForList`.
+As an example, an implicit instance of `Monoid` for `List` defined in the package `Kernel` should be named `catsKernelStdMonoidForList`.
 
 This rule is relatively flexible. Use what you see appropriate. The goal is to maintain uniqueness and avoid conflicts.
 

--- a/kernel/src/main/scala-2.12-/cats/kernel/instances/AllInstances.scala
+++ b/kernel/src/main/scala-2.12-/cats/kernel/instances/AllInstances.scala
@@ -35,4 +35,4 @@ trait AllInstances
 
 trait AllInstancesBinCompat0 extends FiniteDurationInstances
 
-trait AllInstancesBinCompat1 extends SortedMapInstances with SortedSetInstances
+trait AllInstancesBinCompat1 extends SortedMapInstances with SortedSetInstances with EitherInstancesBinCompat0

--- a/kernel/src/main/scala-2.12-/cats/kernel/instances/AllInstances.scala
+++ b/kernel/src/main/scala-2.12-/cats/kernel/instances/AllInstances.scala
@@ -33,9 +33,9 @@ trait AllInstances
     with UUIDInstances
     with VectorInstances
 
-trait AllInstancesBinCompat0 extends FiniteDurationInstances
+private[instances] trait AllInstancesBinCompat0 extends FiniteDurationInstances
 
-trait AllInstancesBinCompat1
+private[instances] trait AllInstancesBinCompat1
     extends SortedMapInstances
     with SortedSetInstances
     with EitherInstancesBinCompat0

--- a/kernel/src/main/scala-2.12-/cats/kernel/instances/AllInstances.scala
+++ b/kernel/src/main/scala-2.12-/cats/kernel/instances/AllInstances.scala
@@ -34,3 +34,5 @@ trait AllInstances
     with VectorInstances
 
 trait AllInstancesBinCompat0 extends FiniteDurationInstances
+
+trait AllInstancesBinCompat1 extends SortedMapInstances with SortedSetInstances

--- a/kernel/src/main/scala-2.12-/cats/kernel/instances/AllInstances.scala
+++ b/kernel/src/main/scala-2.12-/cats/kernel/instances/AllInstances.scala
@@ -35,4 +35,8 @@ trait AllInstances
 
 trait AllInstancesBinCompat0 extends FiniteDurationInstances
 
-trait AllInstancesBinCompat1 extends SortedMapInstances with SortedSetInstances with EitherInstancesBinCompat0
+trait AllInstancesBinCompat1
+    extends SortedMapInstances
+    with SortedSetInstances
+    with EitherInstancesBinCompat0
+    with FunctionInstancesBinCompat0

--- a/kernel/src/main/scala-2.13+/cats/kernel/instances/AllInstances.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/instances/AllInstances.scala
@@ -36,4 +36,4 @@ trait AllInstances
 
 trait AllInstancesBinCompat0 extends FiniteDurationInstances
 
-trait AllInstancesBinCompat1 extends SortedMapInstances with SortedSetInstances
+trait AllInstancesBinCompat1 extends SortedMapInstances with SortedSetInstances with EitherInstancesBinCompat0

--- a/kernel/src/main/scala-2.13+/cats/kernel/instances/AllInstances.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/instances/AllInstances.scala
@@ -36,4 +36,8 @@ trait AllInstances
 
 trait AllInstancesBinCompat0 extends FiniteDurationInstances
 
-trait AllInstancesBinCompat1 extends SortedMapInstances with SortedSetInstances with EitherInstancesBinCompat0
+trait AllInstancesBinCompat1
+    extends SortedMapInstances
+    with SortedSetInstances
+    with EitherInstancesBinCompat0
+    with FunctionInstancesBinCompat0

--- a/kernel/src/main/scala-2.13+/cats/kernel/instances/AllInstances.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/instances/AllInstances.scala
@@ -35,3 +35,5 @@ trait AllInstances
     with VectorInstances
 
 trait AllInstancesBinCompat0 extends FiniteDurationInstances
+
+trait AllInstancesBinCompat1 extends SortedMapInstances with SortedSetInstances

--- a/kernel/src/main/scala-2.13+/cats/kernel/instances/AllInstances.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/instances/AllInstances.scala
@@ -34,9 +34,9 @@ trait AllInstances
     with UUIDInstances
     with VectorInstances
 
-trait AllInstancesBinCompat0 extends FiniteDurationInstances
+private[instances] trait AllInstancesBinCompat0 extends FiniteDurationInstances
 
-trait AllInstancesBinCompat1
+private[instances] trait AllInstancesBinCompat1
     extends SortedMapInstances
     with SortedSetInstances
     with EitherInstancesBinCompat0

--- a/kernel/src/main/scala/cats/kernel/Hash.scala
+++ b/kernel/src/main/scala/cats/kernel/Hash.scala
@@ -55,7 +55,13 @@ object Hash extends HashFunctions[Hash] {
 }
 
 trait HashToHashingConversion {
-  implicit def catsKernelHashToHashing[A](implicit ev: Hash[A]): Hashing[A] = new Hashing[A] {
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.hash.catsKernelHashingForHash")
+  private[kernel] def catsKernelHashToHashing[A](implicit ev: Hash[A]): Hashing[A] =
+    cats.kernel.instances.hash.catsKernelHashingForHash[A]
+}
+
+private[kernel] trait HashToHashingConversionBinCompat0 {
+  implicit def catsKernelHashingForHash[A](implicit ev: Hash[A]): Hashing[A] = new Hashing[A] {
     override def hash(x: A): Int = ev.hash(x)
   }
 }

--- a/kernel/src/main/scala/cats/kernel/instances/EitherInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/EitherInstances.scala
@@ -2,8 +2,19 @@ package cats.kernel
 package instances
 
 trait EitherInstances extends EitherInstances0 {
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.either.catsKernelStdOrderForEither")
+  private[instances] def catsStdOrderForEither[A, B](implicit A: Order[A], B: Order[B]): Order[Either[A, B]] =
+    cats.kernel.instances.either.catsKernelStdOrderForEither[A, B]
 
-  implicit def catsStdOrderForEither[A, B](implicit A: Order[A], B: Order[B]): Order[Either[A, B]] =
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.either.catsKernelStdMonoidForEither")
+  private[instances] def catsDataMonoidForEither[A, B](implicit B: Monoid[B]): Monoid[Either[A, B]] =
+    cats.kernel.instances.either.catsKernelStdMonoidForEither[A, B]
+
+}
+
+private[instances] trait EitherInstancesBinCompat0 extends EitherInstances0BinCompat0 {
+
+  implicit def catsKernelStdOrderForEither[A, B](implicit A: Order[A], B: Order[B]): Order[Either[A, B]] =
     new Order[Either[A, B]] {
       def compare(x: Either[A, B], y: Either[A, B]): Int =
         x match {
@@ -20,7 +31,7 @@ trait EitherInstances extends EitherInstances0 {
         }
     }
 
-  implicit def catsDataMonoidForEither[A, B](implicit B: Monoid[B]): Monoid[Either[A, B]] =
+  implicit def catsKernelStdMonoidForEither[A, B](implicit B: Monoid[B]): Monoid[Either[A, B]] =
     new Monoid[Either[A, B]] {
       def empty: Either[A, B] =
         Right(B.empty)
@@ -38,7 +49,23 @@ trait EitherInstances extends EitherInstances0 {
 
 trait EitherInstances0 extends EitherInstances1 {
 
-  implicit def catsDataSemigroupForEither[A, B](implicit B: Semigroup[B]): Semigroup[Either[A, B]] =
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.either.catsKernelStdMonoidForEither")
+  private[instances] def catsDataSemigroupForEither[A, B](implicit B: Semigroup[B]): Semigroup[Either[A, B]] =
+    cats.kernel.instances.either.catsKernelStdSemigroupForEither[A, B]
+
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.either.catsKernelStdPartialOrderForEither")
+  private[instances] def catsStdPartialOrderForEither[A, B](implicit A: PartialOrder[A],
+                                                            B: PartialOrder[B]): PartialOrder[Either[A, B]] =
+    cats.kernel.instances.either.catsKernelStdPartialOrderForEither[A, B]
+
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.either.catsKernelStdHashForEither")
+  private[instances] def catsStdHashForEither[A, B](implicit A: Hash[A], B: Hash[B]): Hash[Either[A, B]] =
+    cats.kernel.instances.either.catsKernelStdHashForEither[A, B]
+}
+
+private[instances] trait EitherInstances0BinCompat0 extends EitherInstances1BinCompat0 {
+
+  implicit def catsKernelStdSemigroupForEither[A, B](implicit B: Semigroup[B]): Semigroup[Either[A, B]] =
     new Semigroup[Either[A, B]] {
       def combine(x: Either[A, B], y: Either[A, B]): Either[A, B] =
         x match {
@@ -51,8 +78,8 @@ trait EitherInstances0 extends EitherInstances1 {
         }
     }
 
-  implicit def catsStdPartialOrderForEither[A, B](implicit A: PartialOrder[A],
-                                                  B: PartialOrder[B]): PartialOrder[Either[A, B]] =
+  implicit def catsKernelStdPartialOrderForEither[A, B](implicit A: PartialOrder[A],
+                                                        B: PartialOrder[B]): PartialOrder[Either[A, B]] =
     new PartialOrder[Either[A, B]] {
       def partialCompare(x: Either[A, B], y: Either[A, B]): Double =
         x match {
@@ -69,13 +96,20 @@ trait EitherInstances0 extends EitherInstances1 {
         }
     }
 
-  implicit def catsStdHashForEither[A, B](implicit A: Hash[A], B: Hash[B]): Hash[Either[A, B]] = new EitherHash[A, B]
+  implicit def catsKernelStdHashForEither[A, B](implicit A: Hash[A], B: Hash[B]): Hash[Either[A, B]] =
+    new EitherHash[A, B]
 }
 
 trait EitherInstances1 {
 
-  implicit def catsStdEqForEither[A, B](implicit A: Eq[A], B: Eq[B]): Eq[Either[A, B]] = new EitherEq[A, B]
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.either.catsKernelStdHashForEither")
+  private[instances] def catsStdEqForEither[A, B](implicit A: Eq[A], B: Eq[B]): Eq[Either[A, B]] =
+    cats.kernel.instances.either.catsKernelStdEqForEither[A, B]
 
+}
+
+private[instances] trait EitherInstances1BinCompat0 {
+  implicit def catsKernelStdEqForEither[A, B](implicit A: Eq[A], B: Eq[B]): Eq[Either[A, B]] = new EitherEq[A, B]
 }
 
 // isolated class for inheritance

--- a/kernel/src/main/scala/cats/kernel/instances/EitherInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/EitherInstances.scala
@@ -12,7 +12,7 @@ trait EitherInstances extends EitherInstances0 {
 
 }
 
-private[instances] trait EitherInstancesBinCompat0 extends EitherInstances0BinCompat0 {
+private[cats] trait EitherInstancesBinCompat0 extends EitherInstances0BinCompat0 {
   implicit def catsKernelStdOrderForEither[A, B](implicit A: Order[A], B: Order[B]): Order[Either[A, B]] =
     new Order[Either[A, B]] {
       def compare(x: Either[A, B], y: Either[A, B]): Int =

--- a/kernel/src/main/scala/cats/kernel/instances/EitherInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/EitherInstances.scala
@@ -13,7 +13,6 @@ trait EitherInstances extends EitherInstances0 {
 }
 
 private[instances] trait EitherInstancesBinCompat0 extends EitherInstances0BinCompat0 {
-
   implicit def catsKernelStdOrderForEither[A, B](implicit A: Order[A], B: Order[B]): Order[Either[A, B]] =
     new Order[Either[A, B]] {
       def compare(x: Either[A, B], y: Either[A, B]): Int =
@@ -48,7 +47,6 @@ private[instances] trait EitherInstancesBinCompat0 extends EitherInstances0BinCo
 }
 
 trait EitherInstances0 extends EitherInstances1 {
-
   @deprecated("2.0.0-RC2", "Use cats.kernel.instances.either.catsKernelStdMonoidForEither")
   private[instances] def catsDataSemigroupForEither[A, B](implicit B: Semigroup[B]): Semigroup[Either[A, B]] =
     cats.kernel.instances.either.catsKernelStdSemigroupForEither[A, B]

--- a/kernel/src/main/scala/cats/kernel/instances/FunctionInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/FunctionInstances.scala
@@ -37,7 +37,7 @@ private[instances] trait FunctionInstancesBinCompat0 extends FunctionInstances0B
     new Function1Group[A, B] with CommutativeGroup[A => B] { def B: Group[B] = G }
 }
 
-trait FunctionInstances0 extends FunctionInstances1 {
+private[instances] trait FunctionInstances0 extends FunctionInstances1 {
 
   @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdHashForFunction0")
   private[instances] def catsKernelHashForFunction0[A](implicit ev: Hash[A]): Hash[() => A] =
@@ -96,7 +96,7 @@ private[instances] trait FunctionInstances0BinCompat0 extends FunctionInstances1
     new Function1Monoid[A, B] with BoundedSemilattice[A => B] { def B: Monoid[B] = G }
 }
 
-trait FunctionInstances1 extends FunctionInstances2 {
+private[instances] trait FunctionInstances1 extends FunctionInstances2 {
 
   @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdEqForFunction0")
   private[instances] def catsKernelEqForFunction0[A](implicit ev: Eq[A]): Eq[() => A] =
@@ -144,7 +144,7 @@ private[instances] trait FunctionInstances1BinCompat0 extends FunctionInstances2
     new Function1Semigroup[A, B] with Semilattice[A => B] { def B: Semigroup[B] = M }
 }
 
-trait FunctionInstances2 extends FunctionInstances3 {
+private[instances] trait FunctionInstances2 extends FunctionInstances3 {
 
   @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdMonoidForFunction0")
   private[instances] def catsKernelMonoidForFunction0[A](implicit M: Monoid[A]): Monoid[() => A] =
@@ -178,7 +178,7 @@ private[instances] trait FunctionInstances2BinCompat0 extends FunctionInstances3
     new Function1Semigroup[A, B] with Band[A => B] { def B: Semigroup[B] = S }
 }
 
-trait FunctionInstances3 extends FunctionInstances4 {
+private[instances] trait FunctionInstances3 extends FunctionInstances4 {
 
   @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdCommutativeSemigroupForFunction0")
   private[instances] def catsKernelCommutativeSemigroupForFunction0[A](
@@ -205,7 +205,7 @@ private[instances] trait FunctionInstances3BinCompat0 extends FunctionInstances4
     new Function1Semigroup[A, B] with CommutativeSemigroup[A => B] { def B: Semigroup[B] = S }
 }
 
-trait FunctionInstances4 {
+private[instances] trait FunctionInstances4 {
 
   @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdSemigroupForFunction0")
   private[instances] def catsKernelSemigroupForFunction0[A](implicit S: Semigroup[A]): Semigroup[() => A] =

--- a/kernel/src/main/scala/cats/kernel/instances/FunctionInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/FunctionInstances.scala
@@ -19,7 +19,7 @@ trait FunctionInstances extends FunctionInstances0 {
 
 }
 
-private[instances] trait FunctionInstancesBinCompat0 extends FunctionInstances0BinCompat0 {
+private[cats] trait FunctionInstancesBinCompat0 extends FunctionInstances0BinCompat0 {
 
   implicit def catsKernelStdOrderForFunction0[A](implicit ev: Order[A]): Order[() => A] =
     new Order[() => A] {

--- a/kernel/src/main/scala/cats/kernel/instances/FunctionInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/FunctionInstances.scala
@@ -3,43 +3,94 @@ package instances
 
 trait FunctionInstances extends FunctionInstances0 {
 
-  implicit def catsKernelOrderForFunction0[A](implicit ev: Order[A]): Order[() => A] =
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdOrderForFunction0")
+  private[instances] def catsKernelOrderForFunction0[A](implicit ev: Order[A]): Order[() => A] =
+    cats.kernel.instances.function.catsKernelStdOrderForFunction0[A]
+
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdCommutativeGroupForFunction0")
+  private[instances] def catsKernelCommutativeGroupForFunction0[A](
+    implicit G: CommutativeGroup[A]
+  ): CommutativeGroup[() => A] = cats.kernel.instances.function.catsKernelStdCommutativeGroupForFunction0[A]
+
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdCommutativeGroupForFunction1")
+  private[instances] def catsKernelCommutativeGroupForFunction1[A, B](
+    implicit G: CommutativeGroup[B]
+  ): CommutativeGroup[A => B] = cats.kernel.instances.function.catsKernelStdCommutativeGroupForFunction1[A, B]
+
+}
+
+private[instances] trait FunctionInstancesBinCompat0 extends FunctionInstances0BinCompat0 {
+
+  implicit def catsKernelStdOrderForFunction0[A](implicit ev: Order[A]): Order[() => A] =
     new Order[() => A] {
       def compare(x: () => A, y: () => A): Int = ev.compare(x(), y())
     }
 
-  implicit def catsKernelCommutativeGroupForFunction0[A](implicit G: CommutativeGroup[A]): CommutativeGroup[() => A] =
+  implicit def catsKernelStdCommutativeGroupForFunction0[A](
+    implicit G: CommutativeGroup[A]
+  ): CommutativeGroup[() => A] =
     new Function0Group[A] with CommutativeGroup[() => A] { def A: Group[A] = G }
 
-  implicit def catsKernelCommutativeGroupForFunction1[A, B](implicit G: CommutativeGroup[B]): CommutativeGroup[A => B] =
+  implicit def catsKernelStdCommutativeGroupForFunction1[A, B](
+    implicit G: CommutativeGroup[B]
+  ): CommutativeGroup[A => B] =
     new Function1Group[A, B] with CommutativeGroup[A => B] { def B: Group[B] = G }
 }
 
 trait FunctionInstances0 extends FunctionInstances1 {
 
-  implicit def catsKernelHashForFunction0[A](implicit ev: Hash[A]): Hash[() => A] =
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdHashForFunction0")
+  private[instances] def catsKernelHashForFunction0[A](implicit ev: Hash[A]): Hash[() => A] =
+    cats.kernel.instances.function.catsKernelStdHashForFunction0[A]
+
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdPartialOrderForFunction0")
+  private[instances] def catsKernelPartialOrderForFunction0[A](implicit ev: PartialOrder[A]): PartialOrder[() => A] =
+    cats.kernel.instances.function.catsKernelStdPartialOrderForFunction0[A]
+
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdGroupForFunction0")
+  private[instances] def catsKernelGroupForFunction0[A](implicit G: Group[A]): Group[() => A] =
+    cats.kernel.instances.function.catsKernelStdGroupForFunction0[A]
+
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdGroupForFunction1")
+  private[instances] def catsKernelGroupForFunction1[A, B](implicit G: Group[B]): Group[A => B] =
+    cats.kernel.instances.function.catsKernelStdGroupForFunction1[A, B]
+
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdBoundedSemilatticeForFunction0")
+  private[instances] def catsKernelBoundedSemilatticeForFunction0[A](
+    implicit G: BoundedSemilattice[A]
+  ): BoundedSemilattice[() => A] = cats.kernel.instances.function.catsKernelStdBoundedSemilatticeForFunction0[A]
+
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdBoundedSemilatticeForFunction1")
+  private[instances] def catsKernelBoundedSemilatticeForFunction1[A, B](
+    implicit G: BoundedSemilattice[B]
+  ): BoundedSemilattice[A => B] = cats.kernel.instances.function.catsKernelStdBoundedSemilatticeForFunction1[A, B]
+}
+
+private[instances] trait FunctionInstances0BinCompat0 extends FunctionInstances1BinCompat0 {
+
+  implicit def catsKernelStdHashForFunction0[A](implicit ev: Hash[A]): Hash[() => A] =
     new Hash[() => A] {
       def hash(x: () => A) = ev.hash(x())
       def eqv(x: () => A, y: () => A) = ev.eqv(x(), y())
     }
 
-  implicit def catsKernelPartialOrderForFunction0[A](implicit ev: PartialOrder[A]): PartialOrder[() => A] =
+  implicit def catsKernelStdPartialOrderForFunction0[A](implicit ev: PartialOrder[A]): PartialOrder[() => A] =
     new PartialOrder[() => A] {
       def partialCompare(x: () => A, y: () => A): Double = ev.partialCompare(x(), y())
     }
 
-  implicit def catsKernelGroupForFunction0[A](implicit G: Group[A]): Group[() => A] =
+  implicit def catsKernelStdGroupForFunction0[A](implicit G: Group[A]): Group[() => A] =
     new Function0Group[A] { def A: Group[A] = G }
 
-  implicit def catsKernelGroupForFunction1[A, B](implicit G: Group[B]): Group[A => B] =
+  implicit def catsKernelStdGroupForFunction1[A, B](implicit G: Group[B]): Group[A => B] =
     new Function1Group[A, B] { def B: Group[B] = G }
 
-  implicit def catsKernelBoundedSemilatticeForFunction0[A](
+  implicit def catsKernelStdBoundedSemilatticeForFunction0[A](
     implicit G: BoundedSemilattice[A]
   ): BoundedSemilattice[() => A] =
     new Function0Monoid[A] with BoundedSemilattice[() => A] { def A: Monoid[A] = G }
 
-  implicit def catsKernelBoundedSemilatticeForFunction1[A, B](
+  implicit def catsKernelStdBoundedSemilatticeForFunction1[A, B](
     implicit G: BoundedSemilattice[B]
   ): BoundedSemilattice[A => B] =
     new Function1Monoid[A, B] with BoundedSemilattice[A => B] { def B: Monoid[B] = G }
@@ -47,51 +98,108 @@ trait FunctionInstances0 extends FunctionInstances1 {
 
 trait FunctionInstances1 extends FunctionInstances2 {
 
-  implicit def catsKernelEqForFunction0[A](implicit ev: Eq[A]): Eq[() => A] =
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdEqForFunction0")
+  private[instances] def catsKernelEqForFunction0[A](implicit ev: Eq[A]): Eq[() => A] =
+    cats.kernel.instances.function.catsKernelStdEqForFunction0[A]
+
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdCommutativeMonoidForFunction0")
+  private[instances] def catsKernelCommutativeMonoidForFunction0[A](
+    implicit M: CommutativeMonoid[A]
+  ): CommutativeMonoid[() => A] = cats.kernel.instances.function.catsKernelStdCommutativeMonoidForFunction0[A]
+
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdCommutativeMonoidForFunction1")
+  private[instances] def catsKernelCommutativeMonoidForFunction1[A, B](
+    implicit M: CommutativeMonoid[B]
+  ): CommutativeMonoid[A => B] = cats.kernel.instances.function.catsKernelStdCommutativeMonoidForFunction1[A, B]
+
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdSemilatticeForFunction0")
+  private[instances] def catsKernelSemilatticeForFunction0[A](implicit M: Semilattice[A]): Semilattice[() => A] =
+    cats.kernel.instances.function.catsKernelStdSemilatticeForFunction0[A]
+
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdSemilatticeForFunction1")
+  private[instances] def catsKernelSemilatticeForFunction1[A, B](implicit M: Semilattice[B]): Semilattice[A => B] =
+    cats.kernel.instances.function.catsKernelStdSemilatticeForFunction1[A, B]
+}
+
+private[instances] trait FunctionInstances1BinCompat0 extends FunctionInstances2BinCompat0 {
+  implicit def catsKernelStdEqForFunction0[A](implicit ev: Eq[A]): Eq[() => A] =
     new Eq[() => A] {
       def eqv(x: () => A, y: () => A): Boolean = ev.eqv(x(), y())
     }
 
-  implicit def catsKernelCommutativeMonoidForFunction0[A](
+  implicit def catsKernelStdCommutativeMonoidForFunction0[A](
     implicit M: CommutativeMonoid[A]
   ): CommutativeMonoid[() => A] =
     new Function0Monoid[A] with CommutativeMonoid[() => A] { def A: Monoid[A] = M }
 
-  implicit def catsKernelCommutativeMonoidForFunction1[A, B](
+  implicit def catsKernelStdCommutativeMonoidForFunction1[A, B](
     implicit M: CommutativeMonoid[B]
   ): CommutativeMonoid[A => B] =
     new Function1Monoid[A, B] with CommutativeMonoid[A => B] { def B: Monoid[B] = M }
 
-  implicit def catsKernelSemilatticeForFunction0[A](implicit M: Semilattice[A]): Semilattice[() => A] =
+  implicit def catsKernelStdSemilatticeForFunction0[A](implicit M: Semilattice[A]): Semilattice[() => A] =
     new Function0Semigroup[A] with Semilattice[() => A] { def A: Semigroup[A] = M }
 
-  implicit def catsKernelSemilatticeForFunction1[A, B](implicit M: Semilattice[B]): Semilattice[A => B] =
+  implicit def catsKernelStdSemilatticeForFunction1[A, B](implicit M: Semilattice[B]): Semilattice[A => B] =
     new Function1Semigroup[A, B] with Semilattice[A => B] { def B: Semigroup[B] = M }
 }
 
 trait FunctionInstances2 extends FunctionInstances3 {
 
-  implicit def catsKernelMonoidForFunction0[A](implicit M: Monoid[A]): Monoid[() => A] =
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdMonoidForFunction0")
+  private[instances] def catsKernelMonoidForFunction0[A](implicit M: Monoid[A]): Monoid[() => A] =
+    cats.kernel.instances.function.catsKernelStdMonoidForFunction0[A]
+
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdMonoidForFunction1")
+  private[instances] def catsKernelMonoidForFunction1[A, B](implicit M: Monoid[B]): Monoid[A => B] =
+    cats.kernel.instances.function.catsKernelStdMonoidForFunction1[A, B]
+
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdBandForFunction0")
+  private[instances] def catsKernelBandForFunction0[A](implicit S: Band[A]): Band[() => A] =
+    cats.kernel.instances.function.catsKernelStdBandForFunction0[A]
+
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdBandForFunction1")
+  private[instances] def catsKernelBandForFunction1[A, B](implicit S: Band[B]): Band[A => B] =
+    cats.kernel.instances.function.catsKernelStdBandForFunction1[A, B]
+}
+
+private[instances] trait FunctionInstances2BinCompat0 extends FunctionInstances3BinCompat0 {
+
+  implicit def catsKernelStdMonoidForFunction0[A](implicit M: Monoid[A]): Monoid[() => A] =
     new Function0Monoid[A] { def A: Monoid[A] = M }
 
-  implicit def catsKernelMonoidForFunction1[A, B](implicit M: Monoid[B]): Monoid[A => B] =
+  implicit def catsKernelStdMonoidForFunction1[A, B](implicit M: Monoid[B]): Monoid[A => B] =
     new Function1Monoid[A, B] { def B: Monoid[B] = M }
 
-  implicit def catsKernelBandForFunction0[A](implicit S: Band[A]): Band[() => A] =
+  implicit def catsKernelStdBandForFunction0[A](implicit S: Band[A]): Band[() => A] =
     new Function0Semigroup[A] with Band[() => A] { def A: Semigroup[A] = S }
 
-  implicit def catsKernelBandForFunction1[A, B](implicit S: Band[B]): Band[A => B] =
+  implicit def catsKernelStdBandForFunction1[A, B](implicit S: Band[B]): Band[A => B] =
     new Function1Semigroup[A, B] with Band[A => B] { def B: Semigroup[B] = S }
 }
 
 trait FunctionInstances3 extends FunctionInstances4 {
 
-  implicit def catsKernelCommutativeSemigroupForFunction0[A](
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdCommutativeSemigroupForFunction0")
+  private[instances] def catsKernelCommutativeSemigroupForFunction0[A](
+    implicit S: CommutativeSemigroup[A]
+  ): CommutativeSemigroup[() => A] = cats.kernel.instances.function.catsKernelStdCommutativeSemigroupForFunction0[A]
+
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdCommutativeSemigroupForFunction1")
+  private[instances] def catsKernelCommutativeSemigroupForFunction1[A, B](
+    implicit S: CommutativeSemigroup[B]
+  ): CommutativeSemigroup[A => B] = cats.kernel.instances.function.catsKernelStdCommutativeSemigroupForFunction1[A, B]
+
+}
+
+private[instances] trait FunctionInstances3BinCompat0 extends FunctionInstances4BinCompat0 {
+
+  implicit def catsKernelStdCommutativeSemigroupForFunction0[A](
     implicit S: CommutativeSemigroup[A]
   ): CommutativeSemigroup[() => A] =
     new Function0Semigroup[A] with CommutativeSemigroup[() => A] { def A: Semigroup[A] = S }
 
-  implicit def catsKernelCommutativeSemigroupForFunction1[A, B](
+  implicit def catsKernelStdCommutativeSemigroupForFunction1[A, B](
     implicit S: CommutativeSemigroup[B]
   ): CommutativeSemigroup[A => B] =
     new Function1Semigroup[A, B] with CommutativeSemigroup[A => B] { def B: Semigroup[B] = S }
@@ -99,10 +207,21 @@ trait FunctionInstances3 extends FunctionInstances4 {
 
 trait FunctionInstances4 {
 
-  implicit def catsKernelSemigroupForFunction0[A](implicit S: Semigroup[A]): Semigroup[() => A] =
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdSemigroupForFunction0")
+  private[instances] def catsKernelSemigroupForFunction0[A](implicit S: Semigroup[A]): Semigroup[() => A] =
+    cats.kernel.instances.function.catsKernelStdSemigroupForFunction0[A]
+
+  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.function.catsKernelStdSemigroupForFunction1")
+  private[instances] def catsKernelSemigroupForFunction1[A, B](implicit S: Semigroup[B]): Semigroup[A => B] =
+    cats.kernel.instances.function.catsKernelStdSemigroupForFunction1[A, B]
+}
+
+private[instances] trait FunctionInstances4BinCompat0 {
+
+  implicit def catsKernelStdSemigroupForFunction0[A](implicit S: Semigroup[A]): Semigroup[() => A] =
     new Function0Semigroup[A] { def A: Semigroup[A] = S }
 
-  implicit def catsKernelSemigroupForFunction1[A, B](implicit S: Semigroup[B]): Semigroup[A => B] =
+  implicit def catsKernelStdSemigroupForFunction1[A, B](implicit S: Semigroup[B]): Semigroup[A => B] =
     new Function1Semigroup[A, B] { def B: Semigroup[B] = S }
 }
 

--- a/kernel/src/main/scala/cats/kernel/instances/ListInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/ListInstances.scala
@@ -12,7 +12,7 @@ trait ListInstances extends ListInstances1 {
     new ListMonoid[A]
 }
 
-trait ListInstances1 extends ListInstances2 {
+private[instances] trait ListInstances1 extends ListInstances2 {
   implicit def catsKernelStdPartialOrderForList[A: PartialOrder]: PartialOrder[List[A]] =
     new ListPartialOrder[A]
 
@@ -20,7 +20,7 @@ trait ListInstances1 extends ListInstances2 {
     new ListHash[A]
 }
 
-trait ListInstances2 {
+private[instances] trait ListInstances2 {
   implicit def catsKernelStdEqForList[A: Eq]: Eq[List[A]] =
     new ListEq[A]
 }

--- a/kernel/src/main/scala/cats/kernel/instances/MapInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/MapInstances.scala
@@ -13,7 +13,7 @@ trait MapInstances extends MapInstances1 {
     new MapMonoid[K, V] with CommutativeMonoid[Map[K, V]]
 }
 
-trait MapInstances1 {
+private[instances] trait MapInstances1 {
   implicit def catsKernelStdEqForMap[K, V: Eq]: Eq[Map[K, V]] =
     new MapEq[K, V]
   implicit def catsKernelStdMonoidForMap[K, V: Semigroup]: Monoid[Map[K, V]] =

--- a/kernel/src/main/scala/cats/kernel/instances/OptionInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/OptionInstances.scala
@@ -8,17 +8,17 @@ trait OptionInstances extends OptionInstances0 {
     new OptionMonoid[A]
 }
 
-trait OptionInstances0 extends OptionInstances1 {
+private[instances] trait OptionInstances0 extends OptionInstances1 {
   implicit def catsKernelStdPartialOrderForOption[A: PartialOrder]: PartialOrder[Option[A]] =
     new OptionPartialOrder[A]
 }
 
-trait OptionInstances1 extends OptionInstances2 {
+private[instances] trait OptionInstances1 extends OptionInstances2 {
   implicit def catsKernelStdHashForOption[A: Hash]: Hash[Option[A]] =
     new OptionHash[A]
 }
 
-trait OptionInstances2 {
+private[instances] trait OptionInstances2 {
   implicit def catsKernelStdEqForOption[A: Eq]: Eq[Option[A]] =
     new OptionEq[A]
 }

--- a/kernel/src/main/scala/cats/kernel/instances/QueueInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/QueueInstances.scala
@@ -12,7 +12,7 @@ trait QueueInstances extends QueueInstances1 {
     new QueueMonoid[A]
 }
 
-trait QueueInstances1 extends QueueInstances2 {
+private[instances] trait QueueInstances1 extends QueueInstances2 {
   implicit def catsKernelStdPartialOrderForQueue[A: PartialOrder]: PartialOrder[Queue[A]] =
     new QueuePartialOrder[A]
 
@@ -20,7 +20,7 @@ trait QueueInstances1 extends QueueInstances2 {
     new QueueHash[A]
 }
 
-trait QueueInstances2 {
+private[instances] trait QueueInstances2 {
   implicit def catsKernelStdEqForQueue[A: Eq]: Eq[Queue[A]] =
     new QueueEq[A]
 }

--- a/kernel/src/main/scala/cats/kernel/instances/SetInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/SetInstances.scala
@@ -6,7 +6,7 @@ trait SetInstances extends SetInstances1 {
     new SetHash[A]
 }
 
-trait SetInstances1 {
+private[instances] trait SetInstances1 {
   implicit def catsKernelStdPartialOrderForSet[A]: PartialOrder[Set[A]] =
     new SetPartialOrder[A]
 

--- a/kernel/src/main/scala/cats/kernel/instances/SortedMapInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/SortedMapInstances.scala
@@ -1,0 +1,84 @@
+package cats.kernel
+package instances
+
+import scala.collection.immutable.SortedMap
+
+trait SortedMapInstances extends SortedMapInstances2 {
+  implicit def catsKernelStdHashForSortedMap[K: Hash: Order, V: Hash]: Hash[SortedMap[K, V]] =
+    new SortedMapHash[K, V]
+
+  implicit def catsKernelStdCommutativeMonoidForSortedMap[K: Order, V: CommutativeSemigroup]
+    : CommutativeMonoid[SortedMap[K, V]] =
+    new SortedMapCommutativeMonoid[K, V]
+}
+
+trait SortedMapInstances1 {
+  implicit def catsKernelStdEqForSortedMap[K: Order, V: Eq]: Eq[SortedMap[K, V]] =
+    new SortedMapEq[K, V]
+}
+
+trait SortedMapInstances2 extends SortedMapInstances1 {
+  implicit def catsKernelStdMonoidForSortedMap[K: Order, V: Semigroup]: Monoid[SortedMap[K, V]] =
+    new SortedMapMonoid[K, V]
+}
+
+class SortedMapHash[K, V](implicit V: Hash[V], O: Order[K], K: Hash[K])
+    extends SortedMapEq[K, V]()(V, O)
+    with Hash[SortedMap[K, V]] {
+  // adapted from [[scala.util.hashing.MurmurHash3]],
+  // but modified standard `Any#hashCode` to `ev.hash`.
+  import scala.util.hashing.MurmurHash3._
+  def hash(x: SortedMap[K, V]): Int = {
+    var a, b, n = 0
+    var c = 1
+    x.foreach {
+      case (k, v) =>
+        val h = StaticMethods.product2HashWithPrefix(K.hash(k), V.hash(v), "Tuple2")
+        a += h
+        b ^= h
+        c = StaticMethods.updateUnorderedHashC(c, h)
+        n += 1
+    }
+    var h = mapSeed
+    h = mix(h, a)
+    h = mix(h, b)
+    h = mixLast(h, c)
+    finalizeHash(h, n)
+  }
+}
+
+class SortedMapEq[K, V](implicit V: Eq[V], O: Order[K]) extends Eq[SortedMap[K, V]] {
+  def eqv(x: SortedMap[K, V], y: SortedMap[K, V]): Boolean =
+    if (x eq y) true
+    else
+      x.size == y.size && x.forall {
+        case (k, v1) =>
+          y.get(k) match {
+            case Some(v2) => V.eqv(v1, v2)
+            case None     => false
+          }
+      }
+}
+
+class SortedMapCommutativeMonoid[K, V](implicit V: CommutativeSemigroup[V], O: Order[K])
+    extends SortedMapMonoid[K, V]
+    with CommutativeMonoid[SortedMap[K, V]]
+
+class SortedMapMonoid[K, V](implicit V: Semigroup[V], O: Order[K]) extends Monoid[SortedMap[K, V]] {
+
+  def empty: SortedMap[K, V] = SortedMap.empty(O.toOrdering)
+
+  def combine(xs: SortedMap[K, V], ys: SortedMap[K, V]): SortedMap[K, V] =
+    if (xs.size <= ys.size) {
+      xs.foldLeft(ys) {
+        case (my, (k, x)) =>
+          my.updated(k, Semigroup.maybeCombine(x, my.get(k)))
+      }
+    } else {
+      ys.foldLeft(xs) {
+        case (mx, (k, y)) =>
+          mx.updated(k, Semigroup.maybeCombine(mx.get(k), y))
+      }
+    }
+
+}

--- a/kernel/src/main/scala/cats/kernel/instances/SortedSetInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/SortedSetInstances.scala
@@ -1,0 +1,59 @@
+package cats.kernel
+package instances
+
+import cats.kernel.{BoundedSemilattice, Hash, Order}
+import scala.collection.immutable.SortedSet
+
+trait SortedSetInstances extends SortedSetInstances1 {
+  implicit def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
+    new SortedSetHash[A]
+}
+
+trait SortedSetInstances1 {
+  implicit def catsKernelStdOrderForSortedSet[A: Order]: Order[SortedSet[A]] =
+    new SortedSetOrder[A]
+
+  implicit def catsKernelStdBoundedSemilatticeForSortedSet[A: Order]: BoundedSemilattice[SortedSet[A]] =
+    new SortedSetSemilattice[A]
+}
+
+class SortedSetOrder[A: Order] extends Order[SortedSet[A]] {
+  def compare(a1: SortedSet[A], a2: SortedSet[A]): Int =
+    cats.kernel.instances.int.catsKernelStdOrderForInt.compare(a1.size, a2.size) match {
+      case 0 => StaticMethods.iteratorCompare(a1.iterator, a2.iterator)
+      case x => x
+    }
+
+  override def eqv(s1: SortedSet[A], s2: SortedSet[A]): Boolean =
+    StaticMethods.iteratorEq(s1.iterator, s2.iterator)
+}
+
+class SortedSetHash[A: Order: Hash] extends Hash[SortedSet[A]] {
+  import scala.util.hashing.MurmurHash3._
+
+  // adapted from [[scala.util.hashing.MurmurHash3]],
+  // but modified standard `Any#hashCode` to `ev.hash`.
+  def hash(xs: SortedSet[A]): Int = {
+    var a, b, n = 0
+    var c = 1
+    xs.foreach { x =>
+      val h = Hash[A].hash(x)
+      a += h
+      b ^= h
+      c = cats.kernel.instances.StaticMethods.updateUnorderedHashC(c, h)
+      n += 1
+    }
+    var h = setSeed
+    h = mix(h, a)
+    h = mix(h, b)
+    h = mixLast(h, c)
+    finalizeHash(h, n)
+  }
+  override def eqv(s1: SortedSet[A], s2: SortedSet[A]): Boolean =
+    StaticMethods.iteratorEq(s1.iterator, s2.iterator)(Order[A])
+}
+
+class SortedSetSemilattice[A: Order] extends BoundedSemilattice[SortedSet[A]] {
+  def empty: SortedSet[A] = SortedSet.empty(implicitly[Order[A]].toOrdering)
+  def combine(x: SortedSet[A], y: SortedSet[A]): SortedSet[A] = x | y
+}

--- a/kernel/src/main/scala/cats/kernel/instances/SortedSetInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/SortedSetInstances.scala
@@ -9,7 +9,7 @@ trait SortedSetInstances extends SortedSetInstances1 {
     new SortedSetHash[A]
 }
 
-trait SortedSetInstances1 {
+private[instances] trait SortedSetInstances1 {
   implicit def catsKernelStdOrderForSortedSet[A: Order]: Order[SortedSet[A]] =
     new SortedSetOrder[A]
 

--- a/kernel/src/main/scala/cats/kernel/instances/all/package.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/all/package.scala
@@ -1,4 +1,4 @@
 package cats.kernel
 package instances
 
-package object all extends AllInstances with AllInstancesBinCompat0
+package object all extends AllInstances with AllInstancesBinCompat0 with AllInstancesBinCompat1

--- a/kernel/src/main/scala/cats/kernel/instances/either/package.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/either/package.scala
@@ -1,4 +1,4 @@
 package cats.kernel
 package instances
 
-package object either extends EitherInstances
+package object either extends EitherInstances with EitherInstancesBinCompat0

--- a/kernel/src/main/scala/cats/kernel/instances/function/package.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/function/package.scala
@@ -1,4 +1,4 @@
 package cats.kernel
 package instances
 
-package object function extends FunctionInstances
+package object function extends FunctionInstances with FunctionInstancesBinCompat0

--- a/kernel/src/main/scala/cats/kernel/instances/hash.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/hash.scala
@@ -3,4 +3,4 @@ package instances
 
 trait HashInstances extends HashToHashingConversion
 
-object hash extends HashInstances
+object hash extends HashInstances with HashToHashingConversionBinCompat0

--- a/kernel/src/main/scala/cats/kernel/instances/sortedMap/package.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/sortedMap/package.scala
@@ -1,0 +1,4 @@
+package cats.kernel
+package instances
+
+package object sortedMap extends SortedMapInstances

--- a/kernel/src/main/scala/cats/kernel/instances/sortedSet/package.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/sortedSet/package.scala
@@ -1,0 +1,4 @@
+package cats.kernel
+package instances
+
+package object sortedSet extends SortedSetInstances

--- a/tests/src/test/scala/cats/tests/CatsSuite.scala
+++ b/tests/src/test/scala/cats/tests/CatsSuite.scala
@@ -44,6 +44,7 @@ trait CatsSuite
     with AllInstancesBinCompat3
     with AllInstancesBinCompat4
     with AllInstancesBinCompat5
+    with AllInstancesBinCompat6
     with AllSyntax
     with AllSyntaxBinCompat0
     with AllSyntaxBinCompat1

--- a/tests/src/test/scala/cats/tests/EitherSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherSuite.scala
@@ -34,7 +34,7 @@ class EitherSuite extends CatsSuite {
   checkAll("Semigroup[Either[ListWrapper[String], Int]]",
            SerializableTests.serializable(Semigroup[Either[ListWrapper[String], Int]]))
 
-  val partialOrder = catsStdPartialOrderForEither[Int, String]
+  val partialOrder = catsKernelStdPartialOrderForEither[Int, String]
   val order = implicitly[Order[Either[Int, String]]]
   val monad = implicitly[Monad[Either[Int, *]]]
   val show = implicitly[Show[Either[Int, String]]]
@@ -72,7 +72,7 @@ class EitherSuite extends CatsSuite {
   }
 
   test("implicit instances resolve specifically") {
-    val eq = catsStdEqForEither[Int, String]
+    val eq = catsKernelStdEqForEither[Int, String]
     assert(!eq.isInstanceOf[PartialOrder[_]])
     assert(!eq.isInstanceOf[Order[_]])
     assert(!partialOrder.isInstanceOf[Order[_]])

--- a/tests/src/test/scala/cats/tests/OpSuite.scala
+++ b/tests/src/test/scala/cats/tests/OpSuite.scala
@@ -10,7 +10,7 @@ import cats.kernel.laws.discipline.EqTests
 
 class OpSuite extends CatsSuite {
   {
-    implicit val catsKernelEqForOp = Op.catsKernelEqForOp[Function1, Int, MiniInt]
+    implicit val catsDataEqForOp = Op.catsDataEqForOp[Function1, Int, MiniInt]
     checkAll("Op[Function1, Int, MiniInt]", EqTests[Op[Function1, Int, MiniInt]].eqv)
     checkAll("Eq[Op[Function1, Int, MiniInt]]", SerializableTests.serializable(Eq[Op[Function1, Int, MiniInt]]))
   }


### PR DESCRIPTION
## Update

Because some of these fixes are more controversial than I expected, I've split the easy ones out into separate PRs: 

* Move appropriate SortedSet and SortedMap instances to kernel (#3001)
* Fix easy typos (#3002)
* Make bincompat and prioritization traits package-private (#3003)

I'm hoping we can get at least these merged before 2.0, even if the rest has to wait for 2.1.

## Original description

There's currently a lot of inconsistency in Cats, both in the implementation and in the public API. I know this isn't something most people care about, but I hate it, and even for normal people I imagine it has to make contributing and reading the code harder than it should be. This PR aims to fix a few things that can be fixed without breaking binary compatibility in Cats 2, and to put us in a better position to make things even less horrible in Cats 3!

It does break source compatibility, it breaks it all over the place, but in ways that shouldn't affect normal usage. This is part of the reason I'd really like to get these changes into 2.0.0.

### Misnamed instances

Most of these changes are pretty mechanical. I see an `Eq` instance named `zipNelEq`, I get extremely angry, I deprecate it, remove its `implicit`, make it package private, copy the implementation, rename it `catsDataEqForZipNonEmptyList` or whatever it is it actually should be, make sure `validateBC` still passes on all Scala versions, and then repeat dozens of times for the rest of the misnamed stuff. In some cases I've also had to add new `BinCompat` traits for misnamed instances defined in traits (thanks to 2.11).

### SortedSet and SortedMap instances

This is one of the bigger changes. Previously we only had instances for cats-kernel type classes (`Eq`, `Monoid`, etc.) for `SortedSet` and `SortedMap` in cats-core. I don't know why, but I don't think there's a good reason for it. To make things even more confusing, some of the instances for these types in cats-core followed the cats-kernel instance naming convention. I've moved these instances into cats-kernel and done all the necessary juggling to keep from breaking bincompat in cats-core.

### Cleaner public API

I've also made all (or approximately all) `BinCompat` and prioritization traits private to the smallest possible enclosing package (I'm pretty confident the `BinCompat` ones are all done, but the prioritization ones are easier to miss). Some of these were already package-private, but apparently at random. There's no good reason for them to be in the public interface, so they're gone now.

