### PR TITLE
Fix easy typos

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -500,7 +500,10 @@ object NonEmptyList extends NonEmptyListInstances {
           ZipNonEmptyList(fa.value.zipWith(fb.value) { case (a, b) => (a, b) })
       }
 
-    implicit def zipNelEq[A: Eq]: Eq[ZipNonEmptyList[A]] = Eq.by(_.value)
+    @deprecated("2.0.0-RC2", "Use catsDataEqForZipNonEmptyList")
+    private[data] def zipNelEq[A: Eq]: Eq[ZipNonEmptyList[A]] = catsDataEqForZipNonEmptyList[A]
+
+    implicit def catsDataEqForZipNonEmptyList[A: Eq]: Eq[ZipNonEmptyList[A]] = Eq.by(_.value)
   }
 }
 

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -428,6 +428,9 @@ object NonEmptyVector extends NonEmptyVectorInstances with Serializable {
           ZipNonEmptyVector(fa.value.zipWith(fb.value) { case (a, b) => (a, b) })
       }
 
-    implicit def zipNevEq[A: Eq]: Eq[ZipNonEmptyVector[A]] = Eq.by(_.value)
+    @deprecated("2.0.0-RC2", "Use catsDataEqForZipNonEmptyVector")
+    private[data] def zipNevEq[A: Eq]: Eq[ZipNonEmptyVector[A]] = catsDataEqForZipNonEmptyVector[A]
+
+    implicit def catsDataEqForZipNonEmptyVector[A: Eq]: Eq[ZipNonEmptyVector[A]] = Eq.by(_.value)
   }
 }

--- a/core/src/main/scala/cats/data/Op.scala
+++ b/core/src/main/scala/cats/data/Op.scala
@@ -20,8 +20,12 @@ sealed abstract private[data] class OpInstances extends OpInstances0 {
   implicit def catsDataCategoryForOp[Arr[_, _]](implicit ArrC: Category[Arr]): Category[Op[Arr, *, *]] =
     new OpCategory[Arr] { def Arr: Category[Arr] = ArrC }
 
-  implicit def catsKernelEqForOp[Arr[_, _], A, B](implicit ArrEq: Eq[Arr[B, A]]): Eq[Op[Arr, A, B]] =
+  implicit def catsDataEqForOp[Arr[_, _], A, B](implicit ArrEq: Eq[Arr[B, A]]): Eq[Op[Arr, A, B]] =
     new OpEq[Arr, A, B] { def Arr: Eq[Arr[B, A]] = ArrEq }
+
+  @deprecated("2.0.0-RC2", "Use catsDataEqForOp")
+  private[data] def catsKernelEqForOp[Arr[_, _], A, B](implicit ArrEq: Eq[Arr[B, A]]): Eq[Op[Arr, A, B]] =
+    catsDataEqForOp[Arr, A, B]
 }
 
 sealed abstract private[data] class OpInstances0 {

--- a/docs/src/main/tut/guidelines.md
+++ b/docs/src/main/tut/guidelines.md
@@ -80,7 +80,7 @@ therefore name our implicits according to the following rules:
 - If the instance is for multiple type classes, use `InstancesFor` instead of a type class name.
 - If the instance is for a standard library type add `Std` after the package. i.e. `catsStdShowForVector` and `catsKernelStdGroupForTuple`.
 
-As an example, an implicit instance of `Monoid` for `List` defined in the package `Kernel` should be named `catsKernelMonoidForList`.
+As an example, an implicit instance of `Monoid` for `List` defined in the package `Kernel` should be named `catsKernelStdMonoidForList`.
 
 This rule is relatively flexible. Use what you see appropriate. The goal is to maintain uniqueness and avoid conflicts.
 

--- a/tests/src/test/scala/cats/tests/OpSuite.scala
+++ b/tests/src/test/scala/cats/tests/OpSuite.scala
@@ -10,7 +10,7 @@ import cats.kernel.laws.discipline.EqTests
 
 class OpSuite extends CatsSuite {
   {
-    implicit val catsKernelEqForOp = Op.catsKernelEqForOp[Function1, Int, MiniInt]
+    implicit val catsDataEqForOp = Op.catsDataEqForOp[Function1, Int, MiniInt]
     checkAll("Op[Function1, Int, MiniInt]", EqTests[Op[Function1, Int, MiniInt]].eqv)
     checkAll("Eq[Op[Function1, Int, MiniInt]]", SerializableTests.serializable(Eq[Op[Function1, Int, MiniInt]]))
   }


### PR DESCRIPTION
Another piece of #3000, posted separately here with the same motivation as #3001. These are the renamings that don't require new bincompat traits.