### PR TITLE
Make bincompat and prioritization traits package-private

### DIFF
--- a/alleycats-core/src/main/scala/alleycats/Empty.scala
+++ b/alleycats-core/src/main/scala/alleycats/Empty.scala
@@ -22,9 +22,9 @@ object Empty extends EmptyInstances0 {
   def fromEmptyK[F[_], T](implicit ekf: EmptyK[F]): Empty[F[T]] = ekf.synthesize[T]
 }
 
-trait EmptyInstances0 extends compat.IterableEmptyInstance with EmptyInstances1
+private[alleycats] trait EmptyInstances0 extends compat.IterableEmptyInstance with EmptyInstances1
 
-trait EmptyInstances1 {
+private[alleycats] trait EmptyInstances1 {
   // If Monoid extended Empty then this could be an exported subclass instance provided by Monoid
   implicit def monoidIsEmpty[A: Monoid]: Empty[A] =
     Empty(Monoid[A].empty)

--- a/core/src/main/scala-2.12-/cats/instances/all.scala
+++ b/core/src/main/scala-2.12-/cats/instances/all.scala
@@ -33,9 +33,9 @@ trait AllInstances
     with UUIDInstances
     with VectorInstances
 
-trait AllInstancesBinCompat0 extends FunctionInstancesBinCompat0 with Tuple2InstancesBinCompat0
+private[cats] trait AllInstancesBinCompat0 extends FunctionInstancesBinCompat0 with Tuple2InstancesBinCompat0
 
-trait AllInstancesBinCompat1
+private[cats] trait AllInstancesBinCompat1
     extends OptionInstancesBinCompat0
     with ListInstancesBinCompat0
     with VectorInstancesBinCompat0
@@ -43,10 +43,10 @@ trait AllInstancesBinCompat1
     with MapInstancesBinCompat0
     with SortedMapInstancesBinCompat0
 
-trait AllInstancesBinCompat2 extends DurationInstances with FiniteDurationInstances
+private[cats] trait AllInstancesBinCompat2 extends DurationInstances with FiniteDurationInstances
 
-trait AllInstancesBinCompat3 extends AllCoreDurationInstances
+private[cats] trait AllInstancesBinCompat3 extends AllCoreDurationInstances
 
-trait AllInstancesBinCompat4 extends SortedMapInstancesBinCompat1 with MapInstancesBinCompat1
+private[cats] trait AllInstancesBinCompat4 extends SortedMapInstancesBinCompat1 with MapInstancesBinCompat1
 
-trait AllInstancesBinCompat5 extends SortedSetInstancesBinCompat0
+private[cats] trait AllInstancesBinCompat5 extends SortedSetInstancesBinCompat0

--- a/core/src/main/scala-2.12-/cats/instances/stream.scala
+++ b/core/src/main/scala-2.12-/cats/instances/stream.scala
@@ -159,7 +159,7 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
 
 }
 
-trait StreamInstancesBinCompat0 {
+private[instances] trait StreamInstancesBinCompat0 {
   implicit val catsStdTraverseFilterForStream: TraverseFilter[Stream] = new TraverseFilter[Stream] {
     val traverse: Traverse[Stream] = cats.instances.stream.catsStdInstancesForStream
 

--- a/core/src/main/scala-2.13+/cats/instances/all.scala
+++ b/core/src/main/scala-2.13+/cats/instances/all.scala
@@ -34,9 +34,9 @@ trait AllInstances
     with UUIDInstances
     with VectorInstances
 
-trait AllInstancesBinCompat0 extends FunctionInstancesBinCompat0 with Tuple2InstancesBinCompat0
+private[cats] trait AllInstancesBinCompat0 extends FunctionInstancesBinCompat0 with Tuple2InstancesBinCompat0
 
-trait AllInstancesBinCompat1
+private[cats] trait AllInstancesBinCompat1
     extends OptionInstancesBinCompat0
     with ListInstancesBinCompat0
     with VectorInstancesBinCompat0
@@ -44,10 +44,10 @@ trait AllInstancesBinCompat1
     with MapInstancesBinCompat0
     with SortedMapInstancesBinCompat0
 
-trait AllInstancesBinCompat2 extends DurationInstances with FiniteDurationInstances
+private[cats] trait AllInstancesBinCompat2 extends DurationInstances with FiniteDurationInstances
 
-trait AllInstancesBinCompat3 extends AllCoreDurationInstances
+private[cats] trait AllInstancesBinCompat3 extends AllCoreDurationInstances
 
-trait AllInstancesBinCompat4 extends SortedMapInstancesBinCompat1 with MapInstancesBinCompat1
+private[cats] trait AllInstancesBinCompat4 extends SortedMapInstancesBinCompat1 with MapInstancesBinCompat1
 
-trait AllInstancesBinCompat5 extends SortedSetInstancesBinCompat0
+private[cats] trait AllInstancesBinCompat5 extends SortedSetInstancesBinCompat0

--- a/core/src/main/scala-2.13+/cats/instances/stream.scala
+++ b/core/src/main/scala-2.13+/cats/instances/stream.scala
@@ -161,7 +161,7 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
 
 }
 
-trait StreamInstancesBinCompat0 {
+private[instances] trait StreamInstancesBinCompat0 {
   @deprecated("2.0.0-RC2", "Use cats.instances.lazyList")
   implicit val catsStdTraverseFilterForStream: TraverseFilter[Stream] = new TraverseFilter[Stream] {
     val traverse: Traverse[Stream] = cats.instances.stream.catsStdInstancesForStream

--- a/core/src/main/scala/cats/data/Binested.scala
+++ b/core/src/main/scala/cats/data/Binested.scala
@@ -51,7 +51,7 @@ trait BinestedInstances extends BinestedInstances0 {
     }
 }
 
-trait BinestedInstances0 {
+private[data] trait BinestedInstances0 {
   implicit def catsDataBifoldableForBinested[F[_, _], G[_], H[_]](
     implicit F0: Bifoldable[F],
     G0: Foldable[G],

--- a/core/src/main/scala/cats/instances/function.scala
+++ b/core/src/main/scala/cats/instances/function.scala
@@ -9,7 +9,7 @@ import annotation.tailrec
 
 trait FunctionInstances extends cats.kernel.instances.FunctionInstances with Function0Instances with Function1Instances
 
-trait FunctionInstancesBinCompat0 {
+private[instances] trait FunctionInstancesBinCompat0 {
 
   /**
    * Witness for: E => A <-> E => A

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -152,7 +152,7 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
     }
 }
 
-trait ListInstancesBinCompat0 {
+private[instances] trait ListInstancesBinCompat0 {
   implicit val catsStdTraverseFilterForList: TraverseFilter[List] = new TraverseFilter[List] {
     val traverse: Traverse[List] = cats.instances.list.catsStdInstancesForList
 

--- a/core/src/main/scala/cats/instances/map.scala
+++ b/core/src/main/scala/cats/instances/map.scala
@@ -93,7 +93,7 @@ trait MapInstances extends cats.kernel.instances.MapInstances {
 
 }
 
-trait MapInstancesBinCompat0 {
+private[instances] trait MapInstancesBinCompat0 {
 
   implicit val catsStdComposeForMap: Compose[Map] = new Compose[Map] {
 
@@ -139,7 +139,7 @@ trait MapInstancesBinCompat0 {
 
 }
 
-trait MapInstancesBinCompat1 {
+private[instances] trait MapInstancesBinCompat1 {
   implicit def catsStdMonoidKForMap[K]: MonoidK[Map[K, *]] = new MonoidK[Map[K, *]] {
     override def empty[A]: Map[K, A] = Map.empty
 

--- a/core/src/main/scala/cats/instances/option.scala
+++ b/core/src/main/scala/cats/instances/option.scala
@@ -127,7 +127,7 @@ trait OptionInstances extends cats.kernel.instances.OptionInstances {
     }
 }
 
-trait OptionInstancesBinCompat0 {
+private[instances] trait OptionInstancesBinCompat0 {
   implicit val catsStdTraverseFilterForOption: TraverseFilter[Option] = new TraverseFilter[Option] {
     val traverse: Traverse[Option] = cats.instances.option.catsStdInstancesForOption
 

--- a/core/src/main/scala/cats/instances/sortedMap.scala
+++ b/core/src/main/scala/cats/instances/sortedMap.scala
@@ -113,12 +113,12 @@ trait SortedMapInstances extends SortedMapInstances2 {
 
 }
 
-trait SortedMapInstances1 {
+private[instances] trait SortedMapInstances1 {
   implicit def catsStdEqForSortedMap[K: Order, V: Eq]: Eq[SortedMap[K, V]] =
     new SortedMapEq[K, V]
 }
 
-trait SortedMapInstances2 extends SortedMapInstances1 {
+private[instances] trait SortedMapInstances2 extends SortedMapInstances1 {
   implicit def catsStdMonoidForSortedMap[K: Order, V: Semigroup]: Monoid[SortedMap[K, V]] =
     new SortedMapMonoid[K, V]
 }
@@ -184,7 +184,7 @@ class SortedMapMonoid[K, V](implicit V: Semigroup[V], O: Order[K]) extends Monoi
 
 }
 
-trait SortedMapInstancesBinCompat0 {
+private[instances] trait SortedMapInstancesBinCompat0 {
   implicit def catsStdTraverseFilterForSortedMap[K: Order]: TraverseFilter[SortedMap[K, *]] =
     new TraverseFilter[SortedMap[K, *]] {
 
@@ -224,7 +224,7 @@ trait SortedMapInstancesBinCompat0 {
     }
 }
 
-trait SortedMapInstancesBinCompat1 {
+private[instances] trait SortedMapInstancesBinCompat1 {
   implicit def catsStdMonoidKForSortedMap[K: Order]: MonoidK[SortedMap[K, *]] = new MonoidK[SortedMap[K, *]] {
     override def empty[A]: SortedMap[K, A] = SortedMap.empty[K, A](Order[K].toOrdering)
 

--- a/core/src/main/scala/cats/instances/sortedSet.scala
+++ b/core/src/main/scala/cats/instances/sortedSet.scala
@@ -71,7 +71,7 @@ trait SortedSetInstances extends SortedSetInstances1 {
     new SortedSetOrder[A]
 }
 
-trait SortedSetInstances1 {
+private[instances] trait SortedSetInstances1 {
   implicit def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
     new SortedSetHash[A]
 
@@ -79,7 +79,7 @@ trait SortedSetInstances1 {
     new SortedSetSemilattice[A]
 }
 
-trait SortedSetInstancesBinCompat0 {
+private[instances] trait SortedSetInstancesBinCompat0 {
   implicit val catsStdSemigroupalForSortedSet: Semigroupal[SortedSet] = new Semigroupal[SortedSet] {
     override def product[A, B](fa: SortedSet[A], fb: SortedSet[B]): SortedSet[(A, B)] = {
       implicit val orderingA = fa.ordering

--- a/core/src/main/scala/cats/instances/tuple.scala
+++ b/core/src/main/scala/cats/instances/tuple.scala
@@ -7,7 +7,7 @@ import scala.annotation.tailrec
 
 trait TupleInstances extends Tuple2Instances with cats.kernel.instances.TupleInstances
 
-trait Tuple2InstancesBinCompat0 {
+private[instances] trait Tuple2InstancesBinCompat0 {
 
   /**
    * Witness for: (A, A) <-> Boolean => A
@@ -31,7 +31,7 @@ trait Tuple2InstancesBinCompat0 {
   }
 }
 
-sealed trait Tuple2Instances extends Tuple2Instances1 {
+sealed private[instances] trait Tuple2Instances extends Tuple2Instances1 {
   implicit val catsStdBitraverseForTuple2: Bitraverse[Tuple2] =
     new Bitraverse[Tuple2] {
       def bitraverse[G[_]: Applicative, A, B, C, D](fab: (A, B))(f: A => G[C], g: B => G[D]): G[(C, D)] =
@@ -103,26 +103,26 @@ sealed trait Tuple2Instances extends Tuple2Instances1 {
     }
 }
 
-sealed trait Tuple2Instances1 extends Tuple2Instances2 {
+sealed private[instances] trait Tuple2Instances1 extends Tuple2Instances2 {
   implicit def catsStdCommutativeMonadForTuple2[X](implicit MX: CommutativeMonoid[X]): CommutativeMonad[(X, *)] =
     new FlatMapTuple2[X](MX) with CommutativeMonad[(X, *)] {
       def pure[A](a: A): (X, A) = (MX.empty, a)
     }
 }
 
-sealed trait Tuple2Instances2 extends Tuple2Instances3 {
+sealed private[instances] trait Tuple2Instances2 extends Tuple2Instances3 {
   implicit def catsStdCommutativeFlatMapForTuple2[X](implicit MX: CommutativeSemigroup[X]): CommutativeFlatMap[(X, *)] =
     new FlatMapTuple2[X](MX) with CommutativeFlatMap[(X, *)]
 }
 
-sealed trait Tuple2Instances3 extends Tuple2Instances4 {
+sealed private[instances] trait Tuple2Instances3 extends Tuple2Instances4 {
   implicit def catsStdMonadForTuple2[X](implicit MX: Monoid[X]): Monad[(X, *)] =
     new FlatMapTuple2[X](MX) with Monad[(X, *)] {
       def pure[A](a: A): (X, A) = (MX.empty, a)
     }
 }
 
-sealed trait Tuple2Instances4 {
+sealed private[instances] trait Tuple2Instances4 {
   implicit def catsStdFlatMapForTuple2[X](implicit SX: Semigroup[X]): FlatMap[(X, *)] =
     new FlatMapTuple2[X](SX)
 }

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -122,7 +122,7 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
     }
 }
 
-trait VectorInstancesBinCompat0 {
+private[instances] trait VectorInstancesBinCompat0 {
   implicit val catsStdTraverseFilterForVector: TraverseFilter[Vector] = new TraverseFilter[Vector] {
     val traverse: Traverse[Vector] = cats.instances.vector.catsStdInstancesForVector
 

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -1,7 +1,7 @@
 package cats
 package syntax
 
-abstract class AllSyntaxBinCompat
+abstract private[cats] class AllSyntaxBinCompat
     extends AllSyntax
     with AllSyntaxBinCompat0
     with AllSyntaxBinCompat1
@@ -59,9 +59,9 @@ trait AllSyntax
     with VectorSyntax
     with WriterSyntax
 
-trait AllSyntaxBinCompat0 extends UnorderedTraverseSyntax with ApplicativeErrorExtension with TrySyntax
+private[cats] trait AllSyntaxBinCompat0 extends UnorderedTraverseSyntax with ApplicativeErrorExtension with TrySyntax
 
-trait AllSyntaxBinCompat1
+private[cats] trait AllSyntaxBinCompat1
     extends FlatMapOptionSyntax
     with ChoiceSyntax
     with NestedSyntax
@@ -71,7 +71,7 @@ trait AllSyntaxBinCompat1
     with ValidatedExtensionSyntax
     with RepresentableSyntax
 
-trait AllSyntaxBinCompat2
+private[cats] trait AllSyntaxBinCompat2
     extends ParallelTraverseSyntax
     with TraverseFilterSyntax
     with FunctorFilterSyntax
@@ -79,9 +79,9 @@ trait AllSyntaxBinCompat2
     with ListSyntaxBinCompat0
     with ValidatedSyntaxBincompat0
 
-trait AllSyntaxBinCompat3 extends UnorderedFoldableSyntax with Function1Syntax
+private[cats] trait AllSyntaxBinCompat3 extends UnorderedFoldableSyntax with Function1Syntax
 
-trait AllSyntaxBinCompat4
+private[cats] trait AllSyntaxBinCompat4
     extends TraverseFilterSyntaxBinCompat0
     with ApplySyntaxBinCompat0
     with ParallelApplySyntax
@@ -90,6 +90,6 @@ trait AllSyntaxBinCompat4
     with FoldableSyntaxBinCompat1
     with BitraverseSyntaxBinCompat0
 
-trait AllSyntaxBinCompat5 extends ParallelBitraverseSyntax
+private[cats] trait AllSyntaxBinCompat5 extends ParallelBitraverseSyntax
 
-trait AllSyntaxBinCompat6 extends ParallelUnorderedTraverseSyntax
+private[cats] trait AllSyntaxBinCompat6 extends ParallelUnorderedTraverseSyntax

--- a/core/src/main/scala/cats/syntax/apply.scala
+++ b/core/src/main/scala/cats/syntax/apply.scala
@@ -14,7 +14,7 @@ trait ApplySyntax extends TupleSemigroupalSyntax {
     new ApplyOps(fa)
 }
 
-trait ApplySyntaxBinCompat0 {
+private[syntax] trait ApplySyntaxBinCompat0 {
   implicit final def catsSyntaxIfApplyOps[F[_]](fa: F[Boolean]): IfApplyOps[F] =
     new IfApplyOps[F](fa)
 }

--- a/core/src/main/scala/cats/syntax/bitraverse.scala
+++ b/core/src/main/scala/cats/syntax/bitraverse.scala
@@ -23,7 +23,7 @@ final class NestedBitraverseOps[F[_, _], G[_], A, B](private val fgagb: F[G[A], 
     F.bisequence(fgagb)
 }
 
-trait BitraverseSyntaxBinCompat0 {
+private[syntax] trait BitraverseSyntaxBinCompat0 {
   implicit final def catsSyntaxBitraverseBinCompat0[F[_, _]: Bitraverse, A, B](
     fab: F[A, B]
   ): BitraverseOpsBinCompat0[F, A, B] =
@@ -34,7 +34,7 @@ trait BitraverseSyntaxBinCompat0 {
     new LeftNestedBitraverseOps[F, G, A, B](fgab)
 }
 
-final class BitraverseOpsBinCompat0[F[_, _], A, B](val fab: F[A, B]) extends AnyVal {
+final private[syntax] class BitraverseOpsBinCompat0[F[_, _], A, B](val fab: F[A, B]) extends AnyVal {
 
   /**
    *  Traverse over the left side of the structure.

--- a/core/src/main/scala/cats/syntax/either.scala
+++ b/core/src/main/scala/cats/syntax/either.scala
@@ -397,7 +397,7 @@ final class EitherIdOps[A](private val obj: A) extends AnyVal {
 
 }
 
-trait EitherSyntaxBinCompat0 {
+private[syntax] trait EitherSyntaxBinCompat0 {
   implicit final def catsSyntaxEitherBinCompat0[A, B](eab: Either[A, B]): EitherOpsBinCompat0[A, B] =
     new EitherOpsBinCompat0(eab)
 
@@ -405,7 +405,7 @@ trait EitherSyntaxBinCompat0 {
     new EitherIdOpsBinCompat0(a)
 }
 
-final class EitherIdOpsBinCompat0[A](private val value: A) extends AnyVal {
+final private[syntax] class EitherIdOpsBinCompat0[A](private val value: A) extends AnyVal {
 
   /**
    * Wrap a value to a left EitherNec
@@ -432,7 +432,7 @@ final class EitherIdOpsBinCompat0[A](private val value: A) extends AnyVal {
   def rightNec[B]: Either[NonEmptyChain[B], A] = Right(value)
 }
 
-final class EitherOpsBinCompat0[A, B](private val value: Either[A, B]) extends AnyVal {
+final private[syntax] class EitherOpsBinCompat0[A, B](private val value: Either[A, B]) extends AnyVal {
 
   /** Returns a [[cats.data.ValidatedNec]] representation of this disjunction with the `Left` value
    * as a single element on the `Invalid` side of the [[cats.data.NonEmptyList]]. */

--- a/core/src/main/scala/cats/syntax/foldable.scala
+++ b/core/src/main/scala/cats/syntax/foldable.scala
@@ -9,12 +9,12 @@ trait FoldableSyntax extends Foldable.ToFoldableOps with UnorderedFoldable.ToUno
     new FoldableOps[F, A](fa)
 }
 
-trait FoldableSyntaxBinCompat0 {
+private[syntax] trait FoldableSyntaxBinCompat0 {
   implicit final def catsSyntaxFoldableOps0[F[_], A](fa: F[A]): FoldableOps0[F, A] =
     new FoldableOps0[F, A](fa)
 }
 
-trait FoldableSyntaxBinCompat1 {
+private[syntax] trait FoldableSyntaxBinCompat1 {
   implicit final def catsSyntaxFoldableBinCompat0[F[_]](fa: Foldable[F]): FoldableOps1[F] =
     new FoldableOps1(fa)
 }
@@ -305,7 +305,7 @@ final class FoldableOps0[F[_], A](private val fa: F[A]) extends AnyVal {
   }
 }
 
-final class FoldableOps1[F[_]](private val F: Foldable[F]) extends AnyVal {
+final private[syntax] class FoldableOps1[F[_]](private val F: Foldable[F]) extends AnyVal {
 
   /**
    * Separate this Foldable into a Tuple by a separating function `A => H[B, C]` for some `Bifoldable[H]`

--- a/core/src/main/scala/cats/syntax/list.scala
+++ b/core/src/main/scala/cats/syntax/list.scala
@@ -50,11 +50,11 @@ final class ListOps[A](private val la: List[A]) extends AnyVal {
   }
 }
 
-trait ListSyntaxBinCompat0 {
+private[syntax] trait ListSyntaxBinCompat0 {
   implicit final def catsSyntaxListBinCompat0[A](la: List[A]): ListOpsBinCompat0[A] = new ListOpsBinCompat0(la)
 }
 
-final class ListOpsBinCompat0[A](private val la: List[A]) extends AnyVal {
+final private[syntax] class ListOpsBinCompat0[A](private val la: List[A]) extends AnyVal {
 
   /**
    * Groups elements inside this `List` according to the `Order` of the keys

--- a/core/src/main/scala/cats/syntax/reducible.scala
+++ b/core/src/main/scala/cats/syntax/reducible.scala
@@ -10,7 +10,7 @@ final class NestedReducibleOps[F[_], G[_], A](private val fga: F[G[A]]) extends 
   def reduceK(implicit F: Reducible[F], G: SemigroupK[G]): G[A] = F.reduceK(fga)
 }
 
-trait ReducibleSyntaxBinCompat0 {
+private[syntax] trait ReducibleSyntaxBinCompat0 {
   implicit final def catsSyntaxReducibleOps0[F[_], A](fa: F[A]): ReducibleOps0[F, A] =
     new ReducibleOps0[F, A](fa)
 }

--- a/core/src/main/scala/cats/syntax/traverseFilter.scala
+++ b/core/src/main/scala/cats/syntax/traverseFilter.scala
@@ -3,7 +3,7 @@ package syntax
 
 trait TraverseFilterSyntax extends TraverseFilter.ToTraverseFilterOps
 
-trait TraverseFilterSyntaxBinCompat0 {
+private[syntax] trait TraverseFilterSyntaxBinCompat0 {
   implicit def toSequenceFilterOps[F[_], G[_], A](fgoa: F[G[Option[A]]]): SequenceFilterOps[F, G, A] =
     new SequenceFilterOps(fgoa)
 }

--- a/core/src/main/scala/cats/syntax/validated.scala
+++ b/core/src/main/scala/cats/syntax/validated.scala
@@ -24,12 +24,12 @@ final class ValidatedExtension[E, A](private val self: Validated[E, A]) extends 
     new ApplicativeErrorExtensionOps(F).fromValidated(self)
 }
 
-trait ValidatedSyntaxBincompat0 {
+private[syntax] trait ValidatedSyntaxBincompat0 {
   implicit final def catsSyntaxValidatedIdBinCompat0[A](a: A): ValidatedIdOpsBinCompat0[A] =
     new ValidatedIdOpsBinCompat0(a)
 }
 
-final class ValidatedIdOpsBinCompat0[A](private val a: A) extends AnyVal {
+final private[syntax] class ValidatedIdOpsBinCompat0[A](private val a: A) extends AnyVal {
 
   /**
    * Wrap a value to a valid ValidatedNec

--- a/kernel/src/main/scala-2.12-/cats/kernel/instances/AllInstances.scala
+++ b/kernel/src/main/scala-2.12-/cats/kernel/instances/AllInstances.scala
@@ -33,4 +33,4 @@ trait AllInstances
     with UUIDInstances
     with VectorInstances
 
-trait AllInstancesBinCompat0 extends FiniteDurationInstances
+private[instances] trait AllInstancesBinCompat0 extends FiniteDurationInstances

--- a/kernel/src/main/scala-2.12-/cats/kernel/instances/StreamInstances.scala
+++ b/kernel/src/main/scala-2.12-/cats/kernel/instances/StreamInstances.scala
@@ -8,7 +8,7 @@ trait StreamInstances extends StreamInstances1 {
     new StreamMonoid[A]
 }
 
-trait StreamInstances1 extends StreamInstances2 {
+private[instances] trait StreamInstances1 extends StreamInstances2 {
   implicit def catsKernelStdPartialOrderForStream[A: PartialOrder]: PartialOrder[Stream[A]] =
     new StreamPartialOrder[A]
 
@@ -16,7 +16,7 @@ trait StreamInstances1 extends StreamInstances2 {
     new StreamHash[A]
 }
 
-trait StreamInstances2 {
+private[instances] trait StreamInstances2 {
   implicit def catsKernelStdEqForStream[A: Eq]: Eq[Stream[A]] =
     new StreamEq[A]
 }

--- a/kernel/src/main/scala-2.13+/cats/kernel/instances/AllInstances.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/instances/AllInstances.scala
@@ -34,4 +34,4 @@ trait AllInstances
     with UUIDInstances
     with VectorInstances
 
-trait AllInstancesBinCompat0 extends FiniteDurationInstances
+private[instances] trait AllInstancesBinCompat0 extends FiniteDurationInstances

--- a/kernel/src/main/scala-2.13+/cats/kernel/instances/LazyListInstances.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/instances/LazyListInstances.scala
@@ -8,7 +8,7 @@ trait LazyListInstances extends LazyListInstances1 {
     new LazyListMonoid[A]
 }
 
-trait LazyListInstances1 extends LazyListInstances2 {
+private[instances] trait LazyListInstances1 extends LazyListInstances2 {
   implicit def catsKernelStdPartialOrderForLazyList[A: PartialOrder]: PartialOrder[LazyList[A]] =
     new LazyListPartialOrder[A]
 
@@ -16,7 +16,7 @@ trait LazyListInstances1 extends LazyListInstances2 {
     new LazyListHash[A]
 }
 
-trait LazyListInstances2 {
+private[instances] trait LazyListInstances2 {
   implicit def catsKernelStdEqForLazyList[A: Eq]: Eq[LazyList[A]] =
     new LazyListEq[A]
 }

--- a/kernel/src/main/scala-2.13+/cats/kernel/instances/StreamInstances.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/instances/StreamInstances.scala
@@ -10,7 +10,7 @@ trait StreamInstances extends StreamInstances1 {
     new StreamMonoid[A]
 }
 
-trait StreamInstances1 extends StreamInstances2 {
+private[instances] trait StreamInstances1 extends StreamInstances2 {
   @deprecated("2.0.0-RC2", "Use cats.kernel.instances.lazyList")
   implicit def catsKernelStdPartialOrderForStream[A: PartialOrder]: PartialOrder[Stream[A]] =
     new StreamPartialOrder[A]
@@ -20,7 +20,7 @@ trait StreamInstances1 extends StreamInstances2 {
     new StreamHash[A]
 }
 
-trait StreamInstances2 {
+private[instances] trait StreamInstances2 {
   @deprecated("2.0.0-RC2", "Use cats.kernel.instances.lazyList")
   implicit def catsKernelStdEqForStream[A: Eq]: Eq[Stream[A]] =
     new StreamEq[A]

--- a/kernel/src/main/scala/cats/kernel/instances/EitherInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/EitherInstances.scala
@@ -36,7 +36,7 @@ trait EitherInstances extends EitherInstances0 {
     }
 }
 
-trait EitherInstances0 extends EitherInstances1 {
+private[instances] trait EitherInstances0 extends EitherInstances1 {
 
   implicit def catsDataSemigroupForEither[A, B](implicit B: Semigroup[B]): Semigroup[Either[A, B]] =
     new Semigroup[Either[A, B]] {
@@ -72,7 +72,7 @@ trait EitherInstances0 extends EitherInstances1 {
   implicit def catsStdHashForEither[A, B](implicit A: Hash[A], B: Hash[B]): Hash[Either[A, B]] = new EitherHash[A, B]
 }
 
-trait EitherInstances1 {
+private[instances] trait EitherInstances1 {
 
   implicit def catsStdEqForEither[A, B](implicit A: Eq[A], B: Eq[B]): Eq[Either[A, B]] = new EitherEq[A, B]
 

--- a/kernel/src/main/scala/cats/kernel/instances/FunctionInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/FunctionInstances.scala
@@ -15,7 +15,7 @@ trait FunctionInstances extends FunctionInstances0 {
     new Function1Group[A, B] with CommutativeGroup[A => B] { def B: Group[B] = G }
 }
 
-trait FunctionInstances0 extends FunctionInstances1 {
+private[instances] trait FunctionInstances0 extends FunctionInstances1 {
 
   implicit def catsKernelHashForFunction0[A](implicit ev: Hash[A]): Hash[() => A] =
     new Hash[() => A] {
@@ -45,7 +45,7 @@ trait FunctionInstances0 extends FunctionInstances1 {
     new Function1Monoid[A, B] with BoundedSemilattice[A => B] { def B: Monoid[B] = G }
 }
 
-trait FunctionInstances1 extends FunctionInstances2 {
+private[instances] trait FunctionInstances1 extends FunctionInstances2 {
 
   implicit def catsKernelEqForFunction0[A](implicit ev: Eq[A]): Eq[() => A] =
     new Eq[() => A] {
@@ -69,7 +69,7 @@ trait FunctionInstances1 extends FunctionInstances2 {
     new Function1Semigroup[A, B] with Semilattice[A => B] { def B: Semigroup[B] = M }
 }
 
-trait FunctionInstances2 extends FunctionInstances3 {
+private[instances] trait FunctionInstances2 extends FunctionInstances3 {
 
   implicit def catsKernelMonoidForFunction0[A](implicit M: Monoid[A]): Monoid[() => A] =
     new Function0Monoid[A] { def A: Monoid[A] = M }
@@ -84,7 +84,7 @@ trait FunctionInstances2 extends FunctionInstances3 {
     new Function1Semigroup[A, B] with Band[A => B] { def B: Semigroup[B] = S }
 }
 
-trait FunctionInstances3 extends FunctionInstances4 {
+private[instances] trait FunctionInstances3 extends FunctionInstances4 {
 
   implicit def catsKernelCommutativeSemigroupForFunction0[A](
     implicit S: CommutativeSemigroup[A]
@@ -97,7 +97,7 @@ trait FunctionInstances3 extends FunctionInstances4 {
     new Function1Semigroup[A, B] with CommutativeSemigroup[A => B] { def B: Semigroup[B] = S }
 }
 
-trait FunctionInstances4 {
+private[instances] trait FunctionInstances4 {
 
   implicit def catsKernelSemigroupForFunction0[A](implicit S: Semigroup[A]): Semigroup[() => A] =
     new Function0Semigroup[A] { def A: Semigroup[A] = S }

--- a/kernel/src/main/scala/cats/kernel/instances/ListInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/ListInstances.scala
@@ -12,7 +12,7 @@ trait ListInstances extends ListInstances1 {
     new ListMonoid[A]
 }
 
-trait ListInstances1 extends ListInstances2 {
+private[instances] trait ListInstances1 extends ListInstances2 {
   implicit def catsKernelStdPartialOrderForList[A: PartialOrder]: PartialOrder[List[A]] =
     new ListPartialOrder[A]
 
@@ -20,7 +20,7 @@ trait ListInstances1 extends ListInstances2 {
     new ListHash[A]
 }
 
-trait ListInstances2 {
+private[instances] trait ListInstances2 {
   implicit def catsKernelStdEqForList[A: Eq]: Eq[List[A]] =
     new ListEq[A]
 }

--- a/kernel/src/main/scala/cats/kernel/instances/MapInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/MapInstances.scala
@@ -13,7 +13,7 @@ trait MapInstances extends MapInstances1 {
     new MapMonoid[K, V] with CommutativeMonoid[Map[K, V]]
 }
 
-trait MapInstances1 {
+private[instances] trait MapInstances1 {
   implicit def catsKernelStdEqForMap[K, V: Eq]: Eq[Map[K, V]] =
     new MapEq[K, V]
   implicit def catsKernelStdMonoidForMap[K, V: Semigroup]: Monoid[Map[K, V]] =

--- a/kernel/src/main/scala/cats/kernel/instances/OptionInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/OptionInstances.scala
@@ -8,17 +8,17 @@ trait OptionInstances extends OptionInstances0 {
     new OptionMonoid[A]
 }
 
-trait OptionInstances0 extends OptionInstances1 {
+private[instances] trait OptionInstances0 extends OptionInstances1 {
   implicit def catsKernelStdPartialOrderForOption[A: PartialOrder]: PartialOrder[Option[A]] =
     new OptionPartialOrder[A]
 }
 
-trait OptionInstances1 extends OptionInstances2 {
+private[instances] trait OptionInstances1 extends OptionInstances2 {
   implicit def catsKernelStdHashForOption[A: Hash]: Hash[Option[A]] =
     new OptionHash[A]
 }
 
-trait OptionInstances2 {
+private[instances] trait OptionInstances2 {
   implicit def catsKernelStdEqForOption[A: Eq]: Eq[Option[A]] =
     new OptionEq[A]
 }

--- a/kernel/src/main/scala/cats/kernel/instances/QueueInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/QueueInstances.scala
@@ -12,7 +12,7 @@ trait QueueInstances extends QueueInstances1 {
     new QueueMonoid[A]
 }
 
-trait QueueInstances1 extends QueueInstances2 {
+private[instances] trait QueueInstances1 extends QueueInstances2 {
   implicit def catsKernelStdPartialOrderForQueue[A: PartialOrder]: PartialOrder[Queue[A]] =
     new QueuePartialOrder[A]
 
@@ -20,7 +20,7 @@ trait QueueInstances1 extends QueueInstances2 {
     new QueueHash[A]
 }
 
-trait QueueInstances2 {
+private[instances] trait QueueInstances2 {
   implicit def catsKernelStdEqForQueue[A: Eq]: Eq[Queue[A]] =
     new QueueEq[A]
 }

--- a/kernel/src/main/scala/cats/kernel/instances/SetInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/SetInstances.scala
@@ -6,7 +6,7 @@ trait SetInstances extends SetInstances1 {
     new SetHash[A]
 }
 
-trait SetInstances1 {
+private[instances] trait SetInstances1 {
   implicit def catsKernelStdPartialOrderForSet[A]: PartialOrder[Set[A]] =
     new SetPartialOrder[A]
 

--- a/kernel/src/main/scala/cats/kernel/instances/VectorInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/VectorInstances.scala
@@ -10,7 +10,7 @@ trait VectorInstances extends VectorInstances1 {
     new VectorMonoid[A]
 }
 
-trait VectorInstances1 extends VectorInstances2 {
+private[instances] trait VectorInstances1 extends VectorInstances2 {
   implicit def catsKernelStdPartialOrderForVector[A: PartialOrder]: PartialOrder[Vector[A]] =
     new VectorPartialOrder[A]
 
@@ -18,7 +18,7 @@ trait VectorInstances1 extends VectorInstances2 {
     new VectorHash[A]
 }
 
-trait VectorInstances2 {
+private[instances] trait VectorInstances2 {
   implicit def catsKernelStdEqForVector[A: Eq]: Eq[Vector[A]] =
     new VectorEq[A]
 }

--- a/project/KernelBoiler.scala
+++ b/project/KernelBoiler.scala
@@ -169,7 +169,7 @@ object KernelBoiler {
             }
         ),
         InstanceDef(
-          "trait TupleInstances1 extends TupleInstances2 {",
+          "private[instances] trait TupleInstances1 extends TupleInstances2 {",
           tv =>
             new TemplatedBlock(tv) {
               import tv._
@@ -211,7 +211,7 @@ object KernelBoiler {
             }
         ),
         InstanceDef(
-          "trait TupleInstances2 extends TupleInstances3 {",
+          "private[instances] trait TupleInstances2 extends TupleInstances3 {",
           tv =>
             new TemplatedBlock(tv) {
               import tv._
@@ -238,7 +238,7 @@ object KernelBoiler {
             }
         ),
         InstanceDef(
-          "trait TupleInstances3 {",
+          "private[instances] trait TupleInstances3 {",
           tv =>
             new TemplatedBlock(tv) {
               import tv._


### PR DESCRIPTION
One last piece of #3000 that shouldn't be controversial. This change makes all bincompat and prioritization traits (or classes, in a few cases) private to the smallest possible enclosing package.

This is a source-incompatible change, but it's verified to be binary compatible, and there's no good reason for anyone to use these traits explicitly.