### PR TITLE
Fix argument order in deprecations

### DIFF
--- a/core/src/main/scala-2.13+/cats/data/OneAndLowPriority4.scala
+++ b/core/src/main/scala-2.13+/cats/data/OneAndLowPriority4.scala
@@ -5,7 +5,7 @@ import scala.annotation.tailrec
 import scala.collection.mutable.Builder
 
 abstract private[data] class OneAndLowPriority4 {
-  @deprecated("2.0.0-RC2", "Use catsDataComonadForNonEmptyLazyList")
+  @deprecated("Use catsDataComonadForNonEmptyLazyList", "2.0.0-RC2")
   implicit def catsDataComonadForNonEmptyStream: Comonad[OneAnd[Stream, *]] =
     new Comonad[OneAnd[Stream, *]] {
       def coflatMap[A, B](fa: OneAnd[Stream, A])(f: OneAnd[Stream, A] => B): OneAnd[Stream, B] = {

--- a/core/src/main/scala-2.13+/cats/data/ScalaVersionSpecificPackage.scala
+++ b/core/src/main/scala-2.13+/cats/data/ScalaVersionSpecificPackage.scala
@@ -3,14 +3,14 @@ package data
 
 abstract private[data] class ScalaVersionSpecificPackage {
   type NonEmptyLazyList[+A] = NonEmptyLazyList.Type[A]
-  @deprecated("2.0.0-RC2", "Use NonEmptyLazyList")
+  @deprecated("Use NonEmptyLazyList", "2.0.0-RC2")
   type NonEmptyStream[A] = OneAnd[Stream, A]
 
-  @deprecated("2.0.0-RC2", "Use NonEmptyLazyList")
+  @deprecated("Use NonEmptyLazyList", "2.0.0-RC2")
   def NonEmptyStream[A](head: A, tail: Stream[A]): NonEmptyStream[A] =
     OneAnd(head, tail)
 
-  @deprecated("2.0.0-RC2", "Use NonEmptyLazyList")
+  @deprecated("Use NonEmptyLazyList", "2.0.0-RC2")
   def NonEmptyStream[A](head: A, tail: A*): NonEmptyStream[A] =
     OneAnd(head, tail.toStream)
 }

--- a/core/src/main/scala-2.13+/cats/data/ZipStream.scala
+++ b/core/src/main/scala-2.13+/cats/data/ZipStream.scala
@@ -1,10 +1,10 @@
 package cats
 package data
 
-@deprecated("2.0.0-RC2", "Use ZipLazyList")
+@deprecated("Use ZipLazyList", "2.0.0-RC2")
 class ZipStream[A](val value: Stream[A]) extends AnyVal
 
-@deprecated("2.0.0-RC2", "Use ZipLazyList")
+@deprecated("Use ZipLazyList", "2.0.0-RC2")
 object ZipStream {
 
   def apply[A](value: Stream[A]): ZipStream[A] = new ZipStream(value)

--- a/core/src/main/scala-2.13+/cats/instances/ScalaVersionSpecificParallelInstances.scala
+++ b/core/src/main/scala-2.13+/cats/instances/ScalaVersionSpecificParallelInstances.scala
@@ -65,7 +65,7 @@ trait ParallelInstances extends ParallelInstances1 {
         λ[Vector ~> ZipVector](v => new ZipVector(v))
     }
 
-  @deprecated("2.0.0-RC2", "Use catsStdParallelForZipLazyList")
+  @deprecated("Use catsStdParallelForZipLazyList", "2.0.0-RC2")
   implicit def catsStdParallelForZipStream[A]: Parallel[Stream, ZipStream] =
     new Parallel[Stream, ZipStream] {
 

--- a/core/src/main/scala-2.13+/cats/instances/package.scala
+++ b/core/src/main/scala-2.13+/cats/instances/package.scala
@@ -41,7 +41,7 @@ package object instances {
   object sortedMap extends SortedMapInstances with SortedMapInstancesBinCompat0 with SortedMapInstancesBinCompat1
   object sortedSet extends SortedSetInstances with SortedSetInstancesBinCompat0
 
-  @deprecated("2.0.0-RC2", "Use cats.instances.lazyList")
+  @deprecated("Use cats.instances.lazyList", "2.0.0-RC2")
   object stream extends StreamInstances with StreamInstancesBinCompat0
   object lazyList extends LazyListInstances
   object string extends StringInstances

--- a/core/src/main/scala-2.13+/cats/instances/stream.scala
+++ b/core/src/main/scala-2.13+/cats/instances/stream.scala
@@ -7,7 +7,7 @@ import scala.annotation.tailrec
 
 trait StreamInstances extends cats.kernel.instances.StreamInstances {
 
-  @deprecated("2.0.0-RC2", "Use cats.instances.lazyList")
+  @deprecated("Use cats.instances.lazyList", "2.0.0-RC2")
   implicit val catsStdInstancesForStream
     : Traverse[Stream] with Alternative[Stream] with Monad[Stream] with CoflatMap[Stream] =
     new Traverse[Stream] with Alternative[Stream] with Monad[Stream] with CoflatMap[Stream] {
@@ -153,7 +153,7 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
         fa.collectFirst(Function.unlift(f))
     }
 
-  @deprecated("2.0.0-RC2", "Use cats.instances.lazyList")
+  @deprecated("Use cats.instances.lazyList", "2.0.0-RC2")
   implicit def catsStdShowForStream[A: Show]: Show[Stream[A]] =
     new Show[Stream[A]] {
       def show(fa: Stream[A]): String = if (fa.isEmpty) "Stream()" else s"Stream(${fa.head.show}, ?)"
@@ -162,7 +162,7 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
 }
 
 private[instances] trait StreamInstancesBinCompat0 {
-  @deprecated("2.0.0-RC2", "Use cats.instances.lazyList")
+  @deprecated("Use cats.instances.lazyList", "2.0.0-RC2")
   implicit val catsStdTraverseFilterForStream: TraverseFilter[Stream] = new TraverseFilter[Stream] {
     val traverse: Traverse[Stream] = cats.instances.stream.catsStdInstancesForStream
 

--- a/kernel/src/main/scala-2.13+/cats/kernel/instances/StreamInstances.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/instances/StreamInstances.scala
@@ -2,57 +2,57 @@ package cats.kernel
 package instances
 
 trait StreamInstances extends StreamInstances1 {
-  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.lazyList")
+  @deprecated("Use cats.kernel.instances.lazyList", "2.0.0-RC2")
   implicit def catsKernelStdOrderForStream[A: Order]: Order[Stream[A]] =
     new StreamOrder[A]
-  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.lazyList")
+  @deprecated("Use cats.kernel.instances.lazyList", "2.0.0-RC2")
   implicit def catsKernelStdMonoidForStream[A]: Monoid[Stream[A]] =
     new StreamMonoid[A]
 }
 
 private[instances] trait StreamInstances1 extends StreamInstances2 {
-  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.lazyList")
+  @deprecated("Use cats.kernel.instances.lazyList", "2.0.0-RC2")
   implicit def catsKernelStdPartialOrderForStream[A: PartialOrder]: PartialOrder[Stream[A]] =
     new StreamPartialOrder[A]
 
-  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.lazyList")
+  @deprecated("Use cats.kernel.instances.lazyList", "2.0.0-RC2")
   implicit def catsKernelStdHashForStream[A: Hash]: Hash[Stream[A]] =
     new StreamHash[A]
 }
 
 private[instances] trait StreamInstances2 {
-  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.lazyList")
+  @deprecated("Use cats.kernel.instances.lazyList", "2.0.0-RC2")
   implicit def catsKernelStdEqForStream[A: Eq]: Eq[Stream[A]] =
     new StreamEq[A]
 }
 
-@deprecated("2.0.0-RC2", "Use cats.kernel.instances.lazyList")
+@deprecated("Use cats.kernel.instances.lazyList", "2.0.0-RC2")
 class StreamOrder[A](implicit ev: Order[A]) extends Order[Stream[A]] {
   def compare(xs: Stream[A], ys: Stream[A]): Int =
     if (xs eq ys) 0
     else StaticMethods.iteratorCompare(xs.iterator, ys.iterator)
 }
 
-@deprecated("2.0.0-RC2", "Use cats.kernel.instances.lazyList")
+@deprecated("Use cats.kernel.instances.lazyList", "2.0.0-RC2")
 class StreamPartialOrder[A](implicit ev: PartialOrder[A]) extends PartialOrder[Stream[A]] {
   def partialCompare(xs: Stream[A], ys: Stream[A]): Double =
     if (xs eq ys) 0.0
     else StaticMethods.iteratorPartialCompare(xs.iterator, ys.iterator)
 }
 
-@deprecated("2.0.0-RC2", "Use cats.kernel.instances.lazyList")
+@deprecated("Use cats.kernel.instances.lazyList", "2.0.0-RC2")
 class StreamHash[A](implicit ev: Hash[A]) extends StreamEq[A]()(ev) with Hash[Stream[A]] {
   def hash(xs: Stream[A]): Int = StaticMethods.orderedHash(xs)
 }
 
-@deprecated("2.0.0-RC2", "Use cats.kernel.instances.lazyList")
+@deprecated("Use cats.kernel.instances.lazyList", "2.0.0-RC2")
 class StreamEq[A](implicit ev: Eq[A]) extends Eq[Stream[A]] {
   def eqv(xs: Stream[A], ys: Stream[A]): Boolean =
     if (xs eq ys) true
     else StaticMethods.iteratorEq(xs.iterator, ys.iterator)
 }
 
-@deprecated("2.0.0-RC2", "Use cats.kernel.instances.lazyList")
+@deprecated("Use cats.kernel.instances.lazyList", "2.0.0-RC2")
 class StreamMonoid[A] extends Monoid[Stream[A]] {
   def empty: Stream[A] = Stream.empty
   def combine(x: Stream[A], y: Stream[A]): Stream[A] = x ++ y

--- a/laws/src/main/scala-2.13+/cats/laws/discipline/ScalaVersionSpecific.scala
+++ b/laws/src/main/scala-2.13+/cats/laws/discipline/ScalaVersionSpecific.scala
@@ -6,7 +6,7 @@ import org.scalacheck.{Arbitrary, Cogen}
 private[discipline] object ScalaVersionSpecific {
 
   trait ArbitraryInstances {
-    @deprecated("2.0.0-RC2", "Use catsLawsArbitraryForZipLazyList")
+    @deprecated("Use catsLawsArbitraryForZipLazyList", "2.0.0-RC2")
     implicit def catsLawsArbitraryForZipStream[A](implicit A: Arbitrary[A]): Arbitrary[ZipStream[A]] =
       Arbitrary(implicitly[Arbitrary[Stream[A]]].arbitrary.map(v => new ZipStream(v)))
 


### PR DESCRIPTION
I messed this one up, hurray for stringly typed arguments! This PR does nothing but switch the `since` version and message.