### PR TITLE
Fix a few issues related to bin-compat traits

### DIFF
--- a/core/src/main/scala-2.12-/cats/instances/all.scala
+++ b/core/src/main/scala-2.12-/cats/instances/all.scala
@@ -43,9 +43,9 @@ trait AllInstances
     with UUIDInstances
     with VectorInstances
 
-private[cats] trait AllInstancesBinCompat0 extends FunctionInstancesBinCompat0 with Tuple2InstancesBinCompat0
+trait AllInstancesBinCompat0 extends FunctionInstancesBinCompat0 with Tuple2InstancesBinCompat0
 
-private[cats] trait AllInstancesBinCompat1
+trait AllInstancesBinCompat1
     extends OptionInstancesBinCompat0
     with ListInstancesBinCompat0
     with VectorInstancesBinCompat0
@@ -53,12 +53,12 @@ private[cats] trait AllInstancesBinCompat1
     with MapInstancesBinCompat0
     with SortedMapInstancesBinCompat0
 
-private[cats] trait AllInstancesBinCompat2 extends DurationInstances with FiniteDurationInstances
+trait AllInstancesBinCompat2 extends DurationInstances with FiniteDurationInstances
 
-private[cats] trait AllInstancesBinCompat3 extends AllCoreDurationInstances
+trait AllInstancesBinCompat3 extends AllCoreDurationInstances
 
-private[cats] trait AllInstancesBinCompat4 extends SortedMapInstancesBinCompat1 with MapInstancesBinCompat1
+trait AllInstancesBinCompat4 extends SortedMapInstancesBinCompat1 with MapInstancesBinCompat1
 
-private[cats] trait AllInstancesBinCompat5 extends SortedSetInstancesBinCompat0
+trait AllInstancesBinCompat5 extends SortedSetInstancesBinCompat0
 
-private[cats] trait AllInstancesBinCompat6 extends SortedSetInstancesBinCompat1 with SortedMapInstancesBinCompat2
+trait AllInstancesBinCompat6 extends SortedSetInstancesBinCompat1 with SortedMapInstancesBinCompat2

--- a/core/src/main/scala-2.12-/cats/instances/all.scala
+++ b/core/src/main/scala-2.12-/cats/instances/all.scala
@@ -1,6 +1,16 @@
 package cats
 package instances
 
+abstract class AllInstancesBinCompat
+    extends AllInstances
+    with AllInstancesBinCompat0
+    with AllInstancesBinCompat1
+    with AllInstancesBinCompat2
+    with AllInstancesBinCompat3
+    with AllInstancesBinCompat4
+    with AllInstancesBinCompat5
+    with AllInstancesBinCompat6
+
 trait AllInstances
     extends AnyValInstances
     with BigIntInstances

--- a/core/src/main/scala-2.12-/cats/instances/package.scala
+++ b/core/src/main/scala-2.12-/cats/instances/package.scala
@@ -1,15 +1,7 @@
 package cats
 
 package object instances {
-  object all
-      extends AllInstances
-      with AllInstancesBinCompat0
-      with AllInstancesBinCompat1
-      with AllInstancesBinCompat2
-      with AllInstancesBinCompat3
-      with AllInstancesBinCompat4
-      with AllInstancesBinCompat5
-      with AllInstancesBinCompat6
+  object all extends AllInstancesBinCompat
   object bigInt extends BigIntInstances
   object bigDecimal extends BigDecimalInstances
   object bitSet extends BitSetInstances

--- a/core/src/main/scala-2.13+/cats/instances/all.scala
+++ b/core/src/main/scala-2.13+/cats/instances/all.scala
@@ -44,9 +44,9 @@ trait AllInstances
     with UUIDInstances
     with VectorInstances
 
-private[cats] trait AllInstancesBinCompat0 extends FunctionInstancesBinCompat0 with Tuple2InstancesBinCompat0
+trait AllInstancesBinCompat0 extends FunctionInstancesBinCompat0 with Tuple2InstancesBinCompat0
 
-private[cats] trait AllInstancesBinCompat1
+trait AllInstancesBinCompat1
     extends OptionInstancesBinCompat0
     with ListInstancesBinCompat0
     with VectorInstancesBinCompat0
@@ -54,12 +54,12 @@ private[cats] trait AllInstancesBinCompat1
     with MapInstancesBinCompat0
     with SortedMapInstancesBinCompat0
 
-private[cats] trait AllInstancesBinCompat2 extends DurationInstances with FiniteDurationInstances
+trait AllInstancesBinCompat2 extends DurationInstances with FiniteDurationInstances
 
-private[cats] trait AllInstancesBinCompat3 extends AllCoreDurationInstances
+trait AllInstancesBinCompat3 extends AllCoreDurationInstances
 
-private[cats] trait AllInstancesBinCompat4 extends SortedMapInstancesBinCompat1 with MapInstancesBinCompat1
+trait AllInstancesBinCompat4 extends SortedMapInstancesBinCompat1 with MapInstancesBinCompat1
 
-private[cats] trait AllInstancesBinCompat5 extends SortedSetInstancesBinCompat0
+trait AllInstancesBinCompat5 extends SortedSetInstancesBinCompat0
 
-private[cats] trait AllInstancesBinCompat6 extends SortedSetInstancesBinCompat1 with SortedMapInstancesBinCompat2
+trait AllInstancesBinCompat6 extends SortedSetInstancesBinCompat1 with SortedMapInstancesBinCompat2

--- a/core/src/main/scala-2.13+/cats/instances/all.scala
+++ b/core/src/main/scala-2.13+/cats/instances/all.scala
@@ -1,6 +1,16 @@
 package cats
 package instances
 
+abstract class AllInstancesBinCompat
+    extends AllInstances
+    with AllInstancesBinCompat0
+    with AllInstancesBinCompat1
+    with AllInstancesBinCompat2
+    with AllInstancesBinCompat3
+    with AllInstancesBinCompat4
+    with AllInstancesBinCompat5
+    with AllInstancesBinCompat6
+
 trait AllInstances
     extends AnyValInstances
     with BigIntInstances

--- a/core/src/main/scala-2.13+/cats/instances/package.scala
+++ b/core/src/main/scala-2.13+/cats/instances/package.scala
@@ -1,15 +1,7 @@
 package cats
 
 package object instances {
-  object all
-      extends AllInstances
-      with AllInstancesBinCompat0
-      with AllInstancesBinCompat1
-      with AllInstancesBinCompat2
-      with AllInstancesBinCompat3
-      with AllInstancesBinCompat4
-      with AllInstancesBinCompat5
-      with AllInstancesBinCompat6
+  object all extends AllInstancesBinCompat
   object bigInt extends BigIntInstances
   object bigDecimal extends BigDecimalInstances
   object bitSet extends BitSetInstances

--- a/core/src/main/scala/cats/implicits.scala
+++ b/core/src/main/scala/cats/implicits.scala
@@ -7,6 +7,8 @@ object implicits
     with syntax.AllSyntaxBinCompat2
     with syntax.AllSyntaxBinCompat3
     with syntax.AllSyntaxBinCompat4
+    with syntax.AllSyntaxBinCompat5
+    with syntax.AllSyntaxBinCompat6
     with instances.AllInstances
     with instances.AllInstancesBinCompat0
     with instances.AllInstancesBinCompat1
@@ -14,3 +16,4 @@ object implicits
     with instances.AllInstancesBinCompat3
     with instances.AllInstancesBinCompat4
     with instances.AllInstancesBinCompat5
+    with instances.AllInstancesBinCompat6

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -1,7 +1,7 @@
 package cats
 package syntax
 
-abstract private[cats] class AllSyntaxBinCompat
+abstract class AllSyntaxBinCompat
     extends AllSyntax
     with AllSyntaxBinCompat0
     with AllSyntaxBinCompat1
@@ -59,9 +59,9 @@ trait AllSyntax
     with VectorSyntax
     with WriterSyntax
 
-private[cats] trait AllSyntaxBinCompat0 extends UnorderedTraverseSyntax with ApplicativeErrorExtension with TrySyntax
+trait AllSyntaxBinCompat0 extends UnorderedTraverseSyntax with ApplicativeErrorExtension with TrySyntax
 
-private[cats] trait AllSyntaxBinCompat1
+trait AllSyntaxBinCompat1
     extends FlatMapOptionSyntax
     with ChoiceSyntax
     with NestedSyntax
@@ -71,7 +71,7 @@ private[cats] trait AllSyntaxBinCompat1
     with ValidatedExtensionSyntax
     with RepresentableSyntax
 
-private[cats] trait AllSyntaxBinCompat2
+trait AllSyntaxBinCompat2
     extends ParallelTraverseSyntax
     with TraverseFilterSyntax
     with FunctorFilterSyntax
@@ -79,9 +79,9 @@ private[cats] trait AllSyntaxBinCompat2
     with ListSyntaxBinCompat0
     with ValidatedSyntaxBincompat0
 
-private[cats] trait AllSyntaxBinCompat3 extends UnorderedFoldableSyntax with Function1Syntax
+trait AllSyntaxBinCompat3 extends UnorderedFoldableSyntax with Function1Syntax
 
-private[cats] trait AllSyntaxBinCompat4
+trait AllSyntaxBinCompat4
     extends TraverseFilterSyntaxBinCompat0
     with ApplySyntaxBinCompat0
     with ParallelApplySyntax
@@ -90,6 +90,6 @@ private[cats] trait AllSyntaxBinCompat4
     with FoldableSyntaxBinCompat1
     with BitraverseSyntaxBinCompat0
 
-private[cats] trait AllSyntaxBinCompat5 extends ParallelBitraverseSyntax
+trait AllSyntaxBinCompat5 extends ParallelBitraverseSyntax
 
-private[cats] trait AllSyntaxBinCompat6 extends ParallelUnorderedTraverseSyntax
+trait AllSyntaxBinCompat6 extends ParallelUnorderedTraverseSyntax

--- a/tests/src/test/scala/cats/tests/CatsSuite.scala
+++ b/tests/src/test/scala/cats/tests/CatsSuite.scala
@@ -52,6 +52,7 @@ trait CatsSuite
     with AllSyntaxBinCompat3
     with AllSyntaxBinCompat4
     with AllSyntaxBinCompat5
+    with AllSyntaxBinCompat6
     with StrictCatsEquality {
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =

--- a/tests/src/test/scala/cats/tests/SyntaxSuite.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxSuite.scala
@@ -5,7 +5,16 @@ import scala.collection.immutable.SortedSet
 import scala.collection.immutable.SortedMap
 import cats.arrow.Compose
 import cats.data.{Binested, Nested, NonEmptyChain, NonEmptyList, NonEmptySet}
-import cats.instances.{AllInstances, AllInstancesBinCompat0, AllInstancesBinCompat1, AllInstancesBinCompat2}
+import cats.instances.{
+  AllInstances,
+  AllInstancesBinCompat0,
+  AllInstancesBinCompat1,
+  AllInstancesBinCompat2,
+  AllInstancesBinCompat3,
+  AllInstancesBinCompat4,
+  AllInstancesBinCompat5,
+  AllInstancesBinCompat6
+}
 import cats.syntax.AllSyntaxBinCompat
 
 /**
@@ -31,7 +40,11 @@ object SyntaxSuite
     with AllInstances
     with AllInstancesBinCompat0
     with AllInstancesBinCompat1
-    with AllInstancesBinCompat2 {
+    with AllInstancesBinCompat2
+    with AllInstancesBinCompat3
+    with AllInstancesBinCompat4
+    with AllInstancesBinCompat5
+    with AllInstancesBinCompat6 {
 
   // pretend we have a value of type A
   def mock[A]: A = ???


### PR DESCRIPTION
See #3007 and #3008 for some context. This PR does three (related) things:

* It brings everything that depends on the `AllSyntax` and `AllInstances` traits up to date on the latest `BinCompat` levels, fixing #3007 and some similar problems.
* It adds a new `AllInstancesBinCompat` class that works the same way as the existing `AllSyntaxBinCompat`.
* It makes all the `AllXBinCompatN` traits public again (undoing one small piece of #3003). This is necessary to support some common usage (see #3008 for details), but that might be something we decide to stop supporting in the future.