### PR TITLE
Add Parallel.apply overload with one type parameter

### DIFF
--- a/core/src/main/scala/cats/Parallel.scala
+++ b/core/src/main/scala/cats/Parallel.scala
@@ -110,12 +110,14 @@ object NonEmptyParallel {
   type Aux[M[_], F0[_]] = NonEmptyParallel[M] { type F[x] = F0[x] }
 
   def apply[M[_], F[_]](implicit P: NonEmptyParallel.Aux[M, F]): NonEmptyParallel.Aux[M, F] = P
+  def apply[M[_]](implicit P: NonEmptyParallel[M], D: DummyImplicit): NonEmptyParallel.Aux[M, P.F] = P
 }
 
 object Parallel extends ParallelArityFunctions2 {
   type Aux[M[_], F0[_]] = Parallel[M] { type F[x] = F0[x] }
 
   def apply[M[_], F[_]](implicit P: Parallel.Aux[M, F]): Parallel.Aux[M, F] = P
+  def apply[M[_]](implicit P: Parallel[M], D: DummyImplicit): Parallel.Aux[M, P.F] = P
 
   /**
    * Like `Traverse[A].sequence`, but uses the applicative instance

--- a/tests/src/test/scala/cats/tests/ParallelSuite.scala
+++ b/tests/src/test/scala/cats/tests/ParallelSuite.scala
@@ -477,6 +477,26 @@ class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest with Sc
     )
   }
 
+  test("NonEmptyParallel.apply should return an appropriately typed instance given both type parameters") {
+    val p1: NonEmptyParallel.Aux[Either[String, *], Validated[String, *]] =
+      NonEmptyParallel[Either[String, *], Validated[String, *]]
+    val p2: NonEmptyParallel.Aux[NonEmptyList, ZipNonEmptyList] = NonEmptyParallel[NonEmptyList, ZipNonEmptyList]
+  }
+
+  test("NonEmptyParallel.apply should return an appropriately typed instance given the first type parameter") {
+    val p1: NonEmptyParallel.Aux[Either[String, *], Validated[String, *]] = NonEmptyParallel[Either[String, *]]
+    val p2: NonEmptyParallel.Aux[NonEmptyList, ZipNonEmptyList] = NonEmptyParallel[NonEmptyList]
+  }
+
+  test("Parallel.apply should return an appropriately typed instance given both type parameters") {
+    val p1: Parallel.Aux[Either[String, *], Validated[String, *]] = Parallel[Either[String, *], Validated[String, *]]
+    val p2: Parallel.Aux[Stream, ZipStream] = Parallel[Stream, ZipStream]
+  }
+
+  test("Parallel.apply should return an appropriately typed instance given the first type parameter") {
+    val p1: Parallel.Aux[Either[String, *], Validated[String, *]] = Parallel[Either[String, *], Validated[String, *]]
+    val p2: Parallel.Aux[Stream, ZipStream] = Parallel[Stream]
+  }
 }
 
 trait ApplicativeErrorForEitherTest extends AnyFunSuiteLike with Discipline {


### PR DESCRIPTION
I left this out of #3012 intentionally, since I generally avoid overloading and hate the `scala.DummyImplicit` hack, which is necessary here, and since I didn't think the need for it would come up that often.

As I've been working more with 2.0.0-RC2 this week, though, I've decided that we really do want this `Parallel.apply` in 2.0, for a few reasons:

1. The two-type-parameter `apply` is pretty useless.
2. The thing people do when a type class doesn't have a useful `apply` is go to `implicitly`, which in this case is pretty unhelpful for something like `Parallel[Stream]`, since its static return type is unrefined. To get a usefully typed instance, you have to go to something like Shapeless's `the` or define your own version of `Parallel.apply` with a single parameter.
3. In practice using `Parallel` syntax still can be not a great user experience, for a number of reasons, like the fact that if you're working with something like `EitherT`, you might expect the `Parallel[EitherT[F, E, *]]` to be in implicit scope, since a lot of `EitherT`'s other instances are (`Traverse`, `Monad`, etc.), but no, it has to be imported. When I get frustrated by a type class's syntax, I just fall back to trying to use its `apply` and call the methods on the instance directly, which at least shrinks the problem space. In this case, where frustration is especially likely, you really want a `Parallel.apply` that isn't useless.

The implementation is pretty straightforward apart from the horrible `scala.DummyImplicit` part, but without that we'd need a new method name, and the whole point here is easy discovery and matching users' expectations, so I think overloading is the right approach.

The tests are pretty simple checks that the static types come out right. I've also added tests for the old two-type-parameter overloads for consistency.

**Update**: note that this change technically breaks source compatibility—it causes the following code not to compile, although it was fine in 2.0.0-RC2:

```scala
import cats.Parallel, cats.data.ZipStream, cats.implicits._

Parallel.apply: Parallel.Aux[Stream, ZipStream]
```
Same with this (it compiles with 2.0.0-RC2, but not after this change):
```scala
val p: Parallel.Aux[Stream, ZipStream] = Parallel.apply
```
~~Neither of the following compile with 2.0.0-RC1, but off the top of my head I'm not sure why (I only tried 2.13):~~ Both of the following are also fine with 1.x or 2.0.0-RC1 on 2.12 (not 2.0.0-RC1 on 2.13, but that's because of some unrelated aliasing stuff):

```scala
Parallel.apply: Parallel[Stream, ZipStream]
val p: Parallel[Stream, ZipStream] = Parallel.apply
```

There's no reason I can think of that someone would want to do any of this in real code, and I'd be very surprised if it causes problems for anyone.