### PR TITLE
Move Parallel instances for EitherT and OptionT into implicit scope

### DIFF
--- a/core/src/main/scala-2.12-/cats/instances/ScalaVersionSpecificParallelInstances.scala
+++ b/core/src/main/scala-2.12-/cats/instances/ScalaVersionSpecificParallelInstances.scala
@@ -4,7 +4,7 @@ package instances
 import cats.data._
 import cats.kernel.Semigroup
 import cats.syntax.either._
-import cats.{~>, Applicative, Apply, FlatMap, Functor, Monad, NonEmptyParallel, Parallel}
+import cats.{~>, Applicative, Apply, FlatMap, Monad, NonEmptyParallel, Parallel}
 
 trait ParallelInstances extends ParallelInstances1 {
   implicit def catsParallelForEitherValidated[E: Semigroup]: Parallel.Aux[Either[E, *], Validated[E, *]] =
@@ -21,24 +21,10 @@ trait ParallelInstances extends ParallelInstances1 {
         λ[Either[E, *] ~> Validated[E, *]](_.toValidated)
     }
 
-  implicit def catsParallelForOptionTNestedOption[M[_]](
+  @deprecated("Use OptionT.catsDataParallelForOptionT", "2.0.0")
+  private[instances] def catsParallelForOptionTNestedOption[M[_]](
     implicit P: Parallel[M]
-  ): Parallel.Aux[OptionT[M, *], Nested[P.F, Option, *]] = new Parallel[OptionT[M, *]] {
-    type F[x] = Nested[P.F, Option, x]
-
-    implicit val monadM: Monad[M] = P.monad
-
-    def applicative: Applicative[Nested[P.F, Option, *]] =
-      cats.data.Nested.catsDataApplicativeForNested(P.applicative, cats.instances.option.catsStdInstancesForOption)
-
-    def monad: Monad[OptionT[M, *]] = cats.data.OptionT.catsDataMonadErrorMonadForOptionT[M]
-
-    def sequential: Nested[P.F, Option, *] ~> OptionT[M, *] =
-      λ[Nested[P.F, Option, *] ~> OptionT[M, *]](nested => OptionT(P.sequential(nested.value)))
-
-    def parallel: OptionT[M, *] ~> Nested[P.F, Option, *] =
-      λ[OptionT[M, *] ~> Nested[P.F, Option, *]](optT => Nested(P.parallel(optT.value)))
-  }
+  ): Parallel.Aux[OptionT[M, *], Nested[P.F, Option, *]] = OptionT.catsDataParallelForOptionT[M]
 
   implicit def catsStdNonEmptyParallelForZipList[A]: NonEmptyParallel.Aux[List, ZipList] =
     new NonEmptyParallel[List] {
@@ -82,30 +68,9 @@ trait ParallelInstances extends ParallelInstances1 {
         λ[Stream ~> ZipStream](v => new ZipStream(v))
     }
 
-  implicit def catsParallelForEitherTNestedParallelValidated[M[_], E: Semigroup](
+  @deprecated("Use EitherT.catsDataParallelForEitherT", "2.0.0")
+  private[instances] def catsParallelForEitherTNestedParallelValidated[M[_], E: Semigroup](
     implicit P: Parallel[M]
   ): Parallel.Aux[EitherT[M, E, *], Nested[P.F, Validated[E, *], *]] =
-    new Parallel[EitherT[M, E, *]] {
-      type F[x] = Nested[P.F, Validated[E, *], x]
-
-      implicit val monadM: Monad[M] = P.monad
-      implicit val monadEither: Monad[Either[E, *]] = cats.instances.either.catsStdInstancesForEither
-
-      def applicative: Applicative[Nested[P.F, Validated[E, *], *]] =
-        cats.data.Nested.catsDataApplicativeForNested(P.applicative, Validated.catsDataApplicativeErrorForValidated)
-
-      def monad: Monad[EitherT[M, E, *]] = cats.data.EitherT.catsDataMonadErrorForEitherT
-
-      def sequential: Nested[P.F, Validated[E, *], *] ~> EitherT[M, E, *] =
-        λ[Nested[P.F, Validated[E, *], *] ~> EitherT[M, E, *]] { nested =>
-          val mva = P.sequential(nested.value)
-          EitherT(Functor[M].map(mva)(_.toEither))
-        }
-
-      def parallel: EitherT[M, E, *] ~> Nested[P.F, Validated[E, *], *] =
-        λ[EitherT[M, E, *] ~> Nested[P.F, Validated[E, *], *]] { eitherT =>
-          val fea = P.parallel(eitherT.value)
-          Nested(P.applicative.map(fea)(_.toValidated))
-        }
-    }
+    EitherT.catsDataParallelForEitherT[M, E]
 }

--- a/core/src/main/scala-2.12-/cats/instances/ScalaVersionSpecificParallelInstances.scala
+++ b/core/src/main/scala-2.12-/cats/instances/ScalaVersionSpecificParallelInstances.scala
@@ -68,9 +68,9 @@ trait ParallelInstances extends ParallelInstances1 {
         λ[Stream ~> ZipStream](v => new ZipStream(v))
     }
 
-  @deprecated("Use EitherT.catsDataParallelForEitherT", "2.0.0")
+  @deprecated("Use EitherT.catsDataParallelForEitherTWithParallelEffect", "2.0.0")
   private[instances] def catsParallelForEitherTNestedParallelValidated[M[_], E: Semigroup](
     implicit P: Parallel[M]
   ): Parallel.Aux[EitherT[M, E, *], Nested[P.F, Validated[E, *], *]] =
-    EitherT.catsDataParallelForEitherT[M, E]
+    EitherT.catsDataParallelForEitherTWithParallelEffect[M, E]
 }

--- a/core/src/main/scala-2.13+/cats/instances/ScalaVersionSpecificParallelInstances.scala
+++ b/core/src/main/scala-2.13+/cats/instances/ScalaVersionSpecificParallelInstances.scala
@@ -83,9 +83,9 @@ trait ParallelInstances extends ParallelInstances1 {
         λ[LazyList ~> ZipLazyList](v => new ZipLazyList(v))
     }
 
-  @deprecated("Use EitherT.catsDataParallelForEitherT", "2.0.0")
+  @deprecated("Use EitherT.catsDataParallelForEitherTWithParallelEffect", "2.0.0")
   private[instances] def catsParallelForEitherTNestedParallelValidated[M[_], E: Semigroup](
     implicit P: Parallel[M]
   ): Parallel.Aux[EitherT[M, E, *], Nested[P.F, Validated[E, *], *]] =
-    EitherT.catsDataParallelForEitherT[M, E]
+    EitherT.catsDataParallelForEitherTWithParallelEffect[M, E]
 }

--- a/core/src/main/scala-2.13+/cats/instances/ScalaVersionSpecificParallelInstances.scala
+++ b/core/src/main/scala-2.13+/cats/instances/ScalaVersionSpecificParallelInstances.scala
@@ -4,7 +4,7 @@ package instances
 import cats.data._
 import cats.kernel.Semigroup
 import cats.syntax.either._
-import cats.{~>, Applicative, Apply, FlatMap, Functor, Monad, NonEmptyParallel, Parallel}
+import cats.{~>, Applicative, Apply, FlatMap, Monad, NonEmptyParallel, Parallel}
 
 trait ParallelInstances extends ParallelInstances1 {
   implicit def catsParallelForEitherValidated[E: Semigroup]: Parallel.Aux[Either[E, *], Validated[E, *]] =

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -537,7 +537,7 @@ abstract private[data] class EitherTInstances extends EitherTInstances1 {
         EitherT(F.defer(fa.value))
     }
 
-  implicit def catsDataParallelForEitherT[M[_], E: Semigroup](
+  implicit def catsDataParallelForEitherTWithParallelEffect[M[_], E: Semigroup](
     implicit P: Parallel[M]
   ): Parallel.Aux[EitherT[M, E, *], Nested[P.F, Validated[E, *], *]] =
     new Parallel[EitherT[M, E, *]] {

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -598,6 +598,30 @@ abstract private[data] class EitherTInstances1 extends EitherTInstances2 {
       override def ensureOr[A](fa: EitherT[F, L, A])(error: (A) => L)(predicate: (A) => Boolean): EitherT[F, L, A] =
         fa.ensureOr(error)(predicate)(F)
     }
+
+  implicit def catsDataParallelForEitherTWithSequentialEffect[M[_]: Monad, E: Semigroup]
+    : Parallel.Aux[EitherT[M, E, *], Nested[M, Validated[E, *], *]] =
+    new Parallel[EitherT[M, E, *]] {
+      type F[x] = Nested[M, Validated[E, *], x]
+
+      implicit val appValidated: Applicative[Validated[E, *]] = Validated.catsDataApplicativeErrorForValidated
+      implicit val monadEither: Monad[Either[E, *]] = cats.instances.either.catsStdInstancesForEither
+
+      def applicative: Applicative[Nested[M, Validated[E, *], *]] =
+        cats.data.Nested.catsDataApplicativeForNested[M, Validated[E, *]]
+
+      def monad: Monad[EitherT[M, E, *]] = cats.data.EitherT.catsDataMonadErrorForEitherT
+
+      def sequential: Nested[M, Validated[E, *], *] ~> EitherT[M, E, *] =
+        λ[Nested[M, Validated[E, *], *] ~> EitherT[M, E, *]] { nested =>
+          EitherT(Monad[M].map(nested.value)(_.toEither))
+        }
+
+      def parallel: EitherT[M, E, *] ~> Nested[M, Validated[E, *], *] =
+        λ[EitherT[M, E, *] ~> Nested[M, Validated[E, *], *]] { eitherT =>
+          Nested(Monad[M].map(eitherT.value)(_.toValidated))
+        }
+    }
 }
 
 abstract private[data] class EitherTInstances2 extends EitherTInstances3 {

--- a/core/src/main/scala/cats/instances/parallel.scala
+++ b/core/src/main/scala/cats/instances/parallel.scala
@@ -7,7 +7,8 @@ import cats.syntax.either._
 import cats.{~>, Applicative, Monad, Parallel}
 
 private[instances] trait ParallelInstances1 {
-  implicit def catsParallelForEitherTNestedValidated[M[_]: Monad, E: Semigroup]
+  @deprecated("Use EitherT.catsDataParallelForEitherTWithSequentialEffect", "2.0.0")
+  private[instances] def catsParallelForEitherTNestedValidated[M[_]: Monad, E: Semigroup]
     : Parallel.Aux[EitherT[M, E, *], Nested[M, Validated[E, *], *]] =
     new Parallel[EitherT[M, E, *]] {
       type F[x] = Nested[M, Validated[E, *], x]


### PR DESCRIPTION
Fixes #3032. Now the following works:

```scala
scala> import cats.{Id, Parallel}, cats.instances.list._, cats.instances.string._
import cats.{Id, Parallel}
import cats.instances.list._
import cats.instances.string._

scala> type EI[A] = cats.data.EitherT[Id, String, A]
defined type alias EI

scala> implicitly[Parallel[EI]]
res0: cats.Parallel[EI] = cats.data.EitherTInstances$$anon$7@3f7c7017

scala> type EL[A] = cats.data.EitherT[List, String, A]
defined type alias EL

scala> implicitly[Parallel[EL]]
res1: cats.Parallel[EL] = cats.data.EitherTInstances1$$anon$15@1124d0e8

scala> type OI[A] = cats.data.OptionT[Id, A]
defined type alias OI

scala> implicitly[Parallel[OI]]
res2: cats.Parallel[OI] = cats.data.OptionTInstances$$anon$8@3e5db9dc
```

This should have no changes for existing code that doesn't refer to the two `cats.instances.parallel` instances by name (I've made them package-private, not just deprecated them). It doesn't break binary compatibility.