### PR TITLE
Add cats.kernel.instances.finiteDuration package

### DIFF
--- a/kernel/src/main/scala/cats/kernel/instances/finiteDuration/package.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/finiteDuration/package.scala
@@ -1,0 +1,4 @@
+package cats.kernel
+package instances
+
+package object finiteDuration extends FiniteDurationInstances


### PR DESCRIPTION
I know #3036 isn't a high priority but this is a trivial fix, and I'd personally like to see it in 2.0.0. The name matches `cats.instances.finiteDuration`.

No tests, but there are no tests for the `duration` version, either. I confirmed that the following works:

```scala
scala> import cats.kernel.instances.finiteDuration._
import cats.kernel.instances.finiteDuration._

scala> import scala.concurrent.duration.FiniteDuration
import scala.concurrent.duration.FiniteDuration

scala> cats.kernel.LowerBounded[FiniteDuration]
res0: cats.kernel.LowerBounded[scala.concurrent.duration.FiniteDuration] = cats.kernel.instances.FiniteDurationOrder@5ac7386c

scala> cats.kernel.Hash[FiniteDuration]
res1: cats.kernel.Hash[scala.concurrent.duration.FiniteDuration] = cats.kernel.instances.FiniteDurationOrder@5ac7386c
```
Shouldn't break source compatibility and definitely doesn't break bincompat.
