### PR TITLE
Remove unused type parameter for Parallel instances

### DIFF
--- a/core/src/main/scala-2.12-/cats/instances/ScalaVersionSpecificParallelInstances.scala
+++ b/core/src/main/scala-2.12-/cats/instances/ScalaVersionSpecificParallelInstances.scala
@@ -26,7 +26,7 @@ trait ParallelInstances extends ParallelInstances1 {
     implicit P: Parallel[M]
   ): Parallel.Aux[OptionT[M, *], Nested[P.F, Option, *]] = OptionT.catsDataParallelForOptionT[M]
 
-  implicit def catsStdNonEmptyParallelForZipList[A]: NonEmptyParallel.Aux[List, ZipList] =
+  implicit def catsStdNonEmptyParallelForZipList: NonEmptyParallel.Aux[List, ZipList] =
     new NonEmptyParallel[List] {
       type F[x] = ZipList[x]
 
@@ -40,7 +40,7 @@ trait ParallelInstances extends ParallelInstances1 {
         λ[List ~> ZipList](v => new ZipList(v))
     }
 
-  implicit def catsStdNonEmptyParallelForZipVector[A]: NonEmptyParallel.Aux[Vector, ZipVector] =
+  implicit def catsStdNonEmptyParallelForZipVector: NonEmptyParallel.Aux[Vector, ZipVector] =
     new NonEmptyParallel[Vector] {
       type F[x] = ZipVector[x]
 
@@ -54,7 +54,7 @@ trait ParallelInstances extends ParallelInstances1 {
         λ[Vector ~> ZipVector](v => new ZipVector(v))
     }
 
-  implicit def catsStdParallelForZipStream[A]: Parallel.Aux[Stream, ZipStream] =
+  implicit def catsStdParallelForZipStream: Parallel.Aux[Stream, ZipStream] =
     new Parallel[Stream] {
       type F[x] = ZipStream[x]
 

--- a/core/src/main/scala-2.13+/cats/instances/ScalaVersionSpecificParallelInstances.scala
+++ b/core/src/main/scala-2.13+/cats/instances/ScalaVersionSpecificParallelInstances.scala
@@ -26,7 +26,7 @@ trait ParallelInstances extends ParallelInstances1 {
     implicit P: Parallel[M]
   ): Parallel.Aux[OptionT[M, *], Nested[P.F, Option, *]] = OptionT.catsDataParallelForOptionT[M]
 
-  implicit def catsStdNonEmptyParallelForZipList[A]: NonEmptyParallel.Aux[List, ZipList] =
+  implicit def catsStdNonEmptyParallelForZipList: NonEmptyParallel.Aux[List, ZipList] =
     new NonEmptyParallel[List] {
       type F[x] = ZipList[x]
 
@@ -40,7 +40,7 @@ trait ParallelInstances extends ParallelInstances1 {
         λ[List ~> ZipList](v => new ZipList(v))
     }
 
-  implicit def catsStdNonEmptyParallelForZipVector[A]: NonEmptyParallel.Aux[Vector, ZipVector] =
+  implicit def catsStdNonEmptyParallelForZipVector: NonEmptyParallel.Aux[Vector, ZipVector] =
     new NonEmptyParallel[Vector] {
       type F[x] = ZipVector[x]
 
@@ -55,7 +55,7 @@ trait ParallelInstances extends ParallelInstances1 {
     }
 
   @deprecated("Use catsStdParallelForZipLazyList", "2.0.0-RC2")
-  implicit def catsStdParallelForZipStream[A]: Parallel.Aux[Stream, ZipStream] =
+  implicit def catsStdParallelForZipStream: Parallel.Aux[Stream, ZipStream] =
     new Parallel[Stream] {
       type F[x] = ZipStream[x]
 


### PR DESCRIPTION
This PR includes @Billzabob's commit from #2789 but rebased against current master, where the change has to happen in two places, and slightly adjusted to avoid breaking binary compatibility.

I missed @Billzabob's PR the first time around but should have caught this in #3012.

The change does technically break source compatibility, but (while it fixes a real problem) it's also pretty minor, so I'm not worried about it causing anyone problems. I personally think we can / should try to get it into 2.0.0 today.