### PR TITLE
Move standard library type class instances into implicit scope

### DIFF
--- a/core/src/main/scala-2.12/cats/ScalaVersionSpecificInstances.scala
+++ b/core/src/main/scala-2.12/cats/ScalaVersionSpecificInstances.scala
@@ -1,0 +1,36 @@
+package cats
+
+import cats.data.ZipStream
+
+private[cats] trait ScalaVersionSpecificTraverseInstances {
+  implicit def catsTraverseForStream: Traverse[Stream] = cats.instances.stream.catsStdInstancesForStream
+}
+
+private[cats] trait ScalaVersionSpecificShowInstances {
+  implicit def catsShowForStream[A: Show]: Show[Stream[A]] = cats.instances.stream.catsStdShowForStream[A]
+}
+
+private[cats] trait ScalaVersionSpecificSemigroupalInstances {
+  implicit def catsSemigroupalForStream: Semigroupal[Stream] = cats.instances.stream.catsStdInstancesForStream
+}
+
+private[cats] trait ScalaVersionSpecificMonoidKInstances {
+  implicit def catsMonoidKForStream: MonoidK[Stream] = cats.instances.stream.catsStdInstancesForStream
+}
+
+private[cats] trait ScalaVersionSpecificParallelInstances {
+  implicit def catsStdParallelForZipStream: Parallel.Aux[Stream, ZipStream] =
+    cats.instances.stream.catsStdParallelForStreamZipStream
+}
+
+private[cats] trait ScalaVersionSpecificInvariantInstances {
+  implicit def catsInstancesForStream: Monad[Stream] with Alternative[Stream] with CoflatMap[Stream] =
+    cats.instances.stream.catsStdInstancesForStream
+}
+
+private[cats] trait ScalaVersionSpecificTraverseFilterInstances {
+  implicit def catsTraverseFilterForStream: TraverseFilter[Stream] =
+    cats.instances.stream.catsStdTraverseFilterForStream
+}
+
+private[cats] trait ScalaVersionSpecificAlignInstances

--- a/core/src/main/scala-2.13+/cats/ScalaVersionSpecificInstances.scala
+++ b/core/src/main/scala-2.13+/cats/ScalaVersionSpecificInstances.scala
@@ -1,0 +1,81 @@
+package cats
+
+import cats.data.{ZipLazyList, ZipStream}
+import scala.collection.immutable.ArraySeq
+
+private[cats] trait ScalaVersionSpecificTraverseInstances {
+  @deprecated("Use catsTraverseForLazyList", "3.0.0")
+  implicit def catsTraverseForStream: Traverse[Stream] = cats.instances.stream.catsStdInstancesForStream
+
+  implicit def catsTraverseForLazyList: Traverse[LazyList] = cats.instances.lazyList.catsStdInstancesForLazyList
+  implicit def catsTraverseForArraySeq: Traverse[ArraySeq] = cats.instances.arraySeq.catsStdInstancesForArraySeq
+}
+
+private[cats] trait ScalaVersionSpecificShowInstances {
+  @deprecated("Use catsShowForLazyList", "3.0.0")
+  implicit def catsShowForStream[A: Show]: Show[Stream[A]] = cats.instances.stream.catsStdShowForStream[A]
+
+  implicit def catsShowForLazyList[A: Show]: Show[LazyList[A]] = cats.instances.lazyList.catsStdShowForLazyList[A]
+  implicit def catsShowForArraySeq[A: Show]: Show[ArraySeq[A]] = cats.instances.arraySeq.catsStdShowForArraySeq[A]
+}
+
+private[cats] trait ScalaVersionSpecificSemigroupalInstances {
+  @deprecated("Use catsSemigroupalForLazyList", "3.0.0")
+  implicit def catsSemigroupalForStream: Semigroupal[Stream] = cats.instances.stream.catsStdInstancesForStream
+
+  implicit def catsSemigroupalForLazyList: Semigroupal[LazyList] = cats.instances.lazyList.catsStdInstancesForLazyList
+  implicit def catsSemigroupalForArraySeq: Semigroupal[ArraySeq] = cats.instances.arraySeq.catsStdInstancesForArraySeq
+}
+
+private[cats] trait ScalaVersionSpecificMonoidKInstances {
+  @deprecated("Use catsMonoidKForLazyList", "3.0.0")
+  implicit def catsMonoidKForStream: MonoidK[Stream] = cats.instances.stream.catsStdInstancesForStream
+
+  implicit def catsMonoidKForLazyList: MonoidK[LazyList] = cats.instances.lazyList.catsStdInstancesForLazyList
+  implicit def catsMonoidKForArraySeq: MonoidK[ArraySeq] = cats.instances.arraySeq.catsStdInstancesForArraySeq
+}
+
+private[cats] trait ScalaVersionSpecificParallelInstances {
+  @deprecated("Use catsParallelForLazyList", "3.0.0")
+  implicit def catsStdParallelForZipStream: Parallel.Aux[Stream, ZipStream] =
+    cats.instances.parallel.catsStdParallelForZipStream
+
+  implicit def catsStdParallelForZipLazyList: Parallel.Aux[LazyList, ZipLazyList] =
+    cats.instances.lazyList.catsStdParallelForLazyListZipLazyList
+}
+
+private[cats] trait ScalaVersionSpecificInvariantInstances {
+  @deprecated("Use catsInstancesForLazyList", "3.0.0")
+  implicit def catsInstancesForStream: Monad[Stream] with Alternative[Stream] with CoflatMap[Stream] =
+    cats.instances.stream.catsStdInstancesForStream
+
+  implicit def catsInstancesForLazyList: Monad[LazyList] with Alternative[LazyList] with CoflatMap[LazyList] =
+    cats.instances.lazyList.catsStdInstancesForLazyList
+
+  implicit def catsInstancesForArraySeq: Monad[ArraySeq] with Alternative[ArraySeq] with CoflatMap[ArraySeq] =
+    cats.instances.arraySeq.catsStdInstancesForArraySeq
+}
+
+private[cats] trait ScalaVersionSpecificTraverseFilterInstances {
+  @deprecated("Use catsTraverseFilterForLazyList", "3.0.0")
+  implicit def catsTraverseFilterForStream: TraverseFilter[Stream] =
+    cats.instances.stream.catsStdTraverseFilterForStream
+
+  implicit def catsTraverseFilterForLazyList: TraverseFilter[LazyList] =
+    cats.instances.lazyList.catsStdTraverseFilterForLazyList
+
+  implicit def catsTraverseFilterForArraySeq: TraverseFilter[ArraySeq] =
+    cats.instances.arraySeq.catsStdTraverseFilterForArraySeq
+}
+
+private[cats] trait ScalaVersionSpecificAlignInstances {
+  @deprecated("Use catsTraverseFilterForLazyList", "3.0.0")
+  implicit def catsAlignForStream: Align[Stream] =
+    cats.instances.stream.catsStdInstancesForStream
+
+  implicit def catsAlignForLazyList: Align[LazyList] =
+    cats.instances.lazyList.catsStdInstancesForLazyList
+
+  implicit def catsAlignForArraySeq: Align[ArraySeq] =
+    cats.instances.arraySeq.catsStdInstancesForArraySeq
+}

--- a/core/src/main/scala/cats/Align.scala
+++ b/core/src/main/scala/cats/Align.scala
@@ -3,6 +3,7 @@ package cats
 import simulacrum.typeclass
 
 import cats.data.Ior
+import scala.collection.immutable.SortedMap
 
 /**
  * `Align` supports zipping together structures with different shapes,
@@ -83,10 +84,18 @@ import cats.data.Ior
     }
 }
 
-object Align {
+object Align extends ScalaVersionSpecificAlignInstances {
   def semigroup[F[_], A](implicit F: Align[F], A: Semigroup[A]): Semigroup[F[A]] = new Semigroup[F[A]] {
     def combine(x: F[A], y: F[A]): F[A] = Align[F].alignCombine(x, y)
   }
+
+  implicit def catsAlignForList: Align[List] = cats.instances.list.catsStdInstancesForList
+  implicit def catsAlignForOption: Align[Option] = cats.instances.option.catsStdInstancesForOption
+  implicit def catsAlignForVector: Align[Vector] = cats.instances.vector.catsStdInstancesForVector
+  implicit def catsAlignForMap[K]: Align[Map[K, *]] = cats.instances.map.catsStdInstancesForMap[K]
+  implicit def catsAlignForSortedMap[K: Order]: Align[SortedMap[K, *]] =
+    cats.instances.sortedMap.catsStdInstancesForSortedMap[K]
+  implicit def catsAlignForEither[A]: Align[Either[A, *]] = cats.instances.either.catsStdInstancesForEither[A]
 
   private[cats] def alignWithIterator[A, B, C](fa: Iterable[A], fb: Iterable[B])(f: Ior[A, B] => C): Iterator[C] =
     new Iterator[C] {

--- a/core/src/main/scala/cats/Applicative.scala
+++ b/core/src/main/scala/cats/Applicative.scala
@@ -1,7 +1,6 @@
 package cats
 
 import cats.arrow.Arrow
-import cats.instances.list._
 import simulacrum.typeclass
 
 /**
@@ -206,7 +205,7 @@ object Applicative {
    * res0: (Long, Int) = (3,6)
    * }}}
    */
-  implicit def catsApplicativeForArrow[F[_, _], A](implicit F: Arrow[F]): Applicative[F[A, *]] =
+  def catsApplicativeForArrow[F[_, _], A](implicit F: Arrow[F]): Applicative[F[A, *]] =
     new ArrowApplicative[F, A](F)
 
   /**

--- a/core/src/main/scala/cats/Bifoldable.scala
+++ b/core/src/main/scala/cats/Bifoldable.scala
@@ -32,6 +32,11 @@ import simulacrum.typeclass
   }
 }
 
+object Bifoldable {
+  implicit def catsBitraverseForEither: Bitraverse[Either] = cats.instances.either.catsStdBitraverseForEither
+  implicit def catsBitraverseForTuple2: Bitraverse[Tuple2] = cats.instances.tuple.catsStdBitraverseForTuple2
+}
+
 private[cats] trait ComposedBifoldable[F[_, _], G[_, _]] extends Bifoldable[λ[(α, β) => F[G[α, β], G[α, β]]]] {
   implicit def F: Bifoldable[F]
   implicit def G: Bifoldable[G]

--- a/core/src/main/scala/cats/Bifunctor.scala
+++ b/core/src/main/scala/cats/Bifunctor.scala
@@ -55,6 +55,11 @@ import simulacrum.typeclass
   def leftWiden[A, B, AA >: A](fab: F[A, B]): F[AA, B] = fab.asInstanceOf[F[AA, B]]
 }
 
+object Bifunctor {
+  implicit def catsBifunctorForEither: Bifunctor[Either] = cats.instances.either.catsStdBitraverseForEither
+  implicit def catsBifunctorForTuple2: Bifunctor[Tuple2] = cats.instances.tuple.catsStdBitraverseForTuple2
+}
+
 private[cats] trait ComposedBifunctor[F[_, _], G[_, _]] extends Bifunctor[λ[(A, B) => F[G[A, B], G[A, B]]]] {
   def F: Bifunctor[F]
   def G: Bifunctor[G]

--- a/core/src/main/scala/cats/Defer.scala
+++ b/core/src/main/scala/cats/Defer.scala
@@ -1,5 +1,7 @@
 package cats
 
+import scala.util.control.TailCalls.TailRec
+
 /**
  * Defer is a type class that shows the ability to defer creation
  * inside of the type constructor F[_].
@@ -53,4 +55,8 @@ trait Defer[F[_]] extends Serializable {
 
 object Defer {
   def apply[F[_]](implicit defer: Defer[F]): Defer[F] = defer
+
+  implicit def catsDeferForFunction0: Defer[Function0] = cats.instances.function.catsSddDeferForFunction0
+  implicit def catsDeferForFunction1[A]: Defer[Function1[A, *]] = cats.instances.function.catsStdDeferForFunction1[A]
+  implicit def catsDeferForTailRec: Defer[TailRec] = cats.instances.tailRec.catsInstancesForTailRec
 }

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -1,7 +1,6 @@
 package cats
 
 import scala.collection.mutable
-import cats.instances.either._
 import cats.kernel.CommutativeMonoid
 import simulacrum.{noop, typeclass}
 import Foldable.sentinel
@@ -693,8 +692,6 @@ import Foldable.sentinel
    * }}}
    */
   def partitionEither[A, B, C](fa: F[A])(f: A => Either[B, C])(implicit A: Alternative[F]): (F[B], F[C]) = {
-    import cats.instances.tuple._
-
     implicit val mb: Monoid[F[B]] = A.algebra[B]
     implicit val mc: Monoid[F[C]] = A.algebra[C]
 

--- a/core/src/main/scala/cats/FunctorFilter.scala
+++ b/core/src/main/scala/cats/FunctorFilter.scala
@@ -1,5 +1,6 @@
 package cats
 
+import scala.collection.immutable.{Queue, SortedMap}
 import simulacrum.typeclass
 
 /**
@@ -73,4 +74,18 @@ trait FunctorFilter[F[_]] extends Serializable {
    */
   def filterNot[A](fa: F[A])(f: A => Boolean): F[A] =
     mapFilter(fa)(Some(_).filterNot(f))
+}
+
+object FunctorFilter extends ScalaVersionSpecificTraverseFilterInstances {
+  implicit def catsTraverseFilterForOption: TraverseFilter[Option] =
+    cats.instances.option.catsStdTraverseFilterForOption
+  implicit def catsTraverseFilterForList: TraverseFilter[List] = cats.instances.list.catsStdTraverseFilterForList
+  implicit def catsTraverseFilterForVector: TraverseFilter[Vector] =
+    cats.instances.vector.catsStdTraverseFilterForVector
+  implicit def catsFunctorFilterForMap[K: Order]: FunctorFilter[Map[K, *]] =
+    cats.instances.map.catsStdFunctorFilterForMap[K]
+  implicit def catsTraverseFilterForSortedMap[K: Order]: TraverseFilter[SortedMap[K, *]] =
+    cats.instances.sortedMap.catsStdTraverseFilterForSortedMap[K]
+  implicit def catsTraverseFilterForQueue: TraverseFilter[Queue] =
+    cats.instances.queue.catsStdTraverseFilterForQueue
 }

--- a/core/src/main/scala/cats/Invariant.scala
+++ b/core/src/main/scala/cats/Invariant.scala
@@ -1,8 +1,12 @@
 package cats
 
+import cats.arrow.Arrow
 import cats.kernel._
 import simulacrum.typeclass
 import cats.kernel.compat.scalaVersionSpecific._
+import scala.collection.immutable.{Queue, SortedMap}
+import scala.util.Try
+import scala.util.control.TailCalls.TailRec
 
 /**
  * Must obey the laws defined in cats.laws.InvariantLaws.
@@ -45,7 +49,55 @@ import cats.kernel.compat.scalaVersionSpecific._
 }
 
 @suppressUnusedImportWarningForScalaVersionSpecific
-object Invariant {
+object Invariant extends ScalaVersionSpecificInvariantInstances with InvariantInstances0 {
+  implicit def catsInstancesForId: Distributive[Id] with Comonad[Id] = cats.catsInstancesForId
+  implicit def catsComonadForTuple2[A]: Comonad[(A, *)] = cats.instances.tuple.catsStdInstancesForTuple2[A]
+  implicit def catsMonadErrorForEither[A]: MonadError[Either[A, *], A] =
+    cats.instances.either.catsStdInstancesForEither[A]
+  implicit def catsInstancesForOption
+    : MonadError[Option, Unit] with Alternative[Option] with CoflatMap[Option] with CommutativeMonad[Option] =
+    cats.instances.option.catsStdInstancesForOption
+  implicit def catsInstancesForList: Monad[List] with Alternative[List] with CoflatMap[List] =
+    cats.instances.list.catsStdInstancesForList
+  implicit def catsInstancesForVector: Monad[Vector] with Alternative[Vector] with CoflatMap[Vector] =
+    cats.instances.vector.catsStdInstancesForVector
+  implicit def catsInstancesForQueue: Monad[Queue] with Alternative[Queue] with CoflatMap[Queue] =
+    cats.instances.queue.catsStdInstancesForQueue
+  implicit def catsMonadForTailRec: Monad[TailRec] = cats.instances.tailRec.catsInstancesForTailRec
+
+  implicit def catsFlatMapForMap[K]: FlatMap[Map[K, *]] = cats.instances.map.catsStdInstancesForMap[K]
+  implicit def catsFlatMapForSortedMap[K: Order]: FlatMap[SortedMap[K, *]] =
+    cats.instances.sortedMap.catsStdInstancesForSortedMap[K]
+  implicit def catsBimonadForFunction0[I]: Bimonad[Function0] = cats.instances.function.catsStdBimonadForFunction0
+  implicit def catsMonadForFunction1[I]: Monad[I => *] = cats.instances.function.catsStdMonadForFunction1[I]
+  implicit def catsContravariantMonoidalForFunction1[R: Monoid]: ContravariantMonoidal[* => R] =
+    cats.instances.function.catsStdContravariantMonoidalForFunction1[R]
+  implicit def catsFunctorForPair: Functor[λ[P => (P, P)]] = cats.instances.tuple.catsDataFunctorForPair
+
+  implicit def catsInstancesForTry: MonadError[Try, Throwable] with CoflatMap[Try] =
+    cats.instances.try_.catsStdInstancesForTry
+
+  implicit def catsContravariantMonoidalForOrder: ContravariantMonoidal[Order] =
+    cats.instances.order.catsContravariantMonoidalForOrder
+  implicit def catsContravariantMonoidalForPartialOrder: ContravariantMonoidal[PartialOrder] =
+    cats.instances.partialOrder.catsContravariantMonoidalForPartialOrder
+  implicit def catsContravariantMonoidalForOrdering: ContravariantMonoidal[Ordering] =
+    cats.instances.ordering.catsContravariantMonoidalForOrdering
+  implicit def catsContravariantMonoidalForPartialOrdering: ContravariantMonoidal[PartialOrdering] =
+    cats.instances.partialOrdering.catsContravariantMonoidalForPartialOrdering
+  implicit def catsContravariantMonoidalForEq: ContravariantMonoidal[Eq] =
+    cats.instances.eq.catsContravariantMonoidalForEq
+  implicit def catsContravariantMonoidalForEquiv: ContravariantMonoidal[Equiv] =
+    cats.instances.equiv.catsContravariantMonoidalForEquiv
+  implicit def catsContravariantForHash: Contravariant[Hash] =
+    cats.instances.all.catsContravariantForHash
+  implicit def catsInvariantMonoidalForSemigroup: InvariantMonoidal[Semigroup] =
+    cats.instances.invariant.catsInvariantMonoidalSemigroup
+  implicit def catsInvariantMonoidalForCommutativeSemigroup: InvariantMonoidal[CommutativeSemigroup] =
+    cats.instances.invariant.catsInvariantMonoidalCommutativeSemigroup
+  implicit def catsInvariantSemigroupalForMonoid: InvariantSemigroupal[Monoid] =
+    cats.instances.invariant.catsSemigroupalForMonoid
+
   implicit val catsInvariantMonoid: Invariant[Monoid] = new Invariant[Monoid] {
 
     def imap[A, B](fa: Monoid[A])(f: A => B)(g: B => A): Monoid[B] = new Monoid[B] {
@@ -121,4 +173,31 @@ object Invariant {
     }
 
   }
+}
+
+private[cats] trait InvariantInstances0 extends TupleInstances0 {
+  implicit def catsCommutativeMonadForTuple2[X](implicit X: CommutativeMonoid[X]): CommutativeMonad[(X, *)] =
+    cats.instances.tuple.catsStdCommutativeMonadForTuple2[X]
+  implicit def catsContravariantForFunction1[R]: Contravariant[* => R] =
+    cats.instances.function.catsStdContravariantForFunction1[R]
+  implicit def catsDistributiveForFunction0: Distributive[Function0] = cats.instances.function.function0Distributive
+  implicit def catsDistributiveForFunction1[I]: Distributive[I => *] =
+    cats.instances.function.catsStdDistributiveForFunction1[I]
+  implicit def catsApplicativeForArrow[F[_, _], A](implicit F: Arrow[F]): Applicative[F[A, *]] =
+    new ArrowApplicative[F, A](F)
+}
+
+private trait TupleInstances0 extends TupleInstances1 {
+  implicit def catsCommutativeFlatMapForTuple2[X](implicit X: CommutativeSemigroup[X]): CommutativeFlatMap[(X, *)] =
+    cats.instances.tuple.catsStdCommutativeFlatMapForTuple2[X]
+}
+
+private trait TupleInstances1 extends TupleInstances2 {
+  implicit def catsMonadForTuple2[X](implicit X: Monoid[X]): Monad[(X, *)] =
+    cats.instances.tuple.catsStdMonadForTuple2[X]
+}
+
+private trait TupleInstances2 {
+  implicit def catsFlatMapForTuple2[X](implicit X: Semigroup[X]): FlatMap[(X, *)] =
+    cats.instances.tuple.catsStdFlatMapForTuple2[X]
 }

--- a/core/src/main/scala/cats/Parallel.scala
+++ b/core/src/main/scala/cats/Parallel.scala
@@ -1,6 +1,7 @@
 package cats
 
 import cats.arrow.FunctionK
+import cats.data.{Validated, ZipList, ZipVector}
 
 /**
  * Some types that form a FlatMap, are also capable of forming an Apply that supports parallel composition.
@@ -106,11 +107,20 @@ trait Parallel[M[_]] extends NonEmptyParallel[M] {
   }
 }
 
-object NonEmptyParallel {
+object NonEmptyParallel extends ScalaVersionSpecificParallelInstances {
   type Aux[M[_], F0[_]] = NonEmptyParallel[M] { type F[x] = F0[x] }
 
   def apply[M[_], F[_]](implicit P: NonEmptyParallel.Aux[M, F]): NonEmptyParallel.Aux[M, F] = P
   def apply[M[_]](implicit P: NonEmptyParallel[M], D: DummyImplicit): NonEmptyParallel.Aux[M, P.F] = P
+
+  implicit def catsParallelForEitherValidated[E: Semigroup]: Parallel.Aux[Either[E, *], Validated[E, *]] =
+    cats.instances.either.catsParallelForEitherAndValidated[E]
+
+  implicit def catsStdNonEmptyParallelForZipList: NonEmptyParallel.Aux[List, ZipList] =
+    cats.instances.list.catsStdNonEmptyParallelForListZipList
+
+  implicit def catsStdNonEmptyParallelForZipVector: NonEmptyParallel.Aux[Vector, ZipVector] =
+    cats.instances.vector.catsStdNonEmptyParallelForVectorZipVector
 }
 
 object Parallel extends ParallelArityFunctions2 {

--- a/core/src/main/scala/cats/Representable.scala
+++ b/core/src/main/scala/cats/Representable.scala
@@ -145,4 +145,11 @@ object Representable {
     new RepresentableDistributive[F, Rep.Representation] {
       override def R: Aux[F, Rep.Representation] = Rep
     }
+
+  implicit def catsRepresentableForFunction1[E](implicit EF: Functor[E => *]): Representable.Aux[E => *, E] =
+    cats.instances.function.catsStdRepresentableForFunction1[E]
+
+  implicit def catsRepresentableForPair(
+    implicit PF: Functor[λ[P => (P, P)]]
+  ): Representable.Aux[λ[P => (P, P)], Boolean] = cats.instances.tuple.catsDataRepresentableForPair
 }

--- a/core/src/main/scala/cats/SemigroupK.scala
+++ b/core/src/main/scala/cats/SemigroupK.scala
@@ -1,5 +1,6 @@
 package cats
 
+import scala.collection.immutable.{SortedMap, SortedSet}
 import simulacrum.typeclass
 import cats.data.Ior
 
@@ -84,10 +85,22 @@ import cats.data.Ior
     combineK(F.map(fa)(Left(_)), F.map(fb)(Right(_)))
 }
 
-object SemigroupK {
+object SemigroupK extends ScalaVersionSpecificMonoidKInstances {
   def align[F[_]: SemigroupK: Functor]: Align[F] = new Align[F] {
     def align[A, B](fa: F[A], fb: F[B]): F[Ior[A, B]] =
       SemigroupK[F].combineK(Functor[F].map(fa)(Ior.left), Functor[F].map(fb)(Ior.right))
     def functor: Functor[F] = Functor[F]
   }
+
+  implicit def catsMonoidKForOption: MonoidK[Option] = cats.instances.option.catsStdInstancesForOption
+  implicit def catsMonoidKForList: MonoidK[List] = cats.instances.list.catsStdInstancesForList
+  implicit def catsMonoidKForVector: MonoidK[Vector] = cats.instances.vector.catsStdInstancesForVector
+  implicit def catsMonoidKForSet: MonoidK[Set] = cats.instances.set.catsStdInstancesForSet
+  implicit def catsMonoidKForMap[K]: MonoidK[Map[K, *]] = cats.instances.map.catsStdMonoidKForMap[K]
+  implicit def catsSemigroupKForEither[A]: SemigroupK[Either[A, *]] =
+    cats.instances.either.catsStdSemigroupKForEither[A]
+  implicit def catsSemigroupKForSortedSet: SemigroupK[SortedSet] = cats.instances.sortedSet.catsStdInstancesForSortedSet
+  implicit def catsMonoidKForSortedMap[K: Order]: MonoidK[SortedMap[K, *]] =
+    cats.instances.sortedMap.catsStdMonoidKForSortedMap[K]
+  implicit def catsMonoidKForEndo: MonoidK[Endo] = cats.instances.function.catsStdMonoidKForFunction1
 }

--- a/core/src/main/scala/cats/Semigroupal.scala
+++ b/core/src/main/scala/cats/Semigroupal.scala
@@ -1,5 +1,8 @@
 package cats
 
+import cats.kernel.CommutativeSemigroup
+import scala.collection.immutable.{Queue, SortedMap, SortedSet}
+import scala.util.Try
 import simulacrum.typeclass
 
 /**
@@ -42,4 +45,40 @@ import simulacrum.typeclass
   def product[A, B](fa: F[A], fb: F[B]): F[(A, B)]
 }
 
-object Semigroupal extends SemigroupalArityFunctions
+object Semigroupal extends ScalaVersionSpecificSemigroupalInstances with SemigroupalArityFunctions {
+  implicit def catsSemigroupalForOption: Semigroupal[Option] = cats.instances.option.catsStdInstancesForOption
+  implicit def catsSemigroupalForTry: Semigroupal[Try] = cats.instances.try_.catsStdInstancesForTry
+  implicit def catsSemigroupalForList: Semigroupal[List] = cats.instances.list.catsStdInstancesForList
+  implicit def catsSemigroupalForVector: Semigroupal[Vector] = cats.instances.vector.catsStdInstancesForVector
+  implicit def catsSemigroupalForQueue: Semigroupal[Queue] = cats.instances.queue.catsStdInstancesForQueue
+  implicit def catsSemigroupalForMap[K]: Semigroupal[Map[K, *]] = cats.instances.map.catsStdInstancesForMap[K]
+  implicit def catsSemigroupalForEither[A]: Semigroupal[Either[A, *]] =
+    cats.instances.either.catsStdInstancesForEither[A]
+  implicit def catsSemigroupalForSortedSet: Semigroupal[SortedSet] =
+    cats.instances.sortedSet.catsStdSemigroupalForSortedSet
+  implicit def catsSemigroupalForSortedMap[K: Order]: Semigroupal[SortedMap[K, *]] =
+    cats.instances.sortedMap.catsStdInstancesForSortedMap[K]
+  implicit def catsSemigroupalForFunction1[A]: Semigroupal[A => *] =
+    cats.instances.function.catsStdMonadForFunction1[A]
+  implicit def catsSemigroupalForFunction1Contravariant[R: Monoid]: Semigroupal[* => R] =
+    cats.instances.function.catsStdContravariantMonoidalForFunction1[R]
+  implicit def catsSemigroupalForFunction0: Semigroupal[Function0] =
+    cats.instances.function.catsStdBimonadForFunction0
+
+  implicit val catsSemigroupalForOrder: Semigroupal[Order] = cats.instances.order.catsContravariantMonoidalForOrder
+  implicit val catsSemigroupalForPartialOrder: Semigroupal[PartialOrder] =
+    cats.instances.partialOrder.catsContravariantMonoidalForPartialOrder
+  implicit val catsSemigroupalForOrdering: Semigroupal[Ordering] =
+    cats.instances.ordering.catsContravariantMonoidalForOrdering
+  implicit val catsSemigroupalForPartialOrdering: Semigroupal[PartialOrdering] =
+    cats.instances.partialOrdering.catsContravariantMonoidalForPartialOrdering
+  implicit val catsSemigroupalForEq: Semigroupal[Eq] = cats.instances.eq.catsContravariantMonoidalForEq
+  implicit val catsSemigroupalForEquiv: Semigroupal[Equiv] =
+    cats.instances.equiv.catsContravariantMonoidalForEquiv
+  implicit val catsSemigroupalForMonoid: Semigroupal[Monoid] =
+    cats.instances.invariant.catsSemigroupalForMonoid
+  implicit val catsSemigroupalForSemigroup: Semigroupal[Semigroup] =
+    cats.instances.invariant.catsInvariantMonoidalSemigroup
+  implicit val catsSemigroupalForCommutativeSemigroup: Semigroupal[CommutativeSemigroup] =
+    cats.instances.invariant.catsInvariantMonoidalCommutativeSemigroup
+}

--- a/core/src/main/scala/cats/Show.scala
+++ b/core/src/main/scala/cats/Show.scala
@@ -1,5 +1,10 @@
 package cats
 
+import java.util.UUID
+import scala.collection.immutable.{BitSet, Queue, SortedMap, SortedSet}
+import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.util.Try
+
 /**
  * A type class to provide textual representation. It is meant to be a
  * better "toString". Whereas toString exists for any Object,
@@ -12,7 +17,7 @@ trait Show[T] extends Show.ContravariantShow[T]
 /**
  * Hand rolling the type class boilerplate due to scala/bug#6260 and scala/bug#10458
  */
-object Show {
+object Show extends ScalaVersionSpecificShowInstances with ShowInstances {
 
   def apply[A](implicit instance: Show[A]): Show[A] = instance
 
@@ -56,4 +61,40 @@ object Show {
     def contramap[A, B](fa: Show[A])(f: B => A): Show[B] =
       show[B]((fa.show _).compose(f))
   }
+
+  implicit def catsShowForUnit: Show[Unit] = cats.instances.unit.catsStdShowForUnit
+  implicit def catsShowForBoolean: Show[Boolean] = cats.instances.boolean.catsStdShowForBoolean
+  implicit def catsShowForByte: Show[Byte] = cats.instances.byte.catsStdShowForByte
+  implicit def catsShowForShort: Show[Short] = cats.instances.short.catsStdShowForShort
+  implicit def catsShowForInt: Show[Int] = cats.instances.int.catsStdShowForInt
+  implicit def catsShowForLong: Show[Long] = cats.instances.long.catsStdShowForLong
+  implicit def catsShowForFloat: Show[Float] = cats.instances.float.catsStdShowForFloat
+  implicit def catsShowForDouble: Show[Double] = cats.instances.double.catsStdShowForDouble
+  implicit def catsShowForBigInt: Show[BigInt] = cats.instances.bigInt.catsStdShowForBigInt
+  implicit def catsShowForBigDecimal: Show[BigDecimal] = cats.instances.bigDecimal.catsStdShowForBigDecimal
+  implicit def catsShowForChar: Show[Char] = cats.instances.char.catsStdShowForChar
+  implicit def catsShowForSymbol: Show[Symbol] = cats.instances.symbol.catsStdShowForSymbol
+  implicit def catsShowForString: Show[String] = cats.instances.string.catsStdShowForString
+  implicit def catsShowForUUID: Show[UUID] = cats.instances.uuid.catsStdShowForUUID
+  implicit def catsShowForDuration: Show[Duration] = cats.instances.duration.catsStdShowForDurationUnambiguous
+  implicit def catsShowForBitSet: Show[BitSet] = cats.instances.bitSet.catsStdShowForBitSet
+
+  implicit def catsShowForOption[A: Show]: Show[Option[A]] = cats.instances.option.catsStdShowForOption[A]
+  implicit def catsShowForTry[A: Show]: Show[Try[A]] = cats.instances.try_.catsStdShowForTry[A]
+  implicit def catsShowForList[A: Show]: Show[List[A]] = cats.instances.list.catsStdShowForList[A]
+  implicit def catsShowForVector[A: Show]: Show[Vector[A]] = cats.instances.vector.catsStdShowForVector[A]
+  implicit def catsShowForQueue[A: Show]: Show[Queue[A]] = cats.instances.queue.catsStdShowForQueue[A]
+  implicit def catsShowForEither[A: Show, B: Show]: Show[Either[A, B]] =
+    cats.instances.either.catsStdShowForEither[A, B]
+  implicit def catsShowForTuple2[A: Show, B: Show]: Show[(A, B)] = cats.instances.tuple.catsStdShowForTuple2[A, B]
+  implicit def catsShowForSet[A: Show]: Show[Set[A]] = cats.instances.set.catsStdShowForSet[A]
+  implicit def catsShowForMap[K: Show, V: Show]: Show[Map[K, V]] = cats.instances.map.catsStdShowForMap[K, V]
+  implicit def catsShowForSortedSet[A: Show]: Show[SortedSet[A]] = cats.instances.sortedSet.catsStdShowForSortedSet[A]
+  implicit def catsShowForSortedMap[K: Order: Show, V: Show]: Show[SortedMap[K, V]] =
+    cats.instances.sortedMap.catsStdShowForSortedMap[K, V]
+}
+
+private[cats] trait ShowInstances {
+  implicit def catsShowForFiniteDuration: Show[FiniteDuration] =
+    cats.instances.finiteDuration.catsStdShowForFiniteDurationUnambiguous
 }

--- a/core/src/main/scala/cats/Traverse.scala
+++ b/core/src/main/scala/cats/Traverse.scala
@@ -129,3 +129,7 @@ import simulacrum.typeclass
   override def unorderedSequence[G[_]: CommutativeApplicative, A](fga: F[G[A]]): G[F[A]] =
     sequence(fga)
 }
+
+object Traverse {
+  implicit def catsTraverseForEither[A]: Traverse[Either[A, *]] = cats.instances.either.catsStdInstancesForEither[A]
+}

--- a/core/src/main/scala/cats/UnorderedFoldable.scala
+++ b/core/src/main/scala/cats/UnorderedFoldable.scala
@@ -1,7 +1,8 @@
 package cats
 
-import cats.instances.long._
 import cats.kernel.CommutativeMonoid
+import scala.collection.immutable.{Queue, SortedMap, SortedSet}
+import scala.util.Try
 import simulacrum.{noop, typeclass}
 
 /**
@@ -71,7 +72,7 @@ import simulacrum.{noop, typeclass}
     unorderedFoldMap(fa)(a => if (p(a)) 1L else 0L)
 }
 
-object UnorderedFoldable {
+object UnorderedFoldable extends ScalaVersionSpecificTraverseInstances {
   private val orEvalMonoid: CommutativeMonoid[Eval[Boolean]] = new CommutativeMonoid[Eval[Boolean]] {
     val empty: Eval[Boolean] = Eval.False
 
@@ -91,4 +92,23 @@ object UnorderedFoldable {
         case false => Eval.False
       }
   }
+
+  implicit def catsNonEmptyTraverseForId: NonEmptyTraverse[Id] = catsInstancesForId
+  implicit def catsTraverseForOption: Traverse[Option] = cats.instances.option.catsStdInstancesForOption
+  implicit def catsTraverseForList: Traverse[List] = cats.instances.list.catsStdInstancesForList
+  implicit def catsTraverseForVector: Traverse[Vector] = cats.instances.vector.catsStdInstancesForVector
+  implicit def catsTraverseForQueue: Traverse[Queue] = cats.instances.queue.catsStdInstancesForQueue
+  implicit def catsUnorderedTraverseForSet: UnorderedTraverse[Set] = cats.instances.set.catsStdInstancesForSet
+  implicit def catsFoldableForSortedSet: Foldable[SortedSet] = cats.instances.sortedSet.catsStdInstancesForSortedSet
+  implicit def catsTraverseForSortedMap[K: Order]: Traverse[SortedMap[K, *]] =
+    cats.instances.sortedMap.catsStdInstancesForSortedMap[K]
+
+  implicit def catsUnorderedTraverseForMap[K]: UnorderedTraverse[Map[K, *]] =
+    cats.instances.map.catsStdInstancesForMap[K]
+
+  implicit def catsTraverseForEither[A]: Traverse[Either[A, *]] = cats.instances.either.catsStdInstancesForEither[A]
+  implicit def catsInstancesForTuple[A]: Traverse[(A, *)] with Reducible[(A, *)] =
+    cats.instances.tuple.catsStdInstancesForTuple2[A]
+
+  implicit def catsTraverseForTry: Traverse[Try] = cats.instances.try_.catsStdInstancesForTry
 }

--- a/core/src/main/scala/cats/arrow/Compose.scala
+++ b/core/src/main/scala/cats/arrow/Compose.scala
@@ -37,3 +37,9 @@ import simulacrum.typeclass
       def combine(f1: F[A, A], f2: F[A, A]): F[A, A] = self.compose(f1, f2)
     }
 }
+
+object Compose {
+  implicit def catsInstancesForFunction1: ArrowChoice[Function1] with CommutativeArrow[Function1] =
+    cats.instances.function.catsStdInstancesForFunction1
+  implicit def catsComposeForMap: Compose[Map] = cats.instances.map.catsStdComposeForMap
+}

--- a/core/src/main/scala/cats/arrow/Profunctor.scala
+++ b/core/src/main/scala/cats/arrow/Profunctor.scala
@@ -40,3 +40,8 @@ import simulacrum.typeclass
   def rmap[A, B, C](fab: F[A, B])(f: B => C): F[A, C] =
     dimap[A, B, A, C](fab)(identity)(f)
 }
+
+object Profunctor {
+  implicit def catsStrongForFunction1: Strong[Function1] =
+    cats.instances.function.catsStdInstancesForFunction1
+}

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -1,7 +1,7 @@
 package cats
 package data
 
-import cats.instances.either._
+import cats.Bifunctor
 import cats.syntax.EitherUtil
 
 /**

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -2,7 +2,6 @@ package cats
 package data
 
 import cats.data.NonEmptyList.ZipNonEmptyList
-import cats.instances.list._
 
 import scala.annotation.tailrec
 import scala.collection.immutable.{SortedMap, TreeMap, TreeSet}

--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -1,7 +1,6 @@
 package cats
 package data
 
-import cats.instances.sortedMap._
 import cats.kernel._
 import cats.{Always, Apply, Eval, Foldable, Functor, Later, NonEmptyTraverse, Now, SemigroupK, Show}
 

--- a/core/src/main/scala/cats/data/NonEmptySet.scala
+++ b/core/src/main/scala/cats/data/NonEmptySet.scala
@@ -1,7 +1,6 @@
 package cats
 package data
 
-import cats.instances.sortedSet._
 import cats.kernel._
 
 import scala.collection.immutable._

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -2,7 +2,6 @@ package cats
 package data
 
 import cats.data.NonEmptyVector.ZipNonEmptyVector
-import cats.instances.vector._
 
 import scala.annotation.tailrec
 import scala.collection.mutable

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -1,8 +1,6 @@
 package cats
 package data
 
-import cats.instances.option.{catsStdInstancesForOption => optionInstance, catsStdTraverseFilterForOption}
-
 /**
  * `OptionT[F[_], A]` is a light wrapper on an `F[Option[A]]` with some
  * convenient methods for working with this nested structure.
@@ -120,13 +118,13 @@ final case class OptionT[F[_], A](value: F[Option[A]]) {
     eq.eqv(value, that.value)
 
   def traverse[G[_], B](f: A => G[B])(implicit F: Traverse[F], G: Applicative[G]): G[OptionT[F, B]] =
-    G.map(F.compose(optionInstance).traverse(value)(f))(OptionT.apply)
+    G.map(F.compose(Traverse[Option]).traverse(value)(f))(OptionT.apply)
 
   def foldLeft[B](b: B)(f: (B, A) => B)(implicit F: Foldable[F]): B =
-    F.compose(optionInstance).foldLeft(value, b)(f)
+    F.compose(Foldable[Option]).foldLeft(value, b)(f)
 
   def foldRight[B](lb: Eval[B])(f: (A, Eval[B]) => Eval[B])(implicit F: Foldable[F]): Eval[B] =
-    F.compose(optionInstance).foldRight(value, lb)(f)
+    F.compose(Foldable[Option]).foldRight(value, lb)(f)
 
   /**
    * Transform this `OptionT[F, A]` into a `[[Nested]][F, Option, A]`.

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -2,7 +2,6 @@ package cats
 package data
 
 import cats.Foldable
-import cats.kernel.instances.tuple._
 import cats.kernel.CommutativeMonoid
 
 final case class WriterT[F[_], L, V](run: F[(L, V)]) {

--- a/core/src/main/scala/cats/data/ZipList.scala
+++ b/core/src/main/scala/cats/data/ZipList.scala
@@ -1,7 +1,6 @@
 package cats
 package data
 
-import instances.list.catsKernelStdEqForList
 import kernel.compat.scalaVersionSpecific._
 
 class ZipList[A](val value: List[A]) extends AnyVal

--- a/core/src/main/scala/cats/data/ZipVector.scala
+++ b/core/src/main/scala/cats/data/ZipVector.scala
@@ -1,7 +1,6 @@
 package cats
 package data
 
-import instances.vector._
 import kernel.compat.scalaVersionSpecific._
 
 class ZipVector[A](val value: Vector[A]) extends AnyVal

--- a/core/src/main/scala/cats/data/package.scala
+++ b/core/src/main/scala/cats/data/package.scala
@@ -79,7 +79,6 @@ package object data extends ScalaVersionSpecificPackage {
 
   type Store[S, A] = RepresentableStore[S => *, S, A]
   object Store {
-    import cats.instances.function._
     def apply[S, A](f: S => A, s: S): Store[S, A] =
       RepresentableStore[S => *, S, A](f, s)
   }

--- a/free/src/test/scala/cats/free/FreeSuite.scala
+++ b/free/src/test/scala/cats/free/FreeSuite.scala
@@ -228,8 +228,6 @@ class FreeSuite extends CatsSuite {
 }
 
 object FreeSuite extends FreeSuiteInstances {
-  import cats.instances.function._
-
   implicit def trampolineArbitrary[A: Arbitrary]: Arbitrary[Trampoline[A]] =
     freeArbitrary[Function0, A]
 

--- a/free/src/test/scala/cats/free/FreeTSuite.scala
+++ b/free/src/test/scala/cats/free/FreeTSuite.scala
@@ -249,7 +249,6 @@ trait FreeTSuiteInstances {
 
   import FreeT._
   import IndexedStateT._
-  import cats.kernel.instances.option._
   import cats.tests.IndexedStateTSuite._
   import SemigroupalTests._
 

--- a/js/src/test/scala/cats/tests/FutureTests.scala
+++ b/js/src/test/scala/cats/tests/FutureTests.scala
@@ -1,7 +1,7 @@
 package cats.js.tests
 
 import cats.Comonad
-import cats.instances.all._
+import cats.instances.FutureInstances
 import cats.js.instances.Await
 import cats.js.instances.future.futureComonad
 import cats.kernel.Eq
@@ -15,7 +15,7 @@ import org.scalacheck.Arbitrary.arbitrary
 import scala.concurrent.{ExecutionContextExecutor, Future}
 import scala.concurrent.duration._
 
-class FutureTests extends CatsSuite {
+class FutureTests extends CatsSuite with FutureInstances {
   // Replaces Scala.js's `JSExecutionContext.runNow`, which is removed in 1.0.
   // TODO: We shouldn't do this! See: https://github.com/scala-js/scala-js/issues/2102
   implicit private object RunNowExecutionContext extends ExecutionContextExecutor {

--- a/jvm/src/test/scala/cats/tests/FutureSuite.scala
+++ b/jvm/src/test/scala/cats/tests/FutureSuite.scala
@@ -1,6 +1,6 @@
 package cats.jvm.tests
 
-import cats.instances.all._
+import cats.instances.future._
 import cats.kernel.{Eq, Semigroup}
 import cats.kernel.laws.discipline.{MonoidTests => MonoidLawTests, SemigroupTests => SemigroupLawTests}
 import cats.laws.discipline._

--- a/kernel/src/main/scala-2.12/cats/kernel/ScalaVersionSpecificInstances.scala
+++ b/kernel/src/main/scala-2.12/cats/kernel/ScalaVersionSpecificInstances.scala
@@ -1,0 +1,25 @@
+package cats.kernel
+
+private[kernel] trait ScalaVersionSpecificOrderInstances extends ScalaVersionSpecificPartialOrderInstances {
+  implicit def catsKernelOrderForStream[A: Order]: Order[Stream[A]] =
+    cats.kernel.instances.stream.catsKernelStdOrderForStream[A]
+}
+
+private[kernel] trait ScalaVersionSpecificPartialOrderInstances extends ScalaVersionSpecificHashInstances {
+  implicit def catsKernelPartialOrderForStream[A: PartialOrder]: PartialOrder[Stream[A]] =
+    cats.kernel.instances.stream.catsKernelStdPartialOrderForStream[A]
+}
+
+private[kernel] trait ScalaVersionSpecificHashInstances extends ScalaVersionSpecificEqInstances {
+  implicit def catsKernelHashForStream[A: Hash]: Hash[Stream[A]] =
+    cats.kernel.instances.stream.catsKernelStdHashForStream[A]
+}
+
+private[kernel] trait ScalaVersionSpecificEqInstances {
+  implicit def catsKernelEqForStream[A: Eq]: Eq[Stream[A]] = cats.kernel.instances.stream.catsKernelStdEqForStream[A]
+}
+
+private[kernel] trait ScalaVersionSpecificMonoidInstances {
+  implicit def catsKernelMonoidForStream[A]: Monoid[Stream[A]] =
+    cats.kernel.instances.stream.catsKernelStdMonoidForStream[A]
+}

--- a/kernel/src/main/scala-2.13+/cats/kernel/ScalaVersionSpecificInstances.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/ScalaVersionSpecificInstances.scala
@@ -1,0 +1,62 @@
+package cats.kernel
+
+import scala.collection.immutable.ArraySeq
+
+private[kernel] trait ScalaVersionSpecificOrderInstances extends ScalaVersionSpecificPartialOrderInstances {
+  @deprecated("Use catsKernelOrderForLazyList", "3.0.0")
+  implicit def catsKernelOrderForStream[A: Order]: Order[Stream[A]] =
+    cats.kernel.instances.stream.catsKernelStdOrderForStream[A]
+
+  implicit def catsKernelOrderForLazyList[A: Order]: Order[LazyList[A]] =
+    cats.kernel.instances.lazyList.catsKernelStdOrderForLazyList[A]
+
+  implicit def catsKernelOrderForArraySeq[A: Order]: Order[ArraySeq[A]] =
+    cats.kernel.instances.arraySeq.catsKernelStdOrderForArraySeq[A]
+}
+
+private[kernel] trait ScalaVersionSpecificPartialOrderInstances extends ScalaVersionSpecificHashInstances {
+  @deprecated("Use catsKernelPartialOrderForLazyList", "3.0.0")
+  implicit def catsKernelPartialOrderForStream[A: PartialOrder]: PartialOrder[Stream[A]] =
+    cats.kernel.instances.stream.catsKernelStdPartialOrderForStream[A]
+
+  implicit def catsKernelPartialOrderForLazyList[A: PartialOrder]: PartialOrder[LazyList[A]] =
+    cats.kernel.instances.lazyList.catsKernelStdPartialOrderForLazyList[A]
+
+  implicit def catsKernelPartialOrderForArraySeq[A: PartialOrder]: PartialOrder[ArraySeq[A]] =
+    cats.kernel.instances.arraySeq.catsKernelStdPartialOrderForArraySeq[A]
+}
+
+private[kernel] trait ScalaVersionSpecificHashInstances extends ScalaVersionSpecificEqInstances {
+  @deprecated("Use catsKernelHashForLazyList", "3.0.0")
+  implicit def catsKernelHashForStream[A: Hash]: Hash[Stream[A]] =
+    cats.kernel.instances.stream.catsKernelStdHashForStream[A]
+
+  implicit def catsKernelHashForLazyList[A: Hash]: Hash[LazyList[A]] =
+    cats.kernel.instances.lazyList.catsKernelStdHashForLazyList[A]
+
+  implicit def catsKernelHashForArraySeq[A: Hash]: Hash[ArraySeq[A]] =
+    cats.kernel.instances.arraySeq.catsKernelStdHashForArraySeq[A]
+}
+
+private[kernel] trait ScalaVersionSpecificEqInstances {
+  @deprecated("Use catsKernelEqForLazyList", "3.0.0")
+  implicit def catsKernelEqForStream[A: Eq]: Eq[Stream[A]] = cats.kernel.instances.stream.catsKernelStdEqForStream[A]
+
+  implicit def catsKernelEqForLazyList[A: Eq]: Eq[LazyList[A]] =
+    cats.kernel.instances.lazyList.catsKernelStdEqForLazyList[A]
+
+  implicit def catsKernelEqForArraySeq[A: Eq]: Eq[ArraySeq[A]] =
+    cats.kernel.instances.arraySeq.catsKernelStdEqForArraySeq[A]
+}
+
+private[kernel] trait ScalaVersionSpecificMonoidInstances {
+  @deprecated("Use catsKernelMonoidForLazyList", "3.0.0")
+  implicit def catsKernelMonoidForStream[A]: Monoid[Stream[A]] =
+    cats.kernel.instances.stream.catsKernelStdMonoidForStream[A]
+
+  implicit def catsKernelMonoidForLazyList[A]: Monoid[LazyList[A]] =
+    cats.kernel.instances.lazyList.catsKernelStdMonoidForLazyList[A]
+
+  implicit def catsKernelMonoidForArraySeq[A]: Monoid[ArraySeq[A]] =
+    cats.kernel.instances.arraySeq.catsKernelStdMonoidForArraySeq[A]
+}

--- a/kernel/src/main/scala/cats/kernel/Bounded.scala
+++ b/kernel/src/main/scala/cats/kernel/Bounded.scala
@@ -1,5 +1,7 @@
 package cats.kernel
 
+import java.util.UUID
+import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.{specialized => sp}
 
 /**
@@ -20,6 +22,25 @@ trait LowerBoundedFunctions[L[T] <: LowerBounded[T]] {
 
 object LowerBounded extends LowerBoundedFunctions[LowerBounded] {
   @inline def apply[A](implicit l: LowerBounded[A]): LowerBounded[A] = l
+
+  implicit def catsKernelLowerBoundedForUnit: LowerBounded[Unit] = cats.kernel.instances.unit.catsKernelStdOrderForUnit
+  implicit def catsKernelLowerBoundedForBoolean: LowerBounded[Boolean] =
+    cats.kernel.instances.boolean.catsKernelStdOrderForBoolean
+  implicit def catsKernelLowerBoundedForByte: LowerBounded[Byte] = cats.kernel.instances.byte.catsKernelStdOrderForByte
+  implicit def catsKernelLowerBoundedForInt: LowerBounded[Int] = cats.kernel.instances.int.catsKernelStdOrderForInt
+  implicit def catsKernelLowerBoundedForShort: LowerBounded[Short] =
+    cats.kernel.instances.short.catsKernelStdOrderForShort
+  implicit def catsKernelLowerBoundedForLong: LowerBounded[Long] = cats.kernel.instances.long.catsKernelStdOrderForLong
+  implicit def catsKernelLowerBoundedForDuration: LowerBounded[Duration] =
+    cats.kernel.instances.duration.catsKernelStdOrderForDuration
+  implicit def catsKernelLowerBoundedForFiniteDuration: LowerBounded[FiniteDuration] =
+    cats.kernel.instances.all.catsKernelStdOrderForFiniteDuration
+  implicit def catsKernelLowerBoundedForChar: LowerBounded[Char] = cats.kernel.instances.char.catsKernelStdOrderForChar
+  implicit def catsKernelLowerBoundedForString: LowerBounded[String] =
+    cats.kernel.instances.string.catsKernelStdOrderForString
+  implicit def catsKernelLowerBoundedForSymbol: LowerBounded[Symbol] =
+    cats.kernel.instances.symbol.catsKernelStdOrderForSymbol
+  implicit def catsKernelLowerBoundedForUUID: LowerBounded[UUID] = cats.kernel.instances.uuid.catsKernelStdOrderForUUID
 }
 
 /**
@@ -40,4 +61,19 @@ trait UpperBoundedFunctions[U[T] <: UpperBounded[T]] {
 
 object UpperBounded extends UpperBoundedFunctions[UpperBounded] {
   @inline def apply[A](implicit u: UpperBounded[A]): UpperBounded[A] = u
+
+  implicit def catsKernelUpperBoundedForUnit: UpperBounded[Unit] = cats.kernel.instances.unit.catsKernelStdOrderForUnit
+  implicit def catsKernelUpperBoundedForBoolean: UpperBounded[Boolean] =
+    cats.kernel.instances.boolean.catsKernelStdOrderForBoolean
+  implicit def catsKernelUpperBoundedForByte: UpperBounded[Byte] = cats.kernel.instances.byte.catsKernelStdOrderForByte
+  implicit def catsKernelUpperBoundedForInt: UpperBounded[Int] = cats.kernel.instances.int.catsKernelStdOrderForInt
+  implicit def catsKernelUpperBoundedForShort: UpperBounded[Short] =
+    cats.kernel.instances.short.catsKernelStdOrderForShort
+  implicit def catsKernelUpperBoundedForLong: UpperBounded[Long] = cats.kernel.instances.long.catsKernelStdOrderForLong
+  implicit def catsKernelUpperBoundedForDuration: UpperBounded[Duration] =
+    cats.kernel.instances.duration.catsKernelStdOrderForDuration
+  implicit def catsKernelUpperBoundedForFiniteDuration: UpperBounded[FiniteDuration] =
+    cats.kernel.instances.all.catsKernelStdOrderForFiniteDuration
+  implicit def catsKernelUpperBoundedForChar: UpperBounded[Char] = cats.kernel.instances.char.catsKernelStdOrderForChar
+  implicit def catsKernelUpperBoundedForUUID: UpperBounded[UUID] = cats.kernel.instances.uuid.catsKernelStdOrderForUUID
 }

--- a/kernel/src/main/scala/cats/kernel/Semigroup.scala
+++ b/kernel/src/main/scala/cats/kernel/Semigroup.scala
@@ -1,7 +1,10 @@
 package cats.kernel
 
-import scala.{specialized => sp}
 import scala.annotation.tailrec
+import scala.collection.immutable.{BitSet, Queue, SortedMap, SortedSet}
+import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.{specialized => sp}
+import scala.util.{Failure, Success, Try}
 import compat.scalaVersionSpecific._
 
 /**
@@ -130,7 +133,11 @@ abstract class SemigroupFunctions[S[T] <: Semigroup[T]] {
     ev.combineAllOption(as)
 }
 
-object Semigroup extends SemigroupFunctions[Semigroup] {
+object Semigroup
+    extends SemigroupFunctions[Semigroup]
+    with ScalaVersionSpecificMonoidInstances
+    with instances.TupleCommutativeGroupInstances
+    with GroupInstances {
 
   /**
    * Access an implicit `Semigroup[A]`.
@@ -142,5 +149,132 @@ object Semigroup extends SemigroupFunctions[Semigroup] {
    */
   @inline def instance[A](cmb: (A, A) => A): Semigroup[A] = new Semigroup[A] {
     override def combine(x: A, y: A): A = cmb(x, y)
+  }
+
+  implicit def catsKernelBoundedSemilatticeForBitSet: BoundedSemilattice[BitSet] =
+    cats.kernel.instances.bitSet.catsKernelStdSemilatticeForBitSet
+  implicit def catsKernelInstancesForUnit: BoundedSemilattice[Unit] with CommutativeGroup[Unit] =
+    cats.kernel.instances.unit.catsKernelStdAlgebraForUnit
+  implicit def catsKernelCommutativeGroupForByte: CommutativeGroup[Byte] =
+    cats.kernel.instances.byte.catsKernelStdGroupForByte
+  implicit def catsKernelCommutativeGroupForShort: CommutativeGroup[Short] =
+    cats.kernel.instances.short.catsKernelStdGroupForShort
+  implicit def catsKernelCommutativeGroupForInt: CommutativeGroup[Int] =
+    cats.kernel.instances.int.catsKernelStdGroupForInt
+  implicit def catsKernelCommutativeGroupForLong: CommutativeGroup[Long] =
+    cats.kernel.instances.long.catsKernelStdGroupForLong
+  implicit def catsKernelCommutativeGroupForBigInt: CommutativeGroup[BigInt] =
+    cats.kernel.instances.bigInt.catsKernelStdGroupForBigInt
+  implicit def catsKernelCommutativeGroupForBigDecimal: CommutativeGroup[BigDecimal] =
+    cats.kernel.instances.bigDecimal.catsKernelStdGroupForBigDecimal
+  implicit def catsKernelCommutativeGroupForDuration: CommutativeGroup[Duration] =
+    cats.kernel.instances.duration.catsKernelStdGroupForDuration
+  implicit def catsKernelCommutativeGroupForFiniteDuration: CommutativeGroup[FiniteDuration] =
+    cats.kernel.instances.all.catsKernelStdGroupForFiniteDuration
+  implicit def catsKernelCommutativeGroupForDouble: CommutativeGroup[Double] =
+    cats.kernel.instances.double.catsKernelStdGroupForDouble
+  implicit def catsKernelCommutativeGroupForFloat: CommutativeGroup[Float] =
+    cats.kernel.instances.float.catsKernelStdGroupForFloat
+
+  implicit def catsKernelMonoidForString: Monoid[String] = cats.kernel.instances.string.catsKernelStdMonoidForString
+
+  implicit def catsKernelMonoidForOption[A: Semigroup]: Monoid[Option[A]] =
+    cats.kernel.instances.option.catsKernelStdMonoidForOption[A]
+  implicit def catsKernelMonoidForList[A]: Monoid[List[A]] = cats.kernel.instances.list.catsKernelStdMonoidForList[A]
+  implicit def catsKernelMonoidForVector[A]: Monoid[Vector[A]] =
+    cats.kernel.instances.vector.catsKernelStdMonoidForVector[A]
+  implicit def catsKernelMonoidForQueue[A]: Monoid[Queue[A]] =
+    cats.kernel.instances.queue.catsKernelStdMonoidForQueue[A]
+
+  implicit def catsKernelCommutativeGroupForFunction0[A: CommutativeGroup]: CommutativeGroup[() => A] =
+    cats.kernel.instances.function.catsKernelCommutativeGroupForFunction0[A]
+  implicit def catsKernelCommutativeGroupForFunction1[A, B: CommutativeGroup]: CommutativeGroup[A => B] =
+    cats.kernel.instances.function.catsKernelCommutativeGroupForFunction1[A, B]
+
+  implicit def catsKernelBoundedSemilatticeForSet[A]: BoundedSemilattice[Set[A]] =
+    cats.kernel.instances.set.catsKernelStdSemilatticeForSet[A]
+  implicit def catsKernelBoundedSemilatticeForSortedSet[A: Order]: BoundedSemilattice[SortedSet[A]] =
+    cats.kernel.instances.sortedSet.catsKernelStdBoundedSemilatticeForSortedSet[A]
+
+  implicit def catsKernelCommutativeMonoidForMap[K, V: CommutativeSemigroup]: CommutativeMonoid[Map[K, V]] =
+    cats.kernel.instances.map.catsKernelStdCommutativeMonoidForMap[K, V]
+  implicit def catsKernelCommutativeMonoidForSortedMap[K: Order, V: CommutativeSemigroup]
+    : CommutativeMonoid[SortedMap[K, V]] =
+    cats.kernel.instances.sortedMap.catsKernelStdCommutativeMonoidForSortedMap[K, V]
+}
+
+private[kernel] trait GroupInstances extends BoundedSemilatticeInstances {
+  implicit def catsKernelGroupForFunction0[A: Group]: Group[() => A] =
+    cats.kernel.instances.function.catsKernelGroupForFunction0[A]
+  implicit def catsKernelGroupForFunction1[A, B: Group]: Group[A => B] =
+    cats.kernel.instances.function.catsKernelGroupForFunction1[A, B]
+}
+
+private[kernel] trait BoundedSemilatticeInstances extends SemilatticeInstances {
+  implicit def catsKernelBoundedSemilatticeForFunction0[A: BoundedSemilattice]: BoundedSemilattice[() => A] =
+    cats.kernel.instances.function.catsKernelBoundedSemilatticeForFunction0[A]
+  implicit def catsKernelBoundedSemilatticeForFunction1[A, B: BoundedSemilattice]: BoundedSemilattice[A => B] =
+    cats.kernel.instances.function.catsKernelBoundedSemilatticeForFunction1[A, B]
+}
+
+private[kernel] trait SemilatticeInstances extends CommutativeMonoidInstances {
+  implicit def catsKernelSemilatticeForFunction0[A: Semilattice]: Semilattice[() => A] =
+    cats.kernel.instances.function.catsKernelSemilatticeForFunction0[A]
+  implicit def catsKernelSemilatticeForFunction1[A, B: Semilattice]: Semilattice[A => B] =
+    cats.kernel.instances.function.catsKernelSemilatticeForFunction1[A, B]
+}
+
+private[kernel] trait CommutativeMonoidInstances extends MonoidInstances {
+  implicit def catsKernelCommutativeMonoidForFunction0[A: CommutativeMonoid]: CommutativeMonoid[() => A] =
+    cats.kernel.instances.function.catsKernelCommutativeMonoidForFunction0[A]
+  implicit def catsKernelCommutativeMonoidForFunction1[A, B: CommutativeMonoid]: CommutativeMonoid[A => B] =
+    cats.kernel.instances.function.catsKernelCommutativeMonoidForFunction1[A, B]
+}
+
+private[kernel] trait MonoidInstances extends BandInstances {
+  implicit def catsKernelMonoidForFunction0[A: Monoid]: Monoid[() => A] =
+    cats.kernel.instances.function.catsKernelMonoidForFunction0[A]
+  implicit def catsKernelMonoidForFunction1[A, B: Monoid]: Monoid[A => B] =
+    cats.kernel.instances.function.catsKernelMonoidForFunction1[A, B]
+  implicit def catsKernelMonoidForSortedMap[K: Order, V: Semigroup]: Monoid[SortedMap[K, V]] =
+    cats.kernel.instances.sortedMap.catsKernelStdMonoidForSortedMap[K, V]
+  implicit def catsKernelMonoidForEither[A, B: Monoid]: Monoid[Either[A, B]] =
+    cats.kernel.instances.either.catsDataMonoidForEither[A, B]
+  implicit def catsKernelMonoidForTry[A: Monoid]: Monoid[Try[A]] = new TryMonoid[A](Monoid[A])
+}
+
+private[kernel] trait BandInstances extends CommutativeSemigroupInstances {
+  implicit def catsKernelBandForFunction0[A: Band]: Band[() => A] =
+    cats.kernel.instances.function.catsKernelBandForFunction0[A]
+  implicit def catsKernelBandForFunction1[A, B: Band]: Band[A => B] =
+    cats.kernel.instances.function.catsKernelBandForFunction1[A, B]
+}
+
+private[kernel] trait CommutativeSemigroupInstances extends SemigroupInstances {
+  implicit def catsKernelCommutativeSemigroupForFunction0[A: CommutativeSemigroup]: CommutativeSemigroup[() => A] =
+    cats.kernel.instances.function.catsKernelCommutativeSemigroupForFunction0[A]
+  implicit def catsKernelCommutativeSemigroupForFunction1[A, B: CommutativeSemigroup]: CommutativeSemigroup[A => B] =
+    cats.kernel.instances.function.catsKernelCommutativeSemigroupForFunction1[A, B]
+}
+
+private[kernel] trait SemigroupInstances {
+  implicit def catsKernelSemigroupForFunction0[A: Semigroup]: Semigroup[() => A] =
+    cats.kernel.instances.function.catsKernelSemigroupForFunction0[A]
+  implicit def catsKernelSemigroupForFunction1[A, B: Semigroup]: Semigroup[A => B] =
+    cats.kernel.instances.function.catsKernelSemigroupForFunction1[A, B]
+  implicit def catsKernelSemigroupForEither[A, B: Semigroup]: Semigroup[Either[A, B]] =
+    cats.kernel.instances.either.catsDataSemigroupForEither[A, B]
+  implicit def catsKernelSemigroupForTry[A: Semigroup]: Semigroup[Try[A]] = new TrySemigroup[A](Semigroup[A])
+}
+
+private class TryMonoid[A](A: Monoid[A]) extends TrySemigroup[A](A) with Monoid[Try[A]] {
+  def empty: Try[A] = Success(A.empty)
+}
+
+private class TrySemigroup[A](A: Semigroup[A]) extends Semigroup[Try[A]] {
+  def combine(x: Try[A], y: Try[A]): Try[A] = (x, y) match {
+    case (Success(xv), Success(yv)) => Success(A.combine(xv, yv))
+    case (f @ Failure(_), _)        => f
+    case (_, f)                     => f
   }
 }

--- a/project/KernelBoiler.scala
+++ b/project/KernelBoiler.scala
@@ -255,6 +255,194 @@ object KernelBoiler {
                   }
               """
             }
+        ),
+        InstanceDef(
+          "private[kernel] trait TupleBandInstances extends TupleSemigroupInstances {",
+          tv =>
+            new TemplatedBlock(tv) {
+              import tv._
+              def content =
+                block"""
+                implicit def catsKernelBandForTuple${arity}[${`A..N`}](implicit ${constraints("Band")}): Band[${`(A..N)`}] = new Band[${`(A..N)`}] {
+                  def combine(x: ${`(A..N)`}, y: ${`(A..N)`}): ${`(A..N)`} = ${binTuple("combine")}
+                }
+              """
+            }
+        ),
+        InstanceDef(
+          "private[kernel] trait TupleBoundedSemilatticeInstances extends TupleGroupInstances {",
+          tv =>
+            new TemplatedBlock(tv) {
+              import tv._
+              def content =
+                block"""
+                implicit def catsKernelBoundedSemilatticeForTuple${arity}[${`A..N`}](implicit ${constraints(
+                  "BoundedSemilattice"
+                )}): BoundedSemilattice[${`(A..N)`}] = new BoundedSemilattice[${`(A..N)`}] {
+                  def combine(x: ${`(A..N)`}, y: ${`(A..N)`}): ${`(A..N)`} = ${binTuple("combine")}
+                  def empty: ${`(A..N)`} = ${nullaryTuple("empty")}
+                }
+              """
+            }
+        ),
+        InstanceDef(
+          "private[kernel] trait TupleCommutativeGroupInstances extends TupleBoundedSemilatticeInstances {",
+          tv =>
+            new TemplatedBlock(tv) {
+              import tv._
+              def content =
+                block"""
+                implicit def catsKernelCommutativeGroupForTuple${arity}[${`A..N`}](implicit ${constraints(
+                  "CommutativeGroup"
+                )}): CommutativeGroup[${`(A..N)`}] = new CommutativeGroup[${`(A..N)`}] {
+                  def combine(x: ${`(A..N)`}, y: ${`(A..N)`}): ${`(A..N)`} = ${binTuple("combine")}
+                  def empty: ${`(A..N)`} = ${nullaryTuple("empty")}
+                  def inverse(x: ${`(A..N)`}): ${`(A..N)`} = ${unaryTuple("inverse")}
+                }
+              """
+            }
+        ),
+        InstanceDef(
+          "private[kernel] trait TupleCommutativeMonoidInstances extends TupleSemilatticeInstances {",
+          tv =>
+            new TemplatedBlock(tv) {
+              import tv._
+              def content =
+                block"""
+                implicit def catsKernelCommutativeMonoidForTuple${arity}[${`A..N`}](implicit ${constraints(
+                  "CommutativeMonoid"
+                )}): CommutativeMonoid[${`(A..N)`}] = new CommutativeMonoid[${`(A..N)`}] {
+                  def combine(x: ${`(A..N)`}, y: ${`(A..N)`}): ${`(A..N)`} = ${binTuple("combine")}
+                  def empty: ${`(A..N)`} = ${nullaryTuple("empty")}
+                }
+              """
+            }
+        ),
+        InstanceDef(
+          "private[kernel] trait TupleCommutativeSemigroupInstances extends TupleBandInstances {",
+          tv =>
+            new TemplatedBlock(tv) {
+              import tv._
+              def content =
+                block"""
+                implicit def catsKernelCommutativeSemigroupForTuple${arity}[${`A..N`}](implicit ${constraints(
+                  "CommutativeSemigroup"
+                )}): CommutativeSemigroup[${`(A..N)`}] = new CommutativeSemigroup[${`(A..N)`}] {
+                  def combine(x: ${`(A..N)`}, y: ${`(A..N)`}): ${`(A..N)`} = ${binTuple("combine")}
+                }
+              """
+            }
+        ),
+        InstanceDef(
+          "private[kernel] trait TupleEqInstances {",
+          tv =>
+            new TemplatedBlock(tv) {
+              import tv._
+              def content =
+                block"""
+                implicit def catsKernelEqForTuple${arity}[${`A..N`}](implicit ${constraints("Eq")}): Eq[${`(A..N)`}] = new Eq[${`(A..N)`}] {
+                  def eqv(x: ${`(A..N)`}, y: ${`(A..N)`}): Boolean = ${binMethod("eqv").mkString(" && ")}
+                }
+              """
+            }
+        ),
+        InstanceDef(
+          "private[kernel] trait TupleGroupInstances extends TupleCommutativeMonoidInstances {",
+          tv =>
+            new TemplatedBlock(tv) {
+              import tv._
+              def content =
+                block"""
+                implicit def catsKernelGroupForTuple${arity}[${`A..N`}](implicit ${constraints("Group")}): Group[${`(A..N)`}] = new Group[${`(A..N)`}] {
+                  def combine(x: ${`(A..N)`}, y: ${`(A..N)`}): ${`(A..N)`} = ${binTuple("combine")}
+                  def empty: ${`(A..N)`} = ${nullaryTuple("empty")}
+                  def inverse(x: ${`(A..N)`}): ${`(A..N)`} = ${unaryTuple("inverse")}
+                }
+              """
+            }
+        ),
+        InstanceDef(
+          "private[kernel] trait TupleHashInstances extends TupleEqInstances {",
+          tv =>
+            new TemplatedBlock(tv) {
+              import tv._
+              def content =
+                block"""
+              implicit def catsKernelHashForTuple${arity}[${`A..N`}](implicit ${constraints("Hash")}): Hash[${`(A..N)`}] = new Hash[${`(A..N)`}] {
+                def hash(x: ${`(A..N)`}): Int = ${unaryMethod("hash")
+                  .mkString(s"$tupleNHeader(", ", ", ")")}.hashCode()
+                def eqv(x: ${`(A..N)`}, y: ${`(A..N)`}): Boolean = ${binMethod("eqv").mkString(" && ")}
+              }
+              """
+            }
+        ),
+        InstanceDef(
+          "private[kernel] trait TupleMonoidInstances extends TupleCommutativeSemigroupInstances {",
+          tv =>
+            new TemplatedBlock(tv) {
+              import tv._
+              def content =
+                block"""
+                implicit def catsKernelMonoidForTuple${arity}[${`A..N`}](implicit ${constraints("Monoid")}): Monoid[${`(A..N)`}] = new Monoid[${`(A..N)`}] {
+                  def combine(x: ${`(A..N)`}, y: ${`(A..N)`}): ${`(A..N)`} = ${binTuple("combine")}
+                  def empty: ${`(A..N)`} = ${nullaryTuple("empty")}
+                }
+              """
+            }
+        ),
+        InstanceDef(
+          "private[kernel] trait TupleOrderInstances extends TuplePartialOrderInstances {",
+          tv =>
+            new TemplatedBlock(tv) {
+              import tv._
+              def content =
+                block"""
+                implicit def catsKernelOrderForTuple${arity}[${`A..N`}](implicit ${constraints("Order")}): Order[${`(A..N)`}] = new Order[${`(A..N)`}] {
+                  def compare(x: ${`(A..N)`}, y: ${`(A..N)`}): Int =
+                    ${binMethod("compare").mkString("Array(", ", ", ")")}.find(_ != 0).getOrElse(0)
+                }
+              """
+            }
+        ),
+        InstanceDef(
+          "private[kernel] trait TuplePartialOrderInstances extends TupleHashInstances {",
+          tv =>
+            new TemplatedBlock(tv) {
+              import tv._
+              def content =
+                block"""
+                implicit def catsKernelPartialOrderForTuple${arity}[${`A..N`}](implicit ${constraints("PartialOrder")}): PartialOrder[${`(A..N)`}] = new PartialOrder[${`(A..N)`}] {
+                  def partialCompare(x: ${`(A..N)`}, y: ${`(A..N)`}): Double =
+                    ${binMethod("partialCompare").mkString("Array(", ", ", ")")}.find(_ != 0.0).getOrElse(0.0)
+                }
+              """
+            }
+        ),
+        InstanceDef(
+          "private[kernel] trait TupleSemigroupInstances {",
+          tv =>
+            new TemplatedBlock(tv) {
+              import tv._
+              def content =
+                block"""
+                implicit def catsKernelSemigroupForTuple${arity}[${`A..N`}](implicit ${constraints("Semigroup")}): Semigroup[${`(A..N)`}] = new Semigroup[${`(A..N)`}] {
+                  def combine(x: ${`(A..N)`}, y: ${`(A..N)`}): ${`(A..N)`} = ${binTuple("combine")}
+                }
+              """
+            }
+        ),
+        InstanceDef(
+          "private[kernel] trait TupleSemilatticeInstances extends TupleMonoidInstances {",
+          tv =>
+            new TemplatedBlock(tv) {
+              import tv._
+              def content =
+                block"""
+                implicit def catsKernelSemilatticeForTuple${arity}[${`A..N`}](implicit ${constraints("Semilattice")}): Semilattice[${`(A..N)`}] = new Semilattice[${`(A..N)`}] {
+                  def combine(x: ${`(A..N)`}, y: ${`(A..N)`}): ${`(A..N)`} = ${binTuple("combine")}
+                }
+              """
+            }
         )
       )
   }

--- a/testkit/src/main/scala/cats/tests/ListWrapper.scala
+++ b/testkit/src/main/scala/cats/tests/ListWrapper.scala
@@ -1,7 +1,6 @@
 package cats
 package tests
 
-import cats.instances.list._
 import org.scalacheck.{Arbitrary, Cogen}
 import org.scalacheck.Arbitrary.arbitrary
 

--- a/tests/src/test/scala-2.12/cats/tests/NonEmptyStreamSuite.scala
+++ b/tests/src/test/scala-2.12/cats/tests/NonEmptyStreamSuite.scala
@@ -2,8 +2,8 @@ package cats.tests
 
 import cats.{Comonad, Eval, Functor, Monad, NonEmptyTraverse, Now, Reducible, SemigroupK, Show}
 import cats.data.{NonEmptyStream, OneAnd}
-import cats.instances.all._
 import cats.kernel.Semigroup
+import cats.kernel.instances.order.catsKernelOrderingForOrder
 import cats.kernel.laws.discipline.{EqTests, SemigroupTests}
 import cats.laws.discipline._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms

--- a/tests/src/test/scala-2.13+/cats/tests/ScalaVersionSpecific.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/ScalaVersionSpecific.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.{Eval, Foldable, Id, Now}
 import cats.data.NonEmptyLazyList
-import cats.instances.all._
 import cats.laws.discipline.{NonEmptyParallelTests, ParallelTests}
 import cats.laws.discipline.arbitrary._
 import cats.syntax.either._

--- a/tests/src/test/scala/cats/tests/BinCodecInvariantMonoidalSuite.scala
+++ b/tests/src/test/scala/cats/tests/BinCodecInvariantMonoidalSuite.scala
@@ -1,13 +1,13 @@
 package cats.tests
 
 import cats.{InvariantMonoidal, InvariantSemigroupal}
-import cats.implicits._
 import cats.kernel.{Eq, Monoid, Semigroup}
 import cats.kernel.compat.scalaVersionSpecific._
 import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.{ExhaustiveCheck, InvariantMonoidalTests, MiniInt, SerializableTests}
+import cats.syntax.all._
 import org.scalacheck.{Arbitrary, Gen}
 
 @suppressUnusedImportWarningForScalaVersionSpecific

--- a/tests/src/test/scala/cats/tests/EitherSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherSuite.scala
@@ -42,7 +42,7 @@ class EitherSuite extends CatsSuite {
   checkAll("Semigroup[Either[ListWrapper[String], Int]]",
            SerializableTests.serializable(Semigroup[Either[ListWrapper[String], Int]]))
 
-  val partialOrder = catsStdPartialOrderForEither[Int, String]
+  val partialOrder = cats.kernel.instances.either.catsStdPartialOrderForEither[Int, String]
   val order = implicitly[Order[Either[Int, String]]]
   val monad = implicitly[Monad[Either[Int, *]]]
   val show = implicitly[Show[Either[Int, String]]]
@@ -80,7 +80,7 @@ class EitherSuite extends CatsSuite {
   }
 
   test("implicit instances resolve specifically") {
-    val eq = catsStdEqForEither[Int, String]
+    val eq = cats.kernel.instances.either.catsStdEqForEither[Int, String]
     assert(!eq.isInstanceOf[PartialOrder[_]])
     assert(!eq.isInstanceOf[Order[_]])
     assert(!partialOrder.isInstanceOf[Order[_]])

--- a/tests/src/test/scala/cats/tests/FoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/FoldableSuite.scala
@@ -2,7 +2,7 @@ package cats.tests
 
 import cats.{Eval, Foldable, Id, Now}
 import cats.data.{Const, EitherK, IdT, Ior, Nested, NonEmptyList, NonEmptyStream, NonEmptyVector, OneAnd, Validated}
-import cats.instances.all._
+import cats.instances.order._
 import cats.kernel.{Eq, Monoid}
 import cats.kernel.compat.scalaVersionSpecific._
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/FunctionSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctionSuite.scala
@@ -93,7 +93,7 @@ class FunctionSuite extends CatsSuite {
   checkAll("Contravariant[* => Int]", SerializableTests.serializable(Contravariant[* => Int]))
 
   checkAll("Function1", MonoidKTests[λ[α => α => α]].monoidK[MiniInt])
-  checkAll("MonoidK[λ[α => α => α]", SerializableTests.serializable(catsStdMonoidKForFunction1))
+  checkAll("MonoidK[λ[α => α => α]", SerializableTests.serializable(MonoidK[Endo]))
 
   checkAll("Function1[MiniInt, *]",
            DistributiveTests[MiniInt => *].distributive[Int, Int, Int, Id, Function1[MiniInt, *]])

--- a/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTSuite.scala
@@ -481,21 +481,15 @@ class ReaderWriterStateTSuite extends CatsSuite {
 }
 
 object ReaderWriterStateTSuite {
-  def addAndLog(i: Int): ReaderWriterState[String, Vector[String], Int, Int] = {
-    import cats.instances.vector._
-
+  def addAndLog(i: Int): ReaderWriterState[String, Vector[String], Int, Int] =
     ReaderWriterState { (context, state) =>
       (Vector(s"${context}: Added ${i}"), state + i, state + i)
     }
-  }
 
-  def addLogUnit(i: Int): ReaderWriterState[String, Unit, Int, Int] = {
-    import cats.kernel.instances.unit._
-
+  def addLogUnit(i: Int): ReaderWriterState[String, Unit, Int, Int] =
     ReaderWriterState { (context, state) =>
       ((), state + i, state + i)
     }
-  }
 
   implicit def IRWSTEq[F[_], E, L, SA, SB, A](implicit SA: ExhaustiveCheck[SA],
                                               SB: Arbitrary[SB],

--- a/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
@@ -3,7 +3,6 @@ package cats.tests
 import cats._
 import cats.arrow.{Profunctor, Strong}
 import cats.data.{EitherT, IndexedStateT, State, StateT}
-import cats.instances.all._
 import cats.kernel.Eq
 import cats.laws.discipline._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms

--- a/tests/src/test/scala/cats/tests/IorTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IorTSuite.scala
@@ -41,8 +41,6 @@ class IorTSuite extends CatsSuite {
   }
 
   {
-    implicit val F: MonadError[Option, Unit] = catsStdInstancesForOption
-
     checkAll("IorT[Option, String, String]",
              MonadErrorTests[IorT[Option, String, *], Unit].monadError[String, String, String])
     checkAll("MonadError[IorT[Option, *, *]]",

--- a/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
@@ -18,8 +18,8 @@ import cats.{
 }
 import cats.data.NonEmptyVector
 import cats.data.NonEmptyVector.ZipNonEmptyVector
-import cats.instances.all._
 import cats.kernel.Semigroup
+import cats.kernel.instances.order.catsKernelOrderingForOrder
 import cats.kernel.laws.discipline.{EqTests, SemigroupTests}
 import cats.laws.discipline.{
   AlignTests,

--- a/tests/src/test/scala/cats/tests/OrderSuite.scala
+++ b/tests/src/test/scala/cats/tests/OrderSuite.scala
@@ -47,7 +47,6 @@ class OrderSuite extends CatsSuite {
 
 object OrderSuite {
   def summonInstance(): Unit = {
-    import cats.instances.order._
     Invariant[Order]
     Contravariant[Order]
     ContravariantMonoidal[Order]
@@ -58,7 +57,6 @@ object OrderSuite {
   // the Ordering instance from the Order instance should be trumped
   // by the one provided in the Ordering companion object
   {
-    import cats.instances.all._
     Ordering[String]
     class C
     implicit val ording: Ordering[C] = new Ordering[C] {

--- a/tests/src/test/scala/cats/tests/ParallelSuite.scala
+++ b/tests/src/test/scala/cats/tests/ParallelSuite.scala
@@ -508,13 +508,6 @@ class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest with Sc
 }
 
 trait ApplicativeErrorForEitherTest extends AnyFunSuiteLike with FunSuiteDiscipline with Checkers {
-
-  import cats.instances.either._
-  import cats.instances.string._
-  import cats.instances.int._
-  import cats.instances.unit._
-  import cats.instances.tuple._
-
   implicit def eqV[A: Eq, B: Eq]: Eq[Validated[A, B]] = cats.data.Validated.catsDataEqForValidated
 
   {

--- a/tests/src/test/scala/cats/tests/PartialOrderSuite.scala
+++ b/tests/src/test/scala/cats/tests/PartialOrderSuite.scala
@@ -2,7 +2,7 @@ package cats.tests
 
 import cats.{Contravariant, ContravariantMonoidal, Invariant}
 import cats.instances.all._
-import cats.kernel.PartialOrder
+import cats.kernel.{Order, PartialOrder}
 import cats.kernel.laws.discipline.SerializableTests
 import cats.laws.discipline.{ContravariantMonoidalTests, MiniInt}
 import cats.laws.discipline.arbitrary._
@@ -30,6 +30,7 @@ class PartialOrderSuite extends CatsSuite {
 
   test("companion object syntax") {
     forAll { (i: Int, j: Int) =>
+      val catsKernelStdOrderForInt: Order[Int] = Order[Int]
       checkPartialCompare(PartialOrder.partialCompare(i, j), catsKernelStdOrderForInt.partialCompare(i, j))
       PartialOrder.tryCompare(i, j) should ===(catsKernelStdOrderForInt.tryCompare(i, j))
       PartialOrder.pmin(i, j) should ===(catsKernelStdOrderForInt.pmin(i, j))
@@ -58,7 +59,6 @@ class PartialOrderSuite extends CatsSuite {
 
 object PartialOrderSuite {
   def summonInstance(): Unit = {
-    import cats.instances.partialOrder._
     Invariant[PartialOrder]
     Contravariant[PartialOrder]
     ()

--- a/tests/src/test/scala/cats/tests/SemigroupSuite.scala
+++ b/tests/src/test/scala/cats/tests/SemigroupSuite.scala
@@ -9,14 +9,12 @@ import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 class SemigroupSuite extends AnyFunSuiteLike with Matchers with ScalaCheckDrivenPropertyChecks {
   {
-    import cats.implicits._
     Invariant[Semigroup]
     Semigroupal[Semigroup]
     InvariantMonoidal[Semigroup]
   }
 
   {
-    import cats.instances.invariant._
     Invariant[Semigroup]
     Semigroupal[Semigroup]
     InvariantMonoidal[Semigroup]

--- a/tests/src/test/scala/cats/tests/ShowSuite.scala
+++ b/tests/src/test/scala/cats/tests/ShowSuite.scala
@@ -58,9 +58,6 @@ final class ShowSuite2 extends AnyFunSuiteLike {
     "contravariant show for FiniteDuration can be inferred when importing both duration's and finiteDuration's instances"
   ) {
 
-    import cats.instances.duration._
-    import cats.instances.finiteDuration._
-
     implicitly[Order[Duration]]
     implicitly[Order[FiniteDuration]]
 
@@ -68,8 +65,6 @@ final class ShowSuite2 extends AnyFunSuiteLike {
   }
 
   test("all the Duration's and FiniteDuration's instances can be correctly inferred when importing implicits") {
-
-    import cats.implicits._
 
     implicitly[Order[Duration]]
     implicitly[Order[FiniteDuration]]

--- a/tests/src/test/scala/cats/tests/SyntaxSuite.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxSuite.scala
@@ -3,7 +3,6 @@ package cats.tests
 import cats._
 import cats.arrow.Compose
 import cats.data.{Binested, Nested, NonEmptyChain, NonEmptyList, NonEmptySet}
-import cats.instances.all._
 import cats.syntax.all._
 import scala.collection.immutable.{SortedMap, SortedSet}
 

--- a/tests/src/test/scala/cats/tests/TraverseSuite.scala
+++ b/tests/src/test/scala/cats/tests/TraverseSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.{Applicative, Eval, Traverse}
-import cats.instances.all._
 import cats.kernel.compat.scalaVersionSpecific._
 import cats.syntax.foldable._
 import cats.syntax.functor._

--- a/tests/src/test/scala/cats/tests/UnorderedFoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/UnorderedFoldableSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.UnorderedFoldable
-import cats.instances.all._
 import cats.kernel.CommutativeMonoid
 import cats.laws.discipline.UnorderedFoldableTests
 import cats.syntax.unorderedFoldable._
@@ -51,13 +50,13 @@ sealed abstract class UnorderedFoldableSuite[F[_]](name: String)(implicit ArbFSt
 final class UnorderedFoldableSetSuite extends UnorderedFoldableSuite[Set]("set") {
   def iterator[T](set: Set[T]): Iterator[T] = set.iterator
   def specializedUnorderedFoldMap[A, B: CommutativeMonoid](fa: Set[A])(f: A => B): B =
-    catsStdInstancesForSet.unorderedFoldMap(fa)(f)
+    UnorderedFoldable[Set].unorderedFoldMap(fa)(f)
 }
 
 final class UnorderedFoldableMapSuite extends UnorderedFoldableSuite[Map[String, *]]("map") {
   def iterator[T](map: Map[String, T]): Iterator[T] = map.valuesIterator
   def specializedUnorderedFoldMap[A, B: CommutativeMonoid](fa: Map[String, A])(f: A => B): B =
-    catsStdInstancesForMap[String].unorderedFoldMap(fa)(f)
+    UnorderedFoldable[Map[String, *]].unorderedFoldMap(fa)(f)
 }
 
 sealed abstract class SpecializedUnorderedFoldableSuite[F[_]: UnorderedFoldable](name: String)(


### PR DESCRIPTION
Please see [this blog post](https://meta.plasm.us/posts/2019/09/30/implicit-scope-and-cats/) for some additional discussion of this proposal.

This is a proof-of-concept and proposal more than a pull request (even a WIP one), but I don't know a better way to put it up for discussion in a place where changes can be tracked, etc. It's a pretty sweeping change to the way type class instances are provided in Cats, and I haven't talked about it yet in any substantive way with other Cats maintainers.

## Motivation

The basic idea is that instead of type class instances for standard library types (e.g. `Monad[Option]`) living in packages that require users to import them (`cats.instances.option._`), these instances are included in the type class companion objects, where they are available to users in [implicit scope](https://www.scala-lang.org/files/archive/spec/2.13/07-implicits.html), without imports.

This means that Cats users would only ever have to think about imports for syntax, not instances. For example, the following just works:

```scala
scala> cats.Parallel[Either[String, ?]].parProductR(Left("foo"))(Left("bar"))
res0: scala.util.Either[String,Nothing] = Left(foobar)
```
While in Cats now you'd need something like this:

```scala
import cats.instances.parallel._, cats.instances.string._
```
…or the "kitchen sink" `cats.implicits._` import.

This might seem like a small thing, but I've been playing with the idea for a couple months now (starting with [this attempt](https://github.com/travisbrown/dotty-experiments) at porting Cats to Dotty), and I really do feel like it significantly improves my experience of working with Cats. It's just one less you have to worry about everywhere—in your source, in the REPL, etc.

## What this PR does

For this initial experiment, I've added these type class instances to the appropriate companion objects as methods that point to the instances in the `cats.instances` packages. I've changed all code in cats-core, cats-free, and the tests so that there is no use of `cats.instances` imports, the `cats.implicits._` import, or any instances brought into scope by the `Instances` traits.

I'm sure I've missed some instances, and we'd want much better tests before we'd ever consider merging this, but this change verifies that all of the standard library instances used in Cats itself are available  in implicit scope, without imports.

The change is binary compatible with Cats 1.x and 2.x, and while I'm sure that it breaks source compatibility, I'd be surprised if it affects anything but fairly weird cases. You can still import the `instances` instances, and they'll override the implicit scope instances. It's just not necessary.

## Longer term changes

This is entirely hypothetical, but if we decided to go this route in Cats 3 or some other future release, I can imagine a progression like the following:

1. A major release (3.0.0) that does only what this PR does: introduces the implicit scope instances but doesn't remove anything. 
2. A minor release (3.1.0) that deprecates the `instances` traits and packages.
3. A major release (4.0.0) that removes the `instances` traits and packages.

The initial step would be binary compatible with previous releases, but it has such a big effect on usage that I don't personally think introducing it in a minor release is a good idea.

## Challenges

I've been using Scalaz for a few months short of a decade, and in that time it's always taken the approach that Cats inherited, requiring imports for standard library instances. I think this may have been different in earlier versions of Scalaz, but that's not clear from the history in the repo on GitHub, and I haven't done any further archeology yet. I've [asked around about the reasons for this design decision](https://twitter.com/travisbrown/status/1167308493742735365) a few times, and [this thread](https://twitter.com/travisbrown/status/1153353455639175171) includes the most context I know of.

The [biggest immediate difficulty](https://twitter.com/mpilquist/status/1153356781403291652) with putting these instances into implicit scope is the fact that the compiler only searches supertype companions for instances, not subtypes. This means that if you provide the `MonadError` instance for `Option` in the `MonadError` companion object, it won't be found in a search for a `Functor[Option]` instance.

As far as I can tell there are two viable approaches to making instances like this available for subtype searches:

1. Put "upcast" instances in every companion object, so that if you'll always have a `Functor[F]` if you have a `Monad[F]` in implicit scope.
2. Put the instances in the roots of the type class hierarchy, where they'll be always be found when searching supertype companions.

I've experimented with both, and so far the second feels like the better choice. It requires a little more up-front coordination, but with a diagram of the Cats type class hierarchy it's not too bad, and it's much less invasive.

Another potential difficulty involves type class hierarchies that cross module boundaries, as @non and @johnynek point out [here](https://twitter.com/d6/status/1167304018068029440). I think this is addressable, and I've done some experiments in that direction, but we'll definitely need to spend more time looking at how this change would impact real projects like [cats-effect](https://github.com/typelevel/cats-effect), [Algebra](https://github.com/typelevel/algebra), and [Spire](https://github.com/typelevel/spire).

## Compile times

This is the primary thing I'm worried about (see for example [this article](https://www.artima.com/articles/compile_time.html) by Bill Venners for some context). I don't have strong intuitions about the relative compile-time cost of imported implicits vs. the kind of implicit scope search this change requires.

I've done a few experiments in this respect, including running the following several times on both master and this branch:

```bash
sbt clean test:clean
sbt compile
time sbt test:compile
```
And all of the results are within a couple seconds of each other (around 150 seconds on my machine). That's not very scientific, though, and I'm not sure how accurately the Cats test usage reflects the real world usage we care about.

## Jar size
I was also originally a little worried that duplicating the instances would hurt jar sizes in a significant way, especially because in this initial attempt the code-gen for kernel instances isn't as optimized as it could be, and many of the generated instance definitions are duplicated. If we go this route, eventually this wouldn't be a concern at all, since we'd remove the instance packages altogether, but I was worried that in the meantime we'd be stuck with some bloat.

It turns out that this isn't really the case. Here are the cats-core sizes after this change:
```bash
5736    cats-core_2.11.jar
4556    cats-core_2.12.jar
4664    cats-core_2.13.jar
```
And on current master:
```
5704    cats-core_2.11.jar
4528    cats-core_2.12.jar
4632    cats-core_2.13.jar
```
So less than a percent in all cases (+0.71% for 2.13, which has the biggest change).
