### PR TITLE
Hash[Map[K, V]] has unnecessary constraint #3039

### DIFF
--- a/core/src/main/scala/cats/instances/sortedSet.scala
+++ b/core/src/main/scala/cats/instances/sortedSet.scala
@@ -73,7 +73,7 @@ trait SortedSetInstances extends SortedSetInstances1 {
 private[instances] trait SortedSetInstances1 {
   @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet")
   private[instances] def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
-    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A]
+    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet1[A]
 
   @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedSet.catsKernelStdSemilatticeForSortedSet")
   def catsKernelStdSemilatticeForSortedSet[A: Order]: BoundedSemilattice[SortedSet[A]] =
@@ -94,7 +94,7 @@ private[instances] trait SortedSetInstancesBinCompat0 {
 private[instances] trait SortedSetInstancesBinCompat1 extends LowPrioritySortedSetInstancesBinCompat1 {
   // TODO: Remove when this is no longer necessary for binary compatibility.
   implicit override def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
-    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A]
+    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet1[A]
 }
 
 private[instances] trait LowPrioritySortedSetInstancesBinCompat1
@@ -104,7 +104,7 @@ private[instances] trait LowPrioritySortedSetInstancesBinCompat1
     cats.kernel.instances.sortedSet.catsKernelStdOrderForSortedSet[A]
 
   override def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
-    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A]
+    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet1[A]
 }
 
 @deprecated("2.0.0-RC2", "Use cats.kernel.instances.SortedSetHash")

--- a/kernel/src/main/scala/cats/kernel/instances/SortedSetInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/SortedSetInstances.scala
@@ -1,11 +1,14 @@
 package cats.kernel
 package instances
 
-import cats.kernel.{BoundedSemilattice, Hash, Order}
 import scala.collection.immutable.SortedSet
 
 trait SortedSetInstances extends SortedSetInstances1 {
-  implicit def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
+  @deprecated("Will be removed after dropping Scala 2.11 support", "")
+  def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
+    new SortedSetHash[A]
+
+  implicit def catsKernelStdHashForSortedSet1[A: Hash]: Hash[SortedSet[A]] =
     new SortedSetHash[A]
 }
 
@@ -28,7 +31,7 @@ class SortedSetOrder[A: Order] extends Order[SortedSet[A]] {
     StaticMethods.iteratorEq(s1.iterator, s2.iterator)
 }
 
-class SortedSetHash[A: Order: Hash] extends Hash[SortedSet[A]] {
+class SortedSetHash[A: Hash] extends Hash[SortedSet[A]] {
   import scala.util.hashing.MurmurHash3._
 
   // adapted from [[scala.util.hashing.MurmurHash3]],
@@ -50,7 +53,7 @@ class SortedSetHash[A: Order: Hash] extends Hash[SortedSet[A]] {
     finalizeHash(h, n)
   }
   override def eqv(s1: SortedSet[A], s2: SortedSet[A]): Boolean =
-    StaticMethods.iteratorEq(s1.iterator, s2.iterator)(Order[A])
+    StaticMethods.iteratorEq(s1.iterator, s2.iterator)(Eq[A])
 }
 
 class SortedSetSemilattice[A: Order] extends BoundedSemilattice[SortedSet[A]] {

--- a/kernel/src/main/scala/cats/kernel/instances/SortedSetInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/SortedSetInstances.scala
@@ -31,8 +31,12 @@ class SortedSetOrder[A: Order] extends Order[SortedSet[A]] {
     StaticMethods.iteratorEq(s1.iterator, s2.iterator)
 }
 
-class SortedSetHash[A: Hash] extends Hash[SortedSet[A]] {
+// FIXME use context bound in 3.x
+class SortedSetHash[A](implicit hashA: Hash[A]) extends Hash[SortedSet[A]] {
   import scala.util.hashing.MurmurHash3._
+
+  @deprecated("Use the constructor _without_ Order instead, since Order is not required", "2.0.1")
+  def this(o: Order[A], h: Hash[A]) = this()(h)
 
   // adapted from [[scala.util.hashing.MurmurHash3]],
   // but modified standard `Any#hashCode` to `ev.hash`.


### PR DESCRIPTION
Removed `Order` constraint from `Hash[Map[K, V]]`but bincomp is broken. Please advise how it can be overcome

Closes #3039 