### PR TITLE
add more doctest to Ior

### DIFF
--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -25,57 +25,543 @@ import scala.annotation.tailrec
  */
 sealed abstract class Ior[+A, +B] extends Product with Serializable {
 
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> val rightF: Int => String = _.show
+   * scala> val bothF: (String,Int) => String = (a,b) => a.combine(b.show)
+   *
+   * scala> val ior1 = "abc".leftIor[Int]
+   * scala> ior1.fold(identity, rightF, bothF)
+   * res0: String = abc
+   *
+   * scala> val ior2 = 123.rightIor[String]
+   * scala> ior2.fold(identity, rightF, bothF)
+   * res1: String = 123
+   *
+   * scala> val ior3 = Ior.Both("abc", 123)
+   * scala> ior3.fold(identity, rightF, bothF)
+   * res2: String = abc123
+   * }}}
+   */
   final def fold[C](fa: A => C, fb: B => C, fab: (A, B) => C): C = this match {
     case Ior.Left(a)    => fa(a)
     case Ior.Right(b)   => fb(b)
     case Ior.Both(a, b) => fab(a, b)
   }
 
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> val ior1 = "abc".leftIor[Int]
+   * scala> ior1.putLeft(true)
+   * res0: Ior[Boolean, Int] = Left(true)
+   *
+   * scala> val ior2 = 123.rightIor[String]
+   * scala> ior2.putLeft(false)
+   * res1: Ior[Boolean, Int] = Both(false,123)
+   *
+   * scala> val ior3 = Ior.Both("abc",123)
+   * scala> ior3.putLeft(true)
+   * res2: Ior[Boolean, Int] = Both(true,123)
+   * }}}
+   */
   final def putLeft[C](left: C): C Ior B =
     fold(_ => Ior.left(left), Ior.both(left, _), (_, b) => Ior.both(left, b))
+
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> val ior1 = "abc".leftIor[Int]
+   * scala> ior1.putRight(123L)
+   * res0: Ior[String, Long] = Both(abc,123)
+   *
+   * scala> val ior2 = 123.rightIor[String]
+   * scala> ior2.putRight(123L)
+   * res1: Ior[String, Long] = Right(123)
+   *
+   * scala> val ior3 = Ior.Both("abc",123)
+   * scala> ior3.putRight(123L)
+   * res2: Ior[String, Long] = Both(abc,123)
+   * }}}
+   */
   final def putRight[C](right: C): A Ior C =
     fold(Ior.both(_, right), _ => Ior.right(right), (a, _) => Ior.both(a, right))
 
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].isLeft
+   * res0: Boolean = true
+   *
+   * scala> 123.rightIor[String].isLeft
+   * res1: Boolean = false
+   *
+   * scala> Ior.Both("abc", 123).isLeft
+   * res2: Boolean = false
+   * }}}
+   */
   final def isLeft: Boolean = fold(_ => true, _ => false, (_, _) => false)
   final def isRight: Boolean = fold(_ => false, _ => true, (_, _) => false)
   final def isBoth: Boolean = fold(_ => false, _ => false, (_, _) => true)
 
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].left
+   * res0: Option[String] = Some(abc)
+   *
+   * scala> 123.rightIor[String].left
+   * res1: Option[String] = None
+   *
+   * scala> Ior.Both("abc", 123).left
+   * res2: Option[String] = Some(abc)
+   * }}}
+   */
   final def left: Option[A] = fold(a => Some(a), _ => None, (a, _) => Some(a))
+
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].right
+   * res0: Option[Int] = None
+   *
+   * scala> 123.rightIor[String].right
+   * res1: Option[Int] = Some(123)
+   *
+   * scala> Ior.Both("abc", 123).right
+   * res2: Option[Int] = Some(123)
+   * }}}
+   */
   final def right: Option[B] = fold(_ => None, b => Some(b), (_, b) => Some(b))
+
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].onlyLeft
+   * res0: Option[String] = Some(abc)
+   *
+   * scala> 123.rightIor[String].onlyLeft
+   * res1: Option[String] = None
+   *
+   * scala> Ior.Both("abc", 123).onlyLeft
+   * res2: Option[String] = None
+   * }}}
+   */
   final def onlyLeft: Option[A] = fold(a => Some(a), _ => None, (_, _) => None)
+
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].onlyRight
+   * res0: Option[Int] = None
+   *
+   * scala> 123.rightIor[String].onlyRight
+   * res1: Option[Int] = Some(123)
+   *
+   * scala> Ior.Both("abc", 123).onlyRight
+   * res2: Option[Int] = None
+   * }}}
+   */
   final def onlyRight: Option[B] = fold(_ => None, b => Some(b), (_, _) => None)
+
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].onlyLeftOrRight
+   * res0: Option[Either[String, Int]] = Some(Left(abc))
+   *
+   * scala> 123.rightIor[String].onlyLeftOrRight
+   * res1: Option[Either[String, Int]] = Some(Right(123))
+   *
+   * scala> Ior.Both("abc", 123).onlyLeftOrRight
+   * res2: Option[Either[String, Int]] = None
+   * }}}
+   */
   final def onlyLeftOrRight: Option[Either[A, B]] = fold(a => Some(Left(a)), b => Some(Right(b)), (_, _) => None)
+
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].onlyBoth
+   * res0: Option[(String, Int)] = None
+   *
+   * scala> 123.rightIor[String].onlyBoth
+   * res1: Option[(String, Int)] = None
+   *
+   * scala> Ior.Both("abc", 123).onlyBoth
+   * res2: Option[(String, Int)] = Some((abc,123))
+   * }}}
+   */
   final def onlyBoth: Option[(A, B)] = fold(_ => None, _ => None, (a, b) => Some((a, b)))
+
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].pad
+   * res0: (Option[String], Option[Int]) = (Some(abc),None)
+   *
+   * scala> 123.rightIor[String].pad
+   * res1: (Option[String], Option[Int]) = (None,Some(123))
+   *
+   * scala> Ior.Both("abc", 123).pad
+   * res2: (Option[String], Option[Int]) = (Some(abc),Some(123))
+   * }}}
+   */
   final def pad: (Option[A], Option[B]) = fold(a => (Some(a), None), b => (None, Some(b)), (a, b) => (Some(a), Some(b)))
+
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].unwrap
+   * res0: Either[Either[String, Int], (String, Int)] = Left(Left(abc))
+   *
+   * scala> 123.rightIor[String].unwrap
+   * res1: Either[Either[String, Int], (String, Int)] = Left(Right(123))
+   *
+   * scala> Ior.Both("abc", 123).unwrap
+   * res2: Either[Either[String, Int], (String, Int)] = Right((abc,123))
+   * }}}
+   */
   final def unwrap: Either[Either[A, B], (A, B)] =
     fold(a => Left(Left(a)), b => Left(Right(b)), (a, b) => Right((a, b)))
 
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].toIorNes
+   * res0: IorNes[String, Int] = Left(TreeSet(abc))
+   *
+   * scala> 123.rightIor[String].toIorNes
+   * res1: IorNes[String, Int]= Right(123)
+   *
+   * scala> Ior.Both("abc", 123).toIorNes
+   * res2: IorNes[String, Int] = Both(TreeSet(abc),123)
+   * }}}
+   */
   final def toIorNes[AA >: A](implicit O: Order[AA]): IorNes[AA, B] = leftMap(NonEmptySet.one(_))
+
   final def toIorNec[AA >: A]: IorNec[AA, B] = leftMap(NonEmptyChain.one)
+
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].toIorNel
+   * res0: IorNel[String, Int] = Left(NonEmptyList(abc))
+   *
+   * scala> 123.rightIor[String].toIorNel
+   * res1: IorNel[String, Int]= Right(123)
+   *
+   * scala> Ior.Both("abc", 123).toIorNel
+   * res2: IorNel[String, Int] = Both(NonEmptyList(abc),123)
+   * }}}
+   */
   final def toIorNel[AA >: A]: IorNel[AA, B] = leftMap(NonEmptyList.one)
 
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].toEither
+   * res0: Either[String, Int] = Left(abc)
+   *
+   * scala> 123.rightIor[String].toEither
+   * res1: Either[String, Int]= Right(123)
+   *
+   * scala> Ior.Both("abc", 123).toEither
+   * res2: Either[String, Int] = Right(123)
+   * }}}
+   */
   final def toEither: Either[A, B] = fold(Left(_), Right(_), (_, b) => Right(b))
+
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].toValidated
+   * res0: Validated[String, Int] = Invalid(abc)
+   *
+   * scala> 123.rightIor[String].toValidated
+   * res1: Validated[String, Int]= Valid(123)
+   *
+   * scala> Ior.Both("abc", 123).toValidated
+   * res2: Validated[String, Int] = Valid(123)
+   * }}}
+   */
   final def toValidated: Validated[A, B] = fold(Invalid(_), Valid(_), (_, b) => Valid(b))
+
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].toOption
+   * res0: Option[Int] = None
+   *
+   * scala> 123.rightIor[String].toOption
+   * res1: Option[Int]= Some(123)
+   *
+   * scala> Ior.Both("abc", 123).toOption
+   * res2: Option[Int] = Some(123)
+   * }}}
+   */
   final def toOption: Option[B] = right
+
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].toList
+   * res0: List[Int] = List()
+   *
+   * scala> 123.rightIor[String].toList
+   * res1: List[Int]= List(123)
+   *
+   * scala> Ior.Both("abc", 123).toList
+   * res2: List[Int] = List(123)
+   * }}}
+   */
   final def toList: List[B] = right.toList
 
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].to[List, Int]
+   * res0: List[Int] = List()
+   *
+   * scala> 123.rightIor[String].to[List, Int]
+   * res1: List[Int]= List(123)
+   *
+   * scala> Ior.Both("abc", 123).to[List, Int]
+   * res2: List[Int] = List(123)
+   * }}}
+   */
   final def to[F[_], BB >: B](implicit F: Alternative[F]): F[BB] =
     fold(_ => F.empty, F.pure, (_, b) => F.pure(b))
 
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].swap
+   * res0: Ior[Int, String] = Right(abc)
+   *
+   * scala> 123.rightIor[String].swap
+   * res1: Ior[Int, String] = Left(123)
+   *
+   * scala> Ior.Both("abc", 123).swap
+   * res2: Ior[Int, String] = Both(123,abc)
+   * }}}
+   */
   final def swap: B Ior A = fold(Ior.right, Ior.left, (a, b) => Ior.both(b, a))
 
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].exists(_ > 100)
+   * res0: Boolean = false
+   *
+   * scala> 123.rightIor[String].exists(_ > 100)
+   * res1: Boolean = true
+   *
+   * scala> Ior.Both("abc", 123).exists(_ > 100)
+   * res2: Boolean = true
+   * }}}
+   */
   final def exists(p: B => Boolean): Boolean = right.exists(p)
+
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].forall(_ > 100)
+   * res0: Boolean = true
+   *
+   * scala> 123.rightIor[String].forall(_ > 150)
+   * res1: Boolean = false
+   *
+   * scala> Ior.Both("abc", 123).forall(_ > 100)
+   * res2: Boolean = true
+   * }}}
+   */
   final def forall(p: B => Boolean): Boolean = right.forall(p)
+
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].getOrElse(456)
+   * res0: Int = 456
+   *
+   * scala> 123.rightIor[String].getOrElse(456)
+   * res1: Int = 123
+   *
+   * scala> Ior.Both("abc", 123).getOrElse(456)
+   * res2: Int = 123
+   * }}}
+   */
   final def getOrElse[BB >: B](bb: => BB): BB = right.getOrElse(bb)
+
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].valueOr(_.length)
+   * res0: Int = 3
+   *
+   * scala> 123.rightIor[String].valueOr(_.length)
+   * res1: Int = 123
+   *
+   * scala> Ior.Both("abc", 123).valueOr(_.length)
+   * res2: Int = 126
+   * }}}
+   */
   final def valueOr[BB >: B](f: A => BB)(implicit BB: Semigroup[BB]): BB =
     fold(f, identity, (a, b) => BB.combine(f(a), b))
 
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].bimap(_.length, identity)
+   * res0: Ior[Int, Int] = Left(3)
+   *
+   * scala> 123.rightIor[String].bimap(_.length, identity)
+   * res1: Ior[Int, Int] = Right(123)
+   *
+   * scala> Ior.Both("abc", 123).bimap(_.length, identity)
+   * res2: Ior[Int, Int] = Both(3,123)
+   * }}}
+   */
   final def bimap[C, D](fa: A => C, fb: B => D): C Ior D =
     fold(a => Ior.left(fa(a)), b => Ior.right(fb(b)), (a, b) => Ior.both(fa(a), fb(b)))
 
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].bimap(_.length, _ * 2)
+   * res0: Ior[Int, Int] = Left(3)
+   *
+   * scala> 123.rightIor[String].bimap(_.length, _ * 2)
+   * res1: Ior[Int, Int] = Right(246)
+   *
+   * scala> Ior.Both("abc", 123).bimap(_.length, _ * 2)
+   * res2: Ior[Int, Int] = Both(3,246)
+   * }}}
+   */
   final def map[D](f: B => D): A Ior D = bimap(identity, f)
+
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].leftMap(_.length)
+   * res0: Ior[Int, Int] = Left(3)
+   *
+   * scala> 123.rightIor[String].leftMap(_.length)
+   * res1: Ior[Int, Int] = Right(123)
+   *
+   * scala> Ior.Both("abc", 123).leftMap(_.length)
+   * res2: Ior[Int, Int] = Both(3,123)
+   * }}}
+   */
   final def leftMap[C](f: A => C): C Ior B = bimap(f, identity)
 
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].flatMap(i => 456.rightIor[String])
+   * res0: Ior[String, Int] = Left(abc)
+   *
+   * scala> 123.rightIor[String].flatMap(i => (i * 2).rightIor[String])
+   * res1: Ior[String, Int] = Right(246)
+   *
+   * scala> 123.rightIor[String].flatMap(_ => "error".leftIor[Int])
+   * res2: Ior[String, Int] = Left(error)
+   *
+   * scala> Ior.Both("abc", 123).flatMap(_ => 456.rightIor[String])
+   * res3: Ior[String, Int] = Both(abc,456)
+   *
+   * scala> Ior.Both("abc", 123).flatMap(_ => "error".leftIor[Int])
+   * res4: Ior[String, Int] = Left(abcerror)
+   *
+   * scala> Ior.Both("abc", 123).flatMap(_ => Ior.Both("error",456))
+   * res5: Ior[String, Int] = Both(abcerror,456)
+   * }}}
+   */
   final def flatMap[AA >: A, D](f: B => AA Ior D)(implicit AA: Semigroup[AA]): AA Ior D = this match {
     case l @ Ior.Left(_) => l
     case Ior.Right(b)    => f(b)
@@ -98,6 +584,22 @@ sealed abstract class Ior[+A, +B] extends Product with Serializable {
     case Ior.Both(a, b) => F.map(g(b))(d => Ior.both(a, d))
   }
 
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].foldLeft(List(456))((c,b) => b :: c)
+   * res0: List[Int] = List(456)
+   *
+   * scala> 123.rightIor[String].foldLeft(List(456))((c,b) => b :: c)
+   * res1: List[Int] = List(123, 456)
+   *
+   * scala> Ior.Both("abc", 123).foldLeft(List(456))((c,b) => b :: c)
+   * res2: List[Int] = List(123, 456)
+   * }}}
+   */
   final def foldLeft[C](c: C)(f: (C, B) => C): C =
     fold(_ => c, f(c, _), (_, b) => f(c, b))
 
@@ -111,6 +613,31 @@ sealed abstract class Ior[+A, +B] extends Product with Serializable {
   final def mergeRight[AA >: A](implicit ev: B <:< AA): AA =
     fold(identity, ev, (_, b) => ev(b))
 
+  /**
+   * Example:
+   * {{{
+   * scala> import cats.data.Ior
+   * scala> import cats.implicits._
+   *
+   * scala> "abc".leftIor[Int].combine("other".leftIor[Int])
+   * res0: Ior[String, Int] = Left(abcother)
+   *
+   * scala> "abc".leftIor[Int].combine(456.rightIor[String])
+   * res1: Ior[String, Int] = Both(abc,456)
+   *
+   * scala> 123.rightIor[String].combine("other".leftIor[Int])
+   * res2: Ior[String, Int] = Both(other,123)
+   *
+   * scala> Ior.Both("abc", 123).combine(Ior.Both("other",456))
+   * res3: Ior[String, Int] = Both(abcother,579)
+   *
+   * scala> Ior.Both("abc", 123).combine("other".leftIor[Int])
+   * res3: Ior[String, Int] = Both(abcother,123)
+   *
+   * scala> Ior.Both("abc", 123).combine(456.rightIor[String])
+   * res3: Ior[String, Int] = Both(abc,579)
+   * }}}
+   */
   // scalastyle:off cyclomatic.complexity
   final def combine[AA >: A, BB >: B](that: AA Ior BB)(implicit AA: Semigroup[AA], BB: Semigroup[BB]): AA Ior BB =
     this match {


### PR DESCRIPTION
Re: Issue #2479

Add more doctest to Ior methods:

- fold
- putLeft
- putRight
- isLeft
- isRight
- isBoth
- left
- right
- onlyLeft
- onlyRight
- onlyRightOrLeft
- onlyBoth
- pad
- unwrap
- toIorNes
- toIorNel
- toEither
- toValidated
- toOption
- toList
- to
- swap
- exists
- forall
- getOrElse
- valueOr
- bimap
- leftMap
- map
- flatMap
- foldLeft
- combine
