### PR TITLE
Update Semigroup docs for Map

### DIFF
--- a/docs/src/main/tut/typeclasses/semigroup.md
+++ b/docs/src/main/tut/typeclasses/semigroup.md
@@ -58,7 +58,7 @@ for `Map`s.
 ```tut:book:silent
 import cats.implicits._
 
-val map1 = Map("hello" -> 0, "world" -> 1)
+val map1 = Map("hello" -> 1, "world" -> 1)
 val map2 = Map("hello" -> 2, "cats"  -> 3)
 ```
 


### PR DESCRIPTION
I didn't understand that the values in Maps were also combined when two maps are combined - I thought the `"hello" -> 2` entry was simply _replacing_ the `"hello" -> 0` entry in the first map. Giving the first map's `"hello"` a value of `1` results in the combined map having a `"hello" -> 3` entry, showing that the values were combined.

After understanding that, I realized why my code couldn't find an implicit `Semigroup` for my Map - I didn't have an implicit `Semigroup` for my map's values.

Thank you for contributing to Cats!

This is a kind reminder to run `sbt prePR` and commit the changed files, if any, before submitting. 


