### PR TITLE
Mention additional dependencies in lawtesting docs

### DIFF
--- a/docs/src/main/tut/typeclasses/lawtesting.md
+++ b/docs/src/main/tut/typeclasses/lawtesting.md
@@ -82,14 +82,14 @@ object arbitraries {
 Now we can convert these `ScalaCheck` `Properties` into tests that the test framework can run.  [discipline](https://github.com/typelevel/discipline) provides a helper `checkAll` function that performs
 this conversion for two test frameworks: `ScalaTest` and `Specs2`.
 
-* If you are using `Specs2`, extend your test class with `org.typelevel.discipline.specs2.Discipline`.
+* If you are using `Specs2`, extend your test class with `org.typelevel.discipline.specs2.Discipline` (provided by `discipline-specs2`).
 
-* If you are using `ScalaTest`, extend your test class with `org.typelevel.discipline.scalatest.Discipline` and `org.scalatest.funsuite.AnyFunSuiteLike`.
+* If you are using `ScalaTest`, extend your test class with `org.typelevel.discipline.scalatest.Discipline` (provided by `discipline-scalatest`) and `org.scalatest.funsuite.AnyFunSuiteLike`.
 
 * For other test frameworks, you need to resort to their integration with `ScalaCheck` to test
-the `ScalaCheck` `Properties` provided by cats-laws.
+the `ScalaCheck` `Properties` provided by `cats-laws`.
 
-The following example is for ScalaTest.  If not using 
+The following example is for ScalaTest.
 
 ```tut:book
 import cats.implicits._
@@ -109,8 +109,8 @@ class TreeLawTests extends AnyFunSuite with Discipline {
 * `Discipline` provides `checkAll`, and must be mixed into `AnyFunSuite`
 * `arbitraries._` imports the `Arbitrary[Tree[_]]` instances needed to check the laws.
 
-Alternatively, you can use the `CatsSuite` provided by [Cats-testkit-scalatest](https://github.com/typelevel/cats-testkit-scalatest), 
-which is the same `CatsSuite` used in Cats to test all instances.  
+Alternatively, you can use the `CatsSuite` provided by [Cats-testkit-scalatest](https://github.com/typelevel/cats-testkit-scalatest),
+which is the same `CatsSuite` used in Cats to test all instances.
 
 Now when we run `test` in our sbt console, ScalaCheck will test if the `Functor` laws hold for our `Tree` type.
 You should see something like this:


### PR DESCRIPTION
This PR mentions `discipline-scalatest` and `discipline-specs2` in the law testing documentation.

see #3068


