### PR TITLE
update to sbt 1.3.x, uses coursier by default

### DIFF
--- a/core/src/main/scala-2.12/cats/instances/ScalaVersionSpecificParallelInstances.scala
+++ b/core/src/main/scala-2.12/cats/instances/ScalaVersionSpecificParallelInstances.scala
@@ -22,7 +22,7 @@ trait ParallelInstances extends ParallelInstances1 {
     }
 
   @deprecated("Use OptionT.catsDataParallelForOptionT", "2.0.0")
-  private[instances] def catsParallelForOptionTNestedOption[M[_]](
+  def catsParallelForOptionTNestedOption[M[_]](
     implicit P: Parallel[M]
   ): Parallel.Aux[OptionT[M, *], Nested[P.F, Option, *]] = OptionT.catsDataParallelForOptionT[M]
 
@@ -69,7 +69,7 @@ trait ParallelInstances extends ParallelInstances1 {
     }
 
   @deprecated("Use EitherT.catsDataParallelForEitherTWithParallelEffect", "2.0.0")
-  private[instances] def catsParallelForEitherTNestedParallelValidated[M[_], E: Semigroup](
+  def catsParallelForEitherTNestedParallelValidated[M[_], E: Semigroup](
     implicit P: Parallel[M]
   ): Parallel.Aux[EitherT[M, E, *], Nested[P.F, Validated[E, *], *]] =
     EitherT.catsDataParallelForEitherTWithParallelEffect[M, E]

--- a/core/src/main/scala-2.13+/cats/instances/ScalaVersionSpecificParallelInstances.scala
+++ b/core/src/main/scala-2.13+/cats/instances/ScalaVersionSpecificParallelInstances.scala
@@ -22,7 +22,7 @@ trait ParallelInstances extends ParallelInstances1 {
     }
 
   @deprecated("Use OptionT.catsDataParallelForOptionT", "2.0.0")
-  private[instances] def catsParallelForOptionTNestedOption[M[_]](
+  def catsParallelForOptionTNestedOption[M[_]](
     implicit P: Parallel[M]
   ): Parallel.Aux[OptionT[M, *], Nested[P.F, Option, *]] = OptionT.catsDataParallelForOptionT[M]
 
@@ -84,7 +84,7 @@ trait ParallelInstances extends ParallelInstances1 {
     }
 
   @deprecated("Use EitherT.catsDataParallelForEitherTWithParallelEffect", "2.0.0")
-  private[instances] def catsParallelForEitherTNestedParallelValidated[M[_], E: Semigroup](
+  def catsParallelForEitherTNestedParallelValidated[M[_], E: Semigroup](
     implicit P: Parallel[M]
   ): Parallel.Aux[EitherT[M, E, *], Nested[P.F, Validated[E, *], *]] =
     EitherT.catsDataParallelForEitherTWithParallelEffect[M, E]

--- a/core/src/main/scala/cats/data/Op.scala
+++ b/core/src/main/scala/cats/data/Op.scala
@@ -24,7 +24,7 @@ sealed abstract private[data] class OpInstances extends OpInstances0 {
     new OpEq[Arr, A, B] { def Arr: Eq[Arr[B, A]] = ArrEq }
 
   @deprecated("Use catsDataEqForOp", "2.0.0-RC2")
-  private[data] def catsKernelEqForOp[Arr[_, _], A, B](implicit ArrEq: Eq[Arr[B, A]]): Eq[Op[Arr, A, B]] =
+  def catsKernelEqForOp[Arr[_, _], A, B](implicit ArrEq: Eq[Arr[B, A]]): Eq[Op[Arr, A, B]] =
     catsDataEqForOp[Arr, A, B]
 }
 

--- a/core/src/main/scala/cats/instances/parallel.scala
+++ b/core/src/main/scala/cats/instances/parallel.scala
@@ -8,7 +8,7 @@ import cats.{~>, Applicative, Monad, Parallel}
 
 private[instances] trait ParallelInstances1 {
   @deprecated("Use EitherT.catsDataParallelForEitherTWithSequentialEffect", "2.0.0")
-  private[instances] def catsParallelForEitherTNestedValidated[M[_]: Monad, E: Semigroup]
+  def catsParallelForEitherTNestedValidated[M[_]: Monad, E: Semigroup]
     : Parallel.Aux[EitherT[M, E, *], Nested[M, Validated[E, *], *]] =
     new Parallel[EitherT[M, E, *]] {
       type F[x] = Nested[M, Validated[E, *], x]

--- a/core/src/main/scala/cats/instances/sortedMap.scala
+++ b/core/src/main/scala/cats/instances/sortedMap.scala
@@ -9,11 +9,11 @@ import scala.collection.immutable.SortedMap
 trait SortedMapInstances extends SortedMapInstances2 {
 
   @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedMap.catsKernelStdHashForSortedMap")
-  private[instances] def catsStdHashForSortedMap[K: Hash: Order, V: Hash]: Hash[SortedMap[K, V]] =
+  def catsStdHashForSortedMap[K: Hash: Order, V: Hash]: Hash[SortedMap[K, V]] =
     cats.kernel.instances.sortedMap.catsKernelStdHashForSortedMap[K, V]
 
   @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedMap.catsKernelStdCommutativeMonoidForSortedMap")
-  private[instances] def catsStdCommutativeMonoidForSortedMap[K: Order, V: CommutativeSemigroup] =
+  def catsStdCommutativeMonoidForSortedMap[K: Order, V: CommutativeSemigroup] =
     cats.kernel.instances.sortedMap.catsKernelStdCommutativeMonoidForSortedMap[K, V]
 
   implicit def catsStdShowForSortedMap[A: Order, B](implicit showA: Show[A], showB: Show[B]): Show[SortedMap[A, B]] =
@@ -115,13 +115,13 @@ trait SortedMapInstances extends SortedMapInstances2 {
 
 private[instances] trait SortedMapInstances1 {
   @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedMap.catsKernelStdEqForSortedMap")
-  private[instances] def catsStdEqForSortedMap[K: Order, V: Eq]: Eq[SortedMap[K, V]] =
+  def catsStdEqForSortedMap[K: Order, V: Eq]: Eq[SortedMap[K, V]] =
     new SortedMapEq[K, V]
 }
 
 private[instances] trait SortedMapInstances2 extends SortedMapInstances1 {
   @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedMap.catsKernelStdMonoidForSortedMap")
-  private[instances] def catsStdMonoidForSortedMap[K: Order, V: Semigroup]: Monoid[SortedMap[K, V]] =
+  def catsStdMonoidForSortedMap[K: Order, V: Semigroup]: Monoid[SortedMap[K, V]] =
     new SortedMapMonoid[K, V]
 }
 

--- a/core/src/main/scala/cats/instances/sortedSet.scala
+++ b/core/src/main/scala/cats/instances/sortedSet.scala
@@ -76,7 +76,7 @@ private[instances] trait SortedSetInstances1 {
     cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A]
 
   @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedSet.catsKernelStdSemilatticeForSortedSet")
-  private[instances] def catsKernelStdSemilatticeForSortedSet[A: Order]: BoundedSemilattice[SortedSet[A]] =
+  def catsKernelStdSemilatticeForSortedSet[A: Order]: BoundedSemilattice[SortedSet[A]] =
     cats.kernel.instances.sortedSet.catsKernelStdBoundedSemilatticeForSortedSet[A]
 }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,8 +1,7 @@
-addSbtCoursier
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 addSbtPlugin("com.github.gseitz" %% "sbt-release" % "1.0.11")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.0-M2")
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.3.0")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.6.1")
 addSbtPlugin("pl.project13.scala" % "sbt-jmh" % "0.3.7")
 addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")

--- a/project/project/plugins.sbt
+++ b/project/project/plugins.sbt
@@ -1,1 +1,0 @@
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.3")

--- a/scalafix/project/build.properties
+++ b/scalafix/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.2

--- a/scalafix/project/plugins.sbt
+++ b/scalafix/project/plugins.sbt
@@ -1,3 +1,2 @@
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.5")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.2")
 addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.2")


### PR DESCRIPTION
Includes & supersedes #2954, #3075, #3077.

Open problems:
* [ ] for some reason, the BC tests won't work when Coursier is used (we can choose to ignore this)
* [ ] see #2934 for some details on the generic signature problem, but since then a bunch of additional errors surfaced (see below, blocker)

```
[error]  * static method catsParallelForEitherTNestedValidated(cats.Monad,cats.kernel.Semigroup)cats.Parallel in class cats.implicits does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[DirectMissingMethodProblem]("cats.implicits.catsParallelForEitherTNestedValidated")
[error]  * static method catsParallelForEitherTNestedParallelValidated(cats.kernel.Semigroup,cats.Parallel)cats.Parallel in class cats.implicits does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[DirectMissingMethodProblem]("cats.implicits.catsParallelForEitherTNestedParallelValidated")
[error]  * static method catsParallelForOptionTNestedOption(cats.Parallel)cats.Parallel in class cats.implicits does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[DirectMissingMethodProblem]("cats.implicits.catsParallelForOptionTNestedOption")
[error]  * static method catsStdEqForSortedMap(cats.kernel.Order,cats.kernel.Eq)cats.kernel.Eq in class cats.implicits does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[DirectMissingMethodProblem]("cats.implicits.catsStdEqForSortedMap")
[error]  * static method catsStdMonoidForSortedMap(cats.kernel.Order,cats.kernel.Semigroup)cats.kernel.Monoid in class cats.implicits does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[DirectMissingMethodProblem]("cats.implicits.catsStdMonoidForSortedMap")
[error]  * static method catsStdCommutativeMonoidForSortedMap(cats.kernel.Order,cats.kernel.CommutativeSemigroup)cats.kernel.CommutativeMonoid in class cats.implicits does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[DirectMissingMethodProblem]("cats.implicits.catsStdCommutativeMonoidForSortedMap")
[error]  * static method catsStdHashForSortedMap(cats.kernel.Hash,cats.kernel.Order,cats.kernel.Hash)cats.kernel.Hash in class cats.implicits does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[DirectMissingMethodProblem]("cats.implicits.catsStdHashForSortedMap")
[error]  * static method catsKernelStdSemilatticeForSortedSet(cats.kernel.Order)cats.kernel.BoundedSemilattice in class cats.implicits does not have a correspondent in current version
[error]    filter with: ProblemFilters.exclude[DirectMissingMethodProblem]("cats.implicits.catsKernelStdSemilatticeForSortedSet")
```