### PR TITLE
Improve performance of Kleisli: make it a value class

### DIFF
--- a/bench/src/main/scala/cats/bench/KleisliBench.scala
+++ b/bench/src/main/scala/cats/bench/KleisliBench.scala
@@ -1,0 +1,30 @@
+package cats.bench
+
+import cats.Eval
+import cats.data.Kleisli
+import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
+
+@State(Scope.Benchmark)
+class KleisliBench {
+
+  @Benchmark
+  def baselineFlatMap(): Long = {
+    def pure(x: Long) = Eval.now(x)
+    val count = 100
+    val result = (0 until count).foldLeft(pure(0)) { (acc, x) =>
+      acc.flatMap(y => pure(x+y))
+    }
+    result.value
+  }
+
+  @Benchmark
+  def flatMap(): Long = {
+    def pure(x: Long) = Kleisli.pure[Eval, Unit, Long](x)
+    val count = 100
+    val result = (0 until count).foldLeft(pure(0)) { (acc, x) =>
+      acc.flatMap(y => pure(x+y))
+    }
+    result.run(()).value
+  }
+
+}


### PR DESCRIPTION
Make Kleisli a value class, to avoid the runtime cost of new object instantiation.


`sbt 'bench/jmh:run "cats.bench.KleisliBench.*" -f1 -t1 -wi 2 -i2' `

before:
```
[info] Benchmark                      Mode  Cnt       Score   Error  Units
[info] KleisliBench.baselineFlatMap  thrpt    2  299375.289          ops/s
[info] KleisliBench.flatMap          thrpt    2  127897.572          ops/s
```

after:
```
[info] Benchmark                      Mode  Cnt       Score   Error  Units
[info] KleisliBench.baselineFlatMap  thrpt    2  294876.092          ops/s
[info] KleisliBench.flatMap          thrpt    2  155593.301          ops/s
```

