### PR TITLE
ci: Enable 2.13 build for scalajs and linting in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,17 +29,20 @@ stages:
 jobs:
   include:
     # it can speed up the overall build to have the longer-running jobs at the top of this list.
-    - stage: test 
+    - stage: test
       env: TEST="coverage"
       install: pip install --user codecov
       script: sbt coverage buildJVM bench/test coverageReport && codecov
 
-    - stage: test
+    - &js_tests
+      stage: test
       env: TEST="JS tests"
       # http://austinpray.com/ops/2015/09/20/change-travis-node-version.html
       install: rm -rf ~/.nvm && git clone https://github.com/creationix/nvm.git ~/.nvm && (cd ~/.nvm && git checkout `git describe --abbrev=0 --tags`) && source ~/.nvm/nvm.sh && nvm install $TRAVIS_NODE_VERSION
       script: sbt ++$TRAVIS_SCALA_VERSION! validateJS && sbt ++$TRAVIS_SCALA_VERSION! validateKernelJS && sbt ++$TRAVIS_SCALA_VERSION! validateFreeJS
       scala: *scala_version_212
+    - <<: *js_tests
+      scala: *scala_version_213
 
     - &jvm_tests
       stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,7 @@ jobs:
 
     - stage: styling
       env: TEST="linting"
-      script: sbt fmtCheck
+      script: sbt +fmtCheck
 
     - stage: publish snapshot
       script: |

--- a/core/src/main/scala-2.13+/cats/instances/lazyList.scala
+++ b/core/src/main/scala-2.13+/cats/instances/lazyList.scala
@@ -8,7 +8,8 @@ import cats.data.ZipLazyList
 import scala.annotation.tailrec
 
 trait LazyListInstances extends cats.kernel.instances.LazyListInstances {
-  implicit val catsStdInstancesForLazyList: Traverse[LazyList] with Alternative[LazyList] with Monad[LazyList] with CoflatMap[LazyList] =
+  implicit val catsStdInstancesForLazyList
+    : Traverse[LazyList] with Alternative[LazyList] with Monad[LazyList] with CoflatMap[LazyList] =
     new Traverse[LazyList] with Alternative[LazyList] with Monad[LazyList] with CoflatMap[LazyList] {
 
       def empty[A]: LazyList[A] = LazyList.empty

--- a/core/src/main/scala-2.13+/cats/instances/stream.scala
+++ b/core/src/main/scala-2.13+/cats/instances/stream.scala
@@ -9,7 +9,8 @@ import scala.annotation.tailrec
 trait StreamInstances extends cats.kernel.instances.StreamInstances {
 
   @deprecated("Use cats.instances.lazyList", "2.0.0-RC2")
-  implicit val catsStdInstancesForStream: Traverse[Stream] with Alternative[Stream] with Monad[Stream] with CoflatMap[Stream] =
+  implicit val catsStdInstancesForStream
+    : Traverse[Stream] with Alternative[Stream] with Monad[Stream] with CoflatMap[Stream] =
     new Traverse[Stream] with Alternative[Stream] with Monad[Stream] with CoflatMap[Stream] {
 
       def empty[A]: Stream[A] = Stream.Empty

--- a/tests/src/test/scala-2.13+/cats/tests/LazyListSuite.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/LazyListSuite.scala
@@ -1,7 +1,16 @@
 package cats
 package tests
 
-import cats.laws.discipline.{AlternativeTests, CoflatMapTests, CommutativeApplyTests, MonadTests, SemigroupalTests, SerializableTests, TraverseFilterTests, TraverseTests}
+import cats.laws.discipline.{
+  AlternativeTests,
+  CoflatMapTests,
+  CommutativeApplyTests,
+  MonadTests,
+  SemigroupalTests,
+  SerializableTests,
+  TraverseFilterTests,
+  TraverseTests
+}
 import cats.data.ZipLazyList
 import cats.laws.discipline.arbitrary._
 import org.scalatest.funsuite.AnyFunSuiteLike


### PR DESCRIPTION
To improve the quality of Cats, enable more Scala 2.13 builds in CI for each PR. 

- Enable scalaJS build for 2.13. 

- Enable linting for 2.13 specific sources. Because of this new check, also needed to format 2.13 sources :)
