### PR TITLE
Kleisli tapWith default mapping functions

### DIFF
--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -39,6 +39,7 @@ trait AllSyntax
     with HashSyntax
     with InvariantSyntax
     with IorSyntax
+    with KleisliSyntax
     with ListSyntax
     with MonadErrorSyntax
     with MonadSyntax

--- a/core/src/main/scala/cats/syntax/kleisli.scala
+++ b/core/src/main/scala/cats/syntax/kleisli.scala
@@ -1,0 +1,25 @@
+package cats.syntax
+
+import cats.Functor
+import cats.data.Kleisli
+
+trait KleisliSyntax {
+  implicit final def kleisliSyntax[F[_], A, B](kl: Kleisli[F, A, B]): KleisliOps[F, A, B] = new KleisliOps(kl)
+}
+
+final class KleisliOps[F[_], A, B](private val kl: Kleisli[F, A, B]) extends AnyVal {
+
+  /**
+   * Yield computed B combined with input value.
+   *
+   * {{{
+   * scala> import cats.data.Kleisli, cats.implicits._
+   * scala> val base = Kleisli((_: Int).toString.pure[Either[Throwable, *]])
+   * scala> base.tapWithIdentity().run(42)
+   * res0: scala.util.Either[Throwable,(Int, String)] = Right((42,42))
+   * }}}
+   */
+  def tapWithIdentity()(implicit F: Functor[F]): Kleisli[F, A, (A, B)] =
+    kl.tapWith((a: A, b: B) => (a, b))
+
+}

--- a/core/src/main/scala/cats/syntax/kleisli.scala
+++ b/core/src/main/scala/cats/syntax/kleisli.scala
@@ -2,6 +2,7 @@ package cats.syntax
 
 import cats.Functor
 import cats.data.Kleisli
+import cats.syntax.kleisli._
 
 trait KleisliSyntax {
   implicit final def kleisliSyntax[F[_], A, B](kl: Kleisli[F, A, B]): KleisliOps[F, A, B] = new KleisliOps(kl)
@@ -21,5 +22,18 @@ final class KleisliOps[F[_], A, B](private val kl: Kleisli[F, A, B]) extends Any
    */
   def tapWithIdentity()(implicit F: Functor[F]): Kleisli[F, A, (A, B)] =
     kl.tapWith((a: A, b: B) => (a, b))
+
+  /**
+   * Yield computed B combined with input value to passed function,
+   * which can change the context of the Kleisli
+   * {{{
+   * scala> import cats.data.Kleisli, cats.implicits._
+   * scala> val base = Kleisli((_: Int).toString.pure[Either[Throwable, *]])
+   * scala> base.tapWithMapF(_.toOption).run(42)
+   * res0: Option[(Int, String)] = Some((42,42))
+   * }}}
+   */
+  def tapWithMapF[G[_], C](f: F[(A, B)] => G[C])(implicit F: Functor[F]): Kleisli[G, A, C] =
+    kl.tapWithIdentity().mapF(f)
 
 }

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -32,6 +32,7 @@ package object syntax {
   object group extends GroupSyntax
   object invariant extends InvariantSyntax
   object ior extends IorSyntax
+  object kleisli extends KleisliSyntax
   object list extends ListSyntax with ListSyntaxBinCompat0
   object monad extends MonadSyntax
   object monadError extends MonadErrorSyntax

--- a/tests/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/KleisliSuite.scala
@@ -219,6 +219,13 @@ class KleisliSuite extends CatsSuite {
     }
   }
 
+  test("tapWithMapF") {
+    forAll { (f: Kleisli[List, Int, Int], t: List[(Int, Int)] => Option[(Int, Int)], i: Int) =>
+      f.tapWithIdentity().mapF(t).run(i) should ===(f.tapWithMapF(t).run(i))
+      t(f.tapWithIdentity().run(i)) should ===(f.tapWithMapF(t).run(i))
+    }
+  }
+
   test("toReader") {
     forAll { (f: Kleisli[List, Int, String], i: Int) =>
       f.run(i) should ===(f.toReader.run(i))

--- a/tests/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/KleisliSuite.scala
@@ -213,6 +213,12 @@ class KleisliSuite extends CatsSuite {
     }
   }
 
+  test("tapWith identity") {
+    forAll { (f: Kleisli[List, Int, String], i: Int) =>
+      f.run(i).map(s => (i, s)) should ===(f.tapWithIdentity().run(i))
+    }
+  }
+
   test("toReader") {
     forAll { (f: Kleisli[List, Int, String], i: Int) =>
       f.run(i) should ===(f.toReader.run(i))


### PR DESCRIPTION
My goal for this PR is to be able to write something like this (without providing a lot of explicit type information or identity-like mapping functions):

```scala
x.tapWith().mapF(_.use((runProgram[F] _).tupled))
```

where `x: Kleisli[Resource[F, *], CaseClass, EitherK[…] ~> F]` and `runProgram[F]: (CaseClass, EitherK[…] ~> F) => F[Unit]`

Before this PR, I think the above line would look like

```scala
x.tapWith[(CaseClass, EitherK[…] ~> F), CaseClass]((a, b) => (a, b))
  .mapF(_.use((runProgram[F] _).tupled))
```

This PR provides two implementations; the expectation is that one would be dropped before accepting the PR. 

One implementation adds a new `tapWith` method added directly on `Kleisli`. It has some type inference problems, because scalac isn't able to infer the `AA <: A` type. This means callers have to provide the `A` type, which seems redundant since it's already known to the `Kleisli`:

```scala
x.tapWith[CaseClass]().mapF(_.use((runProgram[F] _).tupled))
```

The other implementation is an enhancement method to `Kleisli`. It has the advantage of improved type inference. I couldn't find any other enhancement methods on `Kleisli`, though, so it is stylistically different. It also lacks the ability for the caller to narrow the type, but if they really need to do that they can still fall back to the existing `tapWith` method.

I picked the name `tapWithIdentity` for the enhancement method because I think it had to be something that didn't already exist as a method on `Kleisli`. I'm definitely open to suggestions for a better name.

@kailuowang and I [discussed this briefly on gitter](https://gitter.im/typelevel/cats-dev?at=5d9e9d2e874aeb2d231c31bb) too.

My initial preference is that the enhancement methods be added and we drop 
c867dd6, but I'm looking for feedback from maintainers.