### PR TITLE
Follow-up #3084

### DIFF
--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -204,8 +204,8 @@ import Foldable.sentinel
    *
    * @see [[maximumOptionBy]] for maximum instead of minimum.
    */
-  def minimumOptionBy[A, B: Order](fa: F[A])(f: A => B)(implicit F: Foldable[F]): Option[A] =
-    F.minimumOption(fa)(Order.by(f))
+  def minimumOptionBy[A, B: Order](fa: F[A])(f: A => B): Option[A] =
+    minimumOption(fa)(Order.by(f))
 
   /**
    * Find the maximum `A` item in this structure according to an `Order.by(f)`.
@@ -218,8 +218,8 @@ import Foldable.sentinel
    *
    * @see [[minimumOptionBy]] for minimum instead of maximum.
    */
-  def maximumOptionBy[A, B: Order](fa: F[A])(f: A => B)(implicit F: Foldable[F]): Option[A] =
-    F.maximumOption(fa)(Order.by(f))
+  def maximumOptionBy[A, B: Order](fa: F[A])(f: A => B): Option[A] =
+    maximumOption(fa)(Order.by(f))
 
   /**
    * Get the element at the index of the `Foldable`.

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -202,9 +202,9 @@ import Foldable.sentinel
    * @see [[Reducible#minimumBy]] for a version that doesn't need to return an
    * `Option` for structures that are guaranteed to be non-empty.
    *
-   * @see [[maximumOptionBy]] for maximum instead of minimum.
+   * @see [[maximumByOption]] for maximum instead of minimum.
    */
-  def minimumOptionBy[A, B: Order](fa: F[A])(f: A => B): Option[A] =
+  def minimumByOption[A, B: Order](fa: F[A])(f: A => B): Option[A] =
     minimumOption(fa)(Order.by(f))
 
   /**
@@ -216,9 +216,9 @@ import Foldable.sentinel
    * @see [[Reducible#maximumBy]] for a version that doesn't need to return an
    * `Option` for structures that are guaranteed to be non-empty.
    *
-   * @see [[minimumOptionBy]] for minimum instead of maximum.
+   * @see [[minimumByOption]] for minimum instead of maximum.
    */
-  def maximumOptionBy[A, B: Order](fa: F[A])(f: A => B): Option[A] =
+  def maximumByOption[A, B: Order](fa: F[A])(f: A => B): Option[A] =
     maximumOption(fa)(Order.by(f))
 
   /**

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -199,7 +199,7 @@ import Foldable.sentinel
    * @return `None` if the structure is empty, otherwise the minimum element
    * wrapped in a `Some`.
    *
-   * @see [[Reducible#minimum]] for a version that doesn't need to return an
+   * @see [[Reducible#minimumBy]] for a version that doesn't need to return an
    * `Option` for structures that are guaranteed to be non-empty.
    *
    * @see [[maximumOptionBy]] for maximum instead of minimum.
@@ -213,7 +213,7 @@ import Foldable.sentinel
    * @return `None` if the structure is empty, otherwise the maximum element
    * wrapped in a `Some`.
    *
-   * @see [[Reducible#maximum]] for a version that doesn't need to return an
+   * @see [[Reducible#maximumBy]] for a version that doesn't need to return an
    * `Option` for structures that are guaranteed to be non-empty.
    *
    * @see [[minimumOptionBy]] for minimum instead of maximum.

--- a/core/src/main/scala/cats/Reducible.scala
+++ b/core/src/main/scala/cats/Reducible.scala
@@ -161,16 +161,16 @@ import simulacrum.typeclass
    *
    * @see [[maximumBy]] for maximum instead of minimum.
    */
-  def minimumBy[A, B: Order](fa: F[A])(f: A => B)(implicit F: Reducible[F]): A =
-    F.minimum(fa)(Order.by(f))
+  def minimumBy[A, B: Order](fa: F[A])(f: A => B): A =
+    minimum(fa)(Order.by(f))
 
   /**
    * Find the maximum `A` item in this structure according to an `Order.by(f)`.
    *
    * @see [[minimumBy]] for minimum instead of maximum.
    */
-  def maximumBy[A, B: Order](fa: F[A])(f: A => B)(implicit F: Reducible[F]): A =
-    F.maximum(fa)(Order.by(f))
+  def maximumBy[A, B: Order](fa: F[A])(f: A => B): A =
+    maximum(fa)(Order.by(f))
 
   /**
    * Intercalate/insert an element between the existing elements while reducing.

--- a/tests/src/test/scala/cats/tests/FoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/FoldableSuite.scala
@@ -194,8 +194,8 @@ abstract class FoldableSuite[F[_]: Foldable](name: String)(implicit ArbFInt: Arb
 
   test(s"Foldable[$name].maximumBy/minimumBy") {
     forAll { (fa: F[Int], f: Int => Int) =>
-      val maxOpt = fa.maximumOptionBy(f).map(f)
-      val minOpt = fa.minimumOptionBy(f).map(f)
+      val maxOpt = fa.maximumByOption(f).map(f)
+      val minOpt = fa.minimumByOption(f).map(f)
       val nelOpt = fa.toList.toNel
       maxOpt should ===(nelOpt.map(_.maximumBy(f)).map(f))
       maxOpt should ===(nelOpt.map(_.toList.maxBy(f)).map(f))


### PR DESCRIPTION
This is a follow-up for #3084, with three changes, two of which should be uncontroversial:

* These are methods on the `Foldable` and `Reducible` type classes, and shouldn't have `Foldable` or `Reducible` constraints, so I've removed them.
* I fixed the references in the first `@see` clauses in the API docs for the `Foldable` methods (they should point to the `*By` methods on `Reducible`).

I've also changed the method names from `minimumOptionBy` and `maximumOptionBy` to `minimumByOption` and `maximumByOption`. This is consistent with the standard library's `maxByOption`, and also with e.g. `reduceRightOption` (from both the standard library and Cats). 

Following the standard library here seems like the right thing to do, and these new methods haven't been in a release yet, so we don't need to worry about compatibility. If people would prefer to keep the `OptionBy` versions I can remove that commit, though.

/cc @joroKr21 