### PR TITLE
Fix order of @deprecated arguments

### DIFF
--- a/core/src/main/scala/cats/instances/sortedMap.scala
+++ b/core/src/main/scala/cats/instances/sortedMap.scala
@@ -8,11 +8,11 @@ import scala.collection.immutable.SortedMap
 
 trait SortedMapInstances extends SortedMapInstances2 {
 
-  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedMap.catsKernelStdHashForSortedMap")
+  @deprecated("Use cats.kernel.instances.sortedMap.catsKernelStdHashForSortedMap", "2.0.0-RC2")
   def catsStdHashForSortedMap[K: Hash: Order, V: Hash]: Hash[SortedMap[K, V]] =
     cats.kernel.instances.sortedMap.catsKernelStdHashForSortedMap[K, V]
 
-  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedMap.catsKernelStdCommutativeMonoidForSortedMap")
+  @deprecated("Use cats.kernel.instances.sortedMap.catsKernelStdCommutativeMonoidForSortedMap", "2.0.0-RC2")
   def catsStdCommutativeMonoidForSortedMap[K: Order, V: CommutativeSemigroup] =
     cats.kernel.instances.sortedMap.catsKernelStdCommutativeMonoidForSortedMap[K, V]
 
@@ -114,18 +114,18 @@ trait SortedMapInstances extends SortedMapInstances2 {
 }
 
 private[instances] trait SortedMapInstances1 {
-  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedMap.catsKernelStdEqForSortedMap")
+  @deprecated("Use cats.kernel.instances.sortedMap.catsKernelStdEqForSortedMap", "2.0.0-RC2")
   def catsStdEqForSortedMap[K: Order, V: Eq]: Eq[SortedMap[K, V]] =
     new SortedMapEq[K, V]
 }
 
 private[instances] trait SortedMapInstances2 extends SortedMapInstances1 {
-  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedMap.catsKernelStdMonoidForSortedMap")
+  @deprecated("Use cats.kernel.instances.sortedMap.catsKernelStdMonoidForSortedMap", "2.0.0-RC2")
   def catsStdMonoidForSortedMap[K: Order, V: Semigroup]: Monoid[SortedMap[K, V]] =
     new SortedMapMonoid[K, V]
 }
 
-@deprecated("2.0.0-RC2", "Use cats.kernel.instances.SortedMapHash")
+@deprecated("Use cats.kernel.instances.SortedMapHash", "2.0.0-RC2")
 class SortedMapHash[K, V](implicit V: Hash[V], O: Order[K], K: Hash[K])
     extends SortedMapEq[K, V]
     with Hash[SortedMap[K, V]] {
@@ -133,10 +133,10 @@ class SortedMapHash[K, V](implicit V: Hash[V], O: Order[K], K: Hash[K])
   def hash(x: SortedMap[K, V]): Int = underlying.hash(x)
 }
 
-@deprecated("2.0.0-RC2", "Use cats.kernel.instances.SortedMapEq")
+@deprecated("Use cats.kernel.instances.SortedMapEq", "2.0.0-RC2")
 class SortedMapEq[K, V](implicit V: Eq[V], O: Order[K]) extends cats.kernel.instances.SortedMapEq[K, V]
 
-@deprecated("2.0.0-RC2", "Use cats.kernel.instances.SortedMapCommutativeMonoid")
+@deprecated("Use cats.kernel.instances.SortedMapCommutativeMonoid", "2.0.0-RC2")
 class SortedMapCommutativeMonoid[K, V](implicit V: CommutativeSemigroup[V], O: Order[K])
     extends SortedMapMonoid[K, V]
     with CommutativeMonoid[SortedMap[K, V]] {
@@ -144,7 +144,7 @@ class SortedMapCommutativeMonoid[K, V](implicit V: CommutativeSemigroup[V], O: O
     new cats.kernel.instances.SortedMapCommutativeMonoid[K, V]
 }
 
-@deprecated("2.0.0-RC2", "Use cats.kernel.instances.SortedMapMonoid")
+@deprecated("Use cats.kernel.instances.SortedMapMonoid", "2.0.0-RC2")
 class SortedMapMonoid[K, V](implicit V: Semigroup[V], O: Order[K]) extends cats.kernel.instances.SortedMapMonoid[K, V]
 
 private[instances] trait SortedMapInstancesBinCompat0 {

--- a/core/src/main/scala/cats/instances/sortedSet.scala
+++ b/core/src/main/scala/cats/instances/sortedSet.scala
@@ -65,17 +65,17 @@ trait SortedSetInstances extends SortedSetInstances1 {
       fa.iterator.map(Show[A].show).mkString("SortedSet(", ", ", ")")
   }
 
-  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedSet.catsKernelStdOrderForSortedSet")
+  @deprecated("Use cats.kernel.instances.sortedSet.catsKernelStdOrderForSortedSet", "2.0.0-RC2")
   private[instances] def catsKernelStdOrderForSortedSet[A: Order]: Order[SortedSet[A]] =
     cats.kernel.instances.sortedSet.catsKernelStdOrderForSortedSet[A]
 }
 
 private[instances] trait SortedSetInstances1 {
-  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet")
+  @deprecated("Use cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet", "2.0.0-RC2")
   private[instances] def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
     cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A]
 
-  @deprecated("2.0.0-RC2", "Use cats.kernel.instances.sortedSet.catsKernelStdSemilatticeForSortedSet")
+  @deprecated("Use cats.kernel.instances.sortedSet.catsKernelStdSemilatticeForSortedSet", "2.0.0-RC2")
   def catsKernelStdSemilatticeForSortedSet[A: Order]: BoundedSemilattice[SortedSet[A]] =
     cats.kernel.instances.sortedSet.catsKernelStdBoundedSemilatticeForSortedSet[A]
 }
@@ -107,11 +107,11 @@ private[instances] trait LowPrioritySortedSetInstancesBinCompat1
     cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A]
 }
 
-@deprecated("2.0.0-RC2", "Use cats.kernel.instances.SortedSetHash")
+@deprecated("Use cats.kernel.instances.SortedSetHash", "2.0.0-RC2")
 class SortedSetHash[A: Order: Hash] extends cats.kernel.instances.SortedSetHash[A]
 
-@deprecated("2.0.0-RC2", "Use cats.kernel.instances.SortedSetOrder")
+@deprecated("Use cats.kernel.instances.SortedSetOrder", "2.0.0-RC2")
 class SortedSetOrder[A: Order] extends cats.kernel.instances.SortedSetOrder[A]
 
-@deprecated("2.0.0-RC2", "Use cats.kernel.instances.SortedSetSemilattice")
+@deprecated("Use cats.kernel.instances.SortedSetSemilattice", "2.0.0-RC2")
 class SortedSetSemilattice[A: Order] extends cats.kernel.instances.SortedSetSemilattice[A]


### PR DESCRIPTION
Cleaning up a mistake I made. :smile:

I've confirmed that this change fixes this particular problem everywhere.