### PR TITLE
Check bincompat on stuff we should be checking bincompat for

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,10 +60,13 @@ jobs:
       env: TEST="scalafix"
       script: cd scalafix && sbt tests/test
 
-    - stage: test
+    - &bincompat
+      stage: test
       env: TEST="binary compatibility"
       script: sbt ++$TRAVIS_SCALA_VERSION! validateBC
       scala: *scala_version_212
+    - <<: *bincompat
+      scala: *scala_version_213
 
     - stage: styling
       env: TEST="linting"

--- a/build.sbt
+++ b/build.sbt
@@ -262,12 +262,9 @@ def mimaPrevious(moduleName: String, scalaVer: String, ver: String): List[Module
   // Safety Net for Inclusions
   lazy val extraVersions: List[String] = List("1.0.1", "1.1.0", "1.2.0", "1.3.1", "1.4.0", "1.5.0", "1.6.1")
 
-  if (priorTo2_13(scalaVer)) {
-    (mimaVersions ++ extraVersions)
-      .filterNot(excludedVersions.contains(_))
-      .map(v => "org.typelevel" %% moduleName % v)
-  } else List()
-
+  (mimaVersions ++ (if (priorTo2_13(scalaVer)) extraVersions else Nil))
+    .filterNot(excludedVersions.contains(_))
+    .map(v => "org.typelevel" %% moduleName % v)
 }
 
 def mimaSettings(moduleName: String) =

--- a/core/src/main/scala-2.13+/cats/instances/stream.scala
+++ b/core/src/main/scala-2.13+/cats/instances/stream.scala
@@ -161,7 +161,7 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
     }
 
   @deprecated("Use catsStdParallelForZipLazyList", "2.0.0-RC2")
-  implicit val catsStdParallelForStreamZipStream: Parallel.Aux[Stream, ZipStream] =
+  implicit def catsStdParallelForStreamZipStream: Parallel.Aux[Stream, ZipStream] =
     new Parallel[Stream] {
       type F[x] = ZipStream[x]
 


### PR DESCRIPTION
Fixes #3109. I've also added bincompat checking (currently against 2.0.0 only) for cats-laws, cats-kernel-laws, cats-testkit, alleycats-core, and alleycats-laws.

One piece of breakage slipped into the 2.13 build in #3099. I've verified that Travis CI fails with just the first two commits.
