### PR TITLE
[WIP] set up semaphore

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -4,72 +4,67 @@ agent:
   machine:
     type: e1-standard-4
     os_image: ubuntu1804
-
 blocks:
   - name: Linting
     task:
       env_vars:
         - name: scala_version_212
-          value: &scala_version_212 2.12.9
+          value: 2.12.9
         - name: scala_version_213
-          value: &scala_version_213 2.13.0
-
+          value: 2.13.0
       prologue:
         commands:
           - checkout
-
       jobs:
         - name: Scalastyle and Scalafmt
           commands:
             - sbt scalastyle fmtCheck
-
         - name: Scalafix
           commands:
             - cd scalafix && sbt tests/test
-
         - name: Check binary compatibility
           commands:
             - sbt ++$TRAVIS_SCALA_VERSION! validateBC
           matrix:
             - env_var: TRAVIS_SCALA_VERSION
-              values: [*scala_version_211, *scala_version_212]
-
+              values:
+                - 2.12.9
   - name: Tests
     task:
       env_vars:
         - name: TRAVIS
-          value: "true"
+          value: 'true'
         - name: scala_version_212
-          value: &scala_version_212 2.12.9
+          value: 2.12.9
         - name: scala_version_213
-          value: &scala_version_213 2.13.0
-
+          value: 2.13.0
       prologue:
         commands:
           - checkout
-
       jobs:
         - name: Coverage check
           commands:
             - sbt coverage buildJVM bench/test coverageReport
-
         - name: JVM tests
           commands:
             - sbt ++$TRAVIS_SCALA_VERSION! buildJVM bench/test
           matrix:
             - env_var: TRAVIS_SCALA_VERSION
-              values: [*scala_version_212]
-
+              values:
+                - 2.12.9
         - name: JVM tests 2.13
           commands:
             - sbt ++$TRAVIS_SCALA_VERSION! buildJVM
           env_vars:
             - name: TRAVIS_SCALA_VERSION
-              value: *scala_version_213
-
+              value: 2.13.0
         - name: JS tests
           commands:
-            - sbt ++$TRAVIS_SCALA_VERSION! validateJS && sbt ++$TRAVIS_SCALA_VERSION! validateKernelJS && sbt ++$TRAVIS_SCALA_VERSION! validateFreeJS
+            - >-
+              sbt ++$TRAVIS_SCALA_VERSION! validateJS && sbt
+              ++$TRAVIS_SCALA_VERSION! validateKernelJS && sbt
+              ++$TRAVIS_SCALA_VERSION! validateFreeJS
           matrix:
             - env_var: TRAVIS_SCALA_VERSION
-              values: [*scala_version_212]
+              values:
+                - 2.12.9

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,75 @@
+version: v1.0
+name: Cats
+agent:
+  machine:
+    type: e1-standard-4
+    os_image: ubuntu1804
+
+blocks:
+  - name: Linting
+    task:
+      env_vars:
+        - name: scala_version_212
+          value: &scala_version_212 2.12.9
+        - name: scala_version_213
+          value: &scala_version_213 2.13.0
+
+      prologue:
+        commands:
+          - checkout
+
+      jobs:
+        - name: Scalastyle and Scalafmt
+          commands:
+            - sbt scalastyle fmtCheck
+
+        - name: Scalafix
+          commands:
+            - cd scalafix && sbt tests/test
+
+        - name: Check binary compatibility
+          commands:
+            - sbt ++$TRAVIS_SCALA_VERSION! validateBC
+          matrix:
+            - env_var: TRAVIS_SCALA_VERSION
+              values: [*scala_version_211, *scala_version_212]
+
+  - name: Tests
+    task:
+      env_vars:
+        - name: TRAVIS
+          value: "true"
+        - name: scala_version_212
+          value: &scala_version_212 2.12.9
+        - name: scala_version_213
+          value: &scala_version_213 2.13.0
+
+      prologue:
+        commands:
+          - checkout
+
+      jobs:
+        - name: Coverage check
+          commands:
+            - sbt coverage buildJVM bench/test coverageReport
+
+        - name: JVM tests
+          commands:
+            - sbt ++$TRAVIS_SCALA_VERSION! buildJVM bench/test
+          matrix:
+            - env_var: TRAVIS_SCALA_VERSION
+              values: [*scala_version_212]
+
+        - name: JVM tests 2.13
+          commands:
+            - sbt ++$TRAVIS_SCALA_VERSION! buildJVM
+          env_vars:
+            - name: TRAVIS_SCALA_VERSION
+              value: *scala_version_213
+
+        - name: JS tests
+          commands:
+            - sbt ++$TRAVIS_SCALA_VERSION! validateJS && sbt ++$TRAVIS_SCALA_VERSION! validateKernelJS && sbt ++$TRAVIS_SCALA_VERSION! validateFreeJS
+          matrix:
+            - env_var: TRAVIS_SCALA_VERSION
+              values: [*scala_version_212]


### PR DESCRIPTION
Semaphore would like to donate Cats 8 bare metal performance agents for cats CI. In my tests, it cuts Cats’ build time by half. Now that we have so many TL projects on Travis all sharing 6 slow agents, it’s nice to have some more powerful CI resources. From our typelevel/cats#2319 Semaphore was one of the winners. Preliminary results shows that Cats build 2x fast than Travis. 

This PR is to enable the semaphore build on Cats. Unfortunately I won't have time to work on it (or most other Cats' maintainership work) in the next months. So it's for anyone to grab. 

