### PR TITLE
"Move" type class syntax methods onto type classes

### DIFF
--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -214,6 +214,38 @@ trait Apply[F[_]] extends Functor[F] with InvariantSemigroupal[F] with ApplyArit
       val G = Apply[G]
     }
 
+  /**
+   * An `if-then-else` lifted into the `F` context.
+   * This function combines the effects of the `fcond` condition and of the two branches,
+   * in the order in which they are given.
+   *
+   * The value of the result is, depending on the value of the condition,
+   * the value of the first argument, or the value of the second argument.
+   *
+   * Example:
+   * {{{
+   * scala> import cats.implicits._
+   *
+   * scala> val b1: Option[Boolean] = Some(true)
+   * scala> val asInt1: Option[Int] = Apply[Option].ifA(b1)(Some(1), Some(0))
+   * scala> asInt1.get
+   * res0: Int = 1
+   *
+   * scala> val b2: Option[Boolean] = Some(false)
+   * scala> val asInt2: Option[Int] = Apply[Option].ifA(b2)(Some(1), Some(0))
+   * scala> asInt2.get
+   * res1: Int = 0
+   *
+   * scala> val b3: Option[Boolean] = Some(true)
+   * scala> val asInt3: Option[Int] = Apply[Option].ifA(b3)(Some(1), None)
+   * asInt2: Option[Int] = None
+   *
+   * }}}
+   */
+  def ifA[A](fcond: F[Boolean])(ifTrue: F[A], ifFalse: F[A]): F[A] = {
+    def ite(b: Boolean)(ifTrue: A, ifFalse: A) = if (b) ifTrue else ifFalse
+    ap2(map(fcond)(ite))(ifTrue, ifFalse)
+  }
 }
 
 object Apply {

--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -1,7 +1,6 @@
 package cats
 
-import simulacrum.typeclass
-import simulacrum.noop
+import simulacrum.{noop, typeclass}
 import cats.data.Ior
 
 /**
@@ -242,6 +241,7 @@ trait Apply[F[_]] extends Functor[F] with InvariantSemigroupal[F] with ApplyArit
    *
    * }}}
    */
+  @noop
   def ifA[A](fcond: F[Boolean])(ifTrue: F[A], ifFalse: F[A]): F[A] = {
     def ite(b: Boolean)(ifTrue: A, ifFalse: A) = if (b) ifTrue else ifFalse
     ap2(map(fcond)(ite))(ifTrue, ifFalse)

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -309,6 +309,38 @@ import Foldable.sentinel
     })
 
   /**
+   * Tear down a subset of this structure using a `PartialFunction`.
+   *{{{
+   * scala> import cats.implicits._
+   * scala> val xs = List(1, 2, 3, 4)
+   * scala> Foldable[List].collectFold(xs) { case n if n % 2 == 0 => n }
+   * res0: Int = 6
+   *}}}
+   */
+  @noop
+  def collectFold[A, B](fa: F[A])(f: PartialFunction[A, B])(implicit B: Monoid[B]): B =
+    foldLeft(fa, B.empty)((acc, a) => B.combine(acc, f.applyOrElse(a, (_: A) => B.empty)))
+
+  /**
+   * Tear down a subset of this structure using a `A => Option[M]`.
+   *{{{
+   * scala> import cats.implicits._
+   * scala> val xs = List(1, 2, 3, 4)
+   * scala> def f(n: Int): Option[Int] = if (n % 2 == 0) Some(n) else None
+   * scala> Foldable[List].collectSomeFold(xs)(f)
+   * res0: Int = 6
+   *}}}
+   */
+  def collectFoldSome[A, B](fa: F[A])(f: A => Option[B])(implicit B: Monoid[B]): B =
+    foldLeft(fa, B.empty)(
+      (acc, a) =>
+        f(a) match {
+          case Some(x) => B.combine(acc, x)
+          case None    => acc
+        }
+    )
+
+  /**
    * Fold implemented using the given Monoid[A] instance.
    */
   def fold[A](fa: F[A])(implicit A: Monoid[A]): A =

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -385,6 +385,22 @@ import Foldable.sentinel
   }
 
   /**
+   * Fold implemented by mapping `A` values into `B` in a context `G` and then
+   * combining them using the `MonoidK[G]` instance.
+   *
+   * {{{
+   * scala> import cats._, cats.implicits._
+   * scala> val f: Int => Endo[String] = i => (s => s + i)
+   * scala> val x: Endo[String] = Foldable[List].foldMapK(List(1, 2, 3))(f)
+   * scala> val a = x("foo")
+   * a: String = "foo321"
+   * }}}
+   * */
+  @noop
+  def foldMapK[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: MonoidK[G]): G[B] =
+    foldMap(fa)(f)(G.algebra)
+
+  /**
    * Alias for [[foldM]].
    */
   final def foldLeftM[G[_], A, B](fa: F[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -726,6 +726,84 @@ import Foldable.sentinel
 
   override def unorderedFoldMap[A, B: CommutativeMonoid](fa: F[A])(f: (A) => B): B =
     foldMap(fa)(f)
+
+  /**
+   * Separate this Foldable into a Tuple by a separating function `A => H[B, C]` for some `Bifoldable[H]`
+   * Equivalent to `Functor#map` and then `Alternative#separate`.
+   *
+   * {{{
+   * scala> import cats.implicits._, cats.Foldable, cats.data.Const
+   * scala> val list = List(1,2,3,4)
+   * scala> Foldable[List].partitionBifold(list)(a => ("value " + a.toString(), if (a % 2 == 0) -a else a))
+   * res0: (List[String], List[Int]) = (List(value 1, value 2, value 3, value 4),List(1, -2, 3, -4))
+   * scala> Foldable[List].partitionBifold(list)(a => Const[Int, Nothing with Any](a))
+   * res1: (List[Int], List[Nothing with Any]) = (List(1, 2, 3, 4),List())
+   * }}}
+   */
+  @noop
+  def partitionBifold[H[_, _], A, B, C](fa: F[A])(f: A => H[B, C])(implicit A: Alternative[F],
+                                                                   H: Bifoldable[H]): (F[B], F[C]) = {
+    import cats.instances.tuple._
+
+    implicit val mb: Monoid[F[B]] = A.algebra[B]
+    implicit val mc: Monoid[F[C]] = A.algebra[C]
+
+    foldMap[A, (F[B], F[C])](fa)(
+      a => H.bifoldMap[B, C, (F[B], F[C])](f(a))(b => (A.pure(b), A.empty[C]), c => (A.empty[B], A.pure(c)))
+    )
+  }
+
+  /**
+   * Separate this Foldable into a Tuple by an effectful separating function `A => G[H[B, C]]` for some `Bifoldable[H]`
+   * Equivalent to `Traverse#traverse` over `Alternative#separate`
+   *
+   * {{{
+   * scala> import cats.implicits._, cats.Foldable, cats.data.Const
+   * scala> val list = List(1,2,3,4)
+   * `Const`'s second parameter is never instantiated, so we can use an impossible type:
+   * scala> Foldable[List].partitionBifoldM(list)(a => Option(Const[Int, Nothing with Any](a)))
+   * res0: Option[(List[Int], List[Nothing with Any])] = Some((List(1, 2, 3, 4),List()))
+   * }}}
+   */
+  @noop
+  def partitionBifoldM[G[_], H[_, _], A, B, C](
+    fa: F[A]
+  )(f: A => G[H[B, C]])(implicit A: Alternative[F], M: Monad[G], H: Bifoldable[H]): G[(F[B], F[C])] = {
+    import cats.instances.tuple._
+
+    implicit val mb: Monoid[F[B]] = A.algebra[B]
+    implicit val mc: Monoid[F[C]] = A.algebra[C]
+
+    foldMapM[G, A, (F[B], F[C])](fa)(
+      a =>
+        M.map(f(a)) {
+          H.bifoldMap[B, C, (F[B], F[C])](_)(b => (A.pure(b), A.empty[C]), c => (A.empty[B], A.pure(c)))
+        }
+    )
+  }
+
+  /**
+   * Separate this Foldable into a Tuple by an effectful separating function `A => G[Either[B, C]]`
+   * Equivalent to `Traverse#traverse` over `Alternative#separate`
+   *
+   * {{{
+   * scala> import cats.implicits._, cats.Foldable, cats.Eval
+   * scala> val list = List(1,2,3,4)
+   * scala> val partitioned1 = Foldable[List].partitionEitherM(list)(a => if (a % 2 == 0) Eval.now(Either.left[String, Int](a.toString)) else Eval.now(Either.right[String, Int](a)))
+   * Since `Eval.now` yields a lazy computation, we need to force it to inspect the result:
+   * scala> partitioned1.value
+   * res0: (List[String], List[Int]) = (List(2, 4),List(1, 3))
+   * scala> val partitioned2 = Foldable[List].partitionEitherM(list)(a => Eval.later(Either.right(a * 4)))
+   * scala> partitioned2.value
+   * res1: (List[Nothing], List[Int]) = (List(),List(4, 8, 12, 16))
+   * }}}
+   */
+  @noop
+  def partitionEitherM[G[_], A, B, C](fa: F[A])(f: A => G[Either[B, C]])(implicit A: Alternative[F],
+                                                                         M: Monad[G]): G[(F[B], F[C])] = {
+    import cats.instances.either._
+    partitionBifoldM[G, Either, A, B, C](fa)(f)(A, M, Bifoldable[Either])
+  }
 }
 
 object Foldable {

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -327,7 +327,7 @@ import Foldable.sentinel
    * scala> import cats.implicits._
    * scala> val xs = List(1, 2, 3, 4)
    * scala> def f(n: Int): Option[Int] = if (n % 2 == 0) Some(n) else None
-   * scala> Foldable[List].collectSomeFold(xs)(f)
+   * scala> Foldable[List].collectFoldSome(xs)(f)
    * res0: Int = 6
    *}}}
    */

--- a/core/src/main/scala/cats/Reducible.scala
+++ b/core/src/main/scala/cats/Reducible.scala
@@ -1,7 +1,7 @@
 package cats
 
 import cats.data.{Ior, NonEmptyList}
-import simulacrum.typeclass
+import simulacrum.{noop, typeclass}
 
 /**
  * Data structures that can be reduced to a summary value.
@@ -53,6 +53,22 @@ import simulacrum.typeclass
    */
   def reduceMap[A, B](fa: F[A])(f: A => B)(implicit B: Semigroup[B]): B =
     reduceLeftTo(fa)(f)((b, a) => B.combine(b, f(a)))
+
+  /**
+   * Apply `f` to each element of `fa` and combine them using the
+   * given `SemigroupK[G]`.
+   *
+   * {{{
+   * scala> import cats._, cats.data._, cats.implicits._
+   * scala> val f: Int => Endo[String] = i => (s => s + i)
+   * scala> val x: Endo[String] = Reducible[NonEmptyList].reduceMapK(NonEmptyList.of(1, 2, 3))(f)
+   * scala> val a = x("foo")
+   * a: String = "foo321"
+   * }}}
+   * */
+  @noop
+  def reduceMapK[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: SemigroupK[G]): G[B] =
+    reduceLeftTo(fa)(f)((b, a) => G.combineK(b, f(a)))
 
   /**
    * Apply `f` to the "initial element" of `fa` and combine it with

--- a/core/src/main/scala/cats/TraverseFilter.scala
+++ b/core/src/main/scala/cats/TraverseFilter.scala
@@ -35,6 +35,17 @@ trait TraverseFilter[F[_]] extends FunctorFilter[F] {
   def traverseFilter[G[_], A, B](fa: F[A])(f: A => G[Option[B]])(implicit G: Applicative[G]): G[F[B]]
 
   /**
+   * {{{
+   * scala> import cats.implicits._
+   * scala> val a: List[Either[String, Option[Int]]] = List(Right(Some(1)), Right(Some(5)), Right(Some(3)))
+   * scala> val b: Either[String, List[Int]] = TraverseFilter[List].sequenceFilter(a)
+   * b: Either[String, List[Int]] = Right(List(1, 5, 3))
+   * }}}
+   * */
+  def sequenceFilter[G[_], A](fgoa: F[G[Option[A]]])(implicit G: Applicative[G]): G[F[A]] =
+    traverseFilter(fgoa)(identity)
+
+  /**
    *
    * Filter values inside a `G` context.
    *

--- a/core/src/main/scala/cats/TraverseFilter.scala
+++ b/core/src/main/scala/cats/TraverseFilter.scala
@@ -1,6 +1,6 @@
 package cats
 
-import simulacrum.typeclass
+import simulacrum.{noop, typeclass}
 
 /**
  * `TraverseFilter`, also known as `Witherable`, represents list-like structures
@@ -42,6 +42,7 @@ trait TraverseFilter[F[_]] extends FunctorFilter[F] {
    * b: Either[String, List[Int]] = Right(List(1, 5, 3))
    * }}}
    * */
+  @noop
   def sequenceFilter[G[_], A](fgoa: F[G[Option[A]]])(implicit G: Applicative[G]): G[F[A]] =
     traverseFilter(fgoa)(identity)
 

--- a/core/src/main/scala/cats/UnorderedFoldable.scala
+++ b/core/src/main/scala/cats/UnorderedFoldable.scala
@@ -2,7 +2,7 @@ package cats
 
 import cats.instances.long._
 import cats.kernel.CommutativeMonoid
-import simulacrum.typeclass
+import simulacrum.{noop, typeclass}
 
 /**
  * `UnorderedFoldable` is like a `Foldable` for unordered containers.
@@ -66,6 +66,7 @@ import simulacrum.typeclass
    * res1: Long = 2
    * }}}
    */
+  @noop
   def count[A](fa: F[A])(p: A => Boolean): Long =
     unorderedFoldMap(fa)(a => if (p(a)) 1L else 0L)
 }

--- a/core/src/main/scala/cats/UnorderedFoldable.scala
+++ b/core/src/main/scala/cats/UnorderedFoldable.scala
@@ -1,8 +1,8 @@
 package cats
 
+import cats.instances.long._
 import cats.kernel.CommutativeMonoid
 import simulacrum.typeclass
-import cats.instances.long._
 
 /**
  * `UnorderedFoldable` is like a `Foldable` for unordered containers.
@@ -48,6 +48,26 @@ import cats.instances.long._
    * Note: will not terminate for infinite-sized collections.
    */
   def size[A](fa: F[A]): Long = unorderedFoldMap(fa)(_ => 1L)
+
+  /**
+   * Count the number of elements in the structure that satisfy the given predicate.
+   *
+   * For example:
+   * {{{
+   * scala> import cats.implicits._
+   * scala> val map1 = Map[Int, String]()
+   * scala> val p1: String => Boolean = _.length > 0
+   * scala> UnorderedFoldable[Map[Int, *]].count(map1)(p1)
+   * res0: Long = 0
+   *
+   * scala> val map2 = Map(1 -> "hello", 2 -> "world", 3 -> "!")
+   * scala> val p2: String => Boolean = _.length > 1
+   * scala> UnorderedFoldable[Map[Int, *]].count(map2)(p2)
+   * res1: Long = 2
+   * }}}
+   */
+  def count[A](fa: F[A])(p: A => Boolean): Long =
+    unorderedFoldMap(fa)(a => if (p(a)) 1L else 0L)
 }
 
 object UnorderedFoldable {

--- a/core/src/main/scala/cats/syntax/applicativeError.scala
+++ b/core/src/main/scala/cats/syntax/applicativeError.scala
@@ -1,7 +1,6 @@
 package cats
 package syntax
 
-import cats.data.Validated.{Invalid, Valid}
 import cats.data.{EitherT, Validated}
 
 import scala.reflect.ClassTag
@@ -19,14 +18,15 @@ trait ApplicativeErrorSyntax {
 /**
  * Extension to ApplicativeError in a binary compat way
  */
-trait ApplicativeErrorExtension {
-  implicit final def catsSyntaxApplicativeErrorExtension[F[_], E](
+private[syntax] trait ApplicativeErrorExtension {
+  @deprecated("Use methods on ApplicativeError", "2.1.0-RC1")
+  final def catsSyntaxApplicativeErrorExtension[F[_], E](
     F: ApplicativeError[F, E]
   ): ApplicativeErrorExtensionOps[F, E] =
     new ApplicativeErrorExtensionOps(F)
 }
 
-final class ApplicativeErrorExtensionOps[F[_], E](F: ApplicativeError[F, E]) {
+final private[syntax] class ApplicativeErrorExtensionOps[F[_], E](F: ApplicativeError[F, E]) {
 
   /**
    * Convert from scala.Option
@@ -44,8 +44,7 @@ final class ApplicativeErrorExtensionOps[F[_], E](F: ApplicativeError[F, E]) {
    * res1: scala.Either[String, Int] = Left(Empty)
    * }}}
    */
-  def fromOption[A](oa: Option[A], ifEmpty: => E): F[A] =
-    ApplicativeError.liftFromOption(oa, ifEmpty)(F)
+  private[syntax] def fromOption[A](oa: Option[A], ifEmpty: => E): F[A] = F.fromOption(oa, ifEmpty)
 
   /**
    * Convert from cats.data.Validated
@@ -62,12 +61,7 @@ final class ApplicativeErrorExtensionOps[F[_], E](F: ApplicativeError[F, E]) {
    * res1: scala.Option[Int] = None
    * }}}
    */
-  def fromValidated[A](x: Validated[E, A]): F[A] =
-    x match {
-      case Invalid(e) => F.raiseError(e)
-      case Valid(a)   => F.pure(a)
-    }
-
+  private[syntax] def fromValidated[A](x: Validated[E, A]): F[A] = F.fromValidated(x)
 }
 
 final class ApplicativeErrorIdOps[E](private val e: E) extends AnyVal {

--- a/core/src/main/scala/cats/syntax/applicativeError.scala
+++ b/core/src/main/scala/cats/syntax/applicativeError.scala
@@ -26,41 +26,13 @@ private[syntax] trait ApplicativeErrorExtension {
     new ApplicativeErrorExtensionOps(F)
 }
 
+@deprecated("Use methods on ApplicativeError", "2.1.0-RC1")
 final private[syntax] class ApplicativeErrorExtensionOps[F[_], E](F: ApplicativeError[F, E]) {
 
-  /**
-   * Convert from scala.Option
-   *
-   * Example:
-   * {{{
-   * scala> import cats.implicits._
-   * scala> import cats.ApplicativeError
-   * scala> val F = ApplicativeError[Either[String, *], String]
-   *
-   * scala> F.fromOption(Some(1), "Empty")
-   * res0: scala.Either[String, Int] = Right(1)
-   *
-   * scala> F.fromOption(Option.empty[Int], "Empty")
-   * res1: scala.Either[String, Int] = Left(Empty)
-   * }}}
-   */
+  @deprecated("Use fromOption on ApplicativeError", "2.1.0-RC1")
   private[syntax] def fromOption[A](oa: Option[A], ifEmpty: => E): F[A] = F.fromOption(oa, ifEmpty)
 
-  /**
-   * Convert from cats.data.Validated
-   *
-   * Example:
-   * {{{
-   * scala> import cats.implicits._
-   * scala> import cats.ApplicativeError
-   *
-   * scala> ApplicativeError[Option, Unit].fromValidated(1.valid[Unit])
-   * res0: scala.Option[Int] = Some(1)
-   *
-   * scala> ApplicativeError[Option, Unit].fromValidated(().invalid[Int])
-   * res1: scala.Option[Int] = None
-   * }}}
-   */
+  @deprecated("Use fromValidated on ApplicativeError", "2.1.0-RC1")
   private[syntax] def fromValidated[A](x: Validated[E, A]): F[A] = F.fromValidated(x)
 }
 

--- a/core/src/main/scala/cats/syntax/apply.scala
+++ b/core/src/main/scala/cats/syntax/apply.scala
@@ -49,10 +49,7 @@ final class IfApplyOps[F[_]](private val fcond: F[Boolean]) extends AnyVal {
    *
    * }}}
    */
-  def ifA[A](ifTrue: F[A], ifFalse: F[A])(implicit F: Apply[F]): F[A] = {
-    def ite(b: Boolean)(ifTrue: A, ifFalse: A) = if (b) ifTrue else ifFalse
-    F.ap2(F.map(fcond)(ite))(ifTrue, ifFalse)
-  }
+  def ifA[A](ifTrue: F[A], ifFalse: F[A])(implicit F: Apply[F]): F[A] = F.ifA(fcond)(ifTrue, ifFalse)
 }
 
 final class ApplyOps[F[_], A](private val fa: F[A]) extends AnyVal {

--- a/core/src/main/scala/cats/syntax/bitraverse.scala
+++ b/core/src/main/scala/cats/syntax/bitraverse.scala
@@ -54,7 +54,7 @@ final private[syntax] class BitraverseOpsBinCompat0[F[_, _], A, B](val fab: F[A,
    *  }}}
    */
   def leftTraverse[G[_], C](f: A => G[C])(implicit F: Bitraverse[F], G: Applicative[G]): G[F[C, B]] =
-    F.bitraverse(fab)(f, G.pure(_))
+    F.leftTraverse[G, A, B, C](fab)(f)
 }
 
 final class LeftNestedBitraverseOps[F[_, _], G[_], A, B](val fgab: F[G[A], B]) extends AnyVal {
@@ -81,5 +81,5 @@ final class LeftNestedBitraverseOps[F[_, _], G[_], A, B](val fgab: F[G[A], B]) e
    * }}}
    */
   def leftSequence(implicit F: Bitraverse[F], G: Applicative[G]): G[F[A, B]] =
-    F.bitraverse(fgab)(identity, G.pure(_))
+    F.leftSequence(fgab)
 }

--- a/core/src/main/scala/cats/syntax/foldable.scala
+++ b/core/src/main/scala/cats/syntax/foldable.scala
@@ -166,11 +166,7 @@ final class FoldableOps[F[_], A](private val fa: F[A]) extends AnyVal {
    * res3: Either[String,Option[Int]] = Left(error)
    * }}}
    */
-  def findM[G[_]](p: A => G[Boolean])(implicit F: Foldable[F], G: Monad[G]): G[Option[A]] =
-    G.tailRecM(Foldable.Source.fromFoldable(fa))(_.uncons match {
-      case Some((a, src)) => G.map(p(a))(if (_) Right(Some(a)) else Left(src.value))
-      case None           => G.pure(Right(None))
-    })
+  def findM[G[_]](p: A => G[Boolean])(implicit F: Foldable[F], G: Monad[G]): G[Option[A]] = F.findM[G, A](fa)(p)
 
   /**
    * Tear down a subset of this structure using a `PartialFunction`.

--- a/core/src/main/scala/cats/syntax/foldable.scala
+++ b/core/src/main/scala/cats/syntax/foldable.scala
@@ -170,8 +170,7 @@ final class FoldableOps[F[_], A](private val fa: F[A]) extends AnyVal {
    * res0: Int = 6
    *}}}
    */
-  def collectFold[M](f: PartialFunction[A, M])(implicit F: Foldable[F], M: Monoid[M]): M =
-    F.foldLeft(fa, M.empty)((acc, a) => M.combine(acc, f.applyOrElse(a, (_: A) => M.empty)))
+  def collectFold[M](f: PartialFunction[A, M])(implicit F: Foldable[F], M: Monoid[M]): M = F.collectFold[A, M](fa)(f)
 
   /**
    * Tear down a subset of this structure using a `A => Option[M]`.
@@ -183,14 +182,8 @@ final class FoldableOps[F[_], A](private val fa: F[A]) extends AnyVal {
    * res0: Int = 6
    *}}}
    */
-  def collectSomeFold[M](f: A => Option[M])(implicit F: Foldable[F], M: Monoid[M]): M =
-    F.foldLeft(fa, M.empty)(
-      (acc, a) =>
-        f(a) match {
-          case Some(x) => M.combine(acc, x)
-          case None    => acc
-        }
-    )
+  @deprecated("Use collectFoldSome", "2.1.0-RC1")
+  def collectSomeFold[M](f: A => Option[M])(implicit F: Foldable[F], M: Monoid[M]): M = F.collectFoldSome[A, M](fa)(f)
 }
 
 final class FoldableOps0[F[_], A](private val fa: F[A]) extends AnyVal {

--- a/core/src/main/scala/cats/syntax/foldable.scala
+++ b/core/src/main/scala/cats/syntax/foldable.scala
@@ -284,58 +284,17 @@ final class FoldableOps0[F[_], A](private val fa: F[A]) extends AnyVal {
 @deprecated("Use methods on Foldable", "2.1.0-RC1")
 final private[syntax] class FoldableOps1[F[_]](private val F: Foldable[F]) extends AnyVal {
 
-  /**
-   * Separate this Foldable into a Tuple by a separating function `A => H[B, C]` for some `Bifoldable[H]`
-   * Equivalent to `Functor#map` and then `Alternative#separate`.
-   *
-   * {{{
-   * scala> import cats.implicits._, cats.Foldable, cats.data.Const
-   * scala> val list = List(1,2,3,4)
-   * scala> Foldable[List].partitionBifold(list)(a => ("value " + a.toString(), if (a % 2 == 0) -a else a))
-   * res0: (List[String], List[Int]) = (List(value 1, value 2, value 3, value 4),List(1, -2, 3, -4))
-   * scala> Foldable[List].partitionBifold(list)(a => Const[Int, Nothing with Any](a))
-   * res1: (List[Int], List[Nothing with Any]) = (List(1, 2, 3, 4),List())
-   * }}}
-   */
   @deprecated("Use partitionBifold on Foldable", "2.1.0-RC1")
   def partitionBifold[H[_, _], A, B, C](fa: F[A])(f: A => H[B, C])(implicit A: Alternative[F],
                                                                    H: Bifoldable[H]): (F[B], F[C]) =
     F.partitionBifold[H, A, B, C](fa)(f)
 
-  /**
-   * Separate this Foldable into a Tuple by an effectful separating function `A => G[H[B, C]]` for some `Bifoldable[H]`
-   * Equivalent to `Traverse#traverse` over `Alternative#separate`
-   *
-   * {{{
-   * scala> import cats.implicits._, cats.Foldable, cats.data.Const
-   * scala> val list = List(1,2,3,4)
-   * `Const`'s second parameter is never instantiated, so we can use an impossible type:
-   * scala> Foldable[List].partitionBifoldM(list)(a => Option(Const[Int, Nothing with Any](a)))
-   * res0: Option[(List[Int], List[Nothing with Any])] = Some((List(1, 2, 3, 4),List()))
-   * }}}
-   */
   @deprecated("Use partitionBifoldM on Foldable", "2.1.0-RC1")
   def partitionBifoldM[G[_], H[_, _], A, B, C](
     fa: F[A]
   )(f: A => G[H[B, C]])(implicit A: Alternative[F], M: Monad[G], H: Bifoldable[H]): G[(F[B], F[C])] =
     F.partitionBifoldM[G, H, A, B, C](fa)(f)
 
-  /**
-   * Separate this Foldable into a Tuple by an effectful separating function `A => G[Either[B, C]]`
-   * Equivalent to `Traverse#traverse` over `Alternative#separate`
-   *
-   * {{{
-   * scala> import cats.implicits._, cats.Foldable, cats.Eval
-   * scala> val list = List(1,2,3,4)
-   * scala> val partitioned1 = Foldable[List].partitionEitherM(list)(a => if (a % 2 == 0) Eval.now(Either.left[String, Int](a.toString)) else Eval.now(Either.right[String, Int](a)))
-   * Since `Eval.now` yields a lazy computation, we need to force it to inspect the result:
-   * scala> partitioned1.value
-   * res0: (List[String], List[Int]) = (List(2, 4),List(1, 3))
-   * scala> val partitioned2 = Foldable[List].partitionEitherM(list)(a => Eval.later(Either.right(a * 4)))
-   * scala> partitioned2.value
-   * res1: (List[Nothing], List[Int]) = (List(),List(4, 8, 12, 16))
-   * }}}
-   */
   @deprecated("Use partitionEitherM on Foldable", "2.1.0-RC1")
   def partitionEitherM[G[_], A, B, C](fa: F[A])(f: A => G[Either[B, C]])(implicit A: Alternative[F],
                                                                          M: Monad[G]): G[(F[B], F[C])] =

--- a/core/src/main/scala/cats/syntax/foldable.scala
+++ b/core/src/main/scala/cats/syntax/foldable.scala
@@ -15,7 +15,8 @@ private[syntax] trait FoldableSyntaxBinCompat0 {
 }
 
 private[syntax] trait FoldableSyntaxBinCompat1 {
-  implicit final def catsSyntaxFoldableBinCompat0[F[_]](fa: Foldable[F]): FoldableOps1[F] =
+  @deprecated("Use methods on Foldable", "2.1.0-RC1")
+  final def catsSyntaxFoldableBinCompat0[F[_]](fa: Foldable[F]): FoldableOps1[F] =
     new FoldableOps1(fa)
 }
 
@@ -239,10 +240,8 @@ final class FoldableOps0[F[_], A](private val fa: F[A]) extends AnyVal {
    */
   def partitionBifold[H[_, _], B, C](
     f: A => H[B, C]
-  )(implicit A: Alternative[F], F: Foldable[F], H: Bifoldable[H]): (F[B], F[C]) = {
-    import cats.syntax.foldable._
+  )(implicit A: Alternative[F], F: Foldable[F], H: Bifoldable[H]): (F[B], F[C]) =
     F.partitionBifold[H, A, B, C](fa)(f)(A, H)
-  }
 
   /**
    * Separate this Foldable into a Tuple by an effectful separating function `A => G[H[B, C]]` for some `Bifoldable[H]`
@@ -258,10 +257,8 @@ final class FoldableOps0[F[_], A](private val fa: F[A]) extends AnyVal {
    */
   def partitionBifoldM[G[_], H[_, _], B, C](
     f: A => G[H[B, C]]
-  )(implicit A: Alternative[F], F: Foldable[F], M: Monad[G], H: Bifoldable[H]): G[(F[B], F[C])] = {
-    import cats.syntax.foldable._
+  )(implicit A: Alternative[F], F: Foldable[F], M: Monad[G], H: Bifoldable[H]): G[(F[B], F[C])] =
     F.partitionBifoldM[G, H, A, B, C](fa)(f)(A, M, H)
-  }
 
   /**
    * Separate this Foldable into a Tuple by an effectful separating function `A => G[Either[B, C]]`
@@ -281,12 +278,11 @@ final class FoldableOps0[F[_], A](private val fa: F[A]) extends AnyVal {
    */
   def partitionEitherM[G[_], B, C](
     f: A => G[Either[B, C]]
-  )(implicit A: Alternative[F], F: Foldable[F], M: Monad[G]): G[(F[B], F[C])] = {
-    import cats.syntax.foldable._
+  )(implicit A: Alternative[F], F: Foldable[F], M: Monad[G]): G[(F[B], F[C])] =
     F.partitionEitherM[G, A, B, C](fa)(f)(A, M)
-  }
 }
 
+@deprecated("Use methods on Foldable", "2.1.0-RC1")
 final private[syntax] class FoldableOps1[F[_]](private val F: Foldable[F]) extends AnyVal {
 
   /**
@@ -302,17 +298,10 @@ final private[syntax] class FoldableOps1[F[_]](private val F: Foldable[F]) exten
    * res1: (List[Int], List[Nothing with Any]) = (List(1, 2, 3, 4),List())
    * }}}
    */
+  @deprecated("Use partitionBifold on Foldable", "2.1.0-RC1")
   def partitionBifold[H[_, _], A, B, C](fa: F[A])(f: A => H[B, C])(implicit A: Alternative[F],
-                                                                   H: Bifoldable[H]): (F[B], F[C]) = {
-    import cats.instances.tuple._
-
-    implicit val mb: Monoid[F[B]] = A.algebra[B]
-    implicit val mc: Monoid[F[C]] = A.algebra[C]
-
-    F.foldMap[A, (F[B], F[C])](fa)(
-      a => H.bifoldMap[B, C, (F[B], F[C])](f(a))(b => (A.pure(b), A.empty[C]), c => (A.empty[B], A.pure(c)))
-    )
-  }
+                                                                   H: Bifoldable[H]): (F[B], F[C]) =
+    F.partitionBifold[H, A, B, C](fa)(f)
 
   /**
    * Separate this Foldable into a Tuple by an effectful separating function `A => G[H[B, C]]` for some `Bifoldable[H]`
@@ -326,21 +315,11 @@ final private[syntax] class FoldableOps1[F[_]](private val F: Foldable[F]) exten
    * res0: Option[(List[Int], List[Nothing with Any])] = Some((List(1, 2, 3, 4),List()))
    * }}}
    */
+  @deprecated("Use partitionBifoldM on Foldable", "2.1.0-RC1")
   def partitionBifoldM[G[_], H[_, _], A, B, C](
     fa: F[A]
-  )(f: A => G[H[B, C]])(implicit A: Alternative[F], M: Monad[G], H: Bifoldable[H]): G[(F[B], F[C])] = {
-    import cats.instances.tuple._
-
-    implicit val mb: Monoid[F[B]] = A.algebra[B]
-    implicit val mc: Monoid[F[C]] = A.algebra[C]
-
-    F.foldMapM[G, A, (F[B], F[C])](fa)(
-      a =>
-        M.map(f(a)) {
-          H.bifoldMap[B, C, (F[B], F[C])](_)(b => (A.pure(b), A.empty[C]), c => (A.empty[B], A.pure(c)))
-        }
-    )
-  }
+  )(f: A => G[H[B, C]])(implicit A: Alternative[F], M: Monad[G], H: Bifoldable[H]): G[(F[B], F[C])] =
+    F.partitionBifoldM[G, H, A, B, C](fa)(f)
 
   /**
    * Separate this Foldable into a Tuple by an effectful separating function `A => G[Either[B, C]]`
@@ -358,9 +337,8 @@ final private[syntax] class FoldableOps1[F[_]](private val F: Foldable[F]) exten
    * res1: (List[Nothing], List[Int]) = (List(),List(4, 8, 12, 16))
    * }}}
    */
+  @deprecated("Use partitionEitherM on Foldable", "2.1.0-RC1")
   def partitionEitherM[G[_], A, B, C](fa: F[A])(f: A => G[Either[B, C]])(implicit A: Alternative[F],
-                                                                         M: Monad[G]): G[(F[B], F[C])] = {
-    import cats.instances.either._
-    partitionBifoldM[G, Either, A, B, C](fa)(f)(A, M, Bifoldable[Either])
-  }
+                                                                         M: Monad[G]): G[(F[B], F[C])] =
+    F.partitionEitherM[G, A, B, C](fa)(f)
 }

--- a/core/src/main/scala/cats/syntax/foldable.scala
+++ b/core/src/main/scala/cats/syntax/foldable.scala
@@ -178,7 +178,7 @@ final class FoldableOps[F[_], A](private val fa: F[A]) extends AnyVal {
    * scala> import cats.implicits._
    * scala> val xs = List(1, 2, 3, 4)
    * scala> def f(n: Int): Option[Int] = if (n % 2 == 0) Some(n) else None
-   * scala> xs.collectSomeFold(f)
+   * scala> xs.collectFoldSome(f)
    * res0: Int = 6
    *}}}
    */

--- a/core/src/main/scala/cats/syntax/foldable.scala
+++ b/core/src/main/scala/cats/syntax/foldable.scala
@@ -221,8 +221,7 @@ final class FoldableOps0[F[_], A](private val fa: F[A]) extends AnyVal {
    * a: String = "foo321"
    * }}}
    * */
-  def foldMapK[G[_], B](f: A => G[B])(implicit F: Foldable[F], G: MonoidK[G]): G[B] =
-    F.foldMap(fa)(f)(G.algebra)
+  def foldMapK[G[_], B](f: A => G[B])(implicit F: Foldable[F], G: MonoidK[G]): G[B] = F.foldMapK(fa)(f)
 
   /**
    * Separate this Foldable into a Tuple by an effectful separating function `A => H[B, C]` for some `Bifoldable[H]`

--- a/core/src/main/scala/cats/syntax/foldable.scala
+++ b/core/src/main/scala/cats/syntax/foldable.scala
@@ -134,14 +134,7 @@ final class FoldableOps[F[_], A](private val fa: F[A]) extends AnyVal {
    * }}}
    */
   def collectFirstSomeM[G[_], B](f: A => G[Option[B]])(implicit F: Foldable[F], G: Monad[G]): G[Option[B]] =
-    G.tailRecM(Foldable.Source.fromFoldable(fa))(_.uncons match {
-      case Some((a, src)) =>
-        G.map(f(a)) {
-          case None => Left(src.value)
-          case s    => Right(s)
-        }
-      case None => G.pure(Right(None))
-    })
+    F.collectFirstSomeM[G, A, B](fa)(f)
 
   /**
    * Find the first element matching the effectful predicate, if one exists.

--- a/core/src/main/scala/cats/syntax/reducible.scala
+++ b/core/src/main/scala/cats/syntax/reducible.scala
@@ -29,6 +29,5 @@ final class ReducibleOps0[F[_], A](private val fa: F[A]) extends AnyVal {
    * a: String = "foo321"
    * }}}
    * */
-  def reduceMapK[G[_], B](f: A => G[B])(implicit F: Reducible[F], G: SemigroupK[G]): G[B] =
-    F.reduceLeftTo(fa)(f)((b, a) => G.combineK(b, f(a)))
+  def reduceMapK[G[_], B](f: A => G[B])(implicit F: Reducible[F], G: SemigroupK[G]): G[B] = F.reduceMapK[G, A, B](fa)(f)
 }

--- a/core/src/main/scala/cats/syntax/traverseFilter.scala
+++ b/core/src/main/scala/cats/syntax/traverseFilter.scala
@@ -18,5 +18,5 @@ final class SequenceFilterOps[F[_], G[_], A](private val fgoa: F[G[Option[A]]]) 
    * b: Either[String, List[Int]] = Right(List(1, 5, 3))
    * }}}
    * */
-  def sequenceFilter(implicit F: TraverseFilter[F], G: Applicative[G]): G[F[A]] = F.traverseFilter(fgoa)(identity)
+  def sequenceFilter(implicit F: TraverseFilter[F], G: Applicative[G]): G[F[A]] = F.sequenceFilter(fgoa)
 }

--- a/core/src/main/scala/cats/syntax/unorderedFoldable.scala
+++ b/core/src/main/scala/cats/syntax/unorderedFoldable.scala
@@ -1,8 +1,6 @@
 package cats
 package syntax
 
-import cats.instances.long._
-
 trait UnorderedFoldableSyntax extends UnorderedFoldable.ToUnorderedFoldableOps {
   implicit final def catsSyntaxUnorderedFoldableOps[F[_]: UnorderedFoldable, A](fa: F[A]): UnorderedFoldableOps[F, A] =
     new UnorderedFoldableOps[F, A](fa)
@@ -28,5 +26,5 @@ final class UnorderedFoldableOps[F[_], A](private val fa: F[A]) extends AnyVal {
    * }}}
    */
   def count(p: A => Boolean)(implicit F: UnorderedFoldable[F]): Long =
-    F.unorderedFoldMap(fa)(a => if (p(a)) 1L else 0L)
+    F.count(fa)(p)
 }

--- a/core/src/main/scala/cats/syntax/validated.scala
+++ b/core/src/main/scala/cats/syntax/validated.scala
@@ -21,7 +21,7 @@ trait ValidatedExtensionSyntax {
 
 final class ValidatedExtension[E, A](private val self: Validated[E, A]) extends AnyVal {
   def liftTo[F[_]](implicit F: ApplicativeError[F, _ >: E]): F[A] =
-    new ApplicativeErrorExtensionOps(F).fromValidated(self)
+    F.fromValidated(self)
 }
 
 private[syntax] trait ValidatedSyntaxBincompat0 {


### PR DESCRIPTION
Between 1.0.0 and 2.0.0 we added a lot of new type class operations as syntax methods in order to avoid breaking binary compatibility on 2.11. We don't have to worry about that any more, which means these methods can go on the type classes where they belong.

## Syntax methods

There are two categories of syntax methods that can be moved. The first is something like `findM` for `Foldable`, which should live next to `find` on the type class itself, but right now only exists as syntax for `F[A]` values:

```scala
final class FoldableOps[F[_], A](private val fa: F[A]) extends AnyVal {
  def findM[G[_]](p: A => G[Boolean])(implicit F: Foldable[F], G: Monad[G]): G[Option[A]] = ???
}
```
For methods like this I've added an implementation in the type class (`trait Foldable` in this case):

```scala
  @noop
  def findM[G[_], A](fa: F[A])(p: A => G[Boolean])(implicit G: Monad[G]): G[Option[A]] =
```
I've then changed the syntax implementation to use the new type class method. Note that the `@noop` isn't strictly necessary (except in the case of `leftSequence`, which I think hits a Simulacrum bug)—it's just an optimization to avoid Simulacrum generating redundant syntax methods (since we can't remove the current ones because of bincompat).

The big advantage here is discoverability. Someone looking at the `Foldable` API docs for `find` might wonder whether there's an effectful version, and there is, but they won't currently know that without also looking in `cats.syntax.foldable`.

Another advantage is ease of use. In some cases, like `count` for `UnorderedFoldable`, which currently exists only as syntax, it's very difficult to actually use the method in many cases, because the syntax version collides with the `count` on standard library collections. After this PR you can just `F.count(pred)` on your `UnorderedFoldable` instance.

It's a smaller thing, but these changes also mean less logic in the syntax package, and fewer changes to make when we eventually do break binary compatibility in Cats 3.0 and (fingers crossed) can let Simulacrum or some Simulacrum successor do even more of the syntax boilerplate work.

## Type class instance enrichment methods

The other category of methods I've moved here are things like `fromValidated` for `ApplicativeError`. These methods aren't enriched onto `F[A]` values or whatever, but onto the type class instance itself. In this case we can add the method to the type class and actually "remove" the syntax method, in the sense that we can make the enrichment conversion non-implicit and can deprecated everything involved (we can't _remove_ remove it thanks to bincompat). This means less unnecessary garbage cluttering up implicit search when you import form `cats.syntax`.

## Other issues

* We currently have `collectFirst` and `collectFirstSome` but `collectFold` and `collectSomeFold` (as syntax methods). I've used `collectFoldSome` for consistency in the new proper type class version of `collectFoldSome`, and have deprecated the `collectFoldSome` syntax method.

* There are a few syntax methods that could have been added to type classes that I've omitted. Two examples are `contains_` and `mkString_` for `Foldable`. In all of these cases (and there are only a couple others, I think) the implementations are trivial (like for `contains_`) or the operation is very specific (like `mkString_`) and doesn't feel to me like it really needs to go on the type class.