### PR TITLE
Make 1.x deprecation targets package-private

### DIFF
--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -126,12 +126,12 @@ trait Apply[F[_]] extends Functor[F] with InvariantSemigroupal[F] with ApplyArit
 
   /** Alias for [[productR]]. */
   @deprecated("Use *> or productR instead.", "1.0.0-RC2")
-  @noop @inline final def followedBy[A, B](fa: F[A])(fb: F[B]): F[B] =
+  @noop @inline final private[cats] def followedBy[A, B](fa: F[A])(fb: F[B]): F[B] =
     productR(fa)(fb)
 
   /** Alias for [[productL]]. */
   @deprecated("Use <* or productL instead.", "1.0.0-RC2")
-  @noop @inline final def forEffect[A, B](fa: F[A])(fb: F[B]): F[A] =
+  @noop @inline final private[cats] def forEffect[A, B](fa: F[A])(fb: F[B]): F[A] =
     productL(fa)(fb)
 
   /**

--- a/core/src/main/scala/cats/FlatMap.scala
+++ b/core/src/main/scala/cats/FlatMap.scala
@@ -57,7 +57,7 @@ import simulacrum.noop
   def productREval[A, B](fa: F[A])(fb: Eval[F[B]]): F[B] = flatMap(fa)(_ => fb.value)
 
   @deprecated("Use productREval instead.", "1.0.0-RC2")
-  @noop def followedByEval[A, B](fa: F[A])(fb: Eval[F[B]]): F[B] = productREval(fa)(fb)
+  @noop private[cats] def followedByEval[A, B](fa: F[A])(fb: Eval[F[B]]): F[B] = productREval(fa)(fb)
 
   /**
    * Sequentially compose two actions, discarding any value produced by the second. This variant of
@@ -81,7 +81,7 @@ import simulacrum.noop
   def productLEval[A, B](fa: F[A])(fb: Eval[F[B]]): F[A] = flatMap(fa)(a => map(fb.value)(_ => a))
 
   @deprecated("Use productLEval instead.", "1.0.0-RC2")
-  @noop def forEffectEval[A, B](fa: F[A])(fb: Eval[F[B]]): F[A] = productLEval(fa)(fb)
+  @noop private[cats] def forEffectEval[A, B](fa: F[A])(fb: Eval[F[B]]): F[A] = productLEval(fa)(fb)
 
   override def ap[A, B](ff: F[A => B])(fa: F[A]): F[B] =
     flatMap(ff)(f => map(fa)(f))

--- a/core/src/main/scala/cats/Parallel.scala
+++ b/core/src/main/scala/cats/Parallel.scala
@@ -37,7 +37,7 @@ trait NonEmptyParallel[M[_]] extends Serializable {
     Parallel.parMap2(ma, mb)((_, b) => b)(this)
 
   @deprecated("Use parProductR instead.", "1.0.0-RC2")
-  @inline def parFollowedBy[A, B](ma: M[A])(mb: M[B]): M[B] = parProductR(ma)(mb)
+  @inline private[cats] def parFollowedBy[A, B](ma: M[A])(mb: M[B]): M[B] = parProductR(ma)(mb)
 
   /**
    * Like [[Apply.productL]], but uses the apply instance
@@ -47,7 +47,7 @@ trait NonEmptyParallel[M[_]] extends Serializable {
     Parallel.parMap2(ma, mb)((a, _) => a)(this)
 
   @deprecated("Use parProductL instead.", "1.0.0-RC2")
-  @inline def parForEffect[A, B](ma: M[A])(mb: M[B]): M[A] = parProductL(ma)(mb)
+  @inline private[cats] def parForEffect[A, B](ma: M[A])(mb: M[B]): M[A] = parProductL(ma)(mb)
 
 }
 

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -91,7 +91,7 @@ final case class Kleisli[F[_], -A, B](run: A => F[B]) { self =>
     Kleisli(f.andThen(run))
 
   @deprecated("Use mapK", "1.0.0-RC2")
-  def transform[G[_]](f: FunctionK[F, G]): Kleisli[G, A, B] =
+  private[cats] def transform[G[_]](f: FunctionK[F, G]): Kleisli[G, A, B] =
     mapK(f)
 
   def lower(implicit F: Applicative[F]): Kleisli[F, A, F[B]] =
@@ -207,7 +207,7 @@ sealed private[data] trait KleisliFunctions {
     λ[F ~> Kleisli[F, A, *]](Kleisli.liftF(_))
 
   @deprecated("Use liftF instead", "1.0.0-RC2")
-  def lift[F[_], A, B](x: F[B]): Kleisli[F, A, B] =
+  private[cats] def lift[F[_], A, B](x: F[B]): Kleisli[F, A, B] =
     Kleisli(_ => x)
 
   /**

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -83,7 +83,7 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) {
     NonEmptyList(head, tail ::: other)
 
   @deprecated("Use concatNel", since = "1.0.0-RC1")
-  def concat[AA >: A](other: NonEmptyList[AA]): NonEmptyList[AA] =
+  private[data] def concat[AA >: A](other: NonEmptyList[AA]): NonEmptyList[AA] =
     concatNel(other)
 
   /**

--- a/core/src/main/scala/cats/instances/duration.scala
+++ b/core/src/main/scala/cats/instances/duration.scala
@@ -7,7 +7,7 @@ trait DurationInstances extends cats.kernel.instances.DurationInstances {
 
   @deprecated("Left to keep binary compatibility. Use CoreDurationInstances.catsStdShowForDurationUnambiguous instead.",
               "1.5.0")
-  val catsStdShowForDuration: Show[Duration] =
+  def catsStdShowForDuration: Show[Duration] =
     AllCoreDurationInstances.catsStdShowForDurationUnambiguous
 }
 

--- a/core/src/main/scala/cats/instances/finiteDuration.scala
+++ b/core/src/main/scala/cats/instances/finiteDuration.scala
@@ -9,6 +9,6 @@ trait FiniteDurationInstances extends cats.kernel.instances.FiniteDurationInstan
     "Left to keep binary compatibility. Use CoreFiniteDurationInstances.catsStdShowForFiniteDurationUnambiguous instead.",
     "1.5.0"
   )
-  val catsStdShowForFiniteDuration: Show[FiniteDuration] =
+  def catsStdShowForFiniteDuration: Show[FiniteDuration] =
     AllCoreDurationInstances.catsStdShowForFiniteDurationUnambiguous
 }

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -109,7 +109,4 @@ package object cats {
   val Semigroup = cats.kernel.Semigroup
   val Monoid = cats.kernel.Monoid
   val Group = cats.kernel.Group
-
-  @deprecated("renamed to Semigroupal", "1.0.0-RC1")
-  type Cartesian[F[_]] = Semigroupal[F]
 }

--- a/core/src/main/scala/cats/syntax/apply.scala
+++ b/core/src/main/scala/cats/syntax/apply.scala
@@ -59,11 +59,11 @@ final class ApplyOps[F[_], A](private val fa: F[A]) extends AnyVal {
 
   /** Alias for [[Apply.productR]]. */
   @deprecated("Use *> or productR instead.", "1.0.0-RC2")
-  @inline def followedBy[B](fb: F[B])(implicit F: Apply[F]): F[B] =
+  @inline private[syntax] def followedBy[B](fb: F[B])(implicit F: Apply[F]): F[B] =
     F.productR(fa)(fb)
 
   /** Alias for [[Apply.productL]]. */
   @deprecated("Use <* or productL instead.", "1.0.0-RC2")
-  @inline def forEffect[B](fb: F[B])(implicit F: Apply[F]): F[A] =
+  @inline private[syntax] def forEffect[B](fb: F[B])(implicit F: Apply[F]): F[A] =
     F.productL(fa)(fb)
 }

--- a/core/src/main/scala/cats/syntax/flatMap.scala
+++ b/core/src/main/scala/cats/syntax/flatMap.scala
@@ -33,13 +33,13 @@ final class FlatMapOps[F[_], A](private val fa: F[A]) extends AnyVal {
   def >>[B](fb: => F[B])(implicit F: FlatMap[F]): F[B] = F.flatMap(fa)(_ => fb)
 
   @deprecated("Use <* instead", "1.0.0-RC1")
-  def <<[B](fb: F[B])(implicit F: FlatMap[F]): F[A] = F.productL(fa)(fb)
+  private[syntax] def <<[B](fb: F[B])(implicit F: FlatMap[F]): F[A] = F.productL(fa)(fb)
   @deprecated("Use productREval instead.", "1.0.0-RC2")
-  def followedByEval[B](fb: Eval[F[B]])(implicit F: FlatMap[F]): F[B] =
+  private[syntax] def followedByEval[B](fb: Eval[F[B]])(implicit F: FlatMap[F]): F[B] =
     F.productREval(fa)(fb)
 
   @deprecated("Use productLEval instead.", "1.0.0-RC2")
-  def forEffectEval[B](fb: Eval[F[B]])(implicit F: FlatMap[F]): F[A] =
+  private[syntax] def forEffectEval[B](fb: Eval[F[B]])(implicit F: FlatMap[F]): F[A] =
     F.productLEval(fa)(fb)
 
   /**

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -14,7 +14,7 @@ package object syntax {
   object binested extends BinestedSyntax
   object bitraverse extends BitraverseSyntax with BitraverseSyntaxBinCompat0
   @deprecated("use cats.syntax.semigroupal instead", "1.0.0-RC1")
-  object cartesian extends SemigroupalSyntax
+  private[syntax] object cartesian extends SemigroupalSyntax
   object choice extends ChoiceSyntax
   object coflatMap extends CoflatMapSyntax
   object distributive extends DistributiveSyntax

--- a/core/src/main/scala/cats/syntax/semigroupal.scala
+++ b/core/src/main/scala/cats/syntax/semigroupal.scala
@@ -14,7 +14,7 @@ trait SemigroupalSyntax {
 abstract class SemigroupalOps[F[_], A] extends Semigroupal.Ops[F, A] {
 
   @deprecated("Replaced by an apply syntax, e.g. instead of (a |@| b).map(...) use (a, b).mapN(...)", "1.0.0-MF")
-  final def |@|[B](fb: F[B]): SemigroupalBuilder[F]#SemigroupalBuilder2[A, B] =
+  final private[syntax] def |@|[B](fb: F[B]): SemigroupalBuilder[F]#SemigroupalBuilder2[A, B] =
     new SemigroupalBuilder[F] |@| self |@| fb
 
 }

--- a/free/src/main/scala/cats/free/Coyoneda.scala
+++ b/free/src/main/scala/cats/free/Coyoneda.scala
@@ -53,7 +53,7 @@ sealed abstract class Coyoneda[F[_], A] extends Serializable { self =>
     unsafeApply(f(fi))(ks)
 
   @deprecated("Use mapK", "1.0.0-RC2")
-  final def transform[G[_]](f: FunctionK[F, G]): Aux[G, A, Pivot] =
+  final private[free] def transform[G[_]](f: FunctionK[F, G]): Aux[G, A, Pivot] =
     mapK(f)
 
 }

--- a/free/src/main/scala/cats/free/FreeT.scala
+++ b/free/src/main/scala/cats/free/FreeT.scala
@@ -44,7 +44,7 @@ sealed abstract class FreeT[S[_], M[_], A] extends Product with Serializable {
     mapK(mn)
 
   @deprecated("Use compile", "0.8.0")
-  def interpret[T[_]](st: FunctionK[S, T])(implicit M: Functor[M]): FreeT[T, M, A] = compile(st)
+  private[free] def interpret[T[_]](st: FunctionK[S, T])(implicit M: Functor[M]): FreeT[T, M, A] = compile(st)
 
   /** Change the base functor `S` for a `FreeT` action. */
   def compile[T[_]](st: FunctionK[S, T])(implicit M: Functor[M]): FreeT[T, M, A] =

--- a/free/src/main/scala/cats/free/Trampoline.scala
+++ b/free/src/main/scala/cats/free/Trampoline.scala
@@ -8,7 +8,7 @@ abstract private[free] class TrampolineFunctions {
     Free.pure[Function0, A](a)
 
   @deprecated("Use Trampoline.defer.", "1.0.0-MF")
-  def suspend[A](a: => Trampoline[A]): Trampoline[A] =
+  private[free] def suspend[A](a: => Trampoline[A]): Trampoline[A] =
     defer(a)
 
   def defer[A](a: => Trampoline[A]): Trampoline[A] =

--- a/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
@@ -355,7 +355,7 @@ class DeprecatedNonEmptyListSuite extends CatsSuite {
 
   test("Deprecated NonEmptyList#concat is consistent with List#:::") {
     forAll { (nel: NonEmptyList[Int], l: List[Int], n: Int) =>
-      nel.concat(NonEmptyList(n, l)).toList should ===(nel.toList ::: (n :: l))
+      nel.concatNel(NonEmptyList(n, l)).toList should ===(nel.toList ::: (n :: l))
     }
   }
 }


### PR DESCRIPTION
This PR makes everything that was deprecated in 1.x package-private (in the cases where that's possible without breaking bincompat).

This means less noise in the API docs, and that users will be in a better position to be ready once we can finally clean this stuff up for real.

I don't feel terribly strongly about getting this into 2.1.0, but I think it'd be nice to have.