### PR TITLE
Some minor optimizations

### DIFF
--- a/bench/src/main/scala/cats/bench/ParTraverseBench.scala
+++ b/bench/src/main/scala/cats/bench/ParTraverseBench.scala
@@ -1,0 +1,65 @@
+package cats.bench
+
+import cats.{Bitraverse, Parallel, Traverse}
+import cats.instances.int._
+import cats.instances.either._
+import cats.instances.tuple._
+import cats.instances.vector._
+import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
+
+/**
+ * Results on OpenJDK 64-Bit Server VM (build 25.232-b09, mixed mode)
+ *
+ * bench/jmh:run -i 10 -wi 10 -f 5 -t 1 cats.bench.ParTraverseBench
+ *
+ * Benchmark                                       Mode  Cnt         Score        Error  Units
+ * ParTraverseBench.eitherParBitraversePointfree  thrpt   50  20201469.796 ± 143402.778  ops/s
+ * ParTraverseBench.eitherParBitraversePointfull  thrpt   50  24742265.071 ± 133253.733  ops/s
+ * ParTraverseBench.eitherParTraversePointfree    thrpt   50   1150877.660 ±  10162.432  ops/s
+ * ParTraverseBench.eitherParTraversePointfull    thrpt   50   1221809.128 ±   9997.474  ops/s
+ */
+@State(Scope.Benchmark)
+class ParTraverseBench {
+
+  val xs: Vector[Int] = (1 to 10).toVector
+  val t: (Int, Int) = (1, 2)
+  val f: Int => Either[Int, Int] = Right(_)
+
+  def parTraversePointfree[T[_]: Traverse, M[_], A, B](ta: T[A])(f: A => M[B])(implicit P: Parallel[M]): M[T[B]] = {
+    val gtb: P.F[T[B]] = Traverse[T].traverse(ta)(f.andThen(P.parallel.apply(_)))(P.applicative)
+    P.sequential(gtb)
+  }
+
+  def parTraversePointfull[T[_]: Traverse, M[_], A, B](ta: T[A])(f: A => M[B])(implicit P: Parallel[M]): M[T[B]] = {
+    val gtb: P.F[T[B]] = Traverse[T].traverse(ta)(a => P.parallel(f(a)))(P.applicative)
+    P.sequential(gtb)
+  }
+
+  def parBitraversePointfree[T[_, _]: Bitraverse, M[_], A, B, C, D](
+    tab: T[A, B]
+  )(f: A => M[C], g: B => M[D])(implicit P: Parallel[M]): M[T[C, D]] = {
+    val ftcd: P.F[T[C, D]] =
+      Bitraverse[T].bitraverse(tab)(f.andThen(P.parallel.apply(_)), g.andThen(P.parallel.apply(_)))(P.applicative)
+    P.sequential(ftcd)
+  }
+
+  def parBitraversePointfull[T[_, _]: Bitraverse, M[_], A, B, C, D](
+    tab: T[A, B]
+  )(f: A => M[C], g: B => M[D])(implicit P: Parallel[M]): M[T[C, D]] = {
+    val ftcd: P.F[T[C, D]] =
+      Bitraverse[T].bitraverse(tab)(a => P.parallel.apply(f(a)), b => P.parallel.apply(g(b)))(P.applicative)
+    P.sequential(ftcd)
+  }
+
+  @Benchmark
+  def eitherParTraversePointfree: Either[Int, Vector[Int]] = parTraversePointfree(xs)(f)
+
+  @Benchmark
+  def eitherParTraversePointfull: Either[Int, Vector[Int]] = parTraversePointfull(xs)(f)
+
+  @Benchmark
+  def eitherParBitraversePointfree: Either[Int, (Int, Int)] = parBitraversePointfree(t)(f, f)
+
+  @Benchmark
+  def eitherParBitraversePointfull: Either[Int, (Int, Int)] = parBitraversePointfull(t)(f, f)
+}

--- a/bench/src/main/scala/cats/bench/ValidatedBench.scala
+++ b/bench/src/main/scala/cats/bench/ValidatedBench.scala
@@ -1,0 +1,26 @@
+package cats.bench
+
+import cats.data.Validated
+import cats.data.Validated.{Invalid, Valid}
+import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
+
+@State(Scope.Benchmark)
+class ValidatedBench {
+  val x: Validated[String, Int] = Validated.valid(100)
+
+  def bimapPointfree[E, A, EE, AA](v: Validated[E, A])(fe: E => EE, fa: A => AA): Validated[EE, AA] =
+    v.fold(fe.andThen(Invalid.apply), fa.andThen(Valid.apply))
+
+  def bimapPointfull[E, A, EE, AA](v: Validated[E, A])(fe: E => EE, fa: A => AA): Validated[EE, AA] =
+    v match {
+      case Valid(a) => Valid(fa(a))
+      case Invalid(e) => Invalid(fe(e))
+    }
+
+  @Benchmark
+  def pointfull: Validated[Int, Int] = bimapPointfull(x)(_.length, _ + 1)
+
+
+  @Benchmark
+  def pointfree: Validated[Int, Int] = bimapPointfree(x)(_.length, _ + 1)
+}

--- a/core/src/main/scala/cats/data/Cokleisli.scala
+++ b/core/src/main/scala/cats/data/Cokleisli.scala
@@ -40,7 +40,7 @@ final case class Cokleisli[F[_], A, B](run: F[A] => B) { self =>
     Cokleisli(fc => run(F.map(fc)(f)))
 
   def map[C](f: B => C): Cokleisli[F, A, C] =
-    Cokleisli(f.compose(run))
+    Cokleisli(fa => f(run(fa)))
 
   /**
    * Example:
@@ -53,7 +53,7 @@ final case class Cokleisli[F[_], A, B](run: F[A] => B) { self =>
    * }}}
    */
   def contramapValue[C](f: F[C] => F[A]): Cokleisli[F, C, B] =
-    Cokleisli(run.compose(f))
+    Cokleisli(fc => run(f(fc)))
 
   def flatMap[C](f: B => Cokleisli[F, A, C]): Cokleisli[F, A, C] =
     Cokleisli(fa => f(self.run(fa)).run(fa))

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -356,7 +356,7 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
     })
 
   def flatMapF[AA >: A, D](f: B => F[Either[AA, D]])(implicit F: Monad[F]): EitherT[F, AA, D] =
-    flatMap(f.andThen(EitherT.apply))
+    flatMap(b => EitherT(f(b)))
 
   def transform[C, D](f: Either[A, B] => Either[C, D])(implicit F: Functor[F]): EitherT[F, C, D] =
     EitherT(F.map(value)(f))

--- a/core/src/main/scala/cats/data/Func.scala
+++ b/core/src/main/scala/cats/data/Func.scala
@@ -17,7 +17,7 @@ sealed abstract class Func[F[_], A, B] { self =>
    * Modify the context `F` using transformation `f`.
    */
   def mapK[G[_]](f: F ~> G): Func[G, A, B] =
-    Func.func(run.andThen(f.apply))
+    Func.func(a => f(run(a)))
 }
 
 object Func extends FuncInstances {

--- a/core/src/main/scala/cats/data/IdT.scala
+++ b/core/src/main/scala/cats/data/IdT.scala
@@ -16,7 +16,7 @@ final case class IdT[F[_], A](value: F[A]) {
     IdT[G, A](f(value))
 
   def flatMap[B](f: A => IdT[F, B])(implicit F: FlatMap[F]): IdT[F, B] =
-    IdT(F.flatMap(value)(f.andThen(_.value)))
+    IdT(F.flatMap(value)(a => f(a).value))
 
   def flatMapF[B](f: A => F[B])(implicit F: FlatMap[F]): IdT[F, B] =
     IdT(F.flatMap(value)(f))

--- a/core/src/main/scala/cats/data/IorT.scala
+++ b/core/src/main/scala/cats/data/IorT.scala
@@ -97,7 +97,7 @@ final case class IorT[F[_], A, B](value: F[Ior[A, B]]) {
     })
 
   def flatMapF[AA >: A, D](f: B => F[Ior[AA, D]])(implicit F: Monad[F], AA: Semigroup[AA]): IorT[F, AA, D] =
-    flatMap(f.andThen(IorT.apply))
+    flatMap(b => IorT(f(b)))
 
   def subflatMap[AA >: A, D](f: B => Ior[AA, D])(implicit F: Functor[F], AA: Semigroup[AA]): IorT[F, AA, D] =
     IorT(F.map(value)(_.flatMap(f)))

--- a/core/src/main/scala/cats/data/Nested.scala
+++ b/core/src/main/scala/cats/data/Nested.scala
@@ -250,7 +250,7 @@ abstract private[data] class NestedApplicativeError[F[_], G[_], E]
   def raiseError[A](e: E): Nested[F, G, A] = Nested(AEF.map(AEF.raiseError(e))(G.pure))
 
   def handleErrorWith[A](fa: Nested[F, G, A])(f: E => Nested[F, G, A]): Nested[F, G, A] =
-    Nested(AEF.handleErrorWith(fa.value)(f.andThen(_.value)))
+    Nested(AEF.handleErrorWith(fa.value)(e => f(e).value))
 
 }
 

--- a/core/src/main/scala/cats/data/NonEmptyChain.scala
+++ b/core/src/main/scala/cats/data/NonEmptyChain.scala
@@ -370,7 +370,7 @@ class NonEmptyChainOps[A](private val value: NonEmptyChain[A]) extends AnyVal {
    * Applies the supplied function to each element and returns a new NonEmptyChain from the concatenated results
    */
   final def flatMap[B](f: A => NonEmptyChain[B]): NonEmptyChain[B] =
-    create(toChain.flatMap(f.andThen(_.toChain)))
+    create(toChain.flatMap(a => f(a).toChain))
 
   /**
    * Returns the number of elements in this chain.

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -93,7 +93,7 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) {
     NonEmptyList(head, tail ::: other.toList)
 
   def flatMap[B](f: A => NonEmptyList[B]): NonEmptyList[B] =
-    f(head) ++ tail.flatMap(f.andThen(_.toList))
+    f(head) ++ tail.flatMap(a => f(a).toList)
 
   def ::[AA >: A](a: AA): NonEmptyList[AA] =
     prepend(a)

--- a/core/src/main/scala/cats/data/NonEmptySet.scala
+++ b/core/src/main/scala/cats/data/NonEmptySet.scala
@@ -295,7 +295,7 @@ sealed class NonEmptySetOps[A](val value: NonEmptySet[A]) {
    */
   def concatMap[B](f: A => NonEmptySet[B])(implicit B: Order[B]): NonEmptySet[B] = {
     implicit val ordering = B.toOrdering
-    NonEmptySetImpl.create(toSortedSet.flatMap(f.andThen(_.toSortedSet)))
+    NonEmptySetImpl.create(toSortedSet.flatMap(a => f(a).toSortedSet))
   }
 
   /**

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -389,8 +389,10 @@ sealed abstract class Validated[+E, +A] extends Product with Serializable {
    * res1: Validated[List[String] ,Option[Int]] = Valid(Some(123))
    * }}}
    */
-  def bimap[EE, AA](fe: E => EE, fa: A => AA): Validated[EE, AA] =
-    fold(fe.andThen(Invalid.apply), fa.andThen(Valid.apply))
+  def bimap[EE, AA](fe: E => EE, fa: A => AA): Validated[EE, AA] = this match {
+    case Valid(a)   => Valid(fa(a))
+    case Invalid(e) => Invalid(fe(e))
+  }
 
   /**
    * Example:


### PR DESCRIPTION
This PR replaces some instances of `andThen`, `compose`, etc. with function literals. In all of these cases I think the change improves readability—for example this:

```scala
def curry[X, Y, Z](f: (X, Y) => Z): X => Y => Z = x => y => f(x, y)
Kleisli[M, E, A](curry(Function.untupled(f)).andThen(R.tabulate))
```
Is now this:
```scala
Kleisli[M, E, A](e => R.tabulate(r => f((e, r))))
````
It also improves performance, especially in cases like `parBitraverse` where just rewriting:

```
f.andThen(P.parallel.apply(_)), g.andThen(P.parallel.apply(_))
```
To:
```
a => P.parallel.apply(f(a)), b => P.parallel.apply(g(b))
```
…avoids multiple allocations and some indirection.

I've included a couple of new benchmarks, and some example results for Scala 2.12 and JVM 8 on my desktop machine:

```
Benchmark                                       Mode  Cnt         Score        Error  Units
ParTraverseBench.eitherParBitraversePointfree  thrpt   50  20201469.796 ± 143402.778  ops/s
ParTraverseBench.eitherParBitraversePointfull  thrpt   50  24742265.071 ± 133253.733  ops/s
ParTraverseBench.eitherParTraversePointfree    thrpt   50   1150877.660 ±  10162.432  ops/s
ParTraverseBench.eitherParTraversePointfull    thrpt   50   1221809.128 ±   9997.474  ops/s
```