### PR TITLE
Add adaptError override to MonadError

### DIFF
--- a/core/src/main/scala/cats/MonadError.scala
+++ b/core/src/main/scala/cats/MonadError.scala
@@ -76,6 +76,9 @@ trait MonadError[F[_], E] extends ApplicativeError[F, E] with Monad[F] {
    */
   def redeemWith[A, B](fa: F[A])(recover: E => F[B], bind: A => F[B]): F[B] =
     flatMap(attempt(fa))(_.fold(recover, bind))
+
+  override def adaptError[A](fa: F[A])(pf: PartialFunction[E, E]): F[A] =
+    recoverWith(fa)(pf.andThen(raiseError[A] _))
 }
 
 object MonadError {


### PR DESCRIPTION
We have a pretty bad binary compatibility breakage in 2.1.0-RC1: if you have cats-effect 2.0.0 and cats-core 2.1.0-RC1, you get the following (on both 2.12 and 2.13):
```scala
scala> import cats.syntax.monadError._
import cats.syntax.monadError._

scala> cats.effect.IO(1).adaptError { case e => e }
java.lang.NoSuchMethodError: cats.MonadError.adaptError$(Lcats/MonadError;Ljava/lang/Object;Lscala/PartialFunction;)Ljava/lang/Object;
  at cats.effect.IOLowPriorityInstances$IOEffect.adaptError(IO.scala:767)
  at cats.syntax.MonadErrorOps$.adaptError$extension(monadError.scala:31)
  ... 36 elided
```
Or:
```scala
scala> cats.MonadError[cats.effect.IO, Throwable].adaptError(cats.effect.IO(1)) { case e => e }
java.lang.NoSuchMethodError: cats.MonadError.adaptError$(Lcats/MonadError;Ljava/lang/Object;Lscala/PartialFunction;)Ljava/lang/Object;
  at cats.effect.IOLowPriorityInstances$IOEffect.adaptError(IO.scala:767)
  ... 36 elided
```
And sure enough, if you check the 2.1.0-RC1 jars this synthetic method is missing.

I've confirmed that adding this override reinstates the synthetic method and fixes the issue, or at least this particular manifestation of it.

I don't understand how MiMa didn't catch this, and I'm trying to figure that out now, and to make sure there aren't other changes like this in 2.1.0-RC1. I'll publish an RC2 as soon as I'm confident there aren't more changes like this.

Thanks to @bastewart for catching this issue.

