### PR TITLE
Fix broken binary compatibility

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 Thank you for contributing to Cats!
 
-This is a kind reminder to run `sbt prePR` and commit the changed files, if any, before submitting. 
+This is a kind reminder to run `sbt +prePR` and commit the changed files, if any, before submitting.
 
 

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 Thank you for contributing to Cats!
 
-This is a kind reminder to run `sbt +prePR` and commit the changed files, if any, before submitting. 
+This is a kind reminder to run `sbt prePR` and commit the changed files, if any, before submitting. 
 
 

--- a/kernel/src/main/scala/cats/kernel/instances/ListInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/ListInstances.scala
@@ -13,16 +13,14 @@ trait ListInstances extends ListInstances1 {
 }
 
 private[instances] trait ListInstances1 extends ListInstances2 {
+  implicit def catsKernelStdPartialOrderForList[A: PartialOrder]: PartialOrder[List[A]] =
+    new ListPartialOrder[A]
+
   implicit def catsKernelStdHashForList[A: Hash]: Hash[List[A]] =
     new ListHash[A]
 }
 
-private[instances] trait ListInstances2 extends ListInstances3 {
-  implicit def catsKernelStdPartialOrderForList[A: PartialOrder]: PartialOrder[List[A]] =
-    new ListPartialOrder[A]
-}
-
-private[instances] trait ListInstances3 {
+private[instances] trait ListInstances2 {
   implicit def catsKernelStdEqForList[A: Eq]: Eq[List[A]] =
     new ListEq[A]
 }

--- a/kernel/src/main/scala/cats/kernel/instances/OptionInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/OptionInstances.scala
@@ -6,13 +6,13 @@ trait OptionInstances extends OptionInstances0 {
     new OptionOrder[A]
   implicit def catsKernelStdCommutativeMonoidForOption[A: CommutativeSemigroup]: CommutativeMonoid[Option[A]] =
     new OptionCommutativeMonoid[A]
+  implicit def catsKernelStdMonoidForOption[A: Semigroup]: Monoid[Option[A]] =
+    new OptionMonoid[A]
 }
 
 private[instances] trait OptionInstances0 extends OptionInstances1 {
   implicit def catsKernelStdPartialOrderForOption[A: PartialOrder]: PartialOrder[Option[A]] =
     new OptionPartialOrder[A]
-  implicit def catsKernelStdMonoidForOption[A: Semigroup]: Monoid[Option[A]] =
-    new OptionMonoid[A]
 }
 
 private[instances] trait OptionInstances1 extends OptionInstances2 {

--- a/kernel/src/main/scala/cats/kernel/instances/QueueInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/QueueInstances.scala
@@ -13,16 +13,14 @@ trait QueueInstances extends QueueInstances1 {
 }
 
 private[instances] trait QueueInstances1 extends QueueInstances2 {
+  implicit def catsKernelStdPartialOrderForQueue[A: PartialOrder]: PartialOrder[Queue[A]] =
+    new QueuePartialOrder[A]
+
   implicit def catsKernelStdHashForQueue[A: Hash]: Hash[Queue[A]] =
     new QueueHash[A]
 }
 
-private[instances] trait QueueInstances2 extends QueueInstances3 {
-  implicit def catsKernelStdPartialOrderForQueue[A: PartialOrder]: PartialOrder[Queue[A]] =
-    new QueuePartialOrder[A]
-}
-
-private[instances] trait QueueInstances3 {
+private[instances] trait QueueInstances2 {
   implicit def catsKernelStdEqForQueue[A: Eq]: Eq[Queue[A]] =
     new QueueEq[A]
 }

--- a/kernel/src/main/scala/cats/kernel/instances/VectorInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/VectorInstances.scala
@@ -6,22 +6,19 @@ import compat.scalaVersionSpecific._
 trait VectorInstances extends VectorInstances1 {
   implicit def catsKernelStdOrderForVector[A: Order]: Order[Vector[A]] =
     new VectorOrder[A]
-
   implicit def catsKernelStdMonoidForVector[A]: Monoid[Vector[A]] =
     new VectorMonoid[A]
 }
 
 private[instances] trait VectorInstances1 extends VectorInstances2 {
+  implicit def catsKernelStdPartialOrderForVector[A: PartialOrder]: PartialOrder[Vector[A]] =
+    new VectorPartialOrder[A]
+
   implicit def catsKernelStdHashForVector[A: Hash]: Hash[Vector[A]] =
     new VectorHash[A]
 }
 
-private[instances] trait VectorInstances2 extends VectorInstances3 {
-  implicit def catsKernelStdPartialOrderForVector[A: PartialOrder]: PartialOrder[Vector[A]] =
-    new VectorPartialOrder[A]
-}
-
-private[instances] trait VectorInstances3 {
+private[instances] trait VectorInstances2 {
   implicit def catsKernelStdEqForVector[A: Eq]: Eq[Vector[A]] =
     new VectorEq[A]
 }

--- a/project/KernelBoiler.scala
+++ b/project/KernelBoiler.scala
@@ -201,6 +201,12 @@ object KernelBoiler {
                   .mkString(s"$tupleNHeader(", ", ", ")")}.hashCode()
                     def eqv(x: ${`(A..N)`}, y: ${`(A..N)`}): Boolean = ${binMethod("eqv").mkString(" && ")}
                   }
+
+                implicit def catsKernelStdPartialOrderForTuple${arity}[${`A..N`}](implicit ${constraints("PartialOrder")}): PartialOrder[${`(A..N)`}] =
+                  new PartialOrder[${`(A..N)`}] {
+                    def partialCompare(x: ${`(A..N)`}, y: ${`(A..N)`}): Double =
+                      ${binMethod("partialCompare").mkString("Array(", ", ", ")")}.find(_ != 0.0).getOrElse(0.0)
+                }
         """
             }
         ),
@@ -211,12 +217,6 @@ object KernelBoiler {
               import tv._
               def content =
                 block"""
-                implicit def catsKernelStdPartialOrderForTuple${arity}[${`A..N`}](implicit ${constraints("PartialOrder")}): PartialOrder[${`(A..N)`}] =
-                  new PartialOrder[${`(A..N)`}] {
-                    def partialCompare(x: ${`(A..N)`}, y: ${`(A..N)`}): Double =
-                      ${binMethod("partialCompare").mkString("Array(", ", ", ")")}.find(_ != 0.0).getOrElse(0.0)
-                }
-
                 implicit def catsKernelStdBandForTuple${arity}[${`A..N`}](implicit ${constraints("Band")}): Band[${`(A..N)`}] =
                   new Band[${`(A..N)`}] {
                     def combine(x: ${`(A..N)`}, y: ${`(A..N)`}): ${`(A..N)`} = ${binTuple("combine")}

--- a/tests/src/test/scala/cats/tests/EqSuite.scala
+++ b/tests/src/test/scala/cats/tests/EqSuite.scala
@@ -6,8 +6,6 @@ import cats.laws.discipline.{ContravariantMonoidalTests, MiniInt}
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
 
-import scala.collection.immutable.Queue
-
 class EqSuite extends CatsSuite {
   Invariant[Eq]
   Contravariant[Eq]
@@ -17,24 +15,4 @@ class EqSuite extends CatsSuite {
   checkAll("Eq", ContravariantMonoidalTests[Eq].contravariantMonoidal[MiniInt, Boolean, Boolean])
   checkAll("ContravariantMonoidal[Eq]", SerializableTests.serializable(ContravariantMonoidal[Eq]))
 
-  test("The Eq instance for tuples of A is not ambiguous when A has a Hash and a PartialOrder") {
-
-    import cats.kernel.{Hash, PartialOrder}
-
-    trait A
-    implicit def po: PartialOrder[A] = ???
-    implicit def ho: Hash[A] = ???
-
-    lazy val a2 = implicitly[Eq[(A, A)]]
-    lazy val b2 = implicitly[Eq[(List[A], List[A])]]
-    lazy val c2 = implicitly[Eq[(Set[A], Set[A])]]
-    lazy val d2 = implicitly[Eq[(Vector[A], Vector[A])]]
-    lazy val e2 = implicitly[Eq[(Queue[A], Queue[A])]]
-
-    lazy val a3 = implicitly[Eq[(A, A, A)]]
-    lazy val b3 = implicitly[Eq[(List[A], List[A], List[A])]]
-    lazy val c3 = implicitly[Eq[(Set[A], Set[A], Set[A])]]
-    lazy val d3 = implicitly[Eq[(Vector[A], Vector[A], Vector[A])]]
-    lazy val e3 = implicitly[Eq[(Queue[A], Queue[A], Queue[A])]]
-  }
 }

--- a/tests/src/test/scala/cats/tests/ListSuite.scala
+++ b/tests/src/test/scala/cats/tests/ListSuite.scala
@@ -64,17 +64,6 @@ class ListSuite extends CatsSuite {
       l.show should ===(l.toString)
     }
   }
-
-  test("the instance for `Eq[List[A]]` is not ambiguous when A has a Hash and a PartialOrder") {
-
-    import cats.kernel.{Hash, PartialOrder}
-
-    trait A
-    implicit def po: PartialOrder[A] = ???
-    implicit def ho: Hash[A] = ???
-
-    lazy val _ = implicitly[Eq[List[A]]]
-  }
 }
 
 final class ListInstancesSuite extends AnyFunSuiteLike {

--- a/tests/src/test/scala/cats/tests/QueueSuite.scala
+++ b/tests/src/test/scala/cats/tests/QueueSuite.scala
@@ -35,15 +35,4 @@ class QueueSuite extends CatsSuite {
     Queue(1, 2, 3).show should ===("Queue(1, 2, 3)")
     Queue.empty[Int].show should ===("Queue()")
   }
-
-  test("the instance for `Eq[Queue[A]]` is not ambiguous when A has a Hash and a PartialOrder") {
-
-    import cats.kernel.{Hash, PartialOrder}
-
-    trait A
-    implicit def po: PartialOrder[A] = ???
-    implicit def ho: Hash[A] = ???
-
-    lazy val _ = implicitly[Eq[Queue[A]]]
-  }
 }

--- a/tests/src/test/scala/cats/tests/VectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/VectorSuite.scala
@@ -59,17 +59,6 @@ class VectorSuite extends CatsSuite {
   test("toNev on empty vector returns None") {
     assert(Vector.empty[Int].toNev == None)
   }
-
-  test("the instance for `Eq[Vector[A]]` is not ambiguous when A has a Hash and a PartialOrder") {
-
-    import cats.kernel.{Hash, PartialOrder}
-
-    trait A
-    implicit def po: PartialOrder[A] = ???
-    implicit def ho: Hash[A] = ???
-
-    lazy val _ = implicitly[Eq[Vector[A]]]
-  }
 }
 
 final class VectorInstancesSuite extends AnyFunSuiteLike {


### PR DESCRIPTION
Reverts #3100, #3105, and undoes part of #2834. This unfixes #2891 and #2701, which I think will have to wait for 3.0.

In the case of #2834 I don't think the move was necessary, since the `CommutativeMonoid` one is more specific. In any case moving the other back doesn't break any tests and seems fine:

```scala
scala> import cats.kernel.instances.all._
import cats.kernel.instances.all._

scala> cats.kernel.CommutativeMonoid[Int]
res0: cats.kernel.CommutativeMonoid[Int] = cats.kernel.instances.IntGroup@5c7654d1

scala> cats.kernel.Monoid[Int]
res1: cats.kernel.Monoid[Int] = cats.kernel.instances.IntGroup@5c7654d1

scala> cats.kernel.Monoid[String]
res2: cats.kernel.Monoid[String] = cats.kernel.instances.StringMonoid@77c600b4
```

I've confirmed that my quick-fix MiMa branch [here](https://github.com/lightbend/mima/issues/426) doesn't find any problems after this change and #3162.