### PR TITLE
Make default reduceMapM lazy if reduceRightTo is lazy

### DIFF
--- a/core/src/main/scala/cats/Reducible.scala
+++ b/core/src/main/scala/cats/Reducible.scala
@@ -105,7 +105,7 @@ import simulacrum.{noop, typeclass}
    * }}}
    */
   def reduceMapM[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: FlatMap[G], B: Semigroup[B]): G[B] =
-    reduceLeftM(fa)(f)((b, a) => G.map(f(a))(B.combine(b, _)))
+    reduceRightTo(fa)(f)((a, egb) => G.map2Eval(f(a), egb)(B.combine)).value
 
   /**
    * Overridden from [[Foldable]] for efficiency.


### PR DESCRIPTION
Currently `foldMapM` and `foldMapA` will be lazy if the operations they're built on are sufficiently lazy, but `reduceMapM` isn't.

Take the following stand-alone non-empty stream implementation (I'm not using `NonEmptyStream` because `Stream`'s `reduceRightToOption` isn't lazy enough, which should probably be a separate issue):

```scala
import cats.{Eval, Reducible}

case class NES[A](h: A, t: Stream[A]) { def toStream: Stream[A] = h #:: t }

object NES {
  implicit val nesReducible: Reducible[NES] = new Reducible[NES] {
    def foldLeft[A, B](fa: NES[A], b: B)(f: (B, A) => B): B = fa.toStream.foldLeft(b)(f)
    def foldRight[A, B](fa: NES[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
      fa match {
        case NES(h, Stream()) => f(h, lb)
        case NES(h, th #:: tt) => f(h, Eval.defer(foldRight(NES(th, tt), lb)(f)))
      }
    def reduceLeftTo[A, B](fa: NES[A])(f: A => B)(g: (B, A) => B): B =
      fa.t.foldLeft(f(fa.h))(g)
    def reduceRightTo[A, B](fa: NES[A])(f: A => B)(g: (A, Eval[B]) => Eval[B]): Eval[B] =
      fa match {
        case NES(h, Stream()) => Eval.now(f(h))
        case NES(h, th #:: tt) => g(h, Eval.defer(reduceRightTo(NES(th, tt))(f)(g)))
      }
  }
}
```

Compare `foldMapM`, `foldMapA`, and `reduceMapM`:

```scala
scala> import cats.implicits._
import cats.implicits._

scala> val xs = NES(0, Stream.from(1))
xs: NES[Int] = NES(0,Stream(1, ?))

scala> xs.foldMapM(i => if (i < 10) Right(i) else Left(i))
res0: scala.util.Either[Int,Int] = Left(10)

scala> xs.foldMapA(i => if (i < 10) Right(i) else Left(i))
res1: scala.util.Either[Int,Int] = Left(10)

scala> xs.reduceMapM(i => if (i < 10) Right(i) else Left(i)) // hangs forever

[warn] Canceling execution...
[warn] Run canceled.
```
With the implementation here it works fine:

```scala
scala> xs.reduceMapM(i => if (i < 10) Right(i) else Left(i))
res0: scala.util.Either[Int,Int] = Left(10)
```
It's worth noting that this new implementation doesn't require `FlatMap`, which is one of the things #3150 is addressing via a new `reduceMapA`. If someone has a lazy implementation using the `FlatMap` that would be more efficient (similar to `foldMapM` vs. `foldMapA`), I'd be happy to use it, but I couldn't come up with one.