### PR TITLE
Fix typo in Alternative docs

### DIFF
--- a/docs/src/main/tut/typeclasses/alternative.md
+++ b/docs/src/main/tut/typeclasses/alternative.md
@@ -30,7 +30,7 @@ Like other type classes, `Alternative` instances must obey some laws, in additio
 * Right Absorption: Applying a contextual function `F[A => B]` to `empty [A]` should be `empty [B]`.
   * `ff ap F.empty[A] = F.empty[B]`.
 * Left Distributivity:  Mapping over a combined element must be the combinations of the mapped elements.
-  * `(fa <+> fa2) map f = ((fa map f) <+> (fa2 map f))` where `fa: F[A]` and `fb: F[B]` and `f: A => B`.
+  * `(fa <+> fb) map f = ((fa map f) <+> (fb map f))` where `fa: F[A]` and `fb: F[B]` and `f: A => B`.
 * Right Distributivity: Applying the combination of two functions must be the combination of their applications.
   * `(ff <+> fg) ap fa = (ff ap fa) <+> (fg ap fa)` where `ff: F[A => B]`, `fg: F[A => B]`, and `fa: F[A]`.
 


### PR DESCRIPTION
Fixing a small typo in Alternative docs.


