### PR TITLE
Parenthesize lambda parameters with type annotations

### DIFF
--- a/core/src/main/scala/cats/Composed.scala
+++ b/core/src/main/scala/cats/Composed.scala
@@ -152,7 +152,7 @@ private[cats] trait ComposedSemigroupal[F[_], G[_]]
   def G: Functor[G]
 
   def product[A, B](fa: F[G[A]], fb: F[G[B]]): F[G[(A, B)]] =
-    F.contramap(F.product(fa, fb)) { g: G[(A, B)] =>
+    F.contramap(F.product(fa, fb)) { (g: G[(A, B)]) =>
       (G.map(g)(_._1), G.map(g)(_._2))
     }
 }
@@ -167,7 +167,7 @@ private[cats] trait ComposedInvariantApplySemigroupal[F[_], G[_]]
     F.imap(F.product(fa, fb)) {
       case (ga, gb) =>
         G.map2(ga, gb)(_ -> _)
-    } { g: G[(A, B)] =>
+    } { (g: G[(A, B)]) =>
       (G.map(g)(_._1), G.map(g)(_._2))
     }
 }

--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -325,7 +325,7 @@ object Eval extends EvalInstances {
     type M = Memoize[Any]
     type C = Any => Eval[Any]
 
-    def addToMemo(m: M): C = { a: Any =>
+    def addToMemo(m: M): C = { (a: Any) =>
       m.result = Some(a)
       Now(a)
     }

--- a/core/src/main/scala/cats/Representable.scala
+++ b/core/src/main/scala/cats/Representable.scala
@@ -70,7 +70,7 @@ private trait RepresentableMonad[F[_], R] extends Monad[F] {
     R.tabulate(a => R.index(f(R.index(fa)(a)))(a))
 
   override def tailRecM[A, B](a: A)(f: A => F[Either[A, B]]): F[B] =
-    R.tabulate { r: R =>
+    R.tabulate { (r: R) =>
       @annotation.tailrec
       def loop(a: A): B =
         R.index(f(a))(r) match {

--- a/core/src/main/scala/cats/data/ContT.scala
+++ b/core/src/main/scala/cats/data/ContT.scala
@@ -125,7 +125,7 @@ object ContT {
     DeferCont(() => FromFn(AndThen(fn)))
 
   def tailRecM[M[_], A, B, C](a: A)(fn: A => ContT[M, C, Either[A, B]])(implicit M: Defer[M]): ContT[M, C, B] =
-    ContT[M, C, B] { cb: (B => M[C]) =>
+    ContT[M, C, B] { (cb: (B => M[C])) =>
       def go(a: A): M[C] =
         fn(a).run {
           case Left(a)  => M.defer(go(a))

--- a/core/src/main/scala/cats/data/Func.scala
+++ b/core/src/main/scala/cats/data/Func.scala
@@ -100,14 +100,14 @@ sealed abstract class AppFunc[F[_], A, B] extends Func[F, A, B] { self =>
   def product[G[_]](g: AppFunc[G, A, B]): AppFunc[λ[α => Tuple2K[F, G, α]], A, B] = {
     implicit val FF: Applicative[F] = self.F
     implicit val GG: Applicative[G] = g.F
-    Func.appFunc[λ[α => Tuple2K[F, G, α]], A, B] { a: A =>
+    Func.appFunc[λ[α => Tuple2K[F, G, α]], A, B] { (a: A) =>
       Tuple2K(self.run(a), g.run(a))
     }
   }
 
   def compose[G[_], C](g: AppFunc[G, C, A]): AppFunc[Nested[G, F, *], C, B] = {
     implicit val gfApplicative: Applicative[Nested[G, F, *]] = Nested.catsDataApplicativeForNested[G, F](g.F, F)
-    Func.appFunc[Nested[G, F, *], C, B]({ c: C =>
+    Func.appFunc[Nested[G, F, *], C, B]({ (c: C) =>
       Nested(g.F.map(g.run(c))(self.run))
     })
   }

--- a/core/src/main/scala/cats/data/IndexedStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedStateT.scala
@@ -146,7 +146,7 @@ final class IndexedStateT[F[_], SA, SB, A](val runF: F[SA => F[(SB, A)]]) extend
   def transformS[R](f: R => SA, g: (R, SB) => R)(implicit F: Functor[F]): IndexedStateT[F, R, R, A] =
     StateT.applyF(F.map(runF) {
       sfsa =>
-        { r: R =>
+        { (r: R) =>
           val sa = f(r)
           val fsba = sfsa(sa)
           F.map(fsba) { case (sb, a) => (g(r, sb), a) }

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -580,7 +580,7 @@ private[data] trait KleisliApplicativeError[F[_], A, E]
 
   def raiseError[B](e: E): K[B] = Kleisli(_ => F.raiseError(e))
 
-  def handleErrorWith[B](kb: K[B])(f: E => K[B]): K[B] = Kleisli { a: A =>
+  def handleErrorWith[B](kb: K[B])(f: E => K[B]): K[B] = Kleisli { (a: A) =>
     F.handleErrorWith(kb.run(a))((e: E) => f(e).run(a))
   }
 }

--- a/free/src/test/scala/cats/free/FreeInvariantMonoidalSuite.scala
+++ b/free/src/test/scala/cats/free/FreeInvariantMonoidalSuite.scala
@@ -34,7 +34,7 @@ class FreeInvariantMonoidalSuite extends CatsSuite {
            SerializableTests.serializable(InvariantMonoidal[FreeInvariantMonoidal[BinCodec, *]]))
 
   test("FreeInvariantMonoidal#fold") {
-    forAll { i1: BinCodec[MiniInt] =>
+    forAll { (i1: BinCodec[MiniInt]) =>
       val n = MiniInt.unsafeFromInt(2)
       val i2 = InvariantMonoidal[BinCodec].point(n)
       val iExpr = i1.product(i2.imap(_ * n)(_ / n))

--- a/free/src/test/scala/cats/free/FreeSuite.scala
+++ b/free/src/test/scala/cats/free/FreeSuite.scala
@@ -46,7 +46,7 @@ class FreeSuite extends CatsSuite {
   }
 
   test("compile id") {
-    forAll { x: Free[List, Int] =>
+    forAll { (x: Free[List, Int]) =>
       x.compile(FunctionK.id[List]) should ===(x)
       val fk = Free.compile(FunctionK.id[List])
       fk(x) === x
@@ -54,7 +54,7 @@ class FreeSuite extends CatsSuite {
   }
 
   test("defer doesn't change value") {
-    forAll { x: Free[List, Int] =>
+    forAll { (x: Free[List, Int]) =>
       Free.defer(x) should ===(x)
     }
   }
@@ -66,7 +66,7 @@ class FreeSuite extends CatsSuite {
   }
 
   test("compile consistent with foldMap") {
-    forAll { x: Free[List, Int] =>
+    forAll { (x: Free[List, Int]) =>
       val mapped = x.compile(headOptionU)
       val folded = mapped.foldMap(FunctionK.id[Option])
       folded should ===(x.foldMap(headOptionU))

--- a/free/src/test/scala/cats/free/FreeTSuite.scala
+++ b/free/src/test/scala/cats/free/FreeTSuite.scala
@@ -79,7 +79,7 @@ class FreeTSuite extends CatsSuite {
   }
 
   test("mapK to universal id equivalent to original instance") {
-    forAll { a: FreeTOption[Int] =>
+    forAll { (a: FreeTOption[Int]) =>
       val b = a.mapK(FunctionK.id)
       Eq[FreeTOption[Int]].eqv(a, b) should ===(true)
     }
@@ -93,7 +93,7 @@ class FreeTSuite extends CatsSuite {
   }
 
   test("compile to universal id equivalent to original instance") {
-    forAll { a: FreeTOption[Int] =>
+    forAll { (a: FreeTOption[Int]) =>
       val b = a.compile(FunctionK.id)
       Eq[FreeTOption[Int]].eqv(a, b) should ===(true)
       val fk = FreeT.compile[Option, Option, Option](FunctionK.id)
@@ -109,7 +109,7 @@ class FreeTSuite extends CatsSuite {
   }
 
   test("foldMap consistent with runM") {
-    forAll { a: FreeTOption[Int] =>
+    forAll { (a: FreeTOption[Int]) =>
       val x = a.runM(identity)
       val y = a.foldMap(FunctionK.id)
       val fk = FreeT.foldMap[Option, Option](FunctionK.id)

--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -431,7 +431,7 @@ class Tests extends AnyFunSuiteLike with Discipline with ScalaVersionSpecificTes
     // The `Eq[Order[N]]` instance enumerates all possible `N` values in a
     // `Vector` and considers two `Order[N]` instances to be equal if they
     // result in the same sorting of that vector.
-    implicit val NOrderEq: Eq[Order[N]] = Eq.by { order: Order[N] =>
+    implicit val NOrderEq: Eq[Order[N]] = Eq.by { (order: Order[N]) =>
       Vector.tabulate(nMax)(N).sorted(order.toOrdering)
     }
     implicit val NEqEq: Eq[Eq[N]] = new Eq[Eq[N]] {

--- a/tests/src/test/scala/cats/tests/AndThenSuite.scala
+++ b/tests/src/test/scala/cats/tests/AndThenSuite.scala
@@ -57,7 +57,7 @@ class AndThenSuite extends CatsSuite {
 
   test("andThen is stack safe") {
     val count = if (Platform.isJvm) 500000 else 1000
-    val fs = (0 until count).map(_ => { i: Int => i + 1 })
+    val fs = (0 until count).map(_ => { (i: Int) => i + 1 })
     val result = fs.foldLeft(AndThen((x: Int) => x))(_.andThen(_))(42)
 
     result shouldEqual (count + 42)
@@ -65,7 +65,7 @@ class AndThenSuite extends CatsSuite {
 
   test("compose is stack safe") {
     val count = if (Platform.isJvm) 500000 else 1000
-    val fs = (0 until count).map(_ => { i: Int => i + 1 })
+    val fs = (0 until count).map(_ => { (i: Int) => i + 1 })
     val result = fs.foldLeft(AndThen((x: Int) => x))(_.compose(_))(42)
 
     result shouldEqual (count + 42)

--- a/tests/src/test/scala/cats/tests/BinestedSuite.scala
+++ b/tests/src/test/scala/cats/tests/BinestedSuite.scala
@@ -67,7 +67,7 @@ class BinestedSuite extends CatsSuite {
   }
 
   test("simple syntax-based usage") {
-    forAll { value: (Option[Int], List[Int]) =>
+    forAll { (value: (Option[Int], List[Int])) =>
       value.binested.bimap(_.toString, _.toString).value should ===(value.bimap(_.map(_.toString), _.map(_.toString)))
     }
   }

--- a/tests/src/test/scala/cats/tests/BitSetSuite.scala
+++ b/tests/src/test/scala/cats/tests/BitSetSuite.scala
@@ -13,7 +13,7 @@ class BitSetSuite extends CatsSuite {
     BitSet(1, 1, 2, 3).show should ===("BitSet(1, 2, 3)")
     BitSet.empty.show should ===("BitSet()")
 
-    forAll { fs: BitSet =>
+    forAll { (fs: BitSet) =>
       fs.show should ===(fs.toString)
     }
   }

--- a/tests/src/test/scala/cats/tests/ChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/ChainSuite.scala
@@ -63,7 +63,7 @@ class ChainSuite extends CatsSuite {
   test("show") {
     Show[Chain[Int]].show(Chain(1, 2, 3)) should ===("Chain(1, 2, 3)")
     Chain.empty[Int].show should ===("Chain()")
-    forAll { l: Chain[String] =>
+    forAll { (l: Chain[String]) =>
       l.show should ===(l.toString)
     }
   }
@@ -215,7 +215,7 @@ class ChainSuite extends CatsSuite {
   }
 
   test("Chain#distinct is consistent with List#distinct") {
-    forAll { a: Chain[Int] =>
+    forAll { (a: Chain[Int]) =>
       a.distinct.toList should ===(a.toList.distinct)
     }
   }

--- a/tests/src/test/scala/cats/tests/ConstSuite.scala
+++ b/tests/src/test/scala/cats/tests/ConstSuite.scala
@@ -86,7 +86,7 @@ class ConstSuite extends CatsSuite {
 
     Const(1).show should ===("Const(1)")
 
-    forAll { const: Const[Int, String] =>
+    forAll { (const: Const[Int, String]) =>
       const.show.startsWith("Const(") should ===(true)
       const.show.contains(const.getConst.show)
       const.show should ===(implicitly[Show[Const[Int, String]]].show(const))

--- a/tests/src/test/scala/cats/tests/EitherSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherSuite.scala
@@ -108,7 +108,7 @@ class EitherSuite extends CatsSuite {
   }
 
   test("fromTry is left for failed Try") {
-    forAll { t: Try[Int] =>
+    forAll { (t: Try[Int]) =>
       t.isFailure should ===(Either.fromTry(t).isLeft)
     }
   }
@@ -120,13 +120,13 @@ class EitherSuite extends CatsSuite {
   }
 
   test("leftNel is consistent with left(NEL)") {
-    forAll { s: String =>
+    forAll { (s: String) =>
       Either.leftNel[String, Int](s) should ===(Either.left[NonEmptyList[String], Int](NonEmptyList.one(s)))
     }
   }
 
   test("rightNel is consistent with right") {
-    forAll { i: Int =>
+    forAll { (i: Int) =>
       Either.rightNel[String, Int](i) should ===(Either.right[NonEmptyList[String], Int](i))
     }
   }
@@ -138,23 +138,23 @@ class EitherSuite extends CatsSuite {
   }
 
   test("leftNec is consistent with left(NEC)") {
-    forAll { s: String =>
+    forAll { (s: String) =>
       Either.leftNec[String, Int](s) should ===(Either.left[NonEmptyChain[String], Int](NonEmptyChain.one(s)))
     }
   }
   test("rightNec is consistent with right") {
-    forAll { i: Int =>
+    forAll { (i: Int) =>
       Either.rightNec[String, Int](i) should ===(Either.right[NonEmptyChain[String], Int](i))
     }
   }
 
   test("leftNes is consistent with left(NES)") {
-    forAll { s: String =>
+    forAll { (s: String) =>
       Either.leftNes[String, Int](s) should ===(Either.left[NonEmptySet[String], Int](NonEmptySet.one(s)))
     }
   }
   test("rightNes is consistent with right") {
-    forAll { i: Int =>
+    forAll { (i: Int) =>
       Either.rightNes[String, Int](i) should ===(Either.right[NonEmptySet[String], Int](i))
     }
   }

--- a/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
@@ -291,7 +291,7 @@ class IndexedStateTSuite extends CatsSuite {
   }
 
   test("untilDefinedM works") {
-    val counter = State { i: Int =>
+    val counter = State { (i: Int) =>
       val res = if (i > stackSafeTestSize) Some(i) else None
       (i + 1, res)
     }

--- a/tests/src/test/scala/cats/tests/IorSuite.scala
+++ b/tests/src/test/scala/cats/tests/IorSuite.scala
@@ -196,7 +196,7 @@ class IorSuite extends CatsSuite {
   }
 
   test("Option roundtrip") {
-    forAll { ior: String Ior Int =>
+    forAll { (ior: String Ior Int) =>
       val iorMaybe = Ior.fromOptions(ior.left, ior.right)
       iorMaybe should ===(Some(ior))
     }

--- a/tests/src/test/scala/cats/tests/ListSuite.scala
+++ b/tests/src/test/scala/cats/tests/ListSuite.scala
@@ -42,7 +42,7 @@ class ListSuite extends CatsSuite {
   checkAll("ZipList[Int]", CommutativeApplyTests[ZipList].commutativeApply[Int, Int, Int])
 
   test("nel => list => nel returns original nel")(
-    forAll { fa: NonEmptyList[Int] =>
+    forAll { (fa: NonEmptyList[Int]) =>
       fa.toList.toNel should ===(Some(fa))
     }
   )
@@ -60,7 +60,7 @@ class ListSuite extends CatsSuite {
   test("show") {
     List(1, 2, 3).show should ===("List(1, 2, 3)")
     (Nil: List[Int]).show should ===("List()")
-    forAll { l: List[String] =>
+    forAll { (l: List[String]) =>
       l.show should ===(l.toString)
     }
   }

--- a/tests/src/test/scala/cats/tests/MiniIntSuite.scala
+++ b/tests/src/test/scala/cats/tests/MiniIntSuite.scala
@@ -35,13 +35,13 @@ class MiniIntSuite extends CatsSuite {
   }
 
   test("int roundtrip") {
-    forAll { i: MiniInt =>
+    forAll { (i: MiniInt) =>
       MiniInt.fromInt(i.toInt) should ===(Some(i))
     }
   }
 
   test("int bounds") {
-    forAll(Gen.chooseNum(MiniInt.minIntValue, MiniInt.maxIntValue)) { i: Int =>
+    forAll(Gen.chooseNum(MiniInt.minIntValue, MiniInt.maxIntValue)) { (i: Int) =>
       MiniInt.fromInt(i).map(_.toInt) should ===(Some(i))
     }
   }

--- a/tests/src/test/scala/cats/tests/NonEmptyChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyChainSuite.scala
@@ -138,19 +138,19 @@ class NonEmptyChainSuite extends CatsSuite {
   }
 
   test("NonEmptyChain#distinct is consistent with List#distinct") {
-    forAll { ci: NonEmptyChain[Int] =>
+    forAll { (ci: NonEmptyChain[Int]) =>
       ci.distinct.toList should ===(ci.toList.distinct)
     }
   }
 
   test("init") {
-    forAll { ci: NonEmptyChain[Int] =>
+    forAll { (ci: NonEmptyChain[Int]) =>
       ci.init.toList should ===(ci.toList.init)
     }
   }
 
   test("last") {
-    forAll { ci: NonEmptyChain[Int] =>
+    forAll { (ci: NonEmptyChain[Int]) =>
       ci.last should ===(ci.toList.last)
     }
   }

--- a/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
@@ -219,17 +219,17 @@ class NonEmptyListSuite extends CatsSuite {
   }
 
   test("fromList round trip") {
-    forAll { l: List[Int] =>
+    forAll { (l: List[Int]) =>
       NonEmptyList.fromList(l).map(_.toList).getOrElse(List.empty) should ===(l)
     }
 
-    forAll { nel: NonEmptyList[Int] =>
+    forAll { (nel: NonEmptyList[Int]) =>
       NonEmptyList.fromList(nel.toList) should ===(Some(nel))
     }
   }
 
   test("fromListUnsafe/fromList consistency") {
-    forAll { nel: NonEmptyList[Int] =>
+    forAll { (nel: NonEmptyList[Int]) =>
       NonEmptyList.fromList(nel.toList) should ===(Some(NonEmptyList.fromListUnsafe(nel.toList)))
     }
   }
@@ -248,44 +248,44 @@ class NonEmptyListSuite extends CatsSuite {
   }
 
   test("NonEmptyList#distinct is consistent with List#distinct") {
-    forAll { nel: NonEmptyList[Int] =>
+    forAll { (nel: NonEmptyList[Int]) =>
       nel.distinct.toList should ===(nel.toList.distinct)
     }
   }
 
   test("NonEmptyList#reverse is consistent with List#reverse") {
-    forAll { nel: NonEmptyList[Int] =>
+    forAll { (nel: NonEmptyList[Int]) =>
       nel.reverse.toList should ===(nel.toList.reverse)
     }
   }
 
   test("NonEmptyList#zipWithIndex is consistent with List#zipWithIndex") {
-    forAll { nel: NonEmptyList[Int] =>
+    forAll { (nel: NonEmptyList[Int]) =>
       nel.zipWithIndex.toList should ===(nel.toList.zipWithIndex)
     }
   }
 
   test("NonEmptyList#last is consistent with List#last") {
-    forAll { nel: NonEmptyList[Int] =>
+    forAll { (nel: NonEmptyList[Int]) =>
       nel.last should ===(nel.toList.last)
     }
   }
 
   test("NonEmptyList#init is consistent with List#init") {
-    forAll { nel: NonEmptyList[Int] =>
+    forAll { (nel: NonEmptyList[Int]) =>
       nel.init should ===(nel.toList.init)
     }
   }
 
   test("NonEmptyList#size and length is consistent with List#size") {
-    forAll { nel: NonEmptyList[Int] =>
+    forAll { (nel: NonEmptyList[Int]) =>
       nel.size should ===(nel.toList.size)
       nel.length should ===(nel.toList.size)
     }
   }
 
   test("NonEmptyList#sorted is consistent with List#sorted") {
-    forAll { nel: NonEmptyList[Int] =>
+    forAll { (nel: NonEmptyList[Int]) =>
       nel.sorted.toList should ===(nel.toList.sorted)
     }
   }
@@ -338,13 +338,13 @@ class NonEmptyListSuite extends CatsSuite {
   }
 
   test("NonEmptyList#toNem is consistent with List#toMap and creating NonEmptyMap from it") {
-    forAll { nel: NonEmptyList[(Int, String)] =>
+    forAll { (nel: NonEmptyList[(Int, String)]) =>
       nel.toNem should ===(NonEmptyMap.fromMapUnsafe(SortedMap.empty[Int, String] ++ nel.toList.toMap))
     }
   }
 
   test("NonEmptyList#toNes is consistent with List#toSet and creating NonEmptySet from it") {
-    forAll { nel: NonEmptyList[Int] =>
+    forAll { (nel: NonEmptyList[Int]) =>
       nel.toNes should ===(NonEmptySet.fromSetUnsafe(SortedSet.empty[Int] ++ nel.toList.toSet))
     }
   }

--- a/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
@@ -174,17 +174,17 @@ class NonEmptyMapSuite extends CatsSuite {
   }
 
   test("fromMap round trip") {
-    forAll { l: SortedMap[String, Int] =>
+    forAll { (l: SortedMap[String, Int]) =>
       NonEmptyMap.fromMap(l).map(_.toSortedMap).getOrElse(SortedMap.empty[String, Int]) should ===(l)
     }
 
-    forAll { nem: NonEmptyMap[String, Int] =>
+    forAll { (nem: NonEmptyMap[String, Int]) =>
       NonEmptyMap.fromMap(nem.toSortedMap) should ===(Some(nem))
     }
   }
 
   test("fromMapUnsafe/fromMap consistency") {
-    forAll { nem: NonEmptyMap[String, Int] =>
+    forAll { (nem: NonEmptyMap[String, Int]) =>
       NonEmptyMap.fromMap(nem.toSortedMap) should ===(Some(NonEmptyMap.fromMapUnsafe(nem.toSortedMap)))
     }
   }
@@ -202,14 +202,14 @@ class NonEmptyMapSuite extends CatsSuite {
   }
 
   test("NonEmptyMap#size and length is consistent with Map#size") {
-    forAll { nem: NonEmptyMap[String, Int] =>
+    forAll { (nem: NonEmptyMap[String, Int]) =>
       nem.size should ===(nem.toSortedMap.size.toLong)
       nem.length should ===(nem.toSortedMap.size)
     }
   }
 
   test("NonEmptyMap#toNonEmptyList is consistent with Map#toList and creating NonEmptyList from it") {
-    forAll { nem: NonEmptyMap[String, Int] =>
+    forAll { (nem: NonEmptyMap[String, Int]) =>
       nem.toNel should ===(NonEmptyList.fromListUnsafe(nem.toSortedMap.toList))
     }
   }

--- a/tests/src/test/scala/cats/tests/NonEmptySetSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptySetSuite.scala
@@ -197,17 +197,17 @@ class NonEmptySetSuite extends CatsSuite {
   }
 
   test("fromSet round trip") {
-    forAll { l: SortedSet[Int] =>
+    forAll { (l: SortedSet[Int]) =>
       NonEmptySet.fromSet(l).map(_.toSortedSet).getOrElse(SortedSet.empty[Int]) should ===(l)
     }
 
-    forAll { nes: NonEmptySet[Int] =>
+    forAll { (nes: NonEmptySet[Int]) =>
       NonEmptySet.fromSet(nes.toSortedSet) should ===(Some(nes))
     }
   }
 
   test("fromSetUnsafe/fromSet consistency") {
-    forAll { nes: NonEmptySet[Int] =>
+    forAll { (nes: NonEmptySet[Int]) =>
       NonEmptySet.fromSet(nes.toSortedSet) should ===(Some(NonEmptySet.fromSetUnsafe(nes.toSortedSet)))
     }
   }
@@ -225,13 +225,13 @@ class NonEmptySetSuite extends CatsSuite {
   }
 
   test("NonEmptySet#zipWithIndex is consistent with Set#zipWithIndex") {
-    forAll { nes: NonEmptySet[Int] =>
+    forAll { (nes: NonEmptySet[Int]) =>
       nes.zipWithIndex.toSortedSet should ===(nes.toSortedSet.zipWithIndex)
     }
   }
 
   test("NonEmptySet#length is consistent with Set#size") {
-    forAll { nes: NonEmptySet[Int] =>
+    forAll { (nes: NonEmptySet[Int]) =>
       nes.length should ===(nes.toSortedSet.size)
     }
   }

--- a/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
@@ -314,7 +314,7 @@ class NonEmptyVectorSuite extends CatsSuite {
   }
 
   test("NonEmptyVector#distinct is consistent with Vector#distinct") {
-    forAll { nonEmptyVector: NonEmptyVector[Int] =>
+    forAll { (nonEmptyVector: NonEmptyVector[Int]) =>
       nonEmptyVector.distinct.toVector should ===(nonEmptyVector.toVector.distinct)
     }
   }
@@ -326,7 +326,7 @@ class NonEmptyVectorSuite extends CatsSuite {
   }
 
   test("NonEmptyVector#zipWith is consistent with #zipWithIndex") {
-    forAll { nev: NonEmptyVector[Int] =>
+    forAll { (nev: NonEmptyVector[Int]) =>
       val zw = nev.zipWith(NonEmptyVector.fromVectorUnsafe((0 until nev.length).toVector))(Tuple2.apply)
       nev.zipWithIndex should ===(zw)
     }
@@ -343,13 +343,13 @@ class NonEmptyVectorSuite extends CatsSuite {
   }
 
   test("NonEmptyVector#last is consistent with Vector#last") {
-    forAll { nonEmptyVector: NonEmptyVector[Int] =>
+    forAll { (nonEmptyVector: NonEmptyVector[Int]) =>
       nonEmptyVector.last should ===(nonEmptyVector.toVector.last)
     }
   }
 
   test("NonEmptyVector#init is consistent with Vector#init") {
-    forAll { nonEmptyVector: NonEmptyVector[Int] =>
+    forAll { (nonEmptyVector: NonEmptyVector[Int]) =>
       nonEmptyVector.init should ===(nonEmptyVector.toVector.init)
     }
   }
@@ -358,26 +358,26 @@ class NonEmptyVectorSuite extends CatsSuite {
     val pf: PartialFunction[Int, Double] = {
       case i if (i % 2 == 0) => i.toDouble
     }
-    forAll { nonEmptyVector: NonEmptyVector[Int] =>
+    forAll { (nonEmptyVector: NonEmptyVector[Int]) =>
       nonEmptyVector.collect(pf) should ===(nonEmptyVector.toVector.collect(pf))
     }
   }
 
   test("NonEmptyVector#length and size is consistent with Vector#length") {
-    forAll { nonEmptyVector: NonEmptyVector[Int] =>
+    forAll { (nonEmptyVector: NonEmptyVector[Int]) =>
       nonEmptyVector.length should ===(nonEmptyVector.toVector.length)
       nonEmptyVector.size should ===(nonEmptyVector.toVector.length.toLong)
     }
   }
 
   test("NonEmptyVector#reverse is consistent with Vector#reverse") {
-    forAll { nonEmptyVector: NonEmptyVector[Int] =>
+    forAll { (nonEmptyVector: NonEmptyVector[Int]) =>
       nonEmptyVector.reverse should ===(NonEmptyVector.fromVectorUnsafe(nonEmptyVector.toVector.reverse))
     }
   }
 
   test("NonEmptyVector#zipWithIndex is consistent with Vector#zipWithIndex") {
-    forAll { nonEmptyVector: NonEmptyVector[Int] =>
+    forAll { (nonEmptyVector: NonEmptyVector[Int]) =>
       val expected = NonEmptyVector.fromVectorUnsafe(nonEmptyVector.toVector.zipWithIndex)
       nonEmptyVector.zipWithIndex should ===(expected)
       Traverse[NonEmptyVector].zipWithIndex(nonEmptyVector) should ===(expected)
@@ -385,7 +385,7 @@ class NonEmptyVectorSuite extends CatsSuite {
   }
 
   test("NonEmptyVector#sorted and sortBy is consistent with Vector#sorted and sortBy") {
-    forAll { nonEmptyVector: NonEmptyVector[Int] =>
+    forAll { (nonEmptyVector: NonEmptyVector[Int]) =>
       nonEmptyVector.sorted should ===(NonEmptyVector.fromVectorUnsafe(nonEmptyVector.toVector.sorted))
       nonEmptyVector.sortBy(i => -i) should ===(
         NonEmptyVector.fromVectorUnsafe(nonEmptyVector.toVector.sortBy(i => -i))

--- a/tests/src/test/scala/cats/tests/OptionSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionSuite.scala
@@ -31,7 +31,7 @@ class OptionSuite extends CatsSuite {
     none[Int].show should ===("None")
     1.some.show should ===("Some(1)")
 
-    forAll { fs: Option[String] =>
+    forAll { (fs: Option[String]) =>
       fs.show should ===(fs.toString)
     }
   }

--- a/tests/src/test/scala/cats/tests/OptionTSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionTSuite.scala
@@ -267,13 +267,13 @@ class OptionTSuite extends CatsSuite {
   }
 
   test("OptionT[Id, A].isDefined consistent with Option.isDefined") {
-    forAll { o: Option[Int] =>
+    forAll { (o: Option[Int]) =>
       o.isDefined should ===(OptionT[Id, Int](o).isDefined)
     }
   }
 
   test("OptionT[Id, A].isEmpty consistent with Option.isEmpty") {
-    forAll { o: Option[Int] =>
+    forAll { (o: Option[Int]) =>
       o.isEmpty should ===(OptionT[Id, Int](o).isEmpty)
     }
   }
@@ -336,7 +336,7 @@ class OptionTSuite extends CatsSuite {
   }
 
   test("implicit Show[OptionT] instance and explicit show method are consistent") {
-    forAll { optionT: OptionT[List, Int] =>
+    forAll { (optionT: OptionT[List, Int]) =>
       optionT.show should ===(implicitly[Show[OptionT[List, Int]]].show(optionT))
     }
   }

--- a/tests/src/test/scala/cats/tests/ParallelSuite.scala
+++ b/tests/src/test/scala/cats/tests/ParallelSuite.scala
@@ -16,7 +16,7 @@ import kernel.compat.scalaVersionSpecific._
 class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest with ScalaVersionSpecificParallelSuite {
 
   test("ParSequence Either should accumulate errors") {
-    forAll { es: List[Either[String, Int]] =>
+    forAll { (es: List[Either[String, Int]]) =>
       val lefts = es
         .collect {
           case Left(e) => e
@@ -28,7 +28,7 @@ class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest with Sc
   }
 
   test("ParSequence Ior should accumulate errors") {
-    forAll { es: List[Ior[String, Int]] =>
+    forAll { (es: List[Ior[String, Int]]) =>
       val lefts = es
         .map(_.left)
         .collect {
@@ -40,43 +40,43 @@ class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest with Sc
   }
 
   test("ParSequence Ior should sequence values") {
-    forAll { es: List[Ior[String, Int]] =>
+    forAll { (es: List[Ior[String, Int]]) =>
       es.parSequence.right should ===(es.map(_.toOption).sequence)
     }
   }
 
   test("ParTraverse identity should be equivalent to parSequence") {
-    forAll { es: List[Either[String, Int]] =>
+    forAll { (es: List[Either[String, Int]]) =>
       es.parTraverse(identity) should ===(es.parSequence)
     }
   }
 
   test("ParTraverse_ identity should be equivalent to parSequence_") {
-    forAll { es: SortedSet[Either[String, Int]] =>
+    forAll { (es: SortedSet[Either[String, Int]]) =>
       Parallel.parTraverse_(es)(identity) should ===(Parallel.parSequence_(es))
     }
   }
 
   test("ParTraverse_ syntax should be equivalent to Parallel.parTraverse_") {
-    forAll { es: SortedSet[Either[String, Int]] =>
+    forAll { (es: SortedSet[Either[String, Int]]) =>
       Parallel.parTraverse_(es)(identity) should ===(es.parTraverse_(identity))
     }
   }
 
   test("ParSequence_ syntax should be equivalent to Parallel.parSequence_") {
-    forAll { es: SortedSet[Either[String, Int]] =>
+    forAll { (es: SortedSet[Either[String, Int]]) =>
       Parallel.parSequence_(es) should ===(es.parSequence_)
     }
   }
 
   test("ParNonEmptyTraverse identity should be equivalent to parNonEmptySequence") {
-    forAll { es: NonEmptyVector[Either[String, Int]] =>
+    forAll { (es: NonEmptyVector[Either[String, Int]]) =>
       Parallel.parNonEmptyTraverse(es)(identity) should ===(Parallel.parNonEmptySequence(es))
     }
   }
 
   test("ParNonEmptyTraverse_ identity should be equivalent to parNonEmptySequence_") {
-    forAll { es: NonEmptyList[Either[String, Int]] =>
+    forAll { (es: NonEmptyList[Either[String, Int]]) =>
       Parallel.parNonEmptyTraverse_(es)(identity) should ===(Parallel.parNonEmptySequence_(es))
     }
   }
@@ -107,7 +107,7 @@ class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest with Sc
   }
 
   test("ParBisequence Either should accumulate errors") {
-    forAll { es: ListTuple2[Either[String, Int], Either[String, Int]] =>
+    forAll { (es: ListTuple2[Either[String, Int], Either[String, Int]]) =>
       val lefts = es
         .flatMap {
           case (a, b) => List(a, b)
@@ -122,7 +122,7 @@ class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest with Sc
   }
 
   test("ParBisequence Ior should accumulate errors") {
-    forAll { es: ListTuple2[Ior[String, Int], Ior[String, Int]] =>
+    forAll { (es: ListTuple2[Ior[String, Int], Ior[String, Int]]) =>
       val lefts = es
         .flatMap {
           case (a, b) => List(a, b)
@@ -138,19 +138,19 @@ class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest with Sc
   }
 
   test("ParBisequence Ior should bisequence values") {
-    forAll { es: ListTuple2[Ior[String, Int], Ior[String, Int]] =>
+    forAll { (es: ListTuple2[Ior[String, Int], Ior[String, Int]]) =>
       es.parBisequence.right should ===(es.bimap(_.toOption, _.toOption).bisequence)
     }
   }
 
   test("ParBitraverse identity should be equivalent to parBisequence") {
-    forAll { es: (Either[String, Int], Either[String, Long]) =>
+    forAll { (es: (Either[String, Int], Either[String, Long])) =>
       es.parBitraverse(identity, identity) should ===(es.parBisequence)
     }
   }
 
   test("ParLeftSequence Either should accumulate errors") {
-    forAll { es: ListTuple2[Either[String, Int], Int] =>
+    forAll { (es: ListTuple2[Either[String, Int], Int]) =>
       val lefts = es
         .collect {
           case (Left(e), _) => e
@@ -162,7 +162,7 @@ class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest with Sc
   }
 
   test("ParLeftSequence Ior should accumulate errors") {
-    forAll { es: ListTuple2[Ior[String, Int], Int] =>
+    forAll { (es: ListTuple2[Ior[String, Int], Int]) =>
       val lefts = es
         .map {
           case (a, b) => a.left
@@ -177,19 +177,19 @@ class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest with Sc
   }
 
   test("ParLeftSequence Ior should leftSequence values") {
-    forAll { es: ListTuple2[Ior[String, Int], Int] =>
+    forAll { (es: ListTuple2[Ior[String, Int], Int]) =>
       es.parLeftSequence.right should ===(es.bimap(_.toOption, identity).leftSequence)
     }
   }
 
   test("ParLeftTraverse identity should be equivalent to parLeftSequence") {
-    forAll { es: (Either[String, Int], Either[String, Long]) =>
+    forAll { (es: (Either[String, Int], Either[String, Long])) =>
       es.parLeftTraverse(identity) should ===(es.parLeftSequence)
     }
   }
 
   test("ParFlatTraverse should be equivalent to parTraverse map flatten") {
-    forAll { es: List[Either[String, Int]] =>
+    forAll { (es: List[Either[String, Int]]) =>
       val f: Int => List[Int] = i => List(i, i + 1)
       Parallel.parFlatTraverse(es)(e => e.map(f)) should
         ===(es.parTraverse(e => e.map(f)).map(_.flatten))
@@ -197,19 +197,19 @@ class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest with Sc
   }
 
   test("ParFlatTraverse identity should be equivalent to parFlatSequence") {
-    forAll { es: List[Either[String, List[Int]]] =>
+    forAll { (es: List[Either[String, List[Int]]]) =>
       Parallel.parFlatTraverse(es)(identity) should ===(Parallel.parFlatSequence(es))
     }
   }
 
   test("ParFlatSequence syntax should be equivalent to Parallel.parFlatSequence") {
-    forAll { es: List[Either[String, List[Int]]] =>
+    forAll { (es: List[Either[String, List[Int]]]) =>
       es.parFlatSequence should ===(Parallel.parFlatSequence(es))
     }
   }
 
   test("ParFlatTraverse syntax should be equivalent to Parallel.parFlatTraverse") {
-    forAll { es: List[Either[String, Int]] =>
+    forAll { (es: List[Either[String, Int]]) =>
       val f: Int => List[Int] = i => List(i, i + 1)
       Parallel.parFlatTraverse(es)(e => e.map(f)) should
         ===(es.parFlatTraverse(e => e.map(f)))
@@ -217,7 +217,7 @@ class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest with Sc
   }
 
   test("ParNonEmptyFlatTraverse should be equivalent to parNonEmptyTraverse map flatten") {
-    forAll { es: NonEmptyList[Either[String, Int]] =>
+    forAll { (es: NonEmptyList[Either[String, Int]]) =>
       val f: Int => NonEmptyList[Int] = i => NonEmptyList.of(i, i + 1)
       Parallel.parNonEmptyFlatTraverse(es)(e => e.map(f)) should
         ===(Parallel.parNonEmptyTraverse(es)(e => e.map(f)).map(_.flatten))
@@ -225,7 +225,7 @@ class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest with Sc
   }
 
   test("ParNonEmptyFlatTraverse identity should be equivalent to parNonEmptyFlatSequence") {
-    forAll { es: NonEmptyList[Either[String, NonEmptyList[Int]]] =>
+    forAll { (es: NonEmptyList[Either[String, NonEmptyList[Int]]]) =>
       Parallel.parNonEmptyFlatTraverse(es)(identity) should ===(Parallel.parNonEmptyFlatSequence(es))
     }
   }

--- a/tests/src/test/scala/cats/tests/ReducibleSuite.scala
+++ b/tests/src/test/scala/cats/tests/ReducibleSuite.scala
@@ -118,7 +118,7 @@ abstract class ReducibleSuite[F[_]: Reducible](name: String)(implicit ArbFInt: A
   }
 
   test(s"Reducible[$name].toNonEmptyList/toList consistency") {
-    forAll { fa: F[Int] =>
+    forAll { (fa: F[Int]) =>
       fa.toList.toNel should ===(Some(fa.toNonEmptyList))
     }
   }

--- a/tests/src/test/scala/cats/tests/StreamSuite.scala
+++ b/tests/src/test/scala/cats/tests/StreamSuite.scala
@@ -47,7 +47,7 @@ class StreamSuite extends CatsSuite {
   }
 
   test("Show[Stream] is referentially transparent, unlike Stream.toString") {
-    forAll { stream: Stream[Int] =>
+    forAll { (stream: Stream[Int]) =>
       if (!stream.isEmpty) {
         val unevaluatedLL = stream.map(identity)
         val initialShow = unevaluatedLL.show

--- a/tests/src/test/scala/cats/tests/TrySuite.scala
+++ b/tests/src/test/scala/cats/tests/TrySuite.scala
@@ -37,13 +37,13 @@ class TrySuite extends CatsSuite {
   checkAll("Monoid[Try[Int]]", SerializableTests.serializable(Monoid[Try[Int]]))
 
   test("show") {
-    forAll { fs: Try[String] =>
+    forAll { (fs: Try[String]) =>
       fs.show should ===(fs.toString)
     }
   }
 
   test("catchNonFatal works") {
-    forAll { e: Either[String, Int] =>
+    forAll { (e: Either[String, Int]) =>
       val str = e.fold(identity, _.toString)
       val res = MonadError[Try, Throwable].catchNonFatal(str.toInt)
       // the above should just never cause an uncaught exception
@@ -53,7 +53,7 @@ class TrySuite extends CatsSuite {
   }
 
   test("catchNonFatalEval works") {
-    forAll { e: Either[String, Int] =>
+    forAll { (e: Either[String, Int]) =>
       val str = e.fold(identity, _.toString)
       val res = MonadError[Try, Throwable].catchNonFatalEval(Eval.later(str.toInt))
       // the above should just never cause an uncaught exception
@@ -63,7 +63,7 @@ class TrySuite extends CatsSuite {
   }
 
   test("catchOnly works") {
-    forAll { e: Either[String, Int] =>
+    forAll { (e: Either[String, Int]) =>
       val str = e.fold(identity, _.toString)
       val res = MonadError[Try, Throwable].catchOnly[NumberFormatException](str.toInt)
       // the above should just never cause an uncaught exception
@@ -79,7 +79,7 @@ class TrySuite extends CatsSuite {
   }
 
   test("fromTry works") {
-    forAll { t: Try[Int] =>
+    forAll { (t: Try[Int]) =>
       (MonadError[Try, Throwable].fromTry(t)) should ===(t)
     }
   }

--- a/tests/src/test/scala/cats/tests/TupleSuite.scala
+++ b/tests/src/test/scala/cats/tests/TupleSuite.scala
@@ -49,16 +49,16 @@ class TupleSuite extends CatsSuite {
 
   test("eqv") {
     val eq = Eq[(Int, Long)]
-    forAll { t: (Int, Long) =>
+    forAll { (t: (Int, Long)) =>
       eq.eqv(t, t) should ===(true)
     }
-    forAll { t: (Int, Long) =>
+    forAll { (t: (Int, Long)) =>
       eq.eqv(t, t._1 -> (t._2 + 1)) should ===(false)
     }
   }
 
   test("order") {
-    forAll { t: (Int, Int) =>
+    forAll { (t: (Int, Int)) =>
       val u = t.swap
       Order[(Int, Int)].compare(t, u) should ===(scala.math.Ordering[(Int, Int)].compare(t, u))
     }
@@ -67,7 +67,7 @@ class TupleSuite extends CatsSuite {
   test("show") {
     (1, 2).show should ===("(1,2)")
 
-    forAll { fs: (String, String) =>
+    forAll { (fs: (String, String)) =>
       fs.show should ===(fs.toString)
     }
 

--- a/tests/src/test/scala/cats/tests/UnorderedFoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/UnorderedFoldableSuite.scala
@@ -20,13 +20,13 @@ sealed abstract class UnorderedFoldableSuite[F[_]](name: String)(implicit ArbFSt
     }
 
   test(s"UnorderedFoldable[$name].isEmpty") {
-    forAll { fa: F[String] =>
+    forAll { (fa: F[String]) =>
       instance.isEmpty(fa) should ===(instance.size(fa) === 0L)
     }
   }
 
   test(s"UnorderedFoldable[$name].nonEmpty") {
-    forAll { fa: F[String] =>
+    forAll { (fa: F[String]) =>
       instance.nonEmpty(fa) should ===(instance.size(fa) > 0L)
     }
   }
@@ -39,7 +39,7 @@ sealed abstract class UnorderedFoldableSuite[F[_]](name: String)(implicit ArbFSt
   }
 
   test(s"UnorderedFoldable[$name].size") {
-    forAll { fa: F[String] =>
+    forAll { (fa: F[String]) =>
       implicit val F: UnorderedFoldable[F] = instance
       fa.count(Function.const(true)) should ===(fa.size)
     }

--- a/tests/src/test/scala/cats/tests/ValidatedSuite.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedSuite.scala
@@ -92,7 +92,7 @@ class ValidatedSuite extends CatsSuite {
   }
 
   test("fromTry is invalid for failed try") {
-    forAll { t: Try[Int] =>
+    forAll { (t: Try[Int]) =>
       t.isFailure should ===(Validated.fromTry(t).isInvalid)
     }
   }

--- a/tests/src/test/scala/cats/tests/VectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/VectorSuite.scala
@@ -45,13 +45,13 @@ class VectorSuite extends CatsSuite {
 
     Vector.empty[Int].show should ===("Vector()")
 
-    forAll { vec: Vector[String] =>
+    forAll { (vec: Vector[String]) =>
       vec.show should ===(vec.toString)
     }
   }
 
   test("nev => vector => nev returns original nev")(
-    forAll { fa: NonEmptyVector[Int] =>
+    forAll { (fa: NonEmptyVector[Int]) =>
       assert(fa.toVector.toNev == Some(fa))
     }
   )

--- a/tests/src/test/scala/cats/tests/WriterTSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterTSuite.scala
@@ -30,13 +30,13 @@ class WriterTSuite extends CatsSuite {
   Eq[Writer[Int, Int]]
 
   test("double swap is a noop") {
-    forAll { w: WriterT[List, Int, Int] =>
+    forAll { (w: WriterT[List, Int, Int]) =>
       w.swap.swap should ===(w)
     }
   }
 
   test("reset on pure is a noop") {
-    forAll { i: Int =>
+    forAll { (i: Int) =>
       val w = Monad[WriterT[List, Int, *]].pure(i)
       w should ===(w.reset)
     }


### PR DESCRIPTION
Dotty warns on these and Scala 2 doesn't care, so it seems like we might as well change them now. I personally agree with Dotty and think they look better with the parentheses, anyway.

Dotty says it'll rewrite these with `-rewrite` but I couldn't get it to work so I just used a quick custom Scalafix rule:

```scala
import scalafix.v1.{Patch, SyntacticDocument, SyntacticRule}
import scala.meta.{Term, Token}

class TypedLambdaParamRewrite extends SyntacticRule("TypedLambdaParamRewrite") {
  override def fix(implicit doc: SyntacticDocument): Patch = Patch.fromIterable(
    doc.tree.collect {
      case Term.Function(List(param @ Term.Param(_, _, Some(_), None)), _) =>
        param.tokens.headOption match {
          case Some(Token.LeftParen()) => Patch.empty
          case _ => Patch.replaceTree(param, s"($param)")
        }
    }
  )
}
```
