### PR TITLE
Remove redundant final modifiers on objects

### DIFF
--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -535,7 +535,7 @@ object Chain extends ChainInstances {
 
   private val sentinel: Function1[Any, Any] = new scala.runtime.AbstractFunction1[Any, Any] { def apply(a: Any) = this }
 
-  final private[data] case object Empty extends Chain[Nothing] {
+  private[data] case object Empty extends Chain[Nothing] {
     def isEmpty: Boolean = true
   }
   final private[data] case class Singleton[A](a: A) extends Chain[A] {

--- a/docs/src/main/tut/datatypes/chain.md
+++ b/docs/src/main/tut/datatypes/chain.md
@@ -74,7 +74,7 @@ In code it looks like this:
 ```tut:book
 sealed abstract class Chain[+A]
 
-final case object Empty extends Chain[Nothing]
+case object Empty extends Chain[Nothing]
 final case class Singleton[A](a: A) extends Chain[A]
 final case class Append[A](left: Chain[A], right: Chain[A]) extends Chain[A]
 final case class Wrap[A](seq: Seq[A]) extends Chain[A]

--- a/docs/src/main/tut/datatypes/either.md
+++ b/docs/src/main/tut/datatypes/either.md
@@ -180,7 +180,7 @@ can go wrong in our program.
 object EitherStyle {
   sealed abstract class Error
   final case class NotANumber(string: String) extends Error
-  final case object NoZeroReciprocal extends Error
+  case object NoZeroReciprocal extends Error
 
   def parse(s: String): Either[Error, Int] =
     if (s.matches("-?[0-9]+")) Either.right(s.toInt)
@@ -261,10 +261,10 @@ We may then be tempted to make our entire application share an error data type.
 
 ```tut:silent
 sealed abstract class AppError
-final case object DatabaseError1 extends AppError
-final case object DatabaseError2 extends AppError
-final case object ServiceError1 extends AppError
-final case object ServiceError2 extends AppError
+case object DatabaseError1 extends AppError
+case object DatabaseError2 extends AppError
+case object ServiceError1 extends AppError
+case object ServiceError2 extends AppError
 
 trait DatabaseValue
 

--- a/kernel/src/main/scala/cats/kernel/Comparison.scala
+++ b/kernel/src/main/scala/cats/kernel/Comparison.scala
@@ -4,9 +4,9 @@ package cats.kernel
 sealed abstract class Comparison(val toInt: Int, val toDouble: Double) extends Product with Serializable
 
 object Comparison {
-  final case object GreaterThan extends Comparison(1, 1.0)
-  final case object EqualTo extends Comparison(0, 0.0)
-  final case object LessThan extends Comparison(-1, -1.0)
+  case object GreaterThan extends Comparison(1, 1.0)
+  case object EqualTo extends Comparison(0, 0.0)
+  case object LessThan extends Comparison(-1, -1.0)
 
   // Used for fromDouble
   private val SomeGt = Some(Comparison.GreaterThan)


### PR DESCRIPTION
Similar to #3182. Dotty is complaining about these `final`s on objects and they're unnecessary on Scala 2.