### PR TITLE
Update Function0 syntax

### DIFF
--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -156,7 +156,7 @@ final class Later[A](f: () => A) extends Eval[A] {
 }
 
 object Later {
-  def apply[A](a: => A): Later[A] = new Later(a _)
+  def apply[A](a: => A): Later[A] = new Later(() => a)
 }
 
 /**
@@ -175,7 +175,7 @@ final class Always[A](f: () => A) extends Eval[A] {
 }
 
 object Always {
-  def apply[A](a: => A): Always[A] = new Always(a _)
+  def apply[A](a: => A): Always[A] = new Always(() => a)
 }
 
 object Eval extends EvalInstances {
@@ -188,12 +188,12 @@ object Eval extends EvalInstances {
   /**
    * Construct a lazy Eval[A] value with caching (i.e. Later[A]).
    */
-  def later[A](a: => A): Eval[A] = new Later(a _)
+  def later[A](a: => A): Eval[A] = new Later(() => a)
 
   /**
    * Construct a lazy Eval[A] value without caching (i.e. Always[A]).
    */
-  def always[A](a: => A): Eval[A] = new Always(a _)
+  def always[A](a: => A): Eval[A] = new Always(() => a)
 
   /**
    * Defer a computation which produces an Eval[A] value.
@@ -202,7 +202,7 @@ object Eval extends EvalInstances {
    * which produces an Eval[A] value. Like .flatMap, it is stack-safe.
    */
   def defer[A](a: => Eval[A]): Eval[A] =
-    new Eval.Defer[A](a _) {}
+    new Eval.Defer[A](() => a) {}
 
   /**
    * Static Eval instance for common value `Unit`.


### PR DESCRIPTION
Another Dotty-friendliness change. To be honest I don't think I even realized that eta-expansion syntax could be used for `Function0` in Scala 2. It doesn't work on Dotty:

```scala
4 |  def mk1(x: => String): Thunk = new Thunk(x _)
  |                                           ^^^
  |Only function types can be followed by _ but the current expression has type String
```
I think it makes sense to change these now. For me at least the `() => x` syntax is less bizarre and surprising anyway.

I double-checked that they compile to the same thing.

```scala
class Thunk(val value: () => String)

object Thunk {
  def mk1(x: => String): Thunk = new Thunk(x _)
  def mk2(x: => String): Thunk = new Thunk(() => x)
}
```
Becomes:
```
  public static Thunk mk2(scala.Function0<java.lang.String>);
    descriptor: (Lscala/Function0;)LThunk;
    flags: ACC_PUBLIC, ACC_STATIC
    Code:
      stack=2, locals=1, args_size=1
         0: getstatic     #21                 // Field Thunk$.MODULE$:LThunk$;
         3: aload_0
         4: invokevirtual #23                 // Method Thunk$.mk2:(Lscala/Function0;)LThunk;
         7: areturn
    Signature: #14                          // (Lscala/Function0<Ljava/lang/String;>;)LThunk;
    MethodParameters:
      Name                           Flags
      x                              final

  public static Thunk mk1(scala.Function0<java.lang.String>);
    descriptor: (Lscala/Function0;)LThunk;
    flags: ACC_PUBLIC, ACC_STATIC
    Code:
      stack=2, locals=1, args_size=1
         0: getstatic     #21                 // Field Thunk$.MODULE$:LThunk$;
         3: aload_0
         4: invokevirtual #26                 // Method Thunk$.mk1:(Lscala/Function0;)LThunk;
         7: areturn
    Signature: #14                          // (Lscala/Function0<Ljava/lang/String;>;)LThunk;
    MethodParameters:
      Name                           Flags
      x                              final
```


