### PR TITLE
Avoid unusual kind-projector syntax

### DIFF
--- a/core/src/main/scala/cats/data/Nested.scala
+++ b/core/src/main/scala/cats/data/Nested.scala
@@ -117,10 +117,12 @@ sealed abstract private[data] class NestedInstances3 extends NestedInstances4 {
 }
 
 sealed abstract private[data] class NestedInstances4 extends NestedInstances5 {
-  implicit def catsDataApplicativeErrorForNested[F[_]: ApplicativeError[*[_], E], G[_]: Applicative, E]
-    : ApplicativeError[Nested[F, G, *], E] =
+  implicit def catsDataApplicativeErrorForNested[F[_], G[_], E](
+    implicit F: ApplicativeError[F, E],
+    G0: Applicative[G]
+  ): ApplicativeError[Nested[F, G, *], E] =
     new NestedApplicativeError[F, G, E] {
-      val G: Applicative[G] = Applicative[G]
+      val G: Applicative[G] = G0
 
       val AEF: ApplicativeError[F, E] = ApplicativeError[F, E]
     }

--- a/tests/src/test/scala/cats/tests/OptionTSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionTSuite.scala
@@ -186,7 +186,7 @@ class OptionTSuite extends CatsSuite {
 
   test("MonadError[OptionT[F, *], E] instance has higher priority than MonadError[OptionT[F, *], Unit]") {
 
-    def shouldCompile[F[_]: MonadError[*[_], E], E](x: OptionT[F, Int], e: E): OptionT[F, Int] =
+    def shouldCompile[F[_], E](x: OptionT[F, Int], e: E)(implicit F: MonadError[F, E]): OptionT[F, Int] =
       x.ensure(e)(_ => true)
   }
 


### PR DESCRIPTION
Another Dotty-motivated change. These are the only two places we use kind-projector's `*[_]` syntax, which I personally find pretty unreadable, and I think in both cases writing out the context bounds is a big improvement.

