### PR TITLE
Helping out Dotty's type inference

### DIFF
--- a/core/src/main/scala/cats/ApplicativeError.scala
+++ b/core/src/main/scala/cats/ApplicativeError.scala
@@ -92,7 +92,7 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
    * `F[A]` values.
    */
   def recover[A](fa: F[A])(pf: PartialFunction[E, A]): F[A] =
-    handleErrorWith(fa)(e => (pf.andThen(pure _)).applyOrElse(e, raiseError _))
+    handleErrorWith(fa)(e => (pf.andThen(pure(_))).applyOrElse(e, raiseError(_)))
 
   /**
    * Recover from certain errors by mapping them to an `F[A]` value.

--- a/core/src/main/scala/cats/ApplicativeError.scala
+++ b/core/src/main/scala/cats/ApplicativeError.scala
@@ -92,7 +92,7 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
    * `F[A]` values.
    */
   def recover[A](fa: F[A])(pf: PartialFunction[E, A]): F[A] =
-    handleErrorWith(fa)(e => (pf.andThen(pure(_))).applyOrElse(e, raiseError(_)))
+    handleErrorWith(fa)(e => (pf.andThen(pure(_))).applyOrElse(e, raiseError[A](_)))
 
   /**
    * Recover from certain errors by mapping them to an `F[A]` value.

--- a/core/src/main/scala/cats/Composed.scala
+++ b/core/src/main/scala/cats/Composed.scala
@@ -30,7 +30,7 @@ private[cats] trait ComposedApply[F[_], G[_]] extends Apply[λ[α => F[G[α]]]] 
   def G: Apply[G]
 
   override def ap[A, B](fgf: F[G[A => B]])(fga: F[G[A]]): F[G[B]] =
-    F.ap(F.map(fgf)(gf => G.ap(gf)(_)))(fga)
+    F.ap(F.map(fgf)(gf => (ga: G[A]) => G.ap(gf)(ga)))(fga)
 
   override def product[A, B](fga: F[G[A]], fgb: F[G[B]]): F[G[(A, B)]] =
     F.map2(fga, fgb)(G.product)

--- a/core/src/main/scala/cats/data/IorT.scala
+++ b/core/src/main/scala/cats/data/IorT.scala
@@ -472,7 +472,7 @@ abstract private[data] class IorTInstances1 extends IorTInstances2 {
     type F[x] = IorT[F0, E, x]
     private[this] val identityK: IorT[F0, E, *] ~> IorT[F0, E, *] = FunctionK.id
     private[this] val underlyingParallel: Parallel.Aux[Ior[E, *], Ior[E, *]] =
-      Parallel[Ior[E, *], Ior[E, *]]
+      Ior.catsDataParallelForIor[E]
 
     def parallel: IorT[F0, E, *] ~> IorT[F0, E, *] = identityK
     def sequential: IorT[F0, E, *] ~> IorT[F0, E, *] = identityK

--- a/core/src/main/scala/cats/data/Nested.scala
+++ b/core/src/main/scala/cats/data/Nested.scala
@@ -247,7 +247,7 @@ abstract private[data] class NestedApplicativeError[F[_], G[_], E]
 
   def FG: Applicative[λ[α => F[G[α]]]] = AEF.compose[G](G)
 
-  def raiseError[A](e: E): Nested[F, G, A] = Nested(AEF.map(AEF.raiseError(e))(G.pure))
+  def raiseError[A](e: E): Nested[F, G, A] = Nested(AEF.map(AEF.raiseError[A](e))(G.pure))
 
   def handleErrorWith[A](fa: Nested[F, G, A])(f: E => Nested[F, G, A]): Nested[F, G, A] =
     Nested(AEF.handleErrorWith(fa.value)(e => f(e).value))

--- a/core/src/main/scala/cats/instances/map.scala
+++ b/core/src/main/scala/cats/instances/map.scala
@@ -146,13 +146,13 @@ private[instances] trait MapInstancesBinCompat0 {
       val functor: Functor[Map[K, *]] = cats.instances.map.catsStdInstancesForMap[K]
 
       def mapFilter[A, B](fa: Map[K, A])(f: A => Option[B]) =
-        fa.collect(scala.Function.unlift(t => f(t._2).map(t._1 -> _)))
+        fa.collect(scala.Function.unlift((t: (K, A)) => f(t._2).map(t._1 -> _)))
 
       override def collect[A, B](fa: Map[K, A])(f: PartialFunction[A, B]) =
-        fa.collect(scala.Function.unlift(t => f.lift(t._2).map(t._1 -> _)))
+        fa.collect(scala.Function.unlift((t: (K, A)) => f.lift(t._2).map(t._1 -> _)))
 
       override def flattenOption[A](fa: Map[K, Option[A]]) =
-        fa.collect(scala.Function.unlift(t => t._2.map(t._1 -> _)))
+        fa.collect(scala.Function.unlift((t: (K, Option[A])) => t._2.map(t._1 -> _)))
 
       override def filter[A](fa: Map[K, A])(f: A => Boolean) =
         fa.filter { case (_, v) => f(v) }

--- a/core/src/main/scala/cats/instances/sortedMap.scala
+++ b/core/src/main/scala/cats/instances/sortedMap.scala
@@ -194,13 +194,13 @@ private[instances] trait SortedMapInstancesBinCompat0 {
       }
 
       override def mapFilter[A, B](fa: SortedMap[K, A])(f: (A) => Option[B]): SortedMap[K, B] =
-        fa.collect(scala.Function.unlift(t => f(t._2).map(t._1 -> _)))
+        fa.collect(scala.Function.unlift((t: (K, A)) => f(t._2).map(t._1 -> _)))
 
       override def collect[A, B](fa: SortedMap[K, A])(f: PartialFunction[A, B]): SortedMap[K, B] =
-        fa.collect(scala.Function.unlift(t => f.lift(t._2).map(t._1 -> _)))
+        fa.collect(scala.Function.unlift((t: (K, A)) => f.lift(t._2).map(t._1 -> _)))
 
       override def flattenOption[A](fa: SortedMap[K, Option[A]]): SortedMap[K, A] =
-        fa.collect(scala.Function.unlift(t => t._2.map(t._1 -> _)))
+        fa.collect(scala.Function.unlift((t: (K, Option[A])) => t._2.map(t._1 -> _)))
 
       override def filter[A](fa: SortedMap[K, A])(f: (A) => Boolean): SortedMap[K, A] =
         fa.filter { case (_, v) => f(v) }


### PR DESCRIPTION
These are a few fixes for places where Dotty isn't able to get the type inference right and where I think providing the types doesn't make the code unreasonably verbose (in most of these cases I think it's a readability improvement if anything).