### PR TITLE
Add explicit type annotations for implicit Ordering vals

### DIFF
--- a/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
+++ b/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
@@ -314,7 +314,7 @@ class NonEmptyLazyListOps[A](private val value: NonEmptyLazyList[A]) extends Any
    * Remove duplicates. Duplicates are checked using `Order[_]` instance.
    */
   def distinct[AA >: A](implicit O: Order[AA]): NonEmptyLazyList[AA] = {
-    implicit val ord = O.toOrdering
+    implicit val ord: Ordering[AA] = O.toOrdering
 
     val buf = LazyList.newBuilder[AA]
     toLazyList.foldLeft(TreeSet.empty[AA]) { (elementsSoFar, a) =>

--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -474,7 +474,7 @@ sealed abstract class Chain[+A] {
    * Remove duplicates. Duplicates are checked using `Order[_]` instance.
    */
   def distinct[AA >: A](implicit O: Order[AA]): Chain[AA] = {
-    implicit val ord = O.toOrdering
+    implicit val ord: Ordering[AA] = O.toOrdering
 
     var alreadyIn = TreeSet.empty[AA]
 

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -255,7 +255,7 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) {
    * Remove duplicates. Duplicates are checked using `Order[_]` instance.
    */
   def distinct[AA >: A](implicit O: Order[AA]): NonEmptyList[AA] = {
-    implicit val ord = O.toOrdering
+    implicit val ord: Ordering[AA] = O.toOrdering
 
     val buf = ListBuffer.empty[AA]
     tail.foldLeft(TreeSet(head: AA)) { (elementsSoFar, b) =>

--- a/core/src/main/scala/cats/data/NonEmptySet.scala
+++ b/core/src/main/scala/cats/data/NonEmptySet.scala
@@ -135,7 +135,7 @@ sealed class NonEmptySetOps[A](val value: NonEmptySet[A]) {
    * Applies f to all the elements
    */
   def map[B](f: A => B)(implicit B: Order[B]): NonEmptySet[B] = {
-    implicit val bOrdering = B.toOrdering
+    implicit val bOrdering: Ordering[B] = B.toOrdering
     NonEmptySetImpl.create(toSortedSet.map(f))
   }
 
@@ -219,7 +219,7 @@ sealed class NonEmptySetOps[A](val value: NonEmptySet[A]) {
    * Returns a new `SortedSet` containing all elements where the result of `pf` is defined.
    */
   def collect[B](pf: PartialFunction[A, B])(implicit B: Order[B]): SortedSet[B] = {
-    implicit val ordering = B.toOrdering
+    implicit val ordering: Ordering[B] = B.toOrdering
     toSortedSet.collect(pf)
   }
 
@@ -294,7 +294,7 @@ sealed class NonEmptySetOps[A](val value: NonEmptySet[A]) {
    * }}}
    */
   def concatMap[B](f: A => NonEmptySet[B])(implicit B: Order[B]): NonEmptySet[B] = {
-    implicit val ordering = B.toOrdering
+    implicit val ordering: Ordering[B] = B.toOrdering
     NonEmptySetImpl.create(toSortedSet.flatMap(a => f(a).toSortedSet))
   }
 
@@ -337,7 +337,7 @@ sealed class NonEmptySetOps[A](val value: NonEmptySet[A]) {
    * }}}
    */
   def zipWith[B, C](b: NonEmptySet[B])(f: (A, B) => C)(implicit C: Order[C]): NonEmptySet[C] = {
-    implicit val cOrdering = C.toOrdering
+    implicit val cOrdering: Ordering[C] = C.toOrdering
     NonEmptySetImpl.create((toSortedSet.lazyZip(b.toSortedSet)).map(f))
   }
 

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -195,7 +195,7 @@ final class NonEmptyVector[+A] private (val toVector: Vector[A]) extends AnyVal 
    * Remove duplicates. Duplicates are checked using `Order[_]` instance.
    */
   def distinct[AA >: A](implicit O: Order[AA]): NonEmptyVector[AA] = {
-    implicit val ord = O.toOrdering
+    implicit val ord: Ordering[AA] = O.toOrdering
 
     val buf = Vector.newBuilder[AA]
     tail.foldLeft(TreeSet(head: AA)) { (elementsSoFar, a) =>

--- a/core/src/main/scala/cats/instances/sortedSet.scala
+++ b/core/src/main/scala/cats/instances/sortedSet.scala
@@ -83,8 +83,8 @@ private[instances] trait SortedSetInstances1 {
 private[instances] trait SortedSetInstancesBinCompat0 {
   implicit val catsStdSemigroupalForSortedSet: Semigroupal[SortedSet] = new Semigroupal[SortedSet] {
     override def product[A, B](fa: SortedSet[A], fb: SortedSet[B]): SortedSet[(A, B)] = {
-      implicit val orderingA = fa.ordering
-      implicit val orderingB = fb.ordering
+      implicit val orderingA: Ordering[A] = fa.ordering
+      implicit val orderingB: Ordering[B] = fb.ordering
 
       fa.flatMap(a => fb.map(b => a -> b))
     }

--- a/core/src/main/scala/cats/syntax/list.scala
+++ b/core/src/main/scala/cats/syntax/list.scala
@@ -45,7 +45,7 @@ final class ListOps[A](private val la: List[A]) extends AnyVal {
    * }}}
    */
   def groupByNel[B](f: A => B)(implicit B: Order[B]): SortedMap[B, NonEmptyList[A]] = {
-    implicit val ordering = B.toOrdering
+    implicit val ordering: Ordering[B] = B.toOrdering
     toNel.fold(SortedMap.empty[B, NonEmptyList[A]])(_.groupBy(f))
   }
 }
@@ -72,7 +72,7 @@ final private[syntax] class ListOpsBinCompat0[A](private val la: List[A]) extend
    * }}}
    */
   def groupByNec[B](f: A => B)(implicit B: Order[B]): SortedMap[B, NonEmptyChain[A]] = {
-    implicit val ordering = B.toOrdering
+    implicit val ordering: Ordering[B] = B.toOrdering
     NonEmptyChain.fromSeq(la).fold(SortedMap.empty[B, NonEmptyChain[A]])(_.groupBy(f).toSortedMap)
   }
 }

--- a/core/src/main/scala/cats/syntax/set.scala
+++ b/core/src/main/scala/cats/syntax/set.scala
@@ -46,7 +46,7 @@ final class SetOps[A](private val se: SortedSet[A]) extends AnyVal {
    * }}}
    */
   def groupByNes[B](f: A => B)(implicit B: Order[B]): SortedMap[B, NonEmptySet[A]] = {
-    implicit val ordering = B.toOrdering
+    implicit val ordering: Ordering[B] = B.toOrdering
     toNes.fold(SortedMap.empty[B, NonEmptySet[A]])(_.groupBy(f).toSortedMap)
   }
 }

--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -70,7 +70,7 @@ object KernelCheck {
 
   // Copied from cats-laws.
   implicit def cogenSortedMap[K: Order: Cogen, V: Cogen]: Cogen[SortedMap[K, V]] = {
-    implicit val orderingK = Order[K].toOrdering
+    implicit val orderingK: Ordering[K] = Order[K].toOrdering
 
     implicitly[Cogen[Map[K, V]]].contramap(_.toMap)
   }
@@ -81,7 +81,7 @@ object KernelCheck {
 
   // Copied from cats-laws.
   implicit def cogenSortedSet[A: Order: Cogen]: Cogen[SortedSet[A]] = {
-    implicit val orderingA = Order[A].toOrdering
+    implicit val orderingA: Ordering[A] = Order[A].toOrdering
 
     implicitly[Cogen[Set[A]]].contramap(_.toSet)
   }

--- a/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
@@ -242,8 +242,8 @@ object arbitrary extends ArbitraryInstances0 with ScalaVersionSpecific.Arbitrary
     Arbitrary(getArbitrary[Map[K, V]].map(s => SortedMap.empty[K, V](implicitly[Order[K]].toOrdering) ++ s))
 
   implicit def catsLawsCogenForSortedMap[K: Order: Cogen, V: Order: Cogen]: Cogen[SortedMap[K, V]] = {
-    implicit val orderingK = Order[K].toOrdering
-    implicit val orderingV = Order[V].toOrdering
+    implicit val orderingK: Ordering[K] = Order[K].toOrdering
+    implicit val orderingV: Ordering[V] = Order[V].toOrdering
 
     implicitly[Cogen[Map[K, V]]].contramap(_.toMap)
   }
@@ -252,7 +252,7 @@ object arbitrary extends ArbitraryInstances0 with ScalaVersionSpecific.Arbitrary
     Arbitrary(getArbitrary[Set[A]].map(s => SortedSet.empty[A](implicitly[Order[A]].toOrdering) ++ s))
 
   implicit def catsLawsCogenForSortedSet[A: Order: Cogen]: Cogen[SortedSet[A]] = {
-    implicit val orderingA = Order[A].toOrdering
+    implicit val orderingA: Ordering[A] = Order[A].toOrdering
 
     implicitly[Cogen[Set[A]]].contramap(_.toSet)
   }

--- a/tests/src/test/scala/cats/tests/SortedSetSuite.scala
+++ b/tests/src/test/scala/cats/tests/SortedSetSuite.scala
@@ -54,7 +54,9 @@ object SortedSetIsomorphism extends Isomorphisms[SortedSet] {
   override def associativity[A, B, C](
     fs: (SortedSet[(A, (B, C))], SortedSet[((A, B), C)])
   ): IsEq[SortedSet[(A, B, C)]] = {
-    implicit val ord: Ordering[(A, B, C)] = Ordering.by[(A, B, C), ((A, B), C)] { case (a, b, c) => ((a, b), c) }(fs._2.ordering)
+    implicit val ord: Ordering[(A, B, C)] = Ordering.by[(A, B, C), ((A, B), C)] { case (a, b, c) => ((a, b), c) }(
+      fs._2.ordering
+    )
 
     fs._1.map { case (a, (b, c))   => (a, b, c) } <->
       fs._2.map { case ((a, b), c) => (a, b, c) }

--- a/tests/src/test/scala/cats/tests/SortedSetSuite.scala
+++ b/tests/src/test/scala/cats/tests/SortedSetSuite.scala
@@ -54,19 +54,19 @@ object SortedSetIsomorphism extends Isomorphisms[SortedSet] {
   override def associativity[A, B, C](
     fs: (SortedSet[(A, (B, C))], SortedSet[((A, B), C)])
   ): IsEq[SortedSet[(A, B, C)]] = {
-    implicit val ord = Ordering.by[(A, B, C), ((A, B), C)] { case (a, b, c) => ((a, b), c) }(fs._2.ordering)
+    implicit val ord: Ordering[(A, B, C)] = Ordering.by[(A, B, C), ((A, B), C)] { case (a, b, c) => ((a, b), c) }(fs._2.ordering)
 
     fs._1.map { case (a, (b, c))   => (a, b, c) } <->
       fs._2.map { case ((a, b), c) => (a, b, c) }
   }
 
   override def leftIdentity[A](fs: (SortedSet[(Unit, A)], SortedSet[A])): IsEq[SortedSet[A]] = {
-    implicit val ordering = fs._2.ordering
+    implicit val ordering: Ordering[A] = fs._2.ordering
     fs._1.map(_._2) <-> fs._2
   }
 
   override def rightIdentity[A](fs: (SortedSet[(A, Unit)], SortedSet[A])): IsEq[SortedSet[A]] = {
-    implicit val ordering = fs._2.ordering
+    implicit val ordering: Ordering[A] = fs._2.ordering
     fs._1.map(_._1) <-> fs._2
   }
 }


### PR DESCRIPTION
Dotty was complaining about some of these, so I went ahead and took care of all the `Ordering` ones.

Now the only implicit vals in core without type annotations are things like `new OptionTMonad[F] { implicit val F = F0 }`, which Dotty is fine with. There are still a lot of others in cats-tests, which I'm not able to compile on Dotty yet because I don't have the laws modules working.

The cases in this PR are all local definitions and they're a little more verbose, but personally seeing `implicit val whatever =` makes me anxious even in this context, and I think it's worth making this change even apart from the Dotty considerations.