### PR TITLE
Replace do-while

### DIFF
--- a/free/src/main/scala/cats/free/FreeApplicative.scala
+++ b/free/src/main/scala/cats/free/FreeApplicative.scala
@@ -64,12 +64,13 @@ sealed abstract class FreeApplicative[F[_], A] extends Product with Serializable
         val lengthInitial = argsFLength
         // reassociate the functions into a single fn,
         // and move the arguments into argsF
-        do {
+        while ({
           val ap = argF.asInstanceOf[Ap[F, Any, Any]]
           argsF ::= ap.fp
           argsFLength += 1
           argF = ap.fn.asInstanceOf[FA[F, Any]]
-        } while (argF.isInstanceOf[Ap[F, _, _]])
+          argF.isInstanceOf[Ap[F, _, _]]
+        }) ()
         // consecutive `ap` calls have been queued as operations;
         // argF is no longer an `Ap` node, so the entire topmost left-associated
         // function application branch has been looped through and we've


### PR DESCRIPTION
In Dotty `do` has a [new meaning](https://dotty.epfl.ch/docs/reference/dropped-features/do-while.html), and it doesn't really save much here. (This is the only instance in Cats.)