### PR TITLE
Mark match that is unchecked by Scala 2 as unchecked

### DIFF
--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -687,7 +687,10 @@ sealed abstract private[data] class ChainInstances extends ChainInstances1 {
         fa.foldLeft(b)(f)
       def foldRight[A, B](fa: Chain[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] = {
         def loop(as: Chain[A]): Eval[B] =
-          as match {
+          // In Scala 2 the compiler silently ignores the fact that it can't
+          // prove that this match is exhaustive, but Dotty warns, so we
+          // explicitly mark it as unchecked.
+          (as: @unchecked) match {
             case Chain.nil => lb
             case h ==: t   => f(h, Eval.defer(loop(t)))
           }


### PR DESCRIPTION
The Dotty exhaustivity checker is both smarter and more demanding than Scala 2's, and this is a case where it warns while Scala 2 just silently ignores the fact that it can't prove exhaustivity (it's the only case like this in cats-core).

It would be possible to make the match exhaustive in a way that both compilers would accept by writing something like this:

```scala
  as match {
    case h ==: t   => f(h, Eval.defer(loop(t)))
    case _ => lb
  }
```
…but that results in an extra `ArrayBuffer` instantiation in the empty case. Adding `@unchecked` seems to me like a reasonable fix, since it just flags what the Scala 2 compiler is already doing.