### PR TITLE
Rename rangeE for clarity

### DIFF
--- a/tests/src/test/scala-2.12/cats/tests/NonEmptyStreamSuite.scala
+++ b/tests/src/test/scala-2.12/cats/tests/NonEmptyStreamSuite.scala
@@ -167,6 +167,5 @@ class ReducibleNonEmptyStreamSuite extends ReducibleSuite[NonEmptyStream]("NonEm
     NonEmptyStream(start, tailStart.to(endInclusive).toStream)
   }
 
-  def rangeE[L, R](el: Either[L, R], els: Either[L, R]*): NonEmptyStream[Either[L, R]] =
-    NonEmptyStream(el, els: _*)
+  def fromValues[A](el: A, els: A*): NonEmptyStream[A] = NonEmptyStream(el, els: _*)
 }

--- a/tests/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
@@ -138,6 +138,5 @@ class ReducibleNonEmptyLazyListSuite extends ReducibleSuite[NonEmptyLazyList]("N
   def range(start: Long, endInclusive: Long): NonEmptyLazyList[Long] =
     NonEmptyLazyList(start, (start + 1L).to(endInclusive): _*)
 
-  def rangeE[L, R](el: Either[L, R], els: Either[L, R]*): NonEmptyLazyList[Either[L, R]] =
-    NonEmptyLazyList(el, els: _*)
+  def fromValues[A](el: A, els: A*): NonEmptyLazyList[A] = NonEmptyLazyList(el, els: _*)
 }

--- a/tests/src/test/scala/cats/tests/NonEmptyChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyChainSuite.scala
@@ -162,6 +162,5 @@ class ReducibleNonEmptyChainSuite extends ReducibleSuite[NonEmptyChain]("NonEmpt
   def range(start: Long, endInclusive: Long): NonEmptyChain[Long] =
     NonEmptyChain(start, (start + 1L).to(endInclusive): _*)
 
-  def rangeE[L, R](el: Either[L, R], els: Either[L, R]*): NonEmptyChain[Either[L, R]] =
-    NonEmptyChain(el, els: _*)
+  def fromValues[A](el: A, els: A*): NonEmptyChain[A] = NonEmptyChain(el, els: _*)
 }

--- a/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
@@ -370,6 +370,5 @@ class ReducibleNonEmptyListSuite extends ReducibleSuite[NonEmptyList]("NonEmptyL
     NonEmptyList(start, (tailStart).to(endInclusive).toList)
   }
 
-  def rangeE[L, R](el: Either[L, R], els: Either[L, R]*): NonEmptyList[Either[L, R]] =
-    NonEmptyList(el, List(els: _*))
+  def fromValues[A](el: A, els: A*): NonEmptyList[A] = NonEmptyList(el, List(els: _*))
 }

--- a/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
@@ -404,6 +404,5 @@ class ReducibleNonEmptyVectorSuite extends ReducibleSuite[NonEmptyVector]("NonEm
     NonEmptyVector(start, (tailStart).to(endInclusive).toVector)
   }
 
-  def rangeE[L, R](el: Either[L, R], els: Either[L, R]*): NonEmptyVector[Either[L, R]] =
-    NonEmptyVector(el, Vector(els: _*))
+  def fromValues[A](el: A, els: A*): NonEmptyVector[A] = NonEmptyVector(el, Vector(els: _*))
 }

--- a/tests/src/test/scala/cats/tests/ReducibleSuite.scala
+++ b/tests/src/test/scala/cats/tests/ReducibleSuite.scala
@@ -106,7 +106,7 @@ abstract class ReducibleSuite[F[_]: Reducible](name: String)(implicit ArbFInt: A
     extends FoldableSuite[F](name) {
 
   def range(start: Long, endInclusive: Long): F[Long]
-  def rangeE[L, R](el: Either[L, R], els: Either[L, R]*): F[Either[L, R]]
+  def fromValues[A](el: A, els: A*): F[A]
 
   test(s"Reducible[$name].reduceLeftM stack safety") {
     def nonzero(acc: Long, x: Long): Option[Long] =
@@ -120,13 +120,13 @@ abstract class ReducibleSuite[F[_]: Reducible](name: String)(implicit ArbFInt: A
 
   test(s"Reducible[$name].reduceA successful case") {
     val expected = 6
-    val actual = rangeE(1.asRight[String], 2.asRight[String], 3.asRight[String]).reduceA
+    val actual = fromValues(1.asRight[String], 2.asRight[String], 3.asRight[String]).reduceA
     actual should ===(expected.asRight[String])
   }
 
   test(s"Reducible[$name].reduceA failure case") {
     val expected = "boom!!!"
-    val actual = rangeE(1.asRight, "boom!!!".asLeft, 3.asRight).reduceA
+    val actual = fromValues(1.asRight, "boom!!!".asLeft, 3.asRight).reduceA
     actual should ===(expected.asLeft[Int])
   }
 


### PR DESCRIPTION
This is one small thing that I just noticed in #3150, but I'd already caused enough trouble there so I decided it'd be best to handle in a follow-up. :smile:

I think `rangeE` was named to match `range`, but it doesn't actually create a range, and it's not in any way `Either` specific, so I replaced it with a general `fromValues` method that can be used in these tests.