### PR TITLE
Fix foldA, reduceA, and reduceMapA short-circuiting

### DIFF
--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -412,7 +412,7 @@ import Foldable.sentinel
    * `noop` usage description [[https://github.com/typelevel/simulacrum/issues/162 here]]
    */
   @noop def foldA[G[_], A](fga: F[G[A]])(implicit G: Applicative[G], A: Monoid[A]): G[A] =
-    fold(fga)(Applicative.monoid)
+    foldMapA(fga)(identity)
 
   /**
    * Fold implemented by mapping `A` values into `B` in a context `G` and then

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -341,7 +341,7 @@ import Foldable.sentinel
     )
 
   /**
-   * Fold implemented using the given Monoid[A] instance.
+   * Fold implemented using the given `Monoid[A]` instance.
    */
   def fold[A](fa: F[A])(implicit A: Monoid[A]): A =
     A.combineAll(toIterable(fa))
@@ -397,8 +397,7 @@ import Foldable.sentinel
   /**
    * Fold implemented using the given `Applicative[G]` and `Monoid[A]` instance.
    *
-   * This method is identical to fold, except that we use `Applicative[G]` and `Monoid[A]`
-   * to combine a's inside an applicative G.
+   * This method is similar to [[fold]], but may short-circuit.
    *
    * For example:
    *
@@ -409,7 +408,7 @@ import Foldable.sentinel
    * res0: Either[String, Int] = Right(3)
    * }}}
    *
-   * `noop` usage description [[https://github.com/typelevel/simulacrum/issues/162 here]]
+   * See [[https://github.com/typelevel/simulacrum/issues/162 this issue]] for an explanation of `@noop` usage.
    */
   @noop def foldA[G[_], A](fga: F[G[A]])(implicit G: Applicative[G], A: Monoid[A]): G[A] =
     foldMapA(fga)(identity)
@@ -440,7 +439,7 @@ import Foldable.sentinel
    * Monadic folding on `F` by mapping `A` values to `G[B]`, combining the `B`
    * values using the given `Monoid[B]` instance.
    *
-   * Similar to [[foldM]], but using a `Monoid[B]`.
+   * Similar to [[foldM]], but using a `Monoid[B]`. Will typically be more efficient than [[foldMapA]].
    *
    * {{{
    * scala> import cats.Foldable
@@ -458,9 +457,22 @@ import Foldable.sentinel
     foldM(fa, B.empty)((b, a) => G.map(f(a))(B.combine(b, _)))
 
   /**
-   * Equivalent to foldMapM.
-   * The difference is that foldMapA only requires G to be an Applicative
-   * rather than a Monad. It is also slower due to use of Eval.
+   * Fold in an [[Applicative]] context by mapping the `A` values to `G[B]`. combining
+   * the `B` values using the given `Monoid[B]` instance.
+   *
+   * Similar to [[foldMapM]], but will typically be less efficient.
+   *
+   * {{{
+   * scala> import cats.Foldable
+   * scala> import cats.implicits._
+   * scala> val evenNumbers = List(2,4,6,8,10)
+   * scala> val evenOpt: Int => Option[Int] =
+   *      |   i => if (i % 2 == 0) Some(i) else None
+   * scala> Foldable[List].foldMapA(evenNumbers)(evenOpt)
+   * res0: Option[Int] = Some(30)
+   * scala> Foldable[List].foldMapA(evenNumbers :+ 11)(evenOpt)
+   * res1: Option[Int] = None
+   * }}}
    */
   def foldMapA[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: Applicative[G], B: Monoid[B]): G[B] =
     foldRight(fa, Eval.now(G.pure(B.empty)))((a, egb) => G.map2Eval(f(a), egb)(B.combine)).value

--- a/core/src/main/scala/cats/Reducible.scala
+++ b/core/src/main/scala/cats/Reducible.scala
@@ -89,14 +89,14 @@ import simulacrum.{noop, typeclass}
    * `noop` usage description [[https://github.com/typelevel/simulacrum/issues/162 here]]
    */
   @noop def reduceA[G[_], A](fga: F[G[A]])(implicit G: Apply[G], A: Semigroup[A]): G[A] =
-    reduce(fga)(Apply.semigroup)
+    reduceMapA(fga)(identity)
 
   /**
    * Apply `f` to each `a` of `fa` and combine the result into Apply[G] using the
    * given `Semigroup[B]`.
    */
   def reduceMapA[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: Apply[G], B: Semigroup[B]): G[B] =
-    reduceLeftTo(fa)(f)((gb, a) => G.map2(gb, f(a))(B.combine))
+    reduceRightTo(fa)(f)((a, egb) => G.map2Eval(f(a), egb)(B.combine)).value
 
   /**
    * Monadic reducing by mapping the `A` values to `G[B]`. combining

--- a/tests/src/test/scala/cats/tests/FoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/FoldableSuite.scala
@@ -470,6 +470,13 @@ class FoldableSuiteAdditional extends CatsSuite with ScalaVersionSpecificFoldabl
     assert(ns.foldA == "boom!!!".asLeft[Int])
   }
 
+  test(".foldA short-circuiting") {
+    implicit val F = foldableStreamWithDefaultImpl
+    val ns = Stream.from(1).map(n => if (n >= 100000) Left(n) else Right(n))
+
+    assert(F.foldA(ns) === Left(100000))
+  }
+
   test(".foldLeftM short-circuiting") {
     implicit val F = foldableStreamWithDefaultImpl
     val ns = Stream.continually(1)

--- a/tests/src/test/scala/cats/tests/ReducibleSuite.scala
+++ b/tests/src/test/scala/cats/tests/ReducibleSuite.scala
@@ -99,6 +99,20 @@ class ReducibleSuiteAdditional extends CatsSuite {
 
     assert(xs.reduceMapM(i => if (i < n) Right(i) else Left(i)) === Left(n))
   }
+
+  test("reduceMapA should be stack-safe and short-circuiting if reduceRightTo is sufficiently lazy") {
+    val n = 100000
+    val xs = NES(0, Stream.from(1))
+
+    assert(xs.reduceMapA(i => if (i < n) Right(i) else Left(i)) === Left(n))
+  }
+
+  test("reduceA should be stack-safe and short-circuiting if reduceRightTo is sufficiently lazy") {
+    val n = 100000
+    val xs = NES(Right(0), Stream.from(1).map(i => if (i < n) Right(i) else Left(i)))
+
+    assert(xs.reduceA === Left(n))
+  }
 }
 
 abstract class ReducibleSuite[F[_]: Reducible](name: String)(implicit ArbFInt: Arbitrary[F[Int]],


### PR DESCRIPTION
As discussed in #3150, the only real reason I can see for `foldA` and `reduceA` to exist is because they can short-circuit, while `fold(fga)(Applicative.monoid)` etc. can't. This change fixes them so they actually do short-circuit, and adds some tests to verify this.