### PR TITLE
Add Defer.fix

### DIFF
--- a/core/src/main/scala/cats/Defer.scala
+++ b/core/src/main/scala/cats/Defer.scala
@@ -28,6 +28,27 @@ package cats
  */
 trait Defer[F[_]] extends Serializable {
   def defer[A](fa: => F[A]): F[A]
+
+  /**
+   * Defer instances, like functions, parsers, generators, IO, etc...
+   * often are used in recursive settings where this function is useful
+   *
+   * fix(fn) == fn(fix(fn))
+   *
+   * example:
+   *
+   * val parser: P[Int] =
+   *   Defer[P].fix[Int] { rec =>
+   *     CharsIn("0123456789") | P("(") ~ rec ~ P(")")
+   *   }
+   *
+   * Note, fn may not yield a terminating value in which case both
+   * of the above F[A] run forever.
+   */
+  def fix[A](fn: F[A] => F[A]): F[A] = {
+    lazy val res: F[A] = defer(fn(res))
+    res
+  }
 }
 
 object Defer {

--- a/tests/src/test/scala/cats/tests/FunctionSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctionSuite.scala
@@ -46,6 +46,18 @@ class FunctionSuite extends CatsSuite {
   // TODO: make an binary compatible way to do this
   // checkAll("Function1[Int => *]", DeferTests[Function1[Int, *]].defer[Int])
 
+  test("Defer[Function1[Int, *]].fix computing sum") {
+    val sum2 = Defer[Function1[Int, *]].fix[Int] { rec =>
+
+      { n: Int => if (n <= 0) 0 else n * n + rec(n - 1) }
+    }
+
+    forAll { n0: Int =>
+      val n = n0 & 0x3FF // don't let it get too big
+      assert(sum2(n) == (0 to n).map { n => n * n }.sum)
+    }
+  }
+
   checkAll("Semigroupal[Function1[Int, *]]", SerializableTests.serializable(Semigroupal[Function1[Int, *]]))
 
   checkAll("Function1[MiniInt, Int]", MonadTests[MiniInt => *].monad[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/FunctionSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctionSuite.scala
@@ -47,14 +47,18 @@ class FunctionSuite extends CatsSuite {
   // checkAll("Function1[Int => *]", DeferTests[Function1[Int, *]].defer[Int])
 
   test("Defer[Function1[Int, *]].fix computing sum") {
-    val sum2 = Defer[Function1[Int, *]].fix[Int] { rec =>
-
-      { n: Int => if (n <= 0) 0 else n * n + rec(n - 1) }
+    val sum2 = Defer[Function1[Int, *]].fix[Int] {
+      rec =>
+        { n: Int =>
+          if (n <= 0) 0 else n * n + rec(n - 1)
+        }
     }
 
     forAll { n0: Int =>
       val n = n0 & 0x3FF // don't let it get too big
-      assert(sum2(n) == (0 to n).map { n => n * n }.sum)
+      assert(sum2(n) == (0 to n).map { n =>
+        n * n
+      }.sum)
     }
   }
 

--- a/tests/src/test/scala/cats/tests/FunctionSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctionSuite.scala
@@ -23,6 +23,7 @@ import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
 import cats.kernel.{CommutativeGroup, CommutativeMonoid, CommutativeSemigroup}
 import cats.kernel.{Band, BoundedSemilattice, Semilattice}
+import org.scalacheck.Gen
 
 class FunctionSuite extends CatsSuite {
 
@@ -54,8 +55,8 @@ class FunctionSuite extends CatsSuite {
         }
     }
 
-    forAll { n0: Int =>
-      val n = n0 & 0x3FF // don't let it get too big
+    forAll(Gen.choose(0, 1000)) { n =>
+      // don't let n get too large because this consumes stack
       assert(sum2(n) == (0 to n).map { n =>
         n * n
       }.sum)


### PR DESCRIPTION
A pattern I often use in working with scalacheck.Gen or with Parsers is:
```
lazy val x: Gen[X] = {
  val recurse = Gen.lzy(x)
  //....
}
```
It occurred to me all the types I use this pattern with are generally Defer instances, and more over, we can express `fix` nicely on `Defer` instances since we know we can always return a value (there is no risk of infinite loop at fix application, although it is up to the user if evaluating `F[A]` is safe.

I think this is a useful function to have on Defer.

