### PR TITLE
Avoid infix, tuple, and function syntax when using kind-projector

### DIFF
--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -811,7 +811,7 @@ sealed abstract private[data] class IorInstances extends IorInstances0 {
 
 sealed abstract private[data] class IorInstances0 {
 
-  implicit def catsDataTraverseFunctorForIor[A]: Traverse[A Ior *] = new Traverse[A Ior *] {
+  implicit def catsDataTraverseFunctorForIor[A]: Traverse[Ior[A, *]] = new Traverse[Ior[A, *]] {
     def traverse[F[_]: Applicative, B, C](fa: A Ior B)(f: B => F[C]): F[A Ior C] =
       fa.traverse(f)
     def foldLeft[B, C](fa: A Ior B, b: C)(f: (C, B) => C): C =

--- a/core/src/main/scala/cats/data/package.scala
+++ b/core/src/main/scala/cats/data/package.scala
@@ -77,10 +77,10 @@ package object data extends ScalaVersionSpecificPackage {
   type RWS[E, L, S, A] = ReaderWriterState[E, L, S, A]
   val RWS = ReaderWriterState
 
-  type Store[S, A] = RepresentableStore[S => *, S, A]
+  type Store[S, A] = RepresentableStore[Function1[S, *], S, A]
   object Store {
     import cats.instances.function._
     def apply[S, A](f: S => A, s: S): Store[S, A] =
-      RepresentableStore[S => *, S, A](f, s)
+      RepresentableStore[Function1[S, *], S, A](f, s)
   }
 }

--- a/core/src/main/scala/cats/evidence/Is.scala
+++ b/core/src/main/scala/cats/evidence/Is.scala
@@ -27,7 +27,7 @@ abstract class Is[A, B] extends Serializable {
    * chain much like functions. See also `compose`.
    */
   @inline final def andThen[C](next: B Is C): A Is C =
-    next.substitute[A Is *](this)
+    next.substitute[Is[A, *]](this)
 
   /**
    * `Is` is transitive and therefore values of `Is` can be composed in a
@@ -41,7 +41,7 @@ abstract class Is[A, B] extends Serializable {
    * own inverse, so `x.flip.flip == x`.
    */
   @inline final def flip: B Is A =
-    this.substitute[* Is A](Is.refl)
+    this.substitute[Is[*, A]](Is.refl)
 
   /**
    * Sometimes for more complex substitutions it helps the typechecker to
@@ -63,7 +63,7 @@ abstract class Is[A, B] extends Serializable {
    * value.
    */
   @inline final def predefEq: A =:= B =
-    substitute[A =:= *](implicitly[A =:= A])
+    substitute[=:=[A, *]](implicitly[A =:= A])
 }
 
 sealed abstract class IsInstances {

--- a/core/src/main/scala/cats/instances/function.scala
+++ b/core/src/main/scala/cats/instances/function.scala
@@ -14,10 +14,12 @@ private[instances] trait FunctionInstancesBinCompat0 {
   /**
    * Witness for: E => A <-> E => A
    */
-  implicit def catsStdRepresentableForFunction1[E](implicit EF: Functor[E => *]): Representable.Aux[E => *, E] =
-    new Representable[E => *] {
+  implicit def catsStdRepresentableForFunction1[E](
+    implicit EF: Functor[Function1[E, *]]
+  ): Representable.Aux[Function1[E, *], E] =
+    new Representable[Function1[E, *]] {
       override type Representation = E
-      override val F: Functor[E => *] = EF
+      override val F: Functor[Function1[E, *]] = EF
       override def tabulate[A](f: E => A): E => A = f
       override def index[A](f: E => A): E => A = f
     }
@@ -41,8 +43,8 @@ private[instances] trait FunctionInstancesBinCompat0 {
       }
     }
 
-  implicit def catsStdDeferForFunction1[A]: Defer[A => *] =
-    new Defer[A => *] {
+  implicit def catsStdDeferForFunction1[A]: Defer[Function1[A, *]] =
+    new Defer[Function1[A, *]] {
       case class Deferred[B](fa: () => A => B) extends (A => B) {
         def apply(a: A) = {
           @annotation.tailrec
@@ -98,8 +100,8 @@ sealed private[instances] trait Function0Instances0 {
 }
 
 sealed private[instances] trait Function1Instances extends Function1Instances0 {
-  implicit def catsStdContravariantMonoidalForFunction1[R: Monoid]: ContravariantMonoidal[* => R] =
-    new ContravariantMonoidal[* => R] {
+  implicit def catsStdContravariantMonoidalForFunction1[R: Monoid]: ContravariantMonoidal[Function1[*, R]] =
+    new ContravariantMonoidal[Function1[*, R]] {
       def unit: Unit => R = Function.const(Monoid[R].empty)
       def contramap[A, B](fa: A => R)(f: B => A): B => R =
         fa.compose(f)
@@ -110,8 +112,8 @@ sealed private[instances] trait Function1Instances extends Function1Instances0 {
           }
     }
 
-  implicit def catsStdMonadForFunction1[T1]: Monad[T1 => *] =
-    new Monad[T1 => *] {
+  implicit def catsStdMonadForFunction1[T1]: Monad[Function1[T1, *]] =
+    new Monad[Function1[T1, *]] {
       def pure[R](r: R): T1 => R = _ => r
 
       def flatMap[R1, R2](fa: T1 => R1)(f: R1 => T1 => R2): T1 => R2 =
@@ -165,19 +167,20 @@ sealed private[instances] trait Function1Instances extends Function1Instances0 {
 }
 
 sealed private[instances] trait Function1Instances0 {
-  implicit def catsStdContravariantForFunction1[R]: Contravariant[* => R] =
-    new Contravariant[* => R] {
+  implicit def catsStdContravariantForFunction1[R]: Contravariant[Function1[*, R]] =
+    new Contravariant[Function1[*, R]] {
       def contramap[T1, T0](fa: T1 => R)(f: T0 => T1): T0 => R =
         fa.compose(f)
     }
 
-  implicit def catsStdDistributiveForFunction1[T1]: Distributive[T1 => *] = new Distributive[T1 => *] {
-    def distribute[F[_]: Functor, A, B](fa: F[A])(f: A => (T1 => B)): T1 => F[B] = { t1 =>
-      Functor[F].map(fa)(a => f(a)(t1))
-    }
+  implicit def catsStdDistributiveForFunction1[T1]: Distributive[Function1[T1, *]] =
+    new Distributive[Function1[T1, *]] {
+      def distribute[F[_]: Functor, A, B](fa: F[A])(f: A => (T1 => B)): T1 => F[B] = { t1 =>
+        Functor[F].map(fa)(a => f(a)(t1))
+      }
 
-    def map[A, B](fa: T1 => A)(f: A => B): T1 => B = { t1 =>
-      f(fa(t1))
+      def map[A, B](fa: T1 => A)(f: A => B): T1 => B = { t1 =>
+        f(fa(t1))
+      }
     }
-  }
 }

--- a/core/src/main/scala/cats/instances/tuple.scala
+++ b/core/src/main/scala/cats/instances/tuple.scala
@@ -50,8 +50,9 @@ sealed private[instances] trait Tuple2Instances extends Tuple2Instances1 {
       s"(${aShow.show(f._1)},${bShow.show(f._2)})"
   }
 
-  implicit def catsStdInstancesForTuple2[X]: Traverse[(X, *)] with Comonad[(X, *)] with Reducible[(X, *)] =
-    new Traverse[(X, *)] with Comonad[(X, *)] with Reducible[(X, *)] {
+  implicit def catsStdInstancesForTuple2[X]
+    : Traverse[Tuple2[X, *]] with Comonad[Tuple2[X, *]] with Reducible[Tuple2[X, *]] =
+    new Traverse[Tuple2[X, *]] with Comonad[Tuple2[X, *]] with Reducible[Tuple2[X, *]] {
       def traverse[G[_], A, B](fa: (X, A))(f: A => G[B])(implicit G: Applicative[G]): G[(X, B)] =
         G.map(f(fa._2))((fa._1, _))
 
@@ -104,30 +105,32 @@ sealed private[instances] trait Tuple2Instances extends Tuple2Instances1 {
 }
 
 sealed private[instances] trait Tuple2Instances1 extends Tuple2Instances2 {
-  implicit def catsStdCommutativeMonadForTuple2[X](implicit MX: CommutativeMonoid[X]): CommutativeMonad[(X, *)] =
-    new FlatMapTuple2[X](MX) with CommutativeMonad[(X, *)] {
+  implicit def catsStdCommutativeMonadForTuple2[X](implicit MX: CommutativeMonoid[X]): CommutativeMonad[Tuple2[X, *]] =
+    new FlatMapTuple2[X](MX) with CommutativeMonad[Tuple2[X, *]] {
       def pure[A](a: A): (X, A) = (MX.empty, a)
     }
 }
 
 sealed private[instances] trait Tuple2Instances2 extends Tuple2Instances3 {
-  implicit def catsStdCommutativeFlatMapForTuple2[X](implicit MX: CommutativeSemigroup[X]): CommutativeFlatMap[(X, *)] =
-    new FlatMapTuple2[X](MX) with CommutativeFlatMap[(X, *)]
+  implicit def catsStdCommutativeFlatMapForTuple2[X](
+    implicit MX: CommutativeSemigroup[X]
+  ): CommutativeFlatMap[Tuple2[X, *]] =
+    new FlatMapTuple2[X](MX) with CommutativeFlatMap[Tuple2[X, *]]
 }
 
 sealed private[instances] trait Tuple2Instances3 extends Tuple2Instances4 {
-  implicit def catsStdMonadForTuple2[X](implicit MX: Monoid[X]): Monad[(X, *)] =
-    new FlatMapTuple2[X](MX) with Monad[(X, *)] {
+  implicit def catsStdMonadForTuple2[X](implicit MX: Monoid[X]): Monad[Tuple2[X, *]] =
+    new FlatMapTuple2[X](MX) with Monad[Tuple2[X, *]] {
       def pure[A](a: A): (X, A) = (MX.empty, a)
     }
 }
 
 sealed private[instances] trait Tuple2Instances4 {
-  implicit def catsStdFlatMapForTuple2[X](implicit SX: Semigroup[X]): FlatMap[(X, *)] =
+  implicit def catsStdFlatMapForTuple2[X](implicit SX: Semigroup[X]): FlatMap[Tuple2[X, *]] =
     new FlatMapTuple2[X](SX)
 }
 
-private[instances] class FlatMapTuple2[X](s: Semigroup[X]) extends FlatMap[(X, *)] {
+private[instances] class FlatMapTuple2[X](s: Semigroup[X]) extends FlatMap[Tuple2[X, *]] {
   override def ap[A, B](ff: (X, A => B))(fa: (X, A)): (X, B) = {
     val x = s.combine(ff._1, fa._1)
     val b = ff._2(fa._2)


### PR DESCRIPTION
This is more a question than a proposal, I guess. I'm working on `-Ykind-projector` for Dotty, and I have a WIP implementation that I've confirmed can compile cats-core after #3207, #3193, and the change here (and one big [Simulacrum rewrite](https://github.com/travisbrown/simulacrum-scalafix)).

I think it makes sense to try to minimize the scope of Dotty's kind-projector compatibility, and right now my implementation only handles the type-level `λ[x => ...]` syntax and `*` in ordinary type application (`F[A, *, B, *, C]`). This is a really tiny change—around 50 lines in the parser behind a single `if (ctx.settings.YkindProjector.value)`. Adding support for `*` in tuple types, function types, and infix types would be a lot more invasive.

Maybe we should do it anyway, but for Cats at least only supporting `*` in type application isn't a very painful limitation—it only requires the changes here, and I think some of these changes (like `A Ior *` to `Ior[A, *]`) are readability improvements, anyway.
