### PR TITLE
Update sbt-scalafix and sbt versions

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.4
+sbt.version=1.3.5

--- a/scalafix/project/build.properties
+++ b/scalafix/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.3.4
+sbt.version=1.3.5

--- a/scalafix/project/plugins.sbt
+++ b/scalafix/project/plugins.sbt
@@ -1,2 +1,2 @@
-addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.5")
+addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.11")
 addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.2")


### PR DESCRIPTION
Like #3210 but doesn't fail.

I've seen this error in other contexts from sbt 1.3.5:

```
[error] java.lang.NoClassDefFoundError: org/scalacheck/Test$TestCallback
[error] 	at java.lang.Class.getDeclaredFields0(Native Method)
[error] 	at java.lang.Class.privateGetDeclaredFields(Class.java:2583)
[error] 	at java.lang.Class.getDeclaredFields(Class.java:1916)
```
…and I'm pretty sure it has something to do with having both ScalaCheck 1.13 and 1.14 dependencies around (in this case via the old scalafix-testkit's dependency on some weird ScalaTest 3.2 version). In any case updating Scalafix seems to fix the issue.