### PR TITLE
Replace kind-projector placeholders in infix types

### DIFF
--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -811,7 +811,7 @@ sealed abstract private[data] class IorInstances extends IorInstances0 {
 
 sealed abstract private[data] class IorInstances0 {
 
-  implicit def catsDataTraverseFunctorForIor[A]: Traverse[A Ior *] = new Traverse[A Ior *] {
+  implicit def catsDataTraverseFunctorForIor[A]: Traverse[Ior[A, *]] = new Traverse[Ior[A, *]] {
     def traverse[F[_]: Applicative, B, C](fa: A Ior B)(f: B => F[C]): F[A Ior C] =
       fa.traverse(f)
     def foldLeft[B, C](fa: A Ior B, b: C)(f: (C, B) => C): C =

--- a/core/src/main/scala/cats/evidence/Is.scala
+++ b/core/src/main/scala/cats/evidence/Is.scala
@@ -27,7 +27,7 @@ abstract class Is[A, B] extends Serializable {
    * chain much like functions. See also `compose`.
    */
   @inline final def andThen[C](next: B Is C): A Is C =
-    next.substitute[A Is *](this)
+    next.substitute[Is[A, *]](this)
 
   /**
    * `Is` is transitive and therefore values of `Is` can be composed in a
@@ -41,7 +41,7 @@ abstract class Is[A, B] extends Serializable {
    * own inverse, so `x.flip.flip == x`.
    */
   @inline final def flip: B Is A =
-    this.substitute[* Is A](Is.refl)
+    this.substitute[Is[*, A]](Is.refl)
 
   /**
    * Sometimes for more complex substitutions it helps the typechecker to
@@ -63,7 +63,7 @@ abstract class Is[A, B] extends Serializable {
    * value.
    */
   @inline final def predefEq: A =:= B =
-    substitute[A =:= *](implicitly[A =:= A])
+    substitute[=:=[A, *]](implicitly[A =:= A])
 }
 
 sealed abstract class IsInstances {


### PR DESCRIPTION
This is a subset of #3209 that only changes the use of kind-projector's `*` placeholder in infix types. I added support for `*` in function and tuple types to my `-Ykind-projector` [proposal](https://github.com/lampepfl/dotty/pull/7775) for Dotty, but infix types seem like more of a hassle and I don't think it's worth bothering with.