### PR TITLE
Fix typos

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -407,7 +407,7 @@ lazy val cats = project
   .in(file("."))
   .settings(moduleName := "root", crossScalaVersions := Nil)
   .settings(publishSettings) // these settings are needed to release all aggregated modules under this root module
-  .settings(noPublishSettings) // this is to exclue the root module itself from being published.
+  .settings(noPublishSettings) // this is to exclude the root module itself from being published.
   .aggregate(catsJVM, catsJS)
   .dependsOn(catsJVM, catsJS, tests.jvm % "test-internal -> test")
 

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -161,7 +161,7 @@ import Foldable.sentinel
    * {{{
    * scala> import cats.implicits._
    * scala> val l = List(6, 3, 2)
-   * This is eqivalent to 6 - (3 - 2)
+   * This is equivalent to 6 - (3 - 2)
    * scala> Foldable[List].reduceRightOption(l)((current, rest) => rest.map(current - _)).value
    * res0: Option[Int] = Some(5)
    *

--- a/docs/src/main/tut/datatypes/chain.md
+++ b/docs/src/main/tut/datatypes/chain.md
@@ -118,7 +118,7 @@ This unbalanced tree will always allow iteration in linear time.
 ## NonEmptyChain 
 
 `NonEmptyChain` is the non empty version of `Chain` it does not have a `Monoid` instance since it cannot be empty, but it does have a `Semigroup` instance.
-Likewise, it defines a `NonEmptyTraverse` instace, but no `TraverseFilter` instance.
+Likewise, it defines a `NonEmptyTraverse` instance, but no `TraverseFilter` instance.
 
 There are numerous ways to construct a `NonEmptyChain`, e.g. you can create one from a single element, a `NonEmptyList` or a `NonEmptyVector`:
 

--- a/docs/src/main/tut/nomenclature.md
+++ b/docs/src/main/tut/nomenclature.md
@@ -280,7 +280,7 @@ Because `Сats` is a Scala library and Scala has many knobs and switches, the ac
 - We write type signatures in currified form: parameters are taken one at a time, and they are separated with the arrow `=>` operation. In Scala, a method's parameters may be split in several comma-separated lists.
 - We do not differentiate between methods from the type-class trait (e.g. `trait Functor`), or the companion object, or the syntax companion (`implicit class`).
 - For functions defined as method of the typeclass trait, we ignore the receiver object.
-- We ignore implicit parameters that represent type-class constraints; and write them on a side column instad.
+- We ignore implicit parameters that represent type-class constraints; and write them on a side column instead.
 - We use `A => B` for both `Function1[A, B]` and `PartialFunction[A, B]` parameters, without distinction. We add a side note when one is  a `PartialFunction`.
 - Some functions are defined through the [Partially Applied Type Params](http://typelevel.org/cats/guidelines.html#partially-applied-type-params) pattern. We ignore this.
 - We ignore the distinction between by-name and by-value input parameters. We use the notation `=> A`, without parameters, to indicate constant functions.

--- a/tests/src/test/scala-2.13+/cats/tests/ScalaVersionSpecific.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/ScalaVersionSpecific.scala
@@ -142,7 +142,7 @@ trait ScalaVersionSpecificRegressionSuite { self: RegressionSuite =>
     }
 
     LazyList(1, 2, 6, 8).traverse(validate) should ===(Either.left("6 is greater than 5"))
-    // shouldn't have ever evaluted validate(8)
+    // shouldn't have ever evaluated validate(8)
     checkAndResetCount(3)
 
     LazyList(1, 2, 6, 8).traverse_(validate) should ===(Either.left("6 is greater than 5"))

--- a/tests/src/test/scala/cats/tests/AsSuite.scala
+++ b/tests/src/test/scala/cats/tests/AsSuite.scala
@@ -109,7 +109,7 @@ class AsSuite extends CatsSuite {
     val f2: Bottom => Any = As.conF(cAsA)(f)
   }
 
-  test("we can simultaneously narrow the input and widen the ouptut of a Function1") {
+  test("we can simultaneously narrow the input and widen the output of a Function1") {
     val f: Top => Bottom = _ => Bottom()
     val cAsA: Bottom As Top = implicitly
     val f2: Bottom => Top = As.invF(cAsA, cAsA)(f)

--- a/tests/src/test/scala/cats/tests/BinCodecInvariantMonoidalSuite.scala
+++ b/tests/src/test/scala/cats/tests/BinCodecInvariantMonoidalSuite.scala
@@ -155,7 +155,7 @@ object BinCodecInvariantMonoidalSuite {
 }
 
 class BinCodecInvariantMonoidalSuite extends CatsSuite {
-  // Eveything is defined in a companion object to be serializable.
+  // Everything is defined in a companion object to be serializable.
   import BinCodecInvariantMonoidalSuite._
 
   checkAll("InvariantMonoidal[BinCodec]", InvariantMonoidalTests[BinCodec].invariantMonoidal[MiniInt, MiniInt, MiniInt])

--- a/tests/src/test/scala/cats/tests/FunctorSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctorSuite.scala
@@ -53,7 +53,7 @@ class FunctorSuite extends CatsSuite {
     }
   }
 
-  test("ifF equals map(if(_) ifTrue else ifFalse) for concrete lists and optoins") {
+  test("ifF equals map(if(_) ifTrue else ifFalse) for concrete lists and options") {
     Functor[List].ifF(List(true, false, false, true))(1, 0) should ===(List(1, 0, 0, 1))
     Functor[List].ifF(List.empty[Boolean])(1, 0) should ===(Nil)
     Functor[Option].ifF(Some(true))(1, 0) should ===(Some(1))

--- a/tests/src/test/scala/cats/tests/RegressionSuite.scala
+++ b/tests/src/test/scala/cats/tests/RegressionSuite.scala
@@ -112,7 +112,7 @@ class RegressionSuite extends CatsSuite with ScalaVersionSpecificRegressionSuite
     }
 
     List(1, 2, 6, 8).traverse(validate) should ===(Either.left("6 is greater than 5"))
-    // shouldn't have ever evaluted validate(8)
+    // shouldn't have ever evaluated validate(8)
     checkAndResetCount(3)
 
     Stream(1, 2, 6, 8).traverse(validate) should ===(Either.left("6 is greater than 5"))

--- a/tests/src/test/scala/cats/tests/WordCountSuite.scala
+++ b/tests/src/test/scala/cats/tests/WordCountSuite.scala
@@ -20,7 +20,7 @@ class WordCountSuite extends CatsSuite {
     // A simple counter
     def count[A](a: A): Count[Unit] = liftInt(1)
 
-    // An applicatve functor to count each character
+    // An applicative functor to count each character
     val countChar: AppFunc[Count, Char, Unit] = appFunc(count)
     def testIf(b: Boolean): Int = if (b) 1 else 0
     // An applicative functor to count each line


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos, with https://github.com/bwignall/typochecker to help automate the checking.

`sbt +prePR` did not change any files.


