### PR TITLE
Non empty map order

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -14,15 +14,27 @@ private[data] object NonEmptyMapImpl extends NonEmptyMapInstances with Newtype2 
   private[data] def unwrap[K, A](m: Type[K, A]): SortedMap[K, A] =
     m.asInstanceOf[SortedMap[K, A]]
 
-  def fromMap[K: Order, A](as: SortedMap[K, A]): Option[NonEmptyMap[K, A]] =
+  def fromMap[K, A](as: SortedMap[K, A]): Option[NonEmptyMap[K, A]] =
     if (as.nonEmpty) Option(create(as)) else None
 
-  def fromMapUnsafe[K: Order, A](m: SortedMap[K, A]): NonEmptyMap[K, A] =
+  def fromMapUnsafe[K, A](m: SortedMap[K, A]): NonEmptyMap[K, A] =
     if (m.nonEmpty) create(m)
     else throw new IllegalArgumentException("Cannot create NonEmptyMap from empty map")
 
-  def apply[K, A](head: (K, A), tail: SortedMap[K, A])(implicit K: Order[K]): NonEmptyMap[K, A] =
-    create(SortedMap(head)(K.toOrdering) ++ tail)
+  def apply[K, A](head: (K, A), tail: SortedMap[K, A]): NonEmptyMap[K, A] =
+    create(tail + head)
+
+  @deprecated("Instance of Order for K not needed", "2.1.1")
+  def fromMap[K, A](as: SortedMap[K, A], k: Order[K]): Option[NonEmptyMap[K, A]] =
+    fromMap(as)
+
+  @deprecated("Instance of Order for K not needed", "2.1.1")
+  def fromMapUnsafe[K, A](m: SortedMap[K, A], K: Order[K]): NonEmptyMap[K, A] =
+    fromMapUnsafe(m)
+
+  @deprecated("Instance of Order for K not needed", "2.1.1")
+  def apply[K, A](head: (K, A), tail: SortedMap[K, A], K: Order[K]): NonEmptyMap[K, A] =
+    apply[K, A](head, tail)
 
   def of[K, A](a: (K, A), as: (K, A)*)(implicit K: Order[K]): NonEmptyMap[K, A] =
     create(SortedMap(as: _*)(K.toOrdering) + a)

--- a/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
@@ -214,7 +214,8 @@ class NonEmptyMapSuite extends CatsSuite {
   }
 
   test("NonEmptyMap#updateWith should not act when key is missing") {
-    val single = NonEmptyMap[String, Int](("here", 1), SortedMap())
+    import scala.math.Ordering.{String => StringOrd}
+    val single: NonEmptyMap[String, Int] = NonEmptyMap[String, Int](("here", 1), SortedMap()(StringOrd)) // null: ignored parameter
     single.lookup("notHere") should ===(single.updateWith("notHere")(_ => 1).lookup("notHere"))
   }
 


### PR DESCRIPTION
Overrides and closes https://github.com/typelevel/cats/pull/2318

The methods `fromMap` and `apply` in the NonEmptyMap companion object included an "Order" restriction on the Key type parameter. Although Keys should be ordered, this is not needed for these methods.

- So as to not break binary compatibility, we add some variants that still take the `Order[Key]` parameter, but
- In some tests or locations, where before they had the implicit Order, we now use a `null` value .