### PR TITLE
Publicize Free#foldStep

### DIFF
--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -70,9 +70,10 @@ sealed abstract class Free[S[_], A] extends Product with Serializable {
   }
 
   /**
-   * A combination of step and fold.
+   * A combination of step and fold. May be used to define interpreters with custom
+   * (non-monoidial) control flow.
    */
-  final private[free] def foldStep[B](
+  final def foldStep[B](
     onPure: A => B,
     onSuspend: S[A] => B,
     onFlatMapped: ((S[X], X => Free[S, A]) forSome { type X }) => B


### PR DESCRIPTION
Due to the fact that the algebra itself is private, it is not *currently* possible to implement custom interpreters on top of `Free`. A first-order analogue for this limitation would be as if the only way to look at `List` was `foldLeft`: it's great, and technically can do anything, but it's immensely difficult to do things that are more complicated than a simple traversal. For example, imagine I want to convert a `List[A]` into a `List[(A, A)]` such that all adjacent even/odd values are paired together (i.e. index `0` with index `2`, `1` with `3` and so on). Doing this with a `foldLeft` is possible, but hard (well, at least annoying). The analogous transformation on `Free` is exponentially more difficult with `foldMap`, and also impossible to type check (due to the existentials involved).

`foldStep` breaks down this restriction by giving safe, direct access to the internals of the data structure, enabling much more complex interpreters than what are currently possible with `foldMap` alone. My current practical example of this need comes from the ongoing Cats Effect 3 development, where I have implemented an interpreter which has cooperative parallelism semantics for *`Free`*, yielding at each suspension point, making it possible to write fully pure `Fiber` implementations which still exhibit parallel semantics.