### PR TITLE
fixes #3206 remove references to waffle.io

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -261,8 +261,7 @@ we'll do our best to improve the process.
 
 Discussion around Cats is currently happening in the
 [Gitter channel](https://gitter.im/typelevel/cats) as well as on Github
-issue and PR pages. You can get an overview of who is working on what
-via [Waffle.io](https://waffle.io/typelevel/cats).
+issue and PR pages.
 
 Feel free to open an issue if you notice a bug, have an idea for a
 feature, or have a question about the code. Pull requests are also

--- a/README.md
+++ b/README.md
@@ -246,9 +246,6 @@ is dedicated for Cats development related discussions. For people who wants to
 follow closely and/or to participate in the decisions in Cats development, 
 this is the room to join. 
 
-You can get an overview of who is working on what
-via [Waffle.io](https://waffle.io/typelevel/cats).
-
 People are expected to follow the
 [Scala Code of Conduct](https://www.scala-lang.org/conduct/) when
 discussing Cats on the Github page, Gitter channel, or other


### PR DESCRIPTION
A PR to fix issue #3206 and remove links to waffle.io :

Files changed based on grep:
```
$ grep -rnw . -e 'waffle'
./README.md:250:via [Waffle.io](https://waffle.io/typelevel/cats).
./CONTRIBUTING.md:265:via [Waffle.io](https://waffle.io/typelevel/cats).
```

