### PR TITLE
Add two casts to satisfy Dotty

### DIFF
--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -356,7 +356,7 @@ object Eval extends EvalInstances {
                 case Nil     => a
               }
             case None =>
-              loop(eval, addToMemo(m) :: fs)
+              loop(eval, addToMemo(m.asInstanceOf[M]) :: fs)
           }
         case x =>
           fs match {

--- a/core/src/main/scala/cats/data/AndThen.scala
+++ b/core/src/main/scala/cats/data/AndThen.scala
@@ -122,7 +122,7 @@ sealed abstract class AndThen[-T, +R] extends (T => R) with Product with Seriali
       self match {
         case Concat(left, inner) =>
           self = left.asInstanceOf[AndThen[Any, Any]]
-          right = inner.andThenF(right)
+          right = inner.asInstanceOf[AndThen[Any, Any]].andThenF(right)
 
         case _ => // Single
           self = self.andThenF(right)


### PR DESCRIPTION
These two casts are necessary to compile cats-core with Dotty. I've been using them locally in my cross-compilation experiments, but wanted to understand for myself why Dotty wants them before opening a PR.

I've just been taking a closer look and have convinced myself that in both cases Dotty is doing the right thing, and Scala 2 only compiles the current code because of soundness bugs.

In `AndThen`, the issue is that the compiler is inferring the `E` to be `Any` in the `Concat` case, which isn't sound in general. Consider the following simplification:

```scala
scala> case class Foo[A](f: A => Any)
defined class Foo

scala> def whatever(x: Any) = x match { case Foo(f) => f("") }
                                                         ^
       error: type mismatch;
        found   : String("")
        required: Nothing
```

Inferring `Nothing` here is the safe thing to do, and this failure makes sense. You can trick the compiler into inferring the `A` to be `Any`, though, simply by having it appear in a non-contravariant position in another member:

```scala
scala> case class Foo[A](a: A, f: A => Any)
defined class Foo

scala> def whatever(x: Any) = x match { case Foo(_, f) => f("") }
whatever: (x: Any)Any
```

…which will fail at runtime on e.g. `Foo[Int]`:

```scala
scala> whatever(Foo[Int](1, identity))
java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Integer
  at scala.runtime.BoxesRunTime.unboxToInt(BoxesRunTime.java:100)
  at scala.runtime.java8.JFunction1$mcII$sp.apply(JFunction1$mcII$sp.scala:17)
  at .whatever(<console>:1)
  ... 29 elided
```
Dotty fixes this and refuses to compile the second `Foo`, and it fails on `AndThen` for the same reason:

```scala
[error] -- [E007] Type Mismatch Error: /home/travis/projects/cats/core/src/main/scala/cats/data/AndThen.scala:125:32 
[error] 125 |          right = inner.andThenF(right)
[error]     |                  ^^^^^^^^^^^^^^^^^^^^^
[error]     |                  Found:    cats.data.AndThen[E$4, Any]
[error]     |                  Required: cats.data.AndThen[Any, Any]
```
The `Eval` code also compiles only because the Scala 2 compiler is too willing to infer `Any`. Here's a simplified example that shows the unsoundness:

```scala
trait Foo[+A] {
  def result: Option[A]
}

case class Bar[A]() extends Foo[A] {
  var result: Option[A] = None
}

def whatever(foo: Foo[Any]): Unit = foo match {
  case b @ Bar() => b.result = Some("foo")
}
```
And then:

```scala
scala> val bar = Bar[Int]()
bar: Bar[Int] = Bar()

scala> whatever(bar)

scala> bar.result.get
java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Integer
  at scala.runtime.BoxesRunTime.unboxToInt(BoxesRunTime.java:100)
  ... 29 elided
```

In context both of these cases are optimizations where we're already doing a lot of casting, and personally I think it's reasonable to add two more casts to satisfy the Dotty compiler.