### PR TITLE
Added flatMapK to FreeT

### DIFF
--- a/free/src/main/scala/cats/free/FreeT.scala
+++ b/free/src/main/scala/cats/free/FreeT.scala
@@ -32,6 +32,19 @@ sealed abstract class FreeT[S[_], M[_], A] extends Product with Serializable {
         Suspend(mn(m))
     }
 
+  /**
+   * Modify the context `M` using the transformation `mn`, flattening the free
+   * suspensions into the outer.
+   */
+  def flatMapK[N[_]: Monad](mn: M ~> FreeT[S, N, *])(implicit S: Functor[S]): FreeT[S, N, A] = {
+    def loop(ftft: FreeT[S, FreeT[S, N, *], A]): FreeT[S, N, A] =
+      ftft.resume.flatMap { e =>
+        e.fold(sft => FreeT.liftF[S, N, FreeT[S, FreeT[S, N, *], A]](sft).flatMap(loop(_)), a => FreeT.pure(a))
+      }
+
+    loop(mapK(mn))
+  }
+
   /** Binds the given continuation to the result of this computation. */
   final def flatMap[B](f: A => FreeT[S, M, B]): FreeT[S, M, B] =
     FlatMapped(this, f)

--- a/free/src/main/scala/cats/free/FreeT.scala
+++ b/free/src/main/scala/cats/free/FreeT.scala
@@ -36,7 +36,7 @@ sealed abstract class FreeT[S[_], M[_], A] extends Product with Serializable {
    * Modify the context `M` using the transformation `mn`, flattening the free
    * suspensions into the outer.
    */
-  def flatMapK[N[_]: Monad](mn: M ~> FreeT[S, N, *])(implicit S: Functor[S]): FreeT[S, N, A] = {
+  def flatMapK[N[_]](mn: M ~> FreeT[S, N, *])(implicit S: Functor[S], N: Monad[N]): FreeT[S, N, A] = {
     def loop(ftft: FreeT[S, FreeT[S, N, *], A]): FreeT[S, N, A] =
       ftft.resume.flatMap { e =>
         e.fold(sft => FreeT.liftF[S, N, FreeT[S, FreeT[S, N, *], A]](sft).flatMap(loop(_)), a => FreeT.pure(a))


### PR DESCRIPTION
The analogous function on `Free` is simply `foldMap`, but `FreeT` has an extra (monadic) suspension functor which cannot be manipulated through the same mechanism. `mapK` already exists; this simply provides a way of doing a `mapK`-like transformation where the resulting `N` is *itself* a `FreeT`. This can be useful when you want to manipulate the structure of the interpretation in a composable fashion.