### PR TITLE
Follow up to #3233

### DIFF
--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -233,10 +233,10 @@ object OptionT extends OptionTInstances {
 
   /**
    * Creates a non-empty `OptionT[F, A]` from an `F[A]` value if the given condition is `true`.
-   * Otherwise, the empty `OptionT[F, A]` is returned. Analogous to `Option.when`.
+   * Otherwise, `none[F, A]` is returned. Analogous to `Option.when`.
    */
   def whenF[F[_], A](cond: Boolean)(fa: => F[A])(implicit F: Applicative[F]): OptionT[F, A] =
-    if (cond) OptionT.liftF(fa) else OptionT(F.map(fa)(_ => Option.empty))
+    if (cond) OptionT.liftF(fa) else OptionT.none[F, A]
 
   /**
    * Same as `whenF`, but expressed as a FunctionK for use with mapK.
@@ -253,7 +253,7 @@ object OptionT extends OptionTInstances {
 
   /**
    * Creates an non-empty `OptionT[F, A]` from an `F[A]` if the given condition is `false`.
-   * Otherwise, the empty `OptionT[F, A]` is returned. Analogous to `Option.unless`.
+   * Otherwise, `none[F, A]` is returned. Analogous to `Option.unless`.
    */
   def unlessF[F[_], A](cond: Boolean)(fa: => F[A])(implicit F: Applicative[F]): OptionT[F, A] =
     OptionT.whenF(!cond)(fa)

--- a/tests/src/test/scala/cats/tests/OptionTSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionTSuite.scala
@@ -278,14 +278,16 @@ class OptionTSuite extends CatsSuite {
     }
   }
 
-  test("OptionT.when[Id, A] consistent with the same implementation of Option.when") {
-    val when = (c: Boolean, j: Int) => if (c) Some(j) else None
+  test("OptionT.when[Id, A] consistent with Option.when") {
+    // Option.when is inlined here because it is not available before Scala 2.13
+    def when[A]: (Boolean, A) => Option[A] = (c: Boolean, a: A) => if (c) Some(a) else None
     forAll { (i: Int, b: Boolean) =>
       OptionT.when[Id, Int](b)(i).value should ===(when(b, i))
     }
   }
 
   test("OptionT.whenF[F, A] consistent with Option.when") {
+    // Option.when is inlined here because it is not available before Scala 2.13
     def when[A]: (Boolean, A) => Option[A] = (c: Boolean, a: A) => if (c) Some(a) else None
     forAll { (i: Int, b: Boolean) =>
       OptionT.whenF[Id, Int](b)(i).value should ===(when(b, i))
@@ -302,14 +304,16 @@ class OptionTSuite extends CatsSuite {
     }
   }
 
-  test("OptionT.unless[Id, A] consistent with the same implementation of Option.unless") {
-    val unless = (c: Boolean, j: Int) => if (!c) Some(j) else None
+  test("OptionT.unless[Id, A] consistent with Option.unless") {
+    // Option.unless is inlined here because it is not available before Scala 2.13
+    def unless[A]: (Boolean, A) => Option[A] = (c: Boolean, a: A) => if (!c) Some(a) else None
     forAll { (i: Int, b: Boolean) =>
       OptionT.unless[Id, Int](b)(i).value should ===(unless(b, i))
     }
   }
 
   test("OptionT.unlessF[F, A] consistent with Option.unless") {
+    // Option.unless is inlined here because it is not available before Scala 2.13
     def unless[A]: (Boolean, A) => Option[A] = (c: Boolean, a: A) => if (!c) Some(a) else None
     forAll { (i: Int, b: Boolean) =>
       OptionT.unlessF[Id, Int](b)(i).value should ===(unless(b, i))

--- a/tests/src/test/scala/cats/tests/OptionTSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionTSuite.scala
@@ -286,15 +286,11 @@ class OptionTSuite extends CatsSuite {
     }
   }
 
-  test("OptionT.whenF[F, A] consistent with Option.when") {
+  test("OptionT.whenF[Id, A] consistent with Option.when") {
     // Option.when is inlined here because it is not available before Scala 2.13
     def when[A]: (Boolean, A) => Option[A] = (c: Boolean, a: A) => if (c) Some(a) else None
     forAll { (i: Int, b: Boolean) =>
       OptionT.whenF[Id, Int](b)(i).value should ===(when(b, i))
-    }
-
-    forAll { (i: List[Int], b: Boolean) =>
-      OptionT.whenF[List, Int](b)(i).value should ===(when(b, i).sequence)
     }
   }
 
@@ -312,15 +308,11 @@ class OptionTSuite extends CatsSuite {
     }
   }
 
-  test("OptionT.unlessF[F, A] consistent with Option.unless") {
+  test("OptionT.unlessF[Id, A] consistent with Option.unless") {
     // Option.unless is inlined here because it is not available before Scala 2.13
     def unless[A]: (Boolean, A) => Option[A] = (c: Boolean, a: A) => if (!c) Some(a) else None
     forAll { (i: Int, b: Boolean) =>
       OptionT.unlessF[Id, Int](b)(i).value should ===(unless(b, i))
-    }
-
-    forAll { (i: List[Int], b: Boolean) =>
-      OptionT.unlessF[List, Int](b)(i).value should ===(unless(b, i).sequence)
     }
   }
 

--- a/tests/src/test/scala/cats/tests/OptionTSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionTSuite.scala
@@ -285,10 +285,14 @@ class OptionTSuite extends CatsSuite {
     }
   }
 
-  test("OptionT.whenF[F, A] consistent with the same implementation of Option.when") {
-    val when = (c: Boolean, j: Int) => if (c) Some(j) else None
-    forAll { (li: List[Int], b: Boolean) =>
-      OptionT.whenF(b)(li).value should ===(li.map(when(b, _)))
+  test("OptionT.whenF[F, A] consistent with Option.when") {
+    def when[A]: (Boolean, A) => Option[A] = (c: Boolean, a: A) => if (c) Some(a) else None
+    forAll { (i: Int, b: Boolean) =>
+      OptionT.whenF[Id, Int](b)(i).value should ===(when(b, i))
+    }
+
+    forAll { (i: List[Int], b: Boolean) =>
+      OptionT.whenF[List, Int](b)(i).value should ===(when(b, i).sequence)
     }
   }
 
@@ -305,10 +309,14 @@ class OptionTSuite extends CatsSuite {
     }
   }
 
-  test("OptionT.unlessF[F, A] consistent with the same implementation of Option.unless") {
-    val unless = (c: Boolean, j: Int) => if (!c) Some(j) else None
-    forAll { (li: List[Int], b: Boolean) =>
-      OptionT.unlessF(b)(li).value should ===(li.map(unless(b, _)))
+  test("OptionT.unlessF[F, A] consistent with Option.unless") {
+    def unless[A]: (Boolean, A) => Option[A] = (c: Boolean, a: A) => if (!c) Some(a) else None
+    forAll { (i: Int, b: Boolean) =>
+      OptionT.unlessF[Id, Int](b)(i).value should ===(unless(b, i))
+    }
+
+    forAll { (i: List[Int], b: Boolean) =>
+      OptionT.unlessF[List, Int](b)(i).value should ===(unless(b, i).sequence)
     }
   }
 


### PR DESCRIPTION
A follow up to #3233 based on the helpful comments by @fthomas and @rossabaker:  `OptionT.{whenF, unlessF}` should return `OptionT.none` when the given condition is `false`.