### PR TITLE
Reimplemented MonadError[FreeT[...]] to be correct

### DIFF
--- a/free/src/main/scala/cats/free/FreeT.scala
+++ b/free/src/main/scala/cats/free/FreeT.scala
@@ -240,7 +240,7 @@ sealed abstract private[free] class FreeTInstances extends FreeTInstances0 {
       override def M = E
 
       /*
-       * Quick explanation... The previous version of this function (retained about for
+       * Quick explanation... The previous version of this function (retained above for
        * bincompat) was only able to look at the *top* level M[_] suspension in a Free
        * program. Any suspensions below that in the compute tree were invisible. Thus,
        * if there were errors in that top level suspension, then they would be handled

--- a/free/src/main/scala/cats/free/FreeT.scala
+++ b/free/src/main/scala/cats/free/FreeT.scala
@@ -222,7 +222,8 @@ object FreeT extends FreeTInstances {
 sealed abstract private[free] class FreeTInstances extends FreeTInstances0 {
 
   // retained for binary compatibility. its results are incorrect though and it would fail the laws if we generated things of the form pure(()).flatMap(_ => fa)
-  private[this] def catsFreeMonadErrorForFreeT[S[_], M[_], E](
+  @deprecated("does not handle errors beyond the head suspension; use catsFreeMonadErrorForFreeT2", "2.1.0")
+  def catsFreeMonadErrorForFreeT[S[_], M[_], E](
     implicit E: MonadError[M, E]
   ): MonadError[FreeT[S, M, *], E] =
     new MonadError[FreeT[S, M, *], E] with FreeTMonad[S, M] {

--- a/free/src/test/scala/cats/free/FreeTSuite.scala
+++ b/free/src/test/scala/cats/free/FreeTSuite.scala
@@ -44,6 +44,8 @@ class FreeTSuite extends CatsSuite {
              SerializableTests.serializable(MonadError[FreeTOption, Unit]))
   }
 
+  checkAll("FreeT[Option, Option, Int", DeferTests[FreeTOption].defer[Int])
+
   test("FlatMap stack safety tested with 50k flatMaps") {
     val expected = Applicative[FreeTOption].pure(())
     val result =

--- a/free/src/test/scala/cats/free/FreeTSuite.scala
+++ b/free/src/test/scala/cats/free/FreeTSuite.scala
@@ -115,6 +115,15 @@ class FreeTSuite extends CatsSuite {
     }
   }
 
+  // NB: this does not analogously cause problems for the SemigroupK implementation as semigroup's effects associate while errors do not
+  test("handle errors in non-head suspensions") {
+    type F[A] = FreeT[Id, Option, A]
+    val F = MonadError[F, Unit]
+
+    val eff = F.flatMap(F.pure(()))(_ => F.raiseError[String](()))
+    F.attempt(eff).runM(Some(_)) should ===(Some(Left(())))
+  }
+
   sealed trait Test1Algebra[A]
 
   case class Test1[A](value: Int, f: Int => A) extends Test1Algebra[A]

--- a/laws/src/main/scala/cats/laws/ApplicativeErrorLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplicativeErrorLaws.scala
@@ -54,6 +54,21 @@ trait ApplicativeErrorLaws[F[_], E] extends ApplicativeLaws[F] {
 
   def redeemDerivedFromAttemptMap[A, B](fa: F[A], fe: E => B, fs: A => B): IsEq[F[B]] =
     F.redeem(fa)(fe, fs) <-> F.map(F.attempt(fa))(_.fold(fe, fs))
+
+  /*
+   * These laws, taken together with applicativeErrorHandle, show that errors dominate in
+   * ap, *and* show that handle has lexical semantics over ap. F.unit is used in both laws
+   * because we don't have another way of expressing "an F[_] which does *not* contain any
+   * errors". We could make these laws considerably stronger if such a thing were
+   * expressible. Specifically, what we're missing here is the ability to say that
+   * raiseError distributes over an *arbitrary* number of aps.
+   */
+
+  def raiseErrorDistributesOverApLeft[A](h: E => F[A], e: E) =
+    F.handleErrorWith(F.ap(F.raiseError[Unit => A](e))(F.unit))(h) <-> h(e)
+
+  def raiseErrorDistributesOverApRight[A](h: E => F[A], e: E) =
+    F.handleErrorWith(F.ap(F.pure((a: A) => a))(F.raiseError[A](e)))(h) <-> h(e)
 }
 
 object ApplicativeErrorLaws {

--- a/laws/src/main/scala/cats/laws/discipline/ApplicativeErrorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ApplicativeErrorTests.scala
@@ -56,7 +56,9 @@ trait ApplicativeErrorTests[F[_], E] extends ApplicativeTests[F] {
         "applicativeError onError raise" -> forAll(laws.onErrorRaise[A] _),
         "applicativeError adaptError pure" -> forAll(laws.adaptErrorPure[A] _),
         "applicativeError adaptError raise" -> forAll(laws.adaptErrorRaise[A] _),
-        "applicativeError redeem is derived from attempt and map" -> forAll(laws.redeemDerivedFromAttemptMap[A, B] _)
+        "applicativeError redeem is derived from attempt and map" -> forAll(laws.redeemDerivedFromAttemptMap[A, B] _),
+        "applicativeError handleError . raiseError left-distributes over ap" -> forAll(laws.raiseErrorDistributesOverApLeft[A] _),
+        "applicativeError handleError . raiseError right-distributes over ap" -> forAll(laws.raiseErrorDistributesOverApRight[A] _)
       )
     }
 }

--- a/laws/src/main/scala/cats/laws/discipline/ApplicativeErrorTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ApplicativeErrorTests.scala
@@ -57,8 +57,12 @@ trait ApplicativeErrorTests[F[_], E] extends ApplicativeTests[F] {
         "applicativeError adaptError pure" -> forAll(laws.adaptErrorPure[A] _),
         "applicativeError adaptError raise" -> forAll(laws.adaptErrorRaise[A] _),
         "applicativeError redeem is derived from attempt and map" -> forAll(laws.redeemDerivedFromAttemptMap[A, B] _),
-        "applicativeError handleError . raiseError left-distributes over ap" -> forAll(laws.raiseErrorDistributesOverApLeft[A] _),
-        "applicativeError handleError . raiseError right-distributes over ap" -> forAll(laws.raiseErrorDistributesOverApRight[A] _)
+        "applicativeError handleError . raiseError left-distributes over ap" -> forAll(
+          laws.raiseErrorDistributesOverApLeft[A] _
+        ),
+        "applicativeError handleError . raiseError right-distributes over ap" -> forAll(
+          laws.raiseErrorDistributesOverApRight[A] _
+        )
       )
     }
 }


### PR DESCRIPTION
There's an explanation of this in the comments in the code. I retained the old implementation for binary compatibility, but it is somewhat unfortunate since any code which is hitting that is outright-broken and people may not know it. Then again, I'm not sure how many people (other than me) are using `FreeT`, so maybe it's okay either way.

Fixes #3240