### PR TITLE
Minor changes for Scala.js 1.0 compatibility

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -119,7 +119,7 @@ lazy val commonJsSettings = Seq(
   parallelExecution := false,
   jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv(),
   // batch mode decreases the amount of memory needed to compile Scala.js code
-  scalaJSOptimizerOptions := scalaJSOptimizerOptions.value.withBatchMode(isTravisBuild.value),
+  scalaJSLinkerConfig := scalaJSLinkerConfig.value.withBatchMode(isTravisBuild.value),
   // currently sbt-doctest doesn't work in JS builds
   // https://github.com/tkawachi/sbt-doctest/issues/52
   doctestGenTests := Seq.empty

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,6 @@
+val scalaJSVersion =
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.31")
+
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.2")
 addSbtPlugin("com.github.gseitz" %% "sbt-release" % "1.0.12")
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "2.0.1")
@@ -10,7 +13,7 @@ addSbtPlugin("org.xerial.sbt" % "sbt-sonatype" % "3.8.1")
 addSbtPlugin("com.47deg" % "sbt-microsites" % "1.0.2")
 addSbtPlugin("org.tpolecat" % "tut-plugin" % "0.6.13")
 addSbtPlugin("org.portable-scala" % "sbt-scalajs-crossproject" % "0.6.1")
-addSbtPlugin("org.scala-js" % "sbt-scalajs" % "0.6.31")
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
 addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.3.0")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 

--- a/scripts/scala.js-1.0-publish.sh
+++ b/scripts/scala.js-1.0-publish.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# For temporary use while cross-publishing for Scala.js 0.6 and 1.0.
+
+SCALAJS_VERSION=1.0.0-RC2 sbt +kernelJS/publishSigned
+SCALAJS_VERSION=1.0.0-RC2 sbt +kernelLawsJS/publishSigned
+SCALAJS_VERSION=1.0.0-RC2 sbt +coreJS/publishSigned
+SCALAJS_VERSION=1.0.0-RC2 sbt +lawsJS/publishSigned
+SCALAJS_VERSION=1.0.0-RC2 sbt +freeJS/publishSigned
+SCALAJS_VERSION=1.0.0-RC2 sbt +testkitJS/publishSigned
+SCALAJS_VERSION=1.0.0-RC2 sbt +alleycatsCoreJS/publishSigned
+SCALAJS_VERSION=1.0.0-RC2 sbt +alleycatsLawsJS/publishSigned


### PR DESCRIPTION
These changes make it possible to build Cats on Scala.js 1.0 (currently 1.0.0-RC2) via an environmental variable, without actually changing anything significant about the current build, which is still on Scala.js 0.6.

This approach is currently used by Simulacrum, Discipline (although Discipline does test Scala.js 1.0.0-RC2 in CI, and this change doesn't), etc.

I've confirmed that the following succeeds:

```
SCALAJS_VERSION=1.0.0-RC2 sbt +validateJS
```