### PR TITLE
Avoid ScalaTest 3.1.0 deprecations

### DIFF
--- a/alleycats-tests/js/src/test/scala/alleycats/tests/TestSettings.scala
+++ b/alleycats-tests/js/src/test/scala/alleycats/tests/TestSettings.scala
@@ -2,7 +2,7 @@ package alleycats
 package tests
 
 import org.scalactic.anyvals.{PosInt, PosZDouble, PosZInt}
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.Configuration
 
 trait TestSettings extends Configuration with Matchers {

--- a/alleycats-tests/jvm/src/test/scala/alleycats/tests/TestSettings.scala
+++ b/alleycats-tests/jvm/src/test/scala/alleycats/tests/TestSettings.scala
@@ -2,7 +2,7 @@ package alleycats
 package tests
 
 import org.scalactic.anyvals.{PosInt, PosZDouble, PosZInt}
-import org.scalatest.Matchers
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.Configuration
 
 trait TestSettings extends Configuration with Matchers {


### PR DESCRIPTION
Low-priority but we might as well go ahead and do this.
