### PR TITLE
Some Dotty compat for tests

### DIFF
--- a/free/src/test/scala/cats/free/CofreeSuite.scala
+++ b/free/src/test/scala/cats/free/CofreeSuite.scala
@@ -3,6 +3,7 @@ package free
 
 import cats.data.{NonEmptyList, OptionT}
 import cats.laws.discipline.{ComonadTests, ReducibleTests, SemigroupalTests, SerializableTests, TraverseTests}
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.syntax.list._
 import cats.tests.{CatsSuite, Spooky}
 import org.scalacheck.{Arbitrary, Cogen, Gen}
@@ -11,16 +12,16 @@ class CofreeSuite extends CatsSuite {
 
   import CofreeSuite._
 
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Cofree[Option, *]]
+  implicit val iso: Isomorphisms[Cofree[Option, *]] = Isomorphisms.invariant[Cofree[Option, *]]
 
   checkAll("Cofree[Option, *]", ComonadTests[Cofree[Option, *]].comonad[Int, Int, Int])
   locally {
-    implicit val instance = Cofree.catsTraverseForCofree[Option]
+    implicit val instance: Traverse[Cofree[Option, *]] = Cofree.catsTraverseForCofree[Option]
     checkAll("Cofree[Option, *]", TraverseTests[Cofree[Option, *]].traverse[Int, Int, Int, Int, Option, Option])
     checkAll("Traverse[Cofree[Option, *]]", SerializableTests.serializable(Traverse[Cofree[Option, *]]))
   }
   locally {
-    implicit val instance = Cofree.catsReducibleForCofree[Option]
+    implicit val instance: Reducible[Cofree[Option, *]] = Cofree.catsReducibleForCofree[Option]
     checkAll("Cofree[Option, *]", ReducibleTests[Cofree[Option, *]].reducible[Option, Int, Int])
     checkAll("Reducible[Cofree[Option, *]]", SerializableTests.serializable(Reducible[Cofree[Option, *]]))
   }

--- a/free/src/test/scala/cats/free/CofreeSuite.scala
+++ b/free/src/test/scala/cats/free/CofreeSuite.scala
@@ -2,7 +2,7 @@ package cats
 package free
 
 import cats.data.{NonEmptyList, OptionT}
-import cats.laws.discipline.{ComonadTests, ReducibleTests, SemigroupalTests, SerializableTests, TraverseTests}
+import cats.laws.discipline.{ComonadTests, ReducibleTests, SerializableTests, TraverseTests}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.syntax.list._
 import cats.tests.{CatsSuite, Spooky}

--- a/free/src/test/scala/cats/free/FreeApplicativeSuite.scala
+++ b/free/src/test/scala/cats/free/FreeApplicativeSuite.scala
@@ -3,7 +3,7 @@ package free
 
 import cats.tests.CatsSuite
 import cats.arrow.FunctionK
-import cats.laws.discipline.{ApplicativeTests, SemigroupalTests, SerializableTests}
+import cats.laws.discipline.{ApplicativeTests, SerializableTests}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.data.State
 

--- a/free/src/test/scala/cats/free/FreeApplicativeSuite.scala
+++ b/free/src/test/scala/cats/free/FreeApplicativeSuite.scala
@@ -4,6 +4,7 @@ package free
 import cats.tests.CatsSuite
 import cats.arrow.FunctionK
 import cats.laws.discipline.{ApplicativeTests, SemigroupalTests, SerializableTests}
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.data.State
 
 import org.scalacheck.{Arbitrary, Gen}
@@ -11,7 +12,7 @@ import org.scalacheck.{Arbitrary, Gen}
 class FreeApplicativeSuite extends CatsSuite {
   import FreeApplicativeSuite._
 
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[FreeApplicative[Option, *]]
+  implicit val iso: Isomorphisms[FreeApplicative[Option, *]] = Isomorphisms.invariant[FreeApplicative[Option, *]]
 
   checkAll("FreeApplicative[Option, *]", ApplicativeTests[FreeApplicative[Option, *]].applicative[Int, Int, Int])
   checkAll("Applicative[FreeApplicative[Option, *]]",

--- a/free/src/test/scala/cats/free/FreeInvariantMonoidalSuite.scala
+++ b/free/src/test/scala/cats/free/FreeInvariantMonoidalSuite.scala
@@ -26,7 +26,8 @@ class FreeInvariantMonoidalSuite extends CatsSuite {
       }
     }
 
-  implicit val isoFreeBinCodec = Isomorphisms.invariant[FreeInvariantMonoidal[BinCodec, *]]
+  implicit val isoFreeBinCodec: Isomorphisms[FreeInvariantMonoidal[BinCodec, *]] =
+    Isomorphisms.invariant[FreeInvariantMonoidal[BinCodec, *]]
 
   checkAll("FreeInvariantMonoidal[BinCodec, *]",
            InvariantMonoidalTests[FreeInvariantMonoidal[BinCodec, *]].invariantMonoidal[MiniInt, Boolean, Boolean])

--- a/free/src/test/scala/cats/free/FreeSuite.scala
+++ b/free/src/test/scala/cats/free/FreeSuite.scala
@@ -5,6 +5,7 @@ import cats.arrow.FunctionK
 import cats.data.EitherK
 import cats.laws.discipline.{DeferTests, FoldableTests, MonadTests, SemigroupalTests, SerializableTests, TraverseTests}
 import cats.laws.discipline.arbitrary.catsLawsArbitraryForFn0
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.tests.CatsSuite
 
 import org.scalacheck.{Arbitrary, Cogen, Gen}
@@ -13,7 +14,7 @@ import Arbitrary.arbFunction1
 class FreeSuite extends CatsSuite {
   import FreeSuite._
 
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Free[Option, *]]
+  implicit val iso: Isomorphisms[Free[Option, *]] = Isomorphisms.invariant[Free[Option, *]]
 
   Monad[Free[Id, *]]
   implicitly[Monad[Free[Id, *]]]
@@ -27,14 +28,14 @@ class FreeSuite extends CatsSuite {
   checkAll("Monad[Free[Option, *]]", SerializableTests.serializable(Monad[Free[Option, *]]))
 
   locally {
-    implicit val instance = Free.catsFreeFoldableForFree[Option]
+    implicit val instance: Foldable[Free[Option, *]] = Free.catsFreeFoldableForFree[Option]
 
     checkAll("Free[Option, *]", FoldableTests[Free[Option, *]].foldable[Int, Int])
     checkAll("Foldable[Free[Option,*]]", SerializableTests.serializable(Foldable[Free[Option, *]]))
   }
 
   locally {
-    implicit val instance = Free.catsFreeTraverseForFree[Option]
+    implicit val instance: Traverse[Free[Option, *]] = Free.catsFreeTraverseForFree[Option]
     checkAll("Free[Option,*]", TraverseTests[Free[Option, *]].traverse[Int, Int, Int, Int, Option, Option])
     checkAll("Traverse[Free[Option,*]]", SerializableTests.serializable(Traverse[Free[Option, *]]))
   }

--- a/free/src/test/scala/cats/free/FreeSuite.scala
+++ b/free/src/test/scala/cats/free/FreeSuite.scala
@@ -3,7 +3,7 @@ package free
 
 import cats.arrow.FunctionK
 import cats.data.EitherK
-import cats.laws.discipline.{DeferTests, FoldableTests, MonadTests, SemigroupalTests, SerializableTests, TraverseTests}
+import cats.laws.discipline.{DeferTests, FoldableTests, MonadTests, SerializableTests, TraverseTests}
 import cats.laws.discipline.arbitrary.catsLawsArbitraryForFn0
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.tests.CatsSuite

--- a/jvm/src/test/scala/cats/tests/FutureSuite.scala
+++ b/jvm/src/test/scala/cats/tests/FutureSuite.scala
@@ -45,7 +45,7 @@ class FutureSuite extends CatsSuite {
   checkAll("Future", CoflatMapTests[Future].coflatMap[Int, Int, Int])
 
   {
-    implicit val F = ListWrapper.semigroup[Int]
+    implicit val F: Semigroup[ListWrapper[Int]] = ListWrapper.semigroup[Int]
     checkAll("Future[ListWrapper[Int]]", SemigroupLawTests[Future[ListWrapper[Int]]].semigroup)
   }
 

--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -444,7 +444,7 @@ class Tests extends AnyFunSuiteLike with Discipline with ScalaVersionSpecificTes
           .forall { case (x, y) => a.eqv(x, y) == b.eqv(x, y) }
     }
 
-    implicit val monoidOrderN = Order.whenEqualMonoid[N]
+    implicit val monoidOrderN: Monoid[Order[N]] with Band[Order[N]] = Order.whenEqualMonoid[N]
     checkAll("Monoid[Order[N]]", MonoidTests[Order[N]].monoid)
     checkAll("Band[Order[N]]", BandTests[Order[N]].band)
 

--- a/laws/src/main/scala/cats/laws/NonEmptyTraverseLaws.scala
+++ b/laws/src/main/scala/cats/laws/NonEmptyTraverseLaws.scala
@@ -32,7 +32,7 @@ trait NonEmptyTraverseLaws[F[_]] extends TraverseLaws[F] with ReducibleLaws[F] {
     N: Apply[N],
     M: Apply[M]): IsEq[(M[F[B]], N[F[B]])] = {
     type MN[Z] = (M[Z], N[Z])
-    implicit val MN = new Apply[MN] {
+    implicit val MN: Apply[MN] = new Apply[MN] {
       def ap[X, Y](f: MN[X => Y])(fa: MN[X]): MN[Y] = {
         val (fam, fan) = fa
         val (fm, fn) = f

--- a/laws/src/main/scala/cats/laws/TraverseLaws.scala
+++ b/laws/src/main/scala/cats/laws/TraverseLaws.scala
@@ -33,7 +33,7 @@ trait TraverseLaws[F[_]] extends FunctorLaws[F] with FoldableLaws[F] with Unorde
     N: Applicative[N],
     M: Applicative[M]): IsEq[(M[F[B]], N[F[B]])] = {
     type MN[Z] = (M[Z], N[Z])
-    implicit val MN = new Applicative[MN] {
+    implicit val MN: Applicative[MN] = new Applicative[MN] {
       def pure[X](x: X): MN[X] = (M.pure(x), N.pure(x))
       def ap[X, Y](f: MN[X => Y])(fa: MN[X]): MN[Y] = {
         val (fam, fan) = fa
@@ -67,7 +67,7 @@ trait TraverseLaws[F[_]] extends FunctorLaws[F] with FoldableLaws[F] with Unorde
   def traverseOrderConsistent[A](fa: F[A]): IsEq[Option[A]] = {
     class FirstOption[T](val o: Option[T])
 
-    implicit val firstOptionMonoid = new Monoid[FirstOption[A]] {
+    implicit val firstOptionMonoid: Monoid[FirstOption[A]] = new Monoid[FirstOption[A]] {
       def empty = new FirstOption(None)
       def combine(x: FirstOption[A], y: FirstOption[A]) = new FirstOption(x.o.orElse(y.o))
     }

--- a/laws/src/main/scala/cats/laws/UnorderedTraverseLaws.scala
+++ b/laws/src/main/scala/cats/laws/UnorderedTraverseLaws.scala
@@ -25,7 +25,7 @@ trait UnorderedTraverseLaws[F[_]] extends UnorderedFoldableLaws[F] {
   ): IsEq[(M[F[B]], N[F[B]])] = {
 
     type MN[Z] = (M[Z], N[Z])
-    implicit val MN = new CommutativeApplicative[MN] {
+    implicit val MN: CommutativeApplicative[MN] = new CommutativeApplicative[MN] {
       def pure[X](x: X): MN[X] = (M.pure(x), N.pure(x))
       def ap[X, Y](f: MN[X => Y])(fa: MN[X]): MN[Y] = {
         val (fam, fan) = fa

--- a/testkit/src/main/scala/cats/tests/ListWrapper.scala
+++ b/testkit/src/main/scala/cats/tests/ListWrapper.scala
@@ -27,7 +27,7 @@ import org.scalacheck.Arbitrary.arbitrary
  *
  * {{{
  * {
- *   implicit val functor = ListWrapper.functor
+ *   implicit val functor: Functor[ListWrapper] = ListWrapper.functor
  *   checkAll(..., ...)
  * }
  * }}}

--- a/tests/src/test/scala-2.12/cats/tests/NonEmptyStreamSuite.scala
+++ b/tests/src/test/scala-2.12/cats/tests/NonEmptyStreamSuite.scala
@@ -5,6 +5,7 @@ import cats.data.{NonEmptyStream, OneAnd}
 import cats.instances.stream._
 import cats.kernel.laws.discipline.{EqTests, SemigroupTests}
 import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline._
 
 class NonEmptyStreamSuite extends CatsSuite {
@@ -31,7 +32,7 @@ class NonEmptyStreamSuite extends CatsSuite {
     implicitly[Comonad[NonEmptyStream]]
   }
 
-  implicit val iso2 = SemigroupalTests.Isomorphisms.invariant[NonEmptyStream]
+  implicit val iso2: Isomorphisms[NonEmptyStream] = Isomorphisms.invariant[NonEmptyStream]
 
   checkAll("NonEmptyStream[Int]", MonadTests[NonEmptyStream].monad[Int, Int, Int])
   checkAll("Monad[NonEmptyStream[A]]", SerializableTests.serializable(Monad[NonEmptyStream]))

--- a/tests/src/test/scala-2.13+/cats/tests/LazyListSuite.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/LazyListSuite.scala
@@ -47,7 +47,7 @@ class LazyListSuite extends CatsSuite {
   }
 
   test("Show[LazyList] is referentially transparent, unlike LazyList.toString") {
-    forAll { lazyList: LazyList[Int] =>
+    forAll { (lazyList: LazyList[Int]) =>
       if (!lazyList.isEmpty) {
         val unevaluatedLL = lazyList.map(identity)
         val initialShow = unevaluatedLL.show

--- a/tests/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
@@ -36,14 +36,14 @@ class NonEmptyLazyListSuite extends CatsSuite {
   checkAll("Show[NonEmptyLazyList[Int]]", SerializableTests.serializable(Show[NonEmptyLazyList[Int]]))
 
   {
-    implicit val partialOrder = ListWrapper.partialOrder[Int]
+    implicit val partialOrder: PartialOrder[ListWrapper[Int]] = ListWrapper.partialOrder[Int]
     checkAll("NonEmptyLazyList[ListWrapper[Int]]", PartialOrderTests[NonEmptyLazyList[ListWrapper[Int]]].partialOrder)
     checkAll("PartialOrder[NonEmptyLazyList[ListWrapper[Int]]",
              SerializableTests.serializable(PartialOrder[NonEmptyLazyList[ListWrapper[Int]]]))
   }
 
   {
-    implicit val eqv = ListWrapper.eqv[Int]
+    implicit val eqv: Eq[ListWrapper[Int]] = ListWrapper.eqv[Int]
     checkAll("NonEmptyLazyList[ListWrapper[Int]]", EqTests[NonEmptyLazyList[ListWrapper[Int]]].eqv)
     checkAll("Eq[NonEmptyLazyList[ListWrapper[Int]]",
              SerializableTests.serializable(Eq[NonEmptyLazyList[ListWrapper[Int]]]))

--- a/tests/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
@@ -126,7 +126,7 @@ class NonEmptyLazyListSuite extends CatsSuite {
   }
 
   test("NonEmptyLazyList#distinct is consistent with List#distinct") {
-    forAll { ci: NonEmptyLazyList[Int] =>
+    forAll { (ci: NonEmptyLazyList[Int]) =>
       ci.distinct.toList should ===(ci.toList.distinct)
     }
   }

--- a/tests/src/test/scala-2.13+/cats/tests/ScalaVersionSpecific.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/ScalaVersionSpecific.scala
@@ -48,7 +48,7 @@ trait ScalaVersionSpecificFoldableSuite { self: FoldableSuiteAdditional =>
     dangerous.foldM(0)((acc, a) => if (a < 2) Some(acc + a) else None) should ===(None)
   }
 
-  def foldableLazyListWithDefaultImpl = new Foldable[LazyList] {
+  def foldableLazyListWithDefaultImpl: Foldable[LazyList] = new Foldable[LazyList] {
     def foldLeft[A, B](fa: LazyList[A], b: B)(f: (B, A) => B): B =
       Foldable[LazyList].foldLeft(fa, b)(f)
 
@@ -57,7 +57,7 @@ trait ScalaVersionSpecificFoldableSuite { self: FoldableSuiteAdditional =>
   }
 
   test("Foldable[LazyList].foldLeftM short-circuiting") {
-    implicit val F = foldableLazyListWithDefaultImpl
+    implicit val F: Foldable[LazyList] = foldableLazyListWithDefaultImpl
     val ns = LazyList.continually(1)
     val res = F.foldLeftM[Either[Int, *], Int, Int](ns, 0) { (sum, n) =>
       if (sum >= 100000) Left(sum) else Right(sum + n)
@@ -66,7 +66,7 @@ trait ScalaVersionSpecificFoldableSuite { self: FoldableSuiteAdditional =>
   }
 
   test("Foldable[LazyList].foldLeftM short-circuiting optimality") {
-    implicit val F = foldableLazyListWithDefaultImpl
+    implicit val F: Foldable[LazyList] = foldableLazyListWithDefaultImpl
 
     // test that no more elements are evaluated than absolutely necessary
 
@@ -81,13 +81,13 @@ trait ScalaVersionSpecificFoldableSuite { self: FoldableSuiteAdditional =>
   }
 
   test("Foldable[LazyList].existsM/.forallM short-circuiting") {
-    implicit val F = foldableLazyListWithDefaultImpl
+    implicit val F: Foldable[LazyList] = foldableLazyListWithDefaultImpl
     assert(F.existsM[Id, Boolean](true #:: boomLazyList[Boolean])(identity) == true)
     assert(F.forallM[Id, Boolean](false #:: boomLazyList[Boolean])(identity) == false)
   }
 
   test("Foldable[LazyList].findM/.collectFirstSomeM short-circuiting") {
-    implicit val F = foldableLazyListWithDefaultImpl
+    implicit val F: Foldable[LazyList] = foldableLazyListWithDefaultImpl
     assert((1 #:: boomLazyList[Int]).findM[Id](_ > 0) == Some(1))
     assert((1 #:: boomLazyList[Int]).collectFirstSomeM[Id, Int](Option.apply) == Some(1))
   }

--- a/tests/src/test/scala/cats/tests/AndThenSuite.scala
+++ b/tests/src/test/scala/cats/tests/AndThenSuite.scala
@@ -14,7 +14,8 @@ class AndThenSuite extends CatsSuite {
   checkAll("Semigroupal[AndThen[Int, *]]", SerializableTests.serializable(Semigroupal[AndThen[Int, *]]))
 
   {
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[AndThen[*, Int]]
+    implicit val iso: SemigroupalTests.Isomorphisms[AndThen[*, Int]] =
+      SemigroupalTests.Isomorphisms.invariant[AndThen[*, Int]]
     checkAll("AndThen[*, Int]",
              ContravariantMonoidalTests[AndThen[*, Int]].contravariantMonoidal[MiniInt, Boolean, Boolean])
     checkAll("ContravariantMonoidal[AndThen[*, Int]]",

--- a/tests/src/test/scala/cats/tests/ApplicativeSuite.scala
+++ b/tests/src/test/scala/cats/tests/ApplicativeSuite.scala
@@ -41,7 +41,7 @@ class ApplicativeSuite extends CatsSuite {
   }
 
   {
-    implicit val optionMonoid = Applicative.monoid[Option, Int]
+    implicit val optionMonoid: Monoid[Option[Int]] = Applicative.monoid[Option, Int]
     checkAll("Applicative[Option].monoid", MonoidTests[Option[Int]](optionMonoid).monoid)
   }
 
@@ -51,23 +51,23 @@ class ApplicativeSuite extends CatsSuite {
   }
 
   {
-    implicit val listwrapperApplicative = ListWrapper.applicative
-    implicit val listwrapperCoflatMap = Applicative.coflatMap[ListWrapper]
+    implicit val listwrapperApplicative: Applicative[ListWrapper] = ListWrapper.applicative
+    implicit val listwrapperCoflatMap: CoflatMap[ListWrapper] = Applicative.coflatMap[ListWrapper]
     checkAll("Applicative[ListWrapper].coflatMap", CoflatMapTests[ListWrapper].coflatMap[String, String, String])
 
-    implicit val validatedCoflatMap = Applicative.coflatMap[Validated[String, *]]
+    implicit val validatedCoflatMap: CoflatMap[Validated[String, *]] = Applicative.coflatMap[Validated[String, *]]
     checkAll("Applicative[Validated].coflatMap", CoflatMapTests[Validated[String, *]].coflatMap[String, String, String])
 
-    implicit val constCoflatMap = Applicative.coflatMap[Const[String, *]]
+    implicit val constCoflatMap: CoflatMap[Const[String, *]] = Applicative.coflatMap[Const[String, *]]
     checkAll("Applicative[Const].coflatMap", CoflatMapTests[Const[String, *]].coflatMap[String, String, String])
 
-    implicit val listwrapperAlign = Apply.align[ListWrapper]
+    implicit val listwrapperAlign: Align[ListWrapper] = Apply.align[ListWrapper]
     checkAll("Apply[ListWrapper].align", AlignTests[ListWrapper].align[Int, Int, Int, Int])
 
-    implicit val validatedAlign = Apply.align[Validated[String, *]]
+    implicit val validatedAlign: Align[Validated[String, *]] = Apply.align[Validated[String, *]]
     checkAll("Apply[Validated].align", AlignTests[Validated[String, *]].align[Int, Int, Int, Int])
 
-    implicit val constAlign = Apply.align[Const[String, *]]
+    implicit val constAlign: Align[Const[String, *]] = Apply.align[Const[String, *]]
     checkAll("Apply[Const].align", AlignTests[Const[String, *]].align[Int, Int, Int, Int])
   }
 

--- a/tests/src/test/scala/cats/tests/BinCodecInvariantMonoidalSuite.scala
+++ b/tests/src/test/scala/cats/tests/BinCodecInvariantMonoidalSuite.scala
@@ -163,13 +163,13 @@ class BinCodecInvariantMonoidalSuite extends CatsSuite {
 
   {
     implicit val miniIntMonoid: Monoid[MiniInt] = MiniInt.miniIntAddition
-    implicit val binMonoid = InvariantMonoidal.monoid[BinCodec, MiniInt]
+    implicit val binMonoid: Monoid[BinCodec[MiniInt]] = InvariantMonoidal.monoid[BinCodec, MiniInt]
     checkAll("InvariantMonoidal[BinCodec].monoid", MonoidTests[BinCodec[MiniInt]].monoid)
   }
 
   {
     implicit val miniIntSemigroup: Semigroup[MiniInt] = MiniInt.miniIntAddition
-    implicit val binSemigroup = InvariantSemigroupal.semigroup[BinCodec, MiniInt]
+    implicit val binSemigroup: Semigroup[BinCodec[MiniInt]] = InvariantSemigroupal.semigroup[BinCodec, MiniInt]
     checkAll("InvariantSemigroupal[BinCodec].semigroup", SemigroupTests[BinCodec[MiniInt]].semigroup)
   }
 }

--- a/tests/src/test/scala/cats/tests/BinestedSuite.scala
+++ b/tests/src/test/scala/cats/tests/BinestedSuite.scala
@@ -17,7 +17,7 @@ class BinestedSuite extends CatsSuite {
 
   {
     // Bifunctor + Functor + Functor = Bifunctor
-    implicit val instance = ListWrapper.functor
+    implicit val instance: Functor[ListWrapper] = ListWrapper.functor
     checkAll(
       "Binested[Either, ListWrapper, Option, *, *]",
       BifunctorTests[Binested[Either, ListWrapper, Option, *, *]].bifunctor[Int, Int, Int, String, String, String]
@@ -28,7 +28,7 @@ class BinestedSuite extends CatsSuite {
 
   {
     // Profunctor + Functor + Functor = Profunctor
-    implicit val instance = OptionWrapper.functor
+    implicit val instance: Functor[OptionWrapper] = OptionWrapper.functor
     Eq[OptionWrapper[MiniInt] => Option[Int]]
     checkAll(
       "Binested[Function1, OptionWrapper, Option, *, *]",
@@ -43,7 +43,7 @@ class BinestedSuite extends CatsSuite {
 
   {
     // Bifoldable + foldable + foldable = Bifoldable
-    implicit val instance = ListWrapper.foldable
+    implicit val instance: Foldable[ListWrapper] = ListWrapper.foldable
     checkAll("Binested[Either, ListWrapper, ListWrapper, *, *]",
              BifoldableTests[Binested[Either, ListWrapper, ListWrapper, *, *]].bifoldable[Int, Int, Int])
     checkAll(
@@ -54,7 +54,7 @@ class BinestedSuite extends CatsSuite {
 
   {
     // Bitraverse + traverse + traverse = Bitraverse
-    implicit val instance = ListWrapper.traverse
+    implicit val instance: Traverse[ListWrapper] = ListWrapper.traverse
     checkAll(
       "Binested[Either, ListWrapper, ListWrapper, *, *]",
       BitraverseTests[Binested[Either, ListWrapper, ListWrapper, *, *]]

--- a/tests/src/test/scala/cats/tests/ChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/ChainSuite.scala
@@ -42,20 +42,20 @@ class ChainSuite extends CatsSuite {
   checkAll("TraverseFilter[Chain]", SerializableTests.serializable(TraverseFilter[Chain]))
 
   {
-    implicit val partialOrder = ListWrapper.partialOrder[Int]
+    implicit val partialOrder: PartialOrder[ListWrapper[Int]] = ListWrapper.partialOrder[Int]
     checkAll("Chain[ListWrapper[Int]]", PartialOrderTests[Chain[ListWrapper[Int]]].partialOrder)
     checkAll("PartialOrder[Chain[ListWrapper[Int]]",
              SerializableTests.serializable(PartialOrder[Chain[ListWrapper[Int]]]))
   }
 
   {
-    implicit val eqv = ListWrapper.eqv[Int]
+    implicit val eqv: Eq[ListWrapper[Int]] = ListWrapper.eqv[Int]
     checkAll("Chain[ListWrapper[Int]]", EqTests[Chain[ListWrapper[Int]]].eqv)
     checkAll("Eq[Chain[ListWrapper[Int]]", SerializableTests.serializable(Eq[Chain[ListWrapper[Int]]]))
   }
 
   {
-    implicit val hash = ListWrapper.hash[Int]
+    implicit val hash: Hash[ListWrapper[Int]] = ListWrapper.hash[Int]
     checkAll("Chain[ListWrapper[Int]]", HashTests[Chain[ListWrapper[Int]]].hash)
     checkAll("Hash[Chain[ListWrapper[Int]]", SerializableTests.serializable(Hash[Chain[ListWrapper[Int]]]))
   }

--- a/tests/src/test/scala/cats/tests/CokleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/CokleisliSuite.scala
@@ -7,6 +7,7 @@ import cats.data.{Cokleisli, NonEmptyList}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 class CokleisliSuite extends SlowCatsSuite {
 
@@ -17,7 +18,7 @@ class CokleisliSuite extends SlowCatsSuite {
   implicit def cokleisliEq[F[_], A, B](implicit ev: Eq[F[A] => B]): Eq[Cokleisli[F, A, B]] =
     Eq.by[Cokleisli[F, A, B], F[A] => B](_.run)
 
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Cokleisli[Option, Int, *]]
+  implicit val iso: Isomorphisms[Cokleisli[Option, Int, *]] = Isomorphisms.invariant[Cokleisli[Option, Int, *]]
 
   checkAll("Cokleisli[Option, MiniInt, Int]",
            SemigroupalTests[Cokleisli[Option, MiniInt, *]].semigroupal[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/ConstSuite.scala
+++ b/tests/src/test/scala/cats/tests/ConstSuite.scala
@@ -12,12 +12,14 @@ import cats.kernel.laws.discipline.{
 }
 import cats.data.{Const, NonEmptyList}
 import cats.laws.discipline._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline.arbitrary._
 import cats.tests.Helpers.{CMono, CSemi}
 
 class ConstSuite extends CatsSuite {
 
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Const[String, *]](Const.catsDataTraverseForConst)
+  implicit val iso: Isomorphisms[Const[String, *]] =
+    Isomorphisms.invariant[Const[String, *]](Const.catsDataTraverseForConst)
 
   checkAll("Const[String, Int]", SemigroupalTests[Const[String, *]].semigroupal[Int, Int, Int])
   checkAll("Semigroupal[Const[String, *]]", SerializableTests.serializable(Semigroupal[Const[String, *]]))
@@ -38,8 +40,8 @@ class ConstSuite extends CatsSuite {
   // Get Apply[Const[C : Semigroup, *]], not Applicative[Const[C : Monoid, *]]
   {
     implicit def nonEmptyListSemigroup[A]: Semigroup[NonEmptyList[A]] = SemigroupK[NonEmptyList].algebra
-    implicit val iso =
-      SemigroupalTests.Isomorphisms.invariant[Const[NonEmptyList[String], *]](Const.catsDataContravariantForConst)
+    implicit val iso: Isomorphisms[Const[NonEmptyList[String], *]] =
+      Isomorphisms.invariant[Const[NonEmptyList[String], *]](Const.catsDataContravariantForConst)
     checkAll("Apply[Const[NonEmptyList[String], Int]]", ApplyTests[Const[NonEmptyList[String], *]].apply[Int, Int, Int])
     checkAll("Apply[Const[NonEmptyList[String], *]]",
              SerializableTests.serializable(Apply[Const[NonEmptyList[String], *]]))
@@ -98,7 +100,8 @@ class ConstSuite extends CatsSuite {
   checkAll("Functor[Const[String, *]]", SerializableTests.serializable(Functor[Const[String, *]]))
 
   {
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[Const[CMono, *]](Const.catsDataFunctorForConst)
+    implicit val iso: Isomorphisms[Const[CMono, *]] =
+      Isomorphisms.invariant[Const[CMono, *]](Const.catsDataFunctorForConst)
     checkAll("Const[CMono, Int]", CommutativeApplicativeTests[Const[CMono, *]].commutativeApplicative[Int, Int, Int])
     checkAll("CommutativeApplicative[Const[CMono, *]]",
              SerializableTests.serializable(CommutativeApplicative[Const[CMono, *]]))

--- a/tests/src/test/scala/cats/tests/ContravariantSuite.scala
+++ b/tests/src/test/scala/cats/tests/ContravariantSuite.scala
@@ -12,7 +12,7 @@ import cats.laws.discipline.arbitrary._
 class ContravariantSuite extends CatsSuite {
 
   test("narrow equals contramap(identity)") {
-    implicit val constInst = Const.catsDataContravariantForConst[Int]
+    implicit val constInst: Contravariant[Const[Int, *]] = Const.catsDataContravariantForConst[Int]
     implicit val canEqual: CanEqual[cats.data.Const[Int, Some[Int]], cats.data.Const[Int, Some[Int]]] =
       StrictCatsEquality.lowPriorityConversionCheckedConstraint
     forAll { (i: Int) =>
@@ -44,11 +44,12 @@ class ContravariantSuite extends CatsSuite {
            ContravariantMonoidalTests[Predicate].contravariantMonoidal[Boolean, Boolean, Boolean])
 
   {
-    implicit val predicateMonoid = ContravariantMonoidal.monoid[Predicate, MiniInt]
+    implicit val predicateMonoid: Monoid[Predicate[MiniInt]] = ContravariantMonoidal.monoid[Predicate, MiniInt]
     checkAll("ContravariantMonoidal[Predicate].monoid", MonoidTests[Predicate[MiniInt]].monoid)
   }
   {
-    implicit val predicateSemigroup = ContravariantSemigroupal.semigroup[Predicate, MiniInt]
+    implicit val predicateSemigroup: Semigroup[Predicate[MiniInt]] =
+      ContravariantSemigroupal.semigroup[Predicate, MiniInt]
     checkAll("ContravariantSemigroupal[Predicate].semigroup", SemigroupTests[Predicate[MiniInt]].semigroup)
   }
 

--- a/tests/src/test/scala/cats/tests/EitherKSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherKSuite.scala
@@ -14,7 +14,7 @@ class EitherKSuite extends CatsSuite {
   checkAll("Traverse[EitherK[Option, Option, *]]", SerializableTests.serializable(Traverse[EitherK[Option, Option, *]]))
 
   {
-    implicit val foldable = EitherK.catsDataFoldableForEitherK[Option, Option]
+    implicit val foldable: Foldable[EitherK[Option, Option, *]] = EitherK.catsDataFoldableForEitherK[Option, Option]
     checkAll("EitherK[Option, Option, *]", FoldableTests[EitherK[Option, Option, *]].foldable[Int, Int])
     checkAll("Foldable[EitherK[Option, Option, *]]",
              SerializableTests.serializable(Foldable[EitherK[Option, Option, *]]))
@@ -24,7 +24,7 @@ class EitherKSuite extends CatsSuite {
   checkAll("Comonad[EitherK[Eval, Eval, *]]", SerializableTests.serializable(Comonad[EitherK[Eval, Eval, *]]))
 
   {
-    implicit val coflatMap = EitherK.catsDataCoflatMapForEitherK[Eval, Eval]
+    implicit val coflatMap: CoflatMap[EitherK[Eval, Eval, *]] = EitherK.catsDataCoflatMapForEitherK[Eval, Eval]
     checkAll("EitherK[Eval, Eval, *]", CoflatMapTests[EitherK[Eval, Eval, *]].coflatMap[Int, Int, Int])
     checkAll("CoflatMap[EitherK[Eval, Eval, *]]", SerializableTests.serializable(CoflatMap[EitherK[Eval, Eval, *]]))
   }

--- a/tests/src/test/scala/cats/tests/EitherSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherSuite.scala
@@ -6,11 +6,12 @@ import cats.laws.discipline._
 import cats.kernel.laws.discipline.{EqTests, MonoidTests, OrderTests, PartialOrderTests, SemigroupTests}
 import org.scalatest.funsuite.AnyFunSuiteLike
 import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 import scala.util.Try
 
 class EitherSuite extends CatsSuite {
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Either[Int, *]]
+  implicit val iso: Isomorphisms[Either[Int, *]] = Isomorphisms.invariant[Either[Int, *]]
 
   checkAll("Either[String, Int]", MonoidTests[Either[String, Int]].monoid)
   checkAll("Monoid[Either[String, Int]]", SerializableTests.serializable(Monoid[Either[String, Int]]))
@@ -21,7 +22,7 @@ class EitherSuite extends CatsSuite {
   checkAll("Either[Int, Int]", AlignTests[Either[Int, *]].align[Int, Int, Int, Int])
   checkAll("Align[Either[Int, *]]", SerializableTests.serializable(Align[Either[Int, *]]))
 
-  implicit val eq0 = EitherT.catsDataEqForEitherT[Either[Int, *], Int, Int]
+  implicit val eq0: Eq[EitherT[Either[Int, *], Int, Int]] = EitherT.catsDataEqForEitherT[Either[Int, *], Int, Int]
 
   checkAll("Either[Int, Int]", MonadErrorTests[Either[Int, *], Int].monadError[Int, Int, Int])
   checkAll("MonadError[Either[Int, *]]", SerializableTests.serializable(MonadError[Either[Int, *], Int]))
@@ -46,8 +47,8 @@ class EitherSuite extends CatsSuite {
   val show = implicitly[Show[Either[Int, String]]]
 
   {
-    implicit val S = ListWrapper.eqv[String]
-    implicit val I = ListWrapper.eqv[Int]
+    implicit val S: Eq[ListWrapper[String]] = ListWrapper.eqv[String]
+    implicit val I: Eq[ListWrapper[Int]] = ListWrapper.eqv[Int]
     checkAll("Either[ListWrapper[String], ListWrapper[Int]]",
              EqTests[Either[ListWrapper[String], ListWrapper[Int]]].eqv)
     checkAll("Eq[Either[ListWrapper[String], ListWrapper[Int]]]",

--- a/tests/src/test/scala/cats/tests/EitherTSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherTSuite.scala
@@ -6,11 +6,12 @@ import cats.data.EitherT
 
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.kernel.laws.discipline.{EqTests, MonoidTests, OrderTests, PartialOrderTests, SemigroupTests}
 import scala.util.{Failure, Success, Try}
 
 class EitherTSuite extends CatsSuite {
-  implicit val iso = SemigroupalTests.Isomorphisms
+  implicit val iso: Isomorphisms[EitherT[ListWrapper, String, *]] = Isomorphisms
     .invariant[EitherT[ListWrapper, String, *]](EitherT.catsDataFunctorForEitherT(ListWrapper.functor))
 
   checkAll("EitherT[Eval, String, *]", DeferTests[EitherT[Eval, String, *]].defer[Int])
@@ -23,7 +24,7 @@ class EitherTSuite extends CatsSuite {
   }
 
   {
-    implicit val F = ListWrapper.order[Either[String, Int]]
+    implicit val F: Order[ListWrapper[Either[String, Int]]] = ListWrapper.order[Either[String, Int]]
 
     checkAll("EitherT[List, String, Int]", OrderTests[EitherT[ListWrapper, String, Int]].order)
     checkAll("Order[EitherT[List, String, Int]]",
@@ -32,7 +33,7 @@ class EitherTSuite extends CatsSuite {
 
   {
     // if a Functor for F is defined
-    implicit val F = ListWrapper.functor
+    implicit val F: Functor[ListWrapper] = ListWrapper.functor
 
     checkAll("EitherT[ListWrapper, *, *]",
              BifunctorTests[EitherT[ListWrapper, *, *]].bifunctor[Int, Int, Int, String, String, String])
@@ -45,7 +46,7 @@ class EitherTSuite extends CatsSuite {
 
   {
     // if a Traverse for F is defined
-    implicit val F = ListWrapper.traverse
+    implicit val F: Traverse[ListWrapper] = ListWrapper.traverse
 
     checkAll("EitherT[ListWrapper, Int, *]",
              TraverseTests[EitherT[ListWrapper, Int, *]].traverse[Int, Int, Int, Int, Option, Option])
@@ -61,9 +62,11 @@ class EitherTSuite extends CatsSuite {
   {
     // if a Monad is defined
 
-    implicit val F = ListWrapper.monad
-    implicit val eq0 = EitherT.catsDataEqForEitherT[ListWrapper, String, Either[String, Int]]
-    implicit val eq1 = EitherT.catsDataEqForEitherT[EitherT[ListWrapper, String, *], String, Int](eq0)
+    implicit val F: Monad[ListWrapper] = ListWrapper.monad
+    implicit val eq0: Eq[EitherT[ListWrapper, String, Either[String, Int]]] =
+      EitherT.catsDataEqForEitherT[ListWrapper, String, Either[String, Int]]
+    implicit val eq1: Eq[EitherT[EitherT[ListWrapper, String, *], String, Int]] =
+      EitherT.catsDataEqForEitherT[EitherT[ListWrapper, String, *], String, Int](eq0)
 
     Functor[EitherT[ListWrapper, String, *]]
     Applicative[EitherT[ListWrapper, String, *]]
@@ -80,9 +83,12 @@ class EitherTSuite extends CatsSuite {
     // if a MonadError is defined
     // Tests for catsDataMonadErrorFForEitherT instance, for recovery on errors of F.
 
-    implicit val eq1 = EitherT.catsDataEqForEitherT[Option, String, Either[Unit, String]]
-    implicit val eq2 = EitherT.catsDataEqForEitherT[EitherT[Option, String, *], Unit, String](eq1)
-    implicit val me = EitherT.catsDataMonadErrorFForEitherT[Option, Unit, String](catsStdInstancesForOption)
+    implicit val eq1: Eq[EitherT[Option, String, Either[Unit, String]]] =
+      EitherT.catsDataEqForEitherT[Option, String, Either[Unit, String]]
+    implicit val eq2: Eq[EitherT[EitherT[Option, String, *], Unit, String]] =
+      EitherT.catsDataEqForEitherT[EitherT[Option, String, *], Unit, String](eq1)
+    implicit val me: MonadError[EitherT[Option, String, *], Unit] =
+      EitherT.catsDataMonadErrorFForEitherT[Option, Unit, String](catsStdInstancesForOption)
 
     Functor[EitherT[Option, String, *]]
     Applicative[EitherT[Option, String, *]]
@@ -96,7 +102,7 @@ class EitherTSuite extends CatsSuite {
 
   {
     // if a Monad is defined
-    implicit val F = ListWrapper.monad
+    implicit val F: Monad[ListWrapper] = ListWrapper.monad
 
     Functor[EitherT[ListWrapper, String, *]]
     Applicative[EitherT[ListWrapper, String, *]]
@@ -109,7 +115,7 @@ class EitherTSuite extends CatsSuite {
 
   {
     // if a foldable is defined
-    implicit val F = ListWrapper.foldable
+    implicit val F: Foldable[ListWrapper] = ListWrapper.foldable
 
     checkAll("EitherT[ListWrapper, Int, *]", FoldableTests[EitherT[ListWrapper, Int, *]].foldable[Int, Int])
     checkAll("Foldable[EitherT[ListWrapper, Int, *]]",
@@ -117,7 +123,7 @@ class EitherTSuite extends CatsSuite {
   }
 
   {
-    implicit val F = ListWrapper.partialOrder[Either[String, Int]]
+    implicit val F: PartialOrder[ListWrapper[Either[String, Int]]] = ListWrapper.partialOrder[Either[String, Int]]
 
     checkAll("EitherT[ListWrapper, String, Int]", PartialOrderTests[EitherT[ListWrapper, String, Int]].partialOrder)
     checkAll("PartialOrder[EitherT[ListWrapper, String, Int]]",
@@ -125,7 +131,7 @@ class EitherTSuite extends CatsSuite {
   }
 
   {
-    implicit val F = ListWrapper.semigroup[Either[String, Int]]
+    implicit val F: Semigroup[ListWrapper[Either[String, Int]]] = ListWrapper.semigroup[Either[String, Int]]
 
     checkAll("EitherT[ListWrapper, String, Int]", SemigroupTests[EitherT[ListWrapper, String, Int]].semigroup)
     checkAll("Semigroup[EitherT[ListWrapper, String, Int]]",
@@ -133,7 +139,7 @@ class EitherTSuite extends CatsSuite {
   }
 
   {
-    implicit val F = ListWrapper.monoid[Either[String, Int]]
+    implicit val F: Monoid[ListWrapper[Either[String, Int]]] = ListWrapper.monoid[Either[String, Int]]
 
     Semigroup[EitherT[ListWrapper, String, Int]]
 
@@ -143,7 +149,7 @@ class EitherTSuite extends CatsSuite {
   }
 
   {
-    implicit val F = ListWrapper.eqv[Either[String, Int]]
+    implicit val F: Eq[ListWrapper[Either[String, Int]]] = ListWrapper.eqv[Either[String, Int]]
 
     checkAll("EitherT[ListWrapper, String, Int]", EqTests[EitherT[ListWrapper, String, Int]].eqv)
     checkAll("Eq[EitherT[ListWrapper, String, Int]]",

--- a/tests/src/test/scala/cats/tests/EvalSuite.scala
+++ b/tests/src/test/scala/cats/tests/EvalSuite.scala
@@ -96,7 +96,8 @@ class EvalSuite extends CatsSuite {
   }
 
   {
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[Eval]
+    implicit val iso: SemigroupalTests.Isomorphisms[Eval] =
+      SemigroupalTests.Isomorphisms.invariant[Eval]
     checkAll("Eval[Int]", BimonadTests[Eval].bimonad[Int, Int, Int])
   }
 
@@ -112,27 +113,27 @@ class EvalSuite extends CatsSuite {
   checkAll("Eval[Int]", GroupTests[Eval[Int]].group)
 
   {
-    implicit val A = ListWrapper.monoid[Int]
+    implicit val A: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
     checkAll("Eval[ListWrapper[Int]]", MonoidTests[Eval[ListWrapper[Int]]].monoid)
   }
 
   {
-    implicit val A = ListWrapper.semigroup[Int]
+    implicit val A: Semigroup[ListWrapper[Int]] = ListWrapper.semigroup[Int]
     checkAll("Eval[ListWrapper[Int]]", SemigroupTests[Eval[ListWrapper[Int]]].semigroup)
   }
 
   {
-    implicit val A = ListWrapper.order[Int]
+    implicit val A: Order[ListWrapper[Int]] = ListWrapper.order[Int]
     checkAll("Eval[ListWrapper[Int]]", OrderTests[Eval[ListWrapper[Int]]].order)
   }
 
   {
-    implicit val A = ListWrapper.partialOrder[Int]
+    implicit val A: PartialOrder[ListWrapper[Int]] = ListWrapper.partialOrder[Int]
     checkAll("Eval[ListWrapper[Int]]", PartialOrderTests[Eval[ListWrapper[Int]]].partialOrder)
   }
 
   {
-    implicit val A = ListWrapper.eqv[Int]
+    implicit val A: Eq[ListWrapper[Int]] = ListWrapper.eqv[Int]
     checkAll("Eval[ListWrapper[Int]]", EqTests[Eval[ListWrapper[Int]]].eqv)
   }
 

--- a/tests/src/test/scala/cats/tests/FoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/FoldableSuite.scala
@@ -448,7 +448,7 @@ class FoldableSuiteAdditional extends CatsSuite with ScalaVersionSpecificFoldabl
     dangerous.foldM(0)((acc, a) => if (a < 2) Some(acc + a) else None) should ===(None)
   }
 
-  def foldableStreamWithDefaultImpl = new Foldable[Stream] {
+  def foldableStreamWithDefaultImpl: Foldable[Stream] = new Foldable[Stream] {
     def foldLeft[A, B](fa: Stream[A], b: B)(f: (B, A) => B): B =
       Foldable[Stream].foldLeft(fa, b)(f)
 
@@ -457,28 +457,28 @@ class FoldableSuiteAdditional extends CatsSuite with ScalaVersionSpecificFoldabl
   }
 
   test(".foldA successful case") {
-    implicit val F = foldableStreamWithDefaultImpl
+    implicit val F: Foldable[Stream] = foldableStreamWithDefaultImpl
     val ns = Stream.apply[Either[String, Int]](1.asRight, 2.asRight, 7.asRight)
 
     assert(F.foldA(ns) == 10.asRight[String])
   }
 
   test(".foldA failed case") {
-    implicit val F = foldableStreamWithDefaultImpl
+    implicit val F: Foldable[Stream] = foldableStreamWithDefaultImpl
     val ns = Stream.apply[Either[String, Int]](1.asRight, "boom!!!".asLeft, 7.asRight)
 
     assert(ns.foldA == "boom!!!".asLeft[Int])
   }
 
   test(".foldA short-circuiting") {
-    implicit val F = foldableStreamWithDefaultImpl
+    implicit val F: Foldable[Stream] = foldableStreamWithDefaultImpl
     val ns = Stream.from(1).map(n => if (n >= 100000) Left(n) else Right(n))
 
     assert(F.foldA(ns) === Left(100000))
   }
 
   test(".foldLeftM short-circuiting") {
-    implicit val F = foldableStreamWithDefaultImpl
+    implicit val F: Foldable[Stream] = foldableStreamWithDefaultImpl
     val ns = Stream.continually(1)
     val res = F.foldLeftM[Either[Int, *], Int, Int](ns, 0) { (sum, n) =>
       if (sum >= 100000) Left(sum) else Right(sum + n)
@@ -487,7 +487,7 @@ class FoldableSuiteAdditional extends CatsSuite with ScalaVersionSpecificFoldabl
   }
 
   test(".foldLeftM short-circuiting optimality") {
-    implicit val F = foldableStreamWithDefaultImpl
+    implicit val F: Foldable[Stream] = foldableStreamWithDefaultImpl
 
     // test that no more elements are evaluated than absolutely necessary
 
@@ -502,13 +502,13 @@ class FoldableSuiteAdditional extends CatsSuite with ScalaVersionSpecificFoldabl
   }
 
   test(".existsM/.forallM short-circuiting") {
-    implicit val F = foldableStreamWithDefaultImpl
+    implicit val F: Foldable[Stream] = foldableStreamWithDefaultImpl
     assert(F.existsM[Id, Boolean](true #:: boom[Boolean])(identity) == true)
     assert(F.forallM[Id, Boolean](false #:: boom[Boolean])(identity) == false)
   }
 
   test(".findM/.collectFirstSomeM short-circuiting") {
-    implicit val F = foldableStreamWithDefaultImpl
+    implicit val F: Foldable[Stream] = foldableStreamWithDefaultImpl
     assert((1 #:: boom[Int]).findM[Id](_ > 0) == Some(1))
     assert((1 #:: boom[Int]).collectFirstSomeM[Id, Int](Option.apply) == Some(1))
   }

--- a/tests/src/test/scala/cats/tests/FuncSuite.scala
+++ b/tests/src/test/scala/cats/tests/FuncSuite.scala
@@ -6,6 +6,7 @@ import Func.appFunc
 import cats.Contravariant
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 class FuncSuite extends CatsSuite {
   import cats.laws.discipline.eq._
@@ -14,39 +15,41 @@ class FuncSuite extends CatsSuite {
   implicit def appFuncEq[F[_], A, B](implicit ev: Eq[A => F[B]]): Eq[AppFunc[F, A, B]] =
     Eq.by[AppFunc[F, A, B], A => F[B]](_.run)
 
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Func[Option, Int, *]]
+  implicit val iso: Isomorphisms[Func[Option, Int, *]] = Isomorphisms.invariant[Func[Option, Int, *]]
 
   checkAll("Func[Option, MiniInt, Int]", SemigroupalTests[Func[Option, MiniInt, *]].semigroupal[Int, Int, Int])
   checkAll("Semigroupal[Func[Option, Int, *]]", SerializableTests.serializable(Semigroupal[Func[Option, Int, *]]))
 
   {
-    implicit val catsDataApplicativeForFunc = Func.catsDataApplicativeForFunc[Option, Int]
+    implicit val catsDataApplicativeForFunc: Applicative[Func[Option, Int, *]] =
+      Func.catsDataApplicativeForFunc[Option, Int]
     checkAll("Func[Option, MiniInt, Int]", ApplicativeTests[Func[Option, MiniInt, *]].applicative[Int, Int, Int])
     checkAll("Applicative[Func[Option, Int, *]]", SerializableTests.serializable(Applicative[Func[Option, Int, *]]))
   }
 
   {
-    implicit val catsDataApplyForFunc = Func.catsDataApplyForFunc[Option, MiniInt]
+    implicit val catsDataApplyForFunc: Apply[Func[Option, MiniInt, *]] = Func.catsDataApplyForFunc[Option, MiniInt]
     checkAll("Func[Option, MiniInt, Int]", ApplyTests[Func[Option, MiniInt, *]].apply[Int, Int, Int])
     checkAll("Apply[Func[Option, Int, *]]", SerializableTests.serializable(Apply[Func[Option, Int, *]]))
   }
 
   {
-    implicit val catsDataFunctorForFunc = Func.catsDataFunctorForFunc[Option, Int]
+    implicit val catsDataFunctorForFunc: Functor[Func[Option, Int, *]] = Func.catsDataFunctorForFunc[Option, Int]
     checkAll("Func[Option, MiniInt, Int]", FunctorTests[Func[Option, MiniInt, *]].functor[Int, Int, Int])
     checkAll("Functor[Func[Option, Int, *]]", SerializableTests.serializable(Functor[Func[Option, Int, *]]))
   }
 
   {
-    implicit val funcContravariant = Func.catsDataContravariantForFunc[Show, MiniInt]
+    implicit val funcContravariant: Contravariant[Func[Show, *, MiniInt]] =
+      Func.catsDataContravariantForFunc[Show, MiniInt]
     checkAll("Func[Show, MiniInt, MiniInt]",
              ContravariantTests[Func[Show, *, MiniInt]].contravariant[MiniInt, MiniInt, MiniInt])
     checkAll("Contravariant[Func[Show, *, Int]]", SerializableTests.serializable(Contravariant[Func[Show, *, Int]]))
   }
 
   {
-    implicit val appFuncApp = AppFunc.appFuncApplicative[Option, Int]
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[AppFunc[Option, Int, *]]
+    implicit val appFuncApp: Applicative[AppFunc[Option, Int, *]] = AppFunc.appFuncApplicative[Option, Int]
+    implicit val iso: Isomorphisms[AppFunc[Option, Int, *]] = Isomorphisms.invariant[AppFunc[Option, Int, *]]
     checkAll("AppFunc[Option, MiniInt, MiniInt]",
              ApplicativeTests[AppFunc[Option, MiniInt, *]].applicative[MiniInt, MiniInt, MiniInt])
     checkAll("Applicative[AppFunc[Option, Int, *]]",

--- a/tests/src/test/scala/cats/tests/FunctionSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctionSuite.scala
@@ -21,6 +21,7 @@ import cats.kernel.laws.discipline.{
 import cats.laws.discipline._
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.kernel.{CommutativeGroup, CommutativeMonoid, CommutativeSemigroup}
 import cats.kernel.{Band, BoundedSemilattice, Semilattice}
 import org.scalacheck.Gen
@@ -41,7 +42,7 @@ class FunctionSuite extends CatsSuite {
   checkAll("Function0[Int]", BimonadTests[Function0].bimonad[Int, Int, Int])
   checkAll("Bimonad[Function0]", SerializableTests.serializable(Bimonad[Function0]))
 
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Function1[MiniInt, *]]
+  implicit val iso: Isomorphisms[Function1[MiniInt, *]] = Isomorphisms.invariant[Function1[MiniInt, *]]
   checkAll("Function1[MiniInt, Int]", SemigroupalTests[Function1[MiniInt, *]].semigroupal[Int, Int, Int])
 
   // TODO: make an binary compatible way to do this
@@ -138,7 +139,7 @@ class FunctionSuite extends CatsSuite {
   checkAll("Function1[MiniInt, Grp]", GroupTests[Function1[MiniInt, Grp]].group)
   checkAll("Function1[MiniInt, CGrp]", CommutativeGroupTests[Function1[MiniInt, CGrp]].commutativeGroup)
   // Isos for ContravariantMonoidal
-  implicit val isoCodomain = SemigroupalTests.Isomorphisms.invariant[Function1[*, Long]]
+  implicit val isoCodomain: Isomorphisms[Function1[*, Long]] = Isomorphisms.invariant[Function1[*, Long]]
   checkAll("Function1[*, Monoid]",
            ContravariantMonoidalTests[Function1[*, Long]].contravariantMonoidal[MiniInt, MiniInt, MiniInt])
 

--- a/tests/src/test/scala/cats/tests/FunctionSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctionSuite.scala
@@ -48,7 +48,7 @@ class FunctionSuite extends CatsSuite {
   // checkAll("Function1[Int => *]", DeferTests[Function1[Int, *]].defer[Int])
 
   test("Defer[Function1[Int, *]].fix computing sum") {
-    val sum2 = Defer[Function1[Int, *]].fix[Int] { rec => n: Int =>
+    val sum2 = Defer[Function1[Int, *]].fix[Int] { rec => (n: Int) =>
       if (n <= 0) 0 else n * n + rec(n - 1)
     }
 

--- a/tests/src/test/scala/cats/tests/IdSuite.scala
+++ b/tests/src/test/scala/cats/tests/IdSuite.scala
@@ -4,7 +4,8 @@ package tests
 import cats.laws.discipline._
 
 class IdSuite extends CatsSuite {
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Id]
+  implicit val iso: SemigroupalTests.Isomorphisms[Id] =
+    SemigroupalTests.Isomorphisms.invariant[Id]
 
   checkAll("Id[Int]", BimonadTests[Id].bimonad[Int, Int, Int])
   checkAll("Bimonad[Id]", SerializableTests.serializable(Bimonad[Id]))

--- a/tests/src/test/scala/cats/tests/IdTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IdTSuite.scala
@@ -5,12 +5,13 @@ import cats.data.{Const, IdT, NonEmptyList}
 import cats.kernel.laws.discipline.{EqTests, OrderTests}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import Helpers.CSemi
 
 class IdTSuite extends CatsSuite {
 
-  implicit val iso =
-    SemigroupalTests.Isomorphisms.invariant[IdT[ListWrapper, *]](IdT.catsDataFunctorForIdT(ListWrapper.functor))
+  implicit val iso: Isomorphisms[IdT[ListWrapper, *]] =
+    Isomorphisms.invariant[IdT[ListWrapper, *]](IdT.catsDataFunctorForIdT(ListWrapper.functor))
 
   checkAll("IdT[(CSemi, *), Int]", CommutativeFlatMapTests[IdT[(CSemi, *), *]].commutativeFlatMap[Int, Int, Int])
   checkAll("CommutativeFlatMap[IdT[(CSemi, *), *]]",
@@ -20,35 +21,35 @@ class IdTSuite extends CatsSuite {
   checkAll("CommutativeMonad[IdT[Option, *]]", SerializableTests.serializable(CommutativeMonad[IdT[Option, *]]))
 
   {
-    implicit val F = ListWrapper.eqv[Option[Int]]
+    implicit val F: Eq[ListWrapper[Option[Int]]] = ListWrapper.eqv[Option[Int]]
 
     checkAll("IdT[ListWrapper, Int]", EqTests[IdT[ListWrapper, Int]].eqv)
     checkAll("Eq[IdT[ListWrapper, Int]]", SerializableTests.serializable(Eq[IdT[ListWrapper, Int]]))
   }
 
   {
-    implicit val F = ListWrapper.order[Int]
+    implicit val F: Order[ListWrapper[Int]] = ListWrapper.order[Int]
 
     checkAll("IdT[ListWrapper, Int]", OrderTests[IdT[ListWrapper, Int]].order)
     checkAll("Order[IdT[ListWrapper, Int]]", SerializableTests.serializable(Order[IdT[ListWrapper, Int]]))
   }
 
   {
-    implicit val F = ListWrapper.functor
+    implicit val F: Functor[ListWrapper] = ListWrapper.functor
 
     checkAll("IdT[ListWrapper, Int]", FunctorTests[IdT[ListWrapper, *]].functor[Int, Int, Int])
     checkAll("Functor[IdT[ListWrapper, *]]", SerializableTests.serializable(Functor[IdT[ListWrapper, *]]))
   }
 
   {
-    implicit val F = ListWrapper.applyInstance
+    implicit val F: Apply[ListWrapper] = ListWrapper.applyInstance
 
     checkAll("IdT[ListWrapper, Int]", ApplyTests[IdT[ListWrapper, *]].apply[Int, Int, Int])
     checkAll("Apply[IdT[ListWrapper, *]]", SerializableTests.serializable(Apply[IdT[ListWrapper, *]]))
   }
 
   {
-    implicit val F = ListWrapper.applicative
+    implicit val F: Applicative[ListWrapper] = ListWrapper.applicative
 
     checkAll("IdT[ListWrapper, Int]", ApplicativeTests[IdT[ListWrapper, *]].applicative[Int, Int, Int])
     checkAll("Applicative[IdT[ListWrapper, *]]", SerializableTests.serializable(Applicative[IdT[ListWrapper, *]]))
@@ -62,28 +63,28 @@ class IdTSuite extends CatsSuite {
   }
 
   {
-    implicit val F = ListWrapper.flatMap
+    implicit val F: FlatMap[ListWrapper] = ListWrapper.flatMap
 
     checkAll("IdT[ListWrapper, Int]", FlatMapTests[IdT[ListWrapper, *]].flatMap[Int, Int, Int])
     checkAll("FlatMap[IdT[ListWrapper, *]]", SerializableTests.serializable(FlatMap[IdT[ListWrapper, *]]))
   }
 
   {
-    implicit val F = ListWrapper.monad
+    implicit val F: Monad[ListWrapper] = ListWrapper.monad
 
     checkAll("IdT[ListWrapper, Int]", MonadTests[IdT[ListWrapper, *]].monad[Int, Int, Int])
     checkAll("Monad[IdT[ListWrapper, *]]", SerializableTests.serializable(Monad[IdT[ListWrapper, *]]))
   }
 
   {
-    implicit val F = ListWrapper.foldable
+    implicit val F: Foldable[ListWrapper] = ListWrapper.foldable
 
     checkAll("IdT[ListWrapper, Int]", FoldableTests[IdT[ListWrapper, *]].foldable[Int, Int])
     checkAll("Foldable[IdT[ListWrapper, *]]", SerializableTests.serializable(Foldable[IdT[ListWrapper, *]]))
   }
 
   {
-    implicit val F = ListWrapper.traverse
+    implicit val F: Traverse[ListWrapper] = ListWrapper.traverse
 
     checkAll("IdT[ListWrapper, Int] with Option",
              TraverseTests[IdT[ListWrapper, *]].traverse[Int, Int, Int, Int, Option, Option])
@@ -91,7 +92,7 @@ class IdTSuite extends CatsSuite {
   }
 
   {
-    implicit val F = NonEmptyList.catsDataInstancesForNonEmptyList
+    implicit val F: Traverse[NonEmptyList] = NonEmptyList.catsDataInstancesForNonEmptyList
 
     checkAll("IdT[NonEmptyList, Int]",
              NonEmptyTraverseTests[IdT[NonEmptyList, *]].nonEmptyTraverse[Option, Int, Int, Int, Int, Option, Option])

--- a/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTSuite.scala
@@ -6,6 +6,7 @@ import cats.data.{EitherT, IRWST, IndexedReaderWriterStateT, ReaderWriterState, 
 import cats.laws.discipline._
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import org.scalacheck.Arbitrary
 import cats.arrow.{Profunctor, Strong}
 
@@ -327,8 +328,8 @@ class ReaderWriterStateTSuite extends CatsSuite {
     }
   }
 
-  implicit val iso = SemigroupalTests.Isomorphisms
-    .invariant[IndexedReaderWriterStateT[ListWrapper, String, String, Int, String, *]](
+  implicit val iso: Isomorphisms[IndexedReaderWriterStateT[ListWrapper, String, String, Int, String, *]] =
+    Isomorphisms.invariant[IndexedReaderWriterStateT[ListWrapper, String, String, Int, String, *]](
       IndexedReaderWriterStateT.catsDataFunctorForIRWST(ListWrapper.functor)
     )
 
@@ -419,7 +420,8 @@ class ReaderWriterStateTSuite extends CatsSuite {
   }
 
   {
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[ReaderWriterStateT[Option, Boolean, String, MiniInt, *]]
+    implicit val iso: Isomorphisms[ReaderWriterStateT[Option, Boolean, String, MiniInt, *]] =
+      Isomorphisms.invariant[ReaderWriterStateT[Option, Boolean, String, MiniInt, *]]
     implicit val eqEitherTFA: Eq[EitherT[ReaderWriterStateT[Option, Boolean, String, MiniInt, *], Unit, Int]] =
       EitherT.catsDataEqForEitherT[ReaderWriterStateT[Option, Boolean, String, MiniInt, *], Unit, Int]
 

--- a/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
@@ -8,6 +8,7 @@ import cats.kernel.instances.tuple._
 import cats.laws.discipline._
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.platform.Platform
 
 class IndexedStateTSuite extends CatsSuite {
@@ -321,9 +322,10 @@ class IndexedStateTSuite extends CatsSuite {
     }
   }
 
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[IndexedStateT[ListWrapper, String, Int, *]](
-    IndexedStateT.catsDataFunctorForIndexedStateT(ListWrapper.monad)
-  )
+  implicit val iso: Isomorphisms[IndexedStateT[ListWrapper, String, Int, *]] =
+    Isomorphisms.invariant[IndexedStateT[ListWrapper, String, Int, *]](
+      IndexedStateT.catsDataFunctorForIndexedStateT(ListWrapper.monad)
+    )
 
   {
     // F has a Functor
@@ -366,8 +368,8 @@ class IndexedStateTSuite extends CatsSuite {
   }
 
   {
-    implicit val F0 = ListWrapper.monad
-    implicit val FF = ListWrapper.functorFilter
+    implicit val F0: Monad[ListWrapper] = ListWrapper.monad
+    implicit val FF: FunctorFilter[ListWrapper] = ListWrapper.functorFilter
 
     checkAll("IndexedStateT[ListWrapper, MiniInt, Int, *]",
              FunctorFilterTests[IndexedStateT[ListWrapper, MiniInt, Int, *]].functorFilter[Int, Int, Int])
@@ -429,7 +431,7 @@ class IndexedStateTSuite extends CatsSuite {
 
   {
     // F has a Monad
-    implicit val F = ListWrapper.monad
+    implicit val F: Monad[ListWrapper] = ListWrapper.monad
 
     checkAll("IndexedStateT[ListWrapper, MiniInt, Int, *]",
              MonadTests[IndexedStateT[ListWrapper, MiniInt, MiniInt, *]].monad[Int, Int, Int])
@@ -445,8 +447,8 @@ class IndexedStateTSuite extends CatsSuite {
 
   {
     // F has a Monad and a SemigroupK
-    implicit val F = ListWrapper.monad
-    implicit val S = ListWrapper.semigroupK
+    implicit val F: Monad[ListWrapper] = ListWrapper.monad
+    implicit val S: SemigroupK[ListWrapper] = ListWrapper.semigroupK
 
     checkAll("IndexedStateT[ListWrapper, MiniInt, Int, *]",
              SemigroupKTests[IndexedStateT[ListWrapper, MiniInt, Int, *]].semigroupK[Int])
@@ -456,8 +458,8 @@ class IndexedStateTSuite extends CatsSuite {
 
   {
     // F has an Alternative
-    implicit val G = ListWrapper.monad
-    implicit val F = ListWrapper.alternative
+    implicit val G: Monad[ListWrapper] = ListWrapper.monad
+    implicit val F: Alternative[ListWrapper] = ListWrapper.alternative
     val SA =
       IndexedStateT
         .catsDataAlternativeForIndexedStateT[ListWrapper, MiniInt](ListWrapper.monad, ListWrapper.alternative)
@@ -477,7 +479,7 @@ class IndexedStateTSuite extends CatsSuite {
   }
 
   {
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[State[MiniInt, *]]
+    implicit val iso: Isomorphisms[State[MiniInt, *]] = Isomorphisms.invariant[State[MiniInt, *]]
 
     checkAll("State[MiniInt, *]", MonadTests[State[MiniInt, *]].monad[Int, Int, Int])
     checkAll("Monad[State[Long, *]]", SerializableTests.serializable(Monad[State[Long, *]]))
@@ -485,7 +487,7 @@ class IndexedStateTSuite extends CatsSuite {
 
   {
     // F has a MonadError
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[StateT[Option, MiniInt, *]]
+    implicit val iso: Isomorphisms[StateT[Option, MiniInt, *]] = Isomorphisms.invariant[StateT[Option, MiniInt, *]]
     implicit val eqEitherTFA: Eq[EitherT[StateT[Option, MiniInt, *], Unit, Int]] =
       EitherT.catsDataEqForEitherT[StateT[Option, MiniInt, *], Unit, Int]
 

--- a/tests/src/test/scala/cats/tests/IorSuite.scala
+++ b/tests/src/test/scala/cats/tests/IorSuite.scala
@@ -12,16 +12,17 @@ import cats.laws.discipline.{
 }
 import cats.data.{EitherT, Ior, NonEmptyChain, NonEmptyList, NonEmptySet}
 import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import org.scalacheck.Arbitrary._
 
 class IorSuite extends CatsSuite {
 
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Ior[String, *]]
+  implicit val iso: Isomorphisms[Ior[String, *]] = Isomorphisms.invariant[Ior[String, *]]
 
   checkAll("Ior[String, Int]", SemigroupalTests[Ior[String, *]].semigroupal[Int, Int, Int])
   checkAll("Semigroupal[String Ior *]]", SerializableTests.serializable(Semigroupal[String Ior *]))
 
-  implicit val eq0 = EitherT.catsDataEqForEitherT[Ior[String, *], String, Int]
+  implicit val eq0: Eq[EitherT[Ior[String, *], String, Int]] = EitherT.catsDataEqForEitherT[Ior[String, *], String, Int]
 
   checkAll("Ior[String, Int]", MonadErrorTests[String Ior *, String].monadError[Int, Int, Int])
   checkAll("MonadError[String Ior *]", SerializableTests.serializable(MonadError[String Ior *, String]))

--- a/tests/src/test/scala/cats/tests/IorTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IorTSuite.scala
@@ -11,7 +11,7 @@ class IorTSuite extends CatsSuite {
   checkAll("IorT[Eval, String, *]", DeferTests[IorT[Eval, String, *]].defer[Int])
 
   {
-    implicit val F = ListWrapper.functor
+    implicit val F: Functor[ListWrapper] = ListWrapper.functor
 
     checkAll("IorT[ListWrapper, *, *]",
              BifunctorTests[IorT[ListWrapper, *, *]].bifunctor[Int, Int, Int, String, String, String])
@@ -22,7 +22,7 @@ class IorTSuite extends CatsSuite {
   }
 
   {
-    implicit val F = ListWrapper.traverse
+    implicit val F: Traverse[ListWrapper] = ListWrapper.traverse
 
     checkAll("IorT[ListWrapper, Int, *]",
              TraverseTests[IorT[ListWrapper, Int, *]].traverse[Int, Int, Int, Int, Option, Option])
@@ -30,7 +30,7 @@ class IorTSuite extends CatsSuite {
   }
 
   {
-    implicit val F = ListWrapper.monad
+    implicit val F: Monad[ListWrapper] = ListWrapper.monad
 
     checkAll("IorT[ListWrapper, String, Int]",
              MonadErrorTests[IorT[ListWrapper, String, *], String].monadError[Int, Int, Int])
@@ -48,14 +48,14 @@ class IorTSuite extends CatsSuite {
   }
 
   {
-    implicit val F = ListWrapper.foldable
+    implicit val F: Foldable[ListWrapper] = ListWrapper.foldable
 
     checkAll("IorT[ListWrapper, Int, *]", FoldableTests[IorT[ListWrapper, Int, *]].foldable[Int, Int])
     checkAll("Foldable[IorT[ListWrapper, Int, *]]", SerializableTests.serializable(Foldable[IorT[ListWrapper, Int, *]]))
   }
 
   {
-    implicit val F = ListWrapper.semigroup[Ior[String, Int]]
+    implicit val F: Semigroup[ListWrapper[Ior[String, Int]]] = ListWrapper.semigroup[Ior[String, Int]]
 
     checkAll("IorT[ListWrapper, String, Int]", SemigroupTests[IorT[ListWrapper, String, Int]].semigroup)
     checkAll("Semigroup[IorT[ListWrapper, String, Int]]",
@@ -63,7 +63,7 @@ class IorTSuite extends CatsSuite {
   }
 
   {
-    implicit val F = ListWrapper.monoid[Ior[String, Int]]
+    implicit val F: Monoid[ListWrapper[Ior[String, Int]]] = ListWrapper.monoid[Ior[String, Int]]
 
     checkAll("IorT[ListWrapper, String, Int]", MonoidTests[IorT[ListWrapper, String, Int]].monoid)
     checkAll("Monoid[IorT[ListWrapper, String, Int]]",
@@ -71,7 +71,7 @@ class IorTSuite extends CatsSuite {
   }
 
   {
-    implicit val F = ListWrapper.eqv[Ior[String, Int]]
+    implicit val F: Eq[ListWrapper[Ior[String, Int]]] = ListWrapper.eqv[Ior[String, Int]]
 
     checkAll("IorT[ListWrapper, String, Int]", EqTests[IorT[ListWrapper, String, Int]].eqv)
     checkAll("Eq[IorT[ListWrapper, String, Int]]", SerializableTests.serializable(Eq[IorT[ListWrapper, String, Int]]))

--- a/tests/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/KleisliSuite.scala
@@ -7,6 +7,7 @@ import cats.data.{Const, EitherT, Kleisli, Reader, ReaderT}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
 import cats.laws.discipline.{DeferTests, MonoidKTests, SemigroupKTests}
 import cats.platform.Platform
@@ -19,11 +20,13 @@ class KleisliSuite extends CatsSuite {
   implicit def readerEq[A, B](implicit ev: Eq[A => B]): Eq[Reader[A, B]] =
     kleisliEq
 
-  implicit val eitherTEq = EitherT.catsDataEqForEitherT[Kleisli[Option, MiniInt, *], Unit, Int]
-  implicit val eitherTEq2 = EitherT.catsDataEqForEitherT[Reader[MiniInt, *], Unit, Int]
+  implicit val eitherTEq: Eq[EitherT[Kleisli[Option, MiniInt, *], Unit, Int]] =
+    EitherT.catsDataEqForEitherT[Kleisli[Option, MiniInt, *], Unit, Int]
+  implicit val eitherTEq2: Eq[EitherT[Reader[MiniInt, *], Unit, Int]] =
+    EitherT.catsDataEqForEitherT[Reader[MiniInt, *], Unit, Int]
 
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Kleisli[Option, Int, *]]
-  implicit val iso2 = SemigroupalTests.Isomorphisms.invariant[Reader[Int, *]]
+  implicit val iso: Isomorphisms[Kleisli[Option, Int, *]] = Isomorphisms.invariant[Kleisli[Option, Int, *]]
+  implicit val iso2: Isomorphisms[Reader[Int, *]] = Isomorphisms.invariant[Reader[Int, *]]
 
   {
     implicit val instance: ApplicativeError[Kleisli[Option, MiniInt, *], Unit] =
@@ -104,7 +107,7 @@ class KleisliSuite extends CatsSuite {
   checkAll("Functor[Kleisli[Option, Int, *]]", SerializableTests.serializable(Functor[Kleisli[Option, Int, *]]))
 
   {
-    implicit val FF = ListWrapper.functorFilter
+    implicit val FF: FunctorFilter[ListWrapper] = ListWrapper.functorFilter
 
     checkAll("Kleisli[ListWrapper, MiniInt, *]",
              FunctorFilterTests[Kleisli[ListWrapper, MiniInt, *]].functorFilter[Int, Int, Int])
@@ -127,13 +130,14 @@ class KleisliSuite extends CatsSuite {
            SerializableTests.serializable(Semigroup[Kleisli[Option, Int, String]]))
 
   {
-    implicit val catsDataMonoidKForKleisli = Kleisli.endoMonoidK[Option]
+    implicit val catsDataMonoidKForKleisli: MonoidK[λ[α => Kleisli[Option, α, α]]] = Kleisli.endoMonoidK[Option]
     checkAll("Kleisli[Option, MiniInt, MiniInt]", MonoidKTests[λ[α => Kleisli[Option, α, α]]].monoidK[MiniInt])
     checkAll("MonoidK[λ[α => Kleisli[Option, α, α]]]", SerializableTests.serializable(catsDataMonoidKForKleisli))
   }
 
   {
-    implicit val catsDataSemigroupKForKleisli = Kleisli.endoSemigroupK[Option]
+    implicit val catsDataSemigroupKForKleisli: SemigroupK[λ[α => Kleisli[Option, α, α]]] =
+      Kleisli.endoSemigroupK[Option]
     checkAll("Kleisli[Option, MiniInt, MiniInt]", SemigroupKTests[λ[α => Kleisli[Option, α, α]]].semigroupK[MiniInt])
     checkAll("SemigroupK[λ[α => Kleisli[Option, α, α]]]",
              SerializableTests.serializable(SemigroupK[λ[α => Kleisli[Option, α, α]]]))

--- a/tests/src/test/scala/cats/tests/NestedSuite.scala
+++ b/tests/src/test/scala/cats/tests/NestedSuite.scala
@@ -20,7 +20,7 @@ class NestedSuite extends CatsSuite {
 
   {
     // Invariant composition
-    implicit val instance = ListWrapper.invariant
+    implicit val instance: Invariant[ListWrapper] = ListWrapper.invariant
     checkAll("Nested[ListWrapper, ListWrapper]",
              InvariantTests[Nested[ListWrapper, ListWrapper, *]].invariant[Int, Int, Int])
     checkAll("Invariant[Nested[ListWrapper, ListWrapper, *]]",
@@ -29,8 +29,8 @@ class NestedSuite extends CatsSuite {
 
   {
     // FunctorFilter composition
-    implicit val instance = ListWrapper.functorFilter
-    implicit val functorInstance = ListWrapper.functor
+    implicit val instance: FunctorFilter[ListWrapper] = ListWrapper.functorFilter
+    implicit val functorInstance: Functor[ListWrapper] = ListWrapper.functor
     checkAll("Nested[ListWrapper, ListWrapper]",
              FunctorFilterTests[Nested[ListWrapper, ListWrapper, *]].functorFilter[Int, Int, Int])
     checkAll("FunctorFilter[Nested[ListWrapper, ListWrapper, *]]",
@@ -39,8 +39,8 @@ class NestedSuite extends CatsSuite {
 
   {
     // TraverseFilter composition
-    implicit val instance = ListWrapper.traverseFilter
-    implicit val traverseInstance = ListWrapper.traverse
+    implicit val instance: TraverseFilter[ListWrapper] = ListWrapper.traverseFilter
+    implicit val traverseInstance: Traverse[ListWrapper] = ListWrapper.traverse
     checkAll("Nested[ListWrapper, ListWrapper]",
              TraverseFilterTests[Nested[ListWrapper, ListWrapper, *]].traverseFilter[Int, Int, Int])
     checkAll("TraverseFilter[Nested[ListWrapper, ListWrapper, *]]",
@@ -49,7 +49,8 @@ class NestedSuite extends CatsSuite {
 
   {
     // Invariant + Covariant = Invariant
-    val instance = Nested.catsDataInvariantForCovariantNested(ListWrapper.invariant, ListWrapper.functor)
+    val instance: Invariant[Nested[ListWrapper, ListWrapper, *]] =
+      Nested.catsDataInvariantForCovariantNested(ListWrapper.invariant, ListWrapper.functor)
     checkAll("Nested[ListWrapper, ListWrapper] - Invariant + Covariant",
              InvariantTests[Nested[ListWrapper, ListWrapper, *]](instance).invariant[Int, Int, Int])
     checkAll("Invariant[Nested[ListWrapper, ListWrapper, *]] - Invariant + Covariant",
@@ -66,7 +67,7 @@ class NestedSuite extends CatsSuite {
 
   {
     // Functor composition
-    implicit val instance = ListWrapper.functor
+    implicit val instance: Functor[ListWrapper] = ListWrapper.functor
     checkAll("Nested[Option, ListWrapper, *]", FunctorTests[Nested[Option, ListWrapper, *]].functor[Int, Int, Int])
     checkAll("Functor[Nested[Option, ListWrapper, *]]",
              SerializableTests.serializable(Functor[Nested[Option, ListWrapper, *]]))
@@ -82,7 +83,7 @@ class NestedSuite extends CatsSuite {
 
   {
     // InvariantSemigroupal + Apply functor composition
-    implicit val instance = ListWrapper.invariantSemigroupal
+    implicit val instance: InvariantSemigroupal[ListWrapper] = ListWrapper.invariantSemigroupal
     checkAll("Nested[ListWrapper, Option, *]",
              InvariantSemigroupalTests[Nested[ListWrapper, Option, *]].invariantSemigroupal[Int, Int, Int])
     checkAll("InvariantSemigroupal[Nested[ListWrapper, Const[String, *], *]",
@@ -115,15 +116,13 @@ class NestedSuite extends CatsSuite {
 
   {
     // Apply composition
-    implicit val instance = ListWrapper.applyInstance
+    implicit val instance: Apply[ListWrapper] = ListWrapper.applyInstance
     checkAll("Nested[List, ListWrapper, *]", ApplyTests[Nested[List, ListWrapper, *]].apply[Int, Int, Int])
     checkAll("Apply[Nested[List, ListWrapper, *]]", SerializableTests.serializable(Apply[Nested[List, ListWrapper, *]]))
   }
 
   {
     // CommutativeApply composition
-    implicit val optionApply = Apply[Option]
-    implicit val validatedApply = Apply[Validated[Int, *]]
     checkAll("Nested[Option, Validated[Int, *], *]",
              CommutativeApplyTests[Nested[Option, Validated[Int, *], *]].commutativeApply[Int, Int, Int])
     checkAll("CommutativeApply[Nested[Option, Validated[Int, *], *], *]]",
@@ -132,7 +131,7 @@ class NestedSuite extends CatsSuite {
 
   {
     // Applicative composition
-    implicit val instance = ListWrapper.applicative
+    implicit val instance: Applicative[ListWrapper] = ListWrapper.applicative
     checkAll("Nested[List, ListWrapper, *]", ApplicativeTests[Nested[List, ListWrapper, *]].applicative[Int, Int, Int])
     checkAll("Applicative[Nested[List, ListWrapper, *]]",
              SerializableTests.serializable(Applicative[Nested[List, ListWrapper, *]]))
@@ -140,7 +139,7 @@ class NestedSuite extends CatsSuite {
 
   {
     // CommutativeApplicative composition
-    implicit val instance = ListWrapper.applicative
+    implicit val instance: Applicative[ListWrapper] = ListWrapper.applicative
     checkAll("Nested[Option, Validated[Int, *], *]",
              CommutativeApplicativeTests[Nested[Option, Validated[Int, *], *]].commutativeApplicative[Int, Int, Int])
     checkAll("CommutativeApplicative[Nested[List, ListWrapper, *]]",
@@ -149,7 +148,7 @@ class NestedSuite extends CatsSuite {
 
   {
     // ApplicativeError composition
-    implicit val instance = ListWrapper.applicative
+    implicit val instance: Applicative[ListWrapper] = ListWrapper.applicative
 
     checkAll(
       "Nested[Validated[String, *], ListWrapper, *]",
@@ -163,7 +162,7 @@ class NestedSuite extends CatsSuite {
 
   {
     // Alternative composition
-    implicit val instance = ListWrapper.alternative
+    implicit val instance: Alternative[ListWrapper] = ListWrapper.alternative
     checkAll("Nested[List, ListWrapper, *]", AlternativeTests[Nested[List, ListWrapper, *]].alternative[Int, Int, Int])
     checkAll("Alternative[Nested[List, ListWrapper, *]]",
              SerializableTests.serializable(Alternative[Nested[List, ListWrapper, *]]))
@@ -171,7 +170,7 @@ class NestedSuite extends CatsSuite {
 
   {
     // Foldable composition
-    implicit val instance = ListWrapper.foldable
+    implicit val instance: Foldable[ListWrapper] = ListWrapper.foldable
     checkAll("Nested[List, ListWrapper, *]", FoldableTests[Nested[List, ListWrapper, *]].foldable[Int, Int])
     checkAll("Foldable[Nested[List, ListWrapper, *]]",
              SerializableTests.serializable(Foldable[Nested[List, ListWrapper, *]]))
@@ -179,7 +178,7 @@ class NestedSuite extends CatsSuite {
 
   {
     // Traverse composition
-    implicit val instance = ListWrapper.traverse
+    implicit val instance: Traverse[ListWrapper] = ListWrapper.traverse
     checkAll("Nested[List, ListWrapper, *]",
              TraverseTests[Nested[List, ListWrapper, *]].traverse[Int, Int, Int, Set[Int], Option, Option])
     checkAll("Traverse[Nested[List, ListWrapper, *]]",
@@ -188,7 +187,7 @@ class NestedSuite extends CatsSuite {
 
   {
     // Reducible composition
-    implicit val instance = ListWrapper.foldable
+    implicit val instance: Foldable[ListWrapper] = ListWrapper.foldable
     checkAll("Nested[NonEmptyList, OneAnd[ListWrapper, *], *]",
              ReducibleTests[Nested[NonEmptyList, OneAnd[ListWrapper, *], *]].reducible[Option, Int, Int])
     checkAll("Reducible[Nested[NonEmptyList, OneAnd[ListWrapper, *], *]]",
@@ -208,7 +207,7 @@ class NestedSuite extends CatsSuite {
 
   {
     // SemigroupK composition
-    implicit val instance = ListWrapper.semigroupK
+    implicit val instance: SemigroupK[ListWrapper] = ListWrapper.semigroupK
     checkAll("Nested[ListWrapper, Option, *]", SemigroupKTests[Nested[ListWrapper, Option, *]].semigroupK[Int])
     checkAll("SemigroupK[Nested[ListWrapper, Option, *]]",
              SerializableTests.serializable(SemigroupK[Nested[ListWrapper, Option, *]]))
@@ -216,7 +215,7 @@ class NestedSuite extends CatsSuite {
 
   {
     // MonoidK composition
-    implicit val instance = ListWrapper.monoidK
+    implicit val instance: MonoidK[ListWrapper] = ListWrapper.monoidK
     checkAll("Nested[ListWrapper, Option, *]", MonoidKTests[Nested[ListWrapper, Option, *]].monoidK[Int])
     checkAll("MonoidK[Nested[ListWrapper, Option, *]]",
              SerializableTests.serializable(MonoidK[Nested[ListWrapper, Option, *]]))

--- a/tests/src/test/scala/cats/tests/NonEmptyChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyChainSuite.scala
@@ -27,14 +27,14 @@ class NonEmptyChainSuite extends CatsSuite {
   checkAll("Align[NonEmptyChain]", SerializableTests.serializable(Align[NonEmptyChain]))
 
   {
-    implicit val partialOrder = ListWrapper.partialOrder[Int]
+    implicit val partialOrder: PartialOrder[ListWrapper[Int]] = ListWrapper.partialOrder[Int]
     checkAll("NonEmptyChain[ListWrapper[Int]]", PartialOrderTests[NonEmptyChain[ListWrapper[Int]]].partialOrder)
     checkAll("PartialOrder[NonEmptyChain[ListWrapper[Int]]",
              SerializableTests.serializable(PartialOrder[NonEmptyChain[ListWrapper[Int]]]))
   }
 
   {
-    implicit val eqv = ListWrapper.eqv[Int]
+    implicit val eqv: Eq[ListWrapper[Int]] = ListWrapper.eqv[Int]
     checkAll("NonEmptyChain[ListWrapper[Int]]", EqTests[NonEmptyChain[ListWrapper[Int]]].eqv)
     checkAll("Eq[NonEmptyChain[ListWrapper[Int]]", SerializableTests.serializable(Eq[NonEmptyChain[ListWrapper[Int]]]))
   }

--- a/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
@@ -50,7 +50,7 @@ class NonEmptyListSuite extends CatsSuite {
   checkAll("ZipNonEmptyList[Int]", CommutativeApplyTests[ZipNonEmptyList].commutativeApply[Int, Int, Int])
 
   {
-    implicit val A = ListWrapper.partialOrder[Int]
+    implicit val A: PartialOrder[ListWrapper[Int]] = ListWrapper.partialOrder[Int]
     checkAll("NonEmptyList[ListWrapper[Int]]", PartialOrderTests[NonEmptyList[ListWrapper[Int]]].partialOrder)
     checkAll("PartialOrder[NonEmptyList[ListWrapper[Int]]]",
              SerializableTests.serializable(PartialOrder[NonEmptyList[ListWrapper[Int]]]))
@@ -59,7 +59,7 @@ class NonEmptyListSuite extends CatsSuite {
   }
 
   {
-    implicit val A = ListWrapper.order[Int]
+    implicit val A: Order[ListWrapper[Int]] = ListWrapper.order[Int]
     checkAll("NonEmptyList[ListWrapper[Int]]", OrderTests[NonEmptyList[ListWrapper[Int]]].order)
     checkAll("Order[NonEmptyList[ListWrapper[Int]]]",
              SerializableTests.serializable(Order[NonEmptyList[ListWrapper[Int]]]))

--- a/tests/src/test/scala/cats/tests/NonEmptySetSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptySetSuite.scala
@@ -40,7 +40,7 @@ class NonEmptySetSuite extends CatsSuite {
   checkAll("NonEmptySet[String]", HashTests[NonEmptySet[String]].hash)
 
   {
-    implicit val A = ListWrapper.order[Int]
+    implicit val A: Order[ListWrapper[Int]] = ListWrapper.order[Int]
     checkAll("Eq[NonEmptySet[ListWrapper[Int]]]", SerializableTests.serializable(Eq[NonEmptySet[ListWrapper[Int]]]))
 
     checkAll("NonEmptySet[ListWrapper[Int]]", OrderTests[NonEmptySet[ListWrapper[Int]]].order)

--- a/tests/src/test/scala/cats/tests/OneAndSuite.scala
+++ b/tests/src/test/scala/cats/tests/OneAndSuite.scala
@@ -4,6 +4,7 @@ package tests
 import cats.data.OneAnd
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 class OneAndSuite extends CatsSuite {
   // Lots of collections here.. telling ScalaCheck to calm down a bit
@@ -11,43 +12,43 @@ class OneAndSuite extends CatsSuite {
     PropertyCheckConfiguration(minSuccessful = 20, sizeRange = 5)
 
   {
-    implicit val traverse = OneAnd.catsDataTraverseForOneAnd(ListWrapper.traverse)
+    implicit val traverse: Traverse[OneAnd[ListWrapper, *]] = OneAnd.catsDataTraverseForOneAnd(ListWrapper.traverse)
     checkAll("OneAnd[ListWrapper, Int] with Option",
              TraverseTests[OneAnd[ListWrapper, *]].traverse[Int, Int, Int, Int, Option, Option])
     checkAll("Traverse[OneAnd[ListWrapper, A]]", SerializableTests.serializable(Traverse[OneAnd[ListWrapper, *]]))
   }
 
-  implicit val iso = SemigroupalTests.Isomorphisms
-    .invariant[OneAnd[ListWrapper, *]](OneAnd.catsDataFunctorForOneAnd(ListWrapper.functor))
+  implicit val iso: Isomorphisms[OneAnd[ListWrapper, *]] =
+    Isomorphisms.invariant[OneAnd[ListWrapper, *]](OneAnd.catsDataFunctorForOneAnd(ListWrapper.functor))
 
   // Test instances that have more general constraints
   {
-    implicit val monad = ListWrapper.monad
-    implicit val alt = ListWrapper.alternative
+    implicit val monad: Monad[ListWrapper] = ListWrapper.monad
+    implicit val alt: Alternative[ListWrapper] = ListWrapper.alternative
     checkAll("OneAnd[ListWrapper, Int]", MonadTests[OneAnd[ListWrapper, *]].monad[Int, Int, Int])
     checkAll("MonadTests[OneAnd[ListWrapper, A]]", SerializableTests.serializable(Monad[OneAnd[ListWrapper, *]]))
   }
 
   {
-    implicit val alternative = ListWrapper.alternative
+    implicit val alternative: Alternative[ListWrapper] = ListWrapper.alternative
     checkAll("OneAnd[ListWrapper, Int]", ApplicativeTests[OneAnd[ListWrapper, *]].applicative[Int, Int, Int])
     checkAll("Applicative[OneAnd[ListWrapper, A]]", SerializableTests.serializable(Applicative[OneAnd[ListWrapper, *]]))
   }
 
   {
-    implicit val functor = ListWrapper.functor
+    implicit val functor: Functor[ListWrapper] = ListWrapper.functor
     checkAll("OneAnd[ListWrapper, Int]", FunctorTests[OneAnd[ListWrapper, *]].functor[Int, Int, Int])
     checkAll("Functor[OneAnd[ListWrapper, A]]", SerializableTests.serializable(Functor[OneAnd[ListWrapper, *]]))
   }
 
   {
-    implicit val alternative = ListWrapper.alternative
+    implicit val alternative: Alternative[ListWrapper] = ListWrapper.alternative
     checkAll("OneAnd[ListWrapper, Int]", SemigroupKTests[OneAnd[ListWrapper, *]].semigroupK[Int])
     checkAll("SemigroupK[OneAnd[ListWrapper, A]]", SerializableTests.serializable(SemigroupK[OneAnd[ListWrapper, *]]))
   }
 
   {
-    implicit val foldable = ListWrapper.foldable
+    implicit val foldable: Foldable[ListWrapper] = ListWrapper.foldable
     checkAll("OneAnd[ListWrapper, Int]", FoldableTests[OneAnd[ListWrapper, *]].foldable[Int, Int])
     checkAll("Foldable[OneAnd[ListWrapper, A]]", SerializableTests.serializable(Foldable[OneAnd[ListWrapper, *]]))
   }

--- a/tests/src/test/scala/cats/tests/OpSuite.scala
+++ b/tests/src/test/scala/cats/tests/OpSuite.scala
@@ -10,13 +10,13 @@ import cats.kernel.laws.discipline.EqTests
 
 class OpSuite extends CatsSuite {
   {
-    implicit val catsDataEqForOp = Op.catsDataEqForOp[Function1, Int, MiniInt]
+    implicit val catsDataEqForOp: Eq[Op[Function1, Int, MiniInt]] = Op.catsDataEqForOp[Function1, Int, MiniInt]
     checkAll("Op[Function1, Int, MiniInt]", EqTests[Op[Function1, Int, MiniInt]].eqv)
     checkAll("Eq[Op[Function1, Int, MiniInt]]", SerializableTests.serializable(Eq[Op[Function1, Int, MiniInt]]))
   }
 
   {
-    implicit val catsDataCategoryForOp = Op.catsDataCategoryForOp[Function1]
+    implicit val catsDataCategoryForOp: Category[Op[Function1, *, *]] = Op.catsDataCategoryForOp[Function1]
     checkAll("Op[Function1, *, *]", CategoryTests[Op[Function1, *, *]].category[Char, MiniInt, Char, Boolean])
     checkAll("Category[Op[Function1, *, *]]", SerializableTests.serializable(Category[Op[Function1, *, *]]))
   }

--- a/tests/src/test/scala/cats/tests/OptionTSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionTSuite.scala
@@ -7,9 +7,10 @@ import cats.kernel.laws.discipline.{EqTests, MonoidTests, OrderTests, PartialOrd
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 class OptionTSuite extends CatsSuite {
-  implicit val iso = SemigroupalTests.Isomorphisms
+  implicit val iso: Isomorphisms[OptionT[ListWrapper, *]] = Isomorphisms
     .invariant[OptionT[ListWrapper, *]](OptionT.catsDataFunctorForOptionT(ListWrapper.functor))
 
   checkAll("OptionT[Eval, *]", DeferTests[OptionT[Eval, *]].defer[Int])
@@ -17,7 +18,7 @@ class OptionTSuite extends CatsSuite {
 
   {
     // if a Functor for F is defined
-    implicit val F = ListWrapper.functor
+    implicit val F: Functor[ListWrapper] = ListWrapper.functor
 
     checkAll("OptionT[ListWrapper, *]", FunctorFilterTests[OptionT[ListWrapper, *]].functorFilter[Int, Int, Int])
     checkAll("FunctorFilter[OptionT[ListWrapper, *]]",
@@ -27,7 +28,7 @@ class OptionTSuite extends CatsSuite {
 
   {
     // if a Traverse for F is defined
-    implicit val F = ListWrapper.traverse
+    implicit val F: Traverse[ListWrapper] = ListWrapper.traverse
 
     checkAll("OptionT[ListWrapper, *]", TraverseFilterTests[OptionT[ListWrapper, *]].traverseFilter[Int, Int, Int])
     checkAll("TraverseFilter[OptionT[ListWrapper, *]]",
@@ -36,14 +37,14 @@ class OptionTSuite extends CatsSuite {
   }
 
   {
-    implicit val F = ListWrapper.eqv[Option[Int]]
+    implicit val F: Eq[ListWrapper[Option[Int]]] = ListWrapper.eqv[Option[Int]]
 
     checkAll("OptionT[ListWrapper, Int]", EqTests[OptionT[ListWrapper, Int]].eqv)
     checkAll("Eq[OptionT[ListWrapper, Int]]", SerializableTests.serializable(Eq[OptionT[ListWrapper, Int]]))
   }
 
   {
-    implicit val F = ListWrapper.partialOrder[Option[Int]]
+    implicit val F: PartialOrder[ListWrapper[Option[Int]]] = ListWrapper.partialOrder[Option[Int]]
 
     checkAll("OptionT[ListWrapper, Int]", PartialOrderTests[OptionT[ListWrapper, Int]].partialOrder)
     checkAll("PartialOrder[OptionT[ListWrapper, Int]]",
@@ -53,7 +54,7 @@ class OptionTSuite extends CatsSuite {
   }
 
   {
-    implicit val F = ListWrapper.order[Option[Int]]
+    implicit val F: Order[ListWrapper[Option[Int]]] = ListWrapper.order[Option[Int]]
 
     checkAll("OptionT[ListWrapper, Int]", OrderTests[OptionT[ListWrapper, Int]].order)
     checkAll("Order[OptionT[ListWrapper, Int]]", SerializableTests.serializable(Order[OptionT[ListWrapper, Int]]))
@@ -64,7 +65,7 @@ class OptionTSuite extends CatsSuite {
 
   {
     // F has a Functor
-    implicit val F = ListWrapper.functor
+    implicit val F: Functor[ListWrapper] = ListWrapper.functor
 
     checkAll("OptionT[ListWrapper, Int]", FunctorTests[OptionT[ListWrapper, *]].functor[Int, Int, Int])
     checkAll("Functor[OptionT[ListWrapper, *]]", SerializableTests.serializable(Functor[OptionT[ListWrapper, *]]))
@@ -72,7 +73,7 @@ class OptionTSuite extends CatsSuite {
 
   {
     // F has an Invariant
-    implicit val evidence = ListWrapper.invariant
+    implicit val evidence: Invariant[ListWrapper] = ListWrapper.invariant
     Invariant[ListWrapper]
     Invariant[OptionT[ListWrapper, *]]
 
@@ -99,9 +100,10 @@ class OptionTSuite extends CatsSuite {
 
   {
     // F has a Monad
-    implicit val F = ListWrapper.monad
-    implicit val eq0 = OptionT.catsDataEqForOptionT[ListWrapper, Option[Int]]
-    implicit val eq1 = OptionT.catsDataEqForOptionT[OptionT[ListWrapper, *], Int](eq0)
+    implicit val F: Monad[ListWrapper] = ListWrapper.monad
+    implicit val eq0: Eq[OptionT[ListWrapper, Option[Int]]] = OptionT.catsDataEqForOptionT[ListWrapper, Option[Int]]
+    implicit val eq1: Eq[OptionT[OptionT[ListWrapper, *], Int]] =
+      OptionT.catsDataEqForOptionT[OptionT[ListWrapper, *], Int](eq0)
 
     checkAll("OptionT[ListWrapper, Int]", MonadTests[OptionT[ListWrapper, *]].monad[Int, Int, Int])
     checkAll("Monad[OptionT[ListWrapper, *]]", SerializableTests.serializable(Monad[OptionT[ListWrapper, *]]))
@@ -125,7 +127,8 @@ class OptionTSuite extends CatsSuite {
     // F has a MonadError
     type SEither[A] = Either[String, A]
 
-    implicit val monadError = OptionT.catsDataMonadErrorForOptionT[SEither, String]
+    implicit val monadError: MonadError[OptionT[SEither, *], String] =
+      OptionT.catsDataMonadErrorForOptionT[SEither, String]
 
     checkAll("OptionT[Either[String, *], Int]", MonadErrorTests[OptionT[SEither, *], String].monadError[Int, Int, Int])
     checkAll("MonadError[OptionT[Either[String, *], *]]", SerializableTests.serializable(monadError))
@@ -139,7 +142,7 @@ class OptionTSuite extends CatsSuite {
 
   {
     // F has a Foldable
-    implicit val F = ListWrapper.foldable
+    implicit val F: Foldable[ListWrapper] = ListWrapper.foldable
 
     checkAll("OptionT[ListWrapper, Int]", FoldableTests[OptionT[ListWrapper, *]].foldable[Int, Int])
     checkAll("Foldable[OptionT[ListWrapper, *]]", SerializableTests.serializable(Foldable[OptionT[ListWrapper, *]]))
@@ -147,7 +150,7 @@ class OptionTSuite extends CatsSuite {
 
   {
     // F has a Traverse
-    implicit val F = ListWrapper.traverse
+    implicit val F: Traverse[ListWrapper] = ListWrapper.traverse
 
     checkAll("OptionT[ListWrapper, Int] with Option",
              TraverseTests[OptionT[ListWrapper, *]].traverse[Int, Int, Int, Int, Option, Option])
@@ -179,7 +182,7 @@ class OptionTSuite extends CatsSuite {
 
   {
     // MonadError instance where F has a Monad
-    implicit val F = ListWrapper.monad
+    implicit val F: Monad[ListWrapper] = ListWrapper.monad
     checkAll("OptionT[ListWrapper, Int]", MonadErrorTests[OptionT[ListWrapper, *], Unit].monadError[Int, Int, Int])
     checkAll("MonadError[OptionT[List, *]]", SerializableTests.serializable(MonadError[OptionT[ListWrapper, *], Unit]))
   }
@@ -450,8 +453,8 @@ class OptionTSuite extends CatsSuite {
     Foldable[OptionT[List, *]]
     Traverse[OptionT[List, *]]
 
-    implicit val T = ListWrapper.traverse
-    implicit val M = ListWrapper.monad
+    implicit val T: Traverse[ListWrapper] = ListWrapper.traverse
+    implicit val M: Monad[ListWrapper] = ListWrapper.monad
     Functor[OptionT[ListWrapper, *]]
   }
 

--- a/tests/src/test/scala/cats/tests/ParallelSuite.scala
+++ b/tests/src/test/scala/cats/tests/ParallelSuite.scala
@@ -82,7 +82,7 @@ class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest with Sc
   }
 
   type ListTuple2[A, B] = List[(A, B)]
-  implicit val catsBitraverseForListTuple2 = new Bitraverse[ListTuple2] {
+  implicit val catsBitraverseForListTuple2: Bitraverse[ListTuple2] = new Bitraverse[ListTuple2] {
     def bifoldLeft[A, B, C](fab: ListTuple2[A, B], c: C)(f: (C, A) => C, g: (C, B) => C): C =
       fab.foldLeft(c) { case (c, (a, b)) => g(f(c, a), b) }
     def bifoldRight[A, B, C](fab: ListTuple2[A, B], lc: Eval[C])(f: (A, Eval[C]) => Eval[C],
@@ -410,12 +410,12 @@ class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest with Sc
                                                       IorT.rightT(123)(monadInstance))
 
     val resultSansInstance = {
-      implicit val ev0 = monadInstance
+      implicit val ev0: Monad[Effect] = monadInstance
       checkMarker(iorts.parSequence)
     }
     val resultWithInstance = {
-      implicit val ev0 = monadInstance
-      implicit val ev1 = parallelInstance
+      implicit val ev0: Monad[Effect] = monadInstance
+      implicit val ev1: Parallel.Aux[Effect, Effect] = parallelInstance
       checkMarker(iorts.parSequence)
     }
 
@@ -509,7 +509,8 @@ trait ApplicativeErrorForEitherTest extends AnyFunSuiteLike with Discipline {
   implicit def eqV[A: Eq, B: Eq]: Eq[Validated[A, B]] = cats.data.Validated.catsDataEqForValidated
 
   {
-    implicit val parVal = Parallel.applicativeError[Either[String, *], String]
+    implicit val parVal: ApplicativeError[Validated[String, *], String] =
+      Parallel.applicativeError[Either[String, *], String]
 
     checkAll("ApplicativeError[Validated[String, Int]]",
              ApplicativeErrorTests[Validated[String, *], String].applicativeError[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/RegressionSuite.scala
+++ b/tests/src/test/scala/cats/tests/RegressionSuite.scala
@@ -154,7 +154,12 @@ class RegressionSuite extends CatsSuite with ScalaVersionSpecificRegressionSuite
     EitherT.right[String](Option(1)).handleErrorWith((_: String) => EitherT.pure(2))
 
     {
-      implicit val me = MonadError[EitherT[Option, String, *], Unit]
+      MonadError[EitherT[Option, String, *], Unit]
+    }
+
+    {
+      implicit val me: MonadError[EitherT[Option, String, *], Unit] =
+        EitherT.catsDataMonadErrorFForEitherT[Option, Unit, String]
       EitherT.right[String](Option(1)).handleErrorWith((_: Unit) => EitherT.pure(2))
     }
 

--- a/tests/src/test/scala/cats/tests/RepresentableStoreSuite.scala
+++ b/tests/src/test/scala/cats/tests/RepresentableStoreSuite.scala
@@ -1,10 +1,11 @@
 package cats.tests
 
 import cats.Comonad
+import cats.data.{RepresentableStore, Store}
+import cats.kernel.Eq
 import cats.laws.discipline.{ComonadTests, SerializableTests}
 import cats.laws.discipline.arbitrary._
-import cats.data.RepresentableStore
-import cats.data.Store
+import org.scalacheck.{Arbitrary, Cogen}
 
 class RepresentableStoreSuite extends CatsSuite {
 
@@ -12,13 +13,23 @@ class RepresentableStoreSuite extends CatsSuite {
   // checkAll("Comonad[Store[String, *]]", ComonadTests[Store[String, *]].comonad[Int, Int, Int])
 
   {
-    implicit val pairComonad = RepresentableStore.catsDataRepresentableStoreComonad[λ[P => (P, P)], Boolean]
-    implicit val arbStore = catsLawsArbitraryForRepresentableStore[λ[P => (P, P)], Boolean, Int]
-    implicit val cogenStore = catsLawsCogenForRepresentableStore[λ[P => (P, P)], Boolean, Int]
-    implicit val eqStore = cats.laws.discipline.eq.catsLawsEqForRepresentableStore[λ[P => (P, P)], Boolean, Int]
-    implicit val eqStoreStore = cats.laws.discipline.eq
-      .catsLawsEqForRepresentableStore[λ[P => (P, P)], Boolean, RepresentableStore[λ[P => (P, P)], Boolean, Int]]
-    implicit val eqStoreStoreStore =
+    implicit val pairComonad: Comonad[RepresentableStore[λ[P => (P, P)], Boolean, *]] =
+      RepresentableStore.catsDataRepresentableStoreComonad[λ[P => (P, P)], Boolean]
+    implicit val arbStore: Arbitrary[RepresentableStore[λ[P => (P, P)], Boolean, Int]] =
+      catsLawsArbitraryForRepresentableStore[λ[P => (P, P)], Boolean, Int]
+    implicit val cogenStore: Cogen[RepresentableStore[λ[P => (P, P)], Boolean, Int]] =
+      catsLawsCogenForRepresentableStore[λ[P => (P, P)], Boolean, Int]
+    implicit val eqStore: Eq[RepresentableStore[λ[P => (P, P)], Boolean, Int]] =
+      cats.laws.discipline.eq.catsLawsEqForRepresentableStore[λ[P => (P, P)], Boolean, Int]
+    implicit val eqStoreStore
+      : Eq[RepresentableStore[λ[P => (P, P)], Boolean, RepresentableStore[λ[P => (P, P)], Boolean, Int]]] =
+      cats.laws.discipline.eq
+        .catsLawsEqForRepresentableStore[λ[P => (P, P)], Boolean, RepresentableStore[λ[P => (P, P)], Boolean, Int]]
+    implicit val eqStoreStoreStore: Eq[
+      RepresentableStore[λ[P => (P, P)], Boolean, RepresentableStore[λ[P => (P, P)],
+                                                                     Boolean,
+                                                                     RepresentableStore[λ[P => (P, P)], Boolean, Int]]]
+    ] =
       cats.laws.discipline.eq.catsLawsEqForRepresentableStore[λ[P => (P, P)], Boolean, RepresentableStore[λ[
         P => (P, P)
       ], Boolean, RepresentableStore[λ[P => (P, P)], Boolean, Int]]]

--- a/tests/src/test/scala/cats/tests/RepresentableSuite.scala
+++ b/tests/src/test/scala/cats/tests/RepresentableSuite.scala
@@ -58,6 +58,7 @@ class RepresentableSuite extends CatsSuite {
   val reprPair = Representable[Pair]
   val reprMiniIntFunc = Representable[MiniInt => *]
   val isoPair: Isomorphisms[Pair] = Isomorphisms.invariant[Pair]
+  val isoMiniIntFunc: Isomorphisms[MiniInt => *] = Isomorphisms.invariant[MiniInt => *]
 
   {
     implicit val andMonoid: Monoid[Boolean] = new Monoid[Boolean] {
@@ -72,6 +73,7 @@ class RepresentableSuite extends CatsSuite {
   }
 
   {
+    implicit val isoFun1: Isomorphisms[MiniInt => *] = isoMiniIntFunc
     implicit val monadInstance: Monad[MiniInt => *] = Representable.monad[MiniInt => *](reprMiniIntFunc)
     checkAll("MiniInt => *", MonadTests[MiniInt => *].monad[String, String, String])
   }

--- a/tests/src/test/scala/cats/tests/RepresentableSuite.scala
+++ b/tests/src/test/scala/cats/tests/RepresentableSuite.scala
@@ -11,7 +11,7 @@ import cats.laws.discipline.{
   RepresentableTests,
   SerializableTests
 }
-import cats.{Bimonad, Eq, Eval, Id, Representable}
+import cats.{Bimonad, Distributive, Eq, Eval, Id, Monad, Monoid, Representable}
 import org.scalacheck.Arbitrary
 import cats.data.Kleisli
 
@@ -32,7 +32,8 @@ class RepresentableSuite extends CatsSuite {
   checkAll("Representable[Eval]", SerializableTests.serializable(Representable[Eval]))
 
   {
-    implicit val representableKleisliPair = Kleisli.catsDataRepresentableForKleisli[Pair, Boolean, MiniInt]
+    implicit val representableKleisliPair: Representable.Aux[Kleisli[Pair, MiniInt, *], (MiniInt, Boolean)] =
+      Kleisli.catsDataRepresentableForKleisli[Pair, Boolean, MiniInt]
 
     implicit def kleisliEq[F[_], A, B](implicit ev: Eq[A => F[B]]): Eq[Kleisli[F, A, B]] =
       Eq.by[Kleisli[F, A, B], A => F[B]](_.run)
@@ -54,29 +55,29 @@ class RepresentableSuite extends CatsSuite {
              SerializableTests.serializable(Representable[Kleisli[Pair, MiniInt, *]]))
   }
 
+  val reprPair = Representable[Pair]
+  val reprMiniIntFunc = Representable[MiniInt => *]
+  val isoPair: Isomorphisms[Pair] = Isomorphisms.invariant[Pair]
+
   {
-    implicit val andMonoid = new cats.Monoid[Boolean] {
+    implicit val andMonoid: Monoid[Boolean] = new Monoid[Boolean] {
       def empty: Boolean = true
       override def combine(x: Boolean, y: Boolean): Boolean = x && y
     }
 
-    implicit val isoPair = Isomorphisms.invariant[Pair]
-    implicit val bimonadInstance = Representable.bimonad[Pair, Boolean]
+    implicit val isoPairInstance: Isomorphisms[Pair] = isoPair
+    implicit val bimonadInstance: Bimonad[Pair] = Representable.bimonad[Pair, Boolean](reprPair, Monoid[Boolean])
     checkAll("Pair[Int]", BimonadTests[Pair].bimonad[Int, Int, Int])
     checkAll("Bimonad[Pair]", SerializableTests.serializable(Bimonad[Pair]))
   }
 
   {
-    // the monadInstance below made a conflict to resolve this one.
-    // TODO: ceedubs is this needed*
-    implicit val isoFun1: Isomorphisms[MiniInt => *] = Isomorphisms.invariant[MiniInt => *]
-
-    implicit val monadInstance = Representable.monad[MiniInt => *]
+    implicit val monadInstance: Monad[MiniInt => *] = Representable.monad[MiniInt => *](reprMiniIntFunc)
     checkAll("MiniInt => *", MonadTests[MiniInt => *].monad[String, String, String])
   }
 
   {
-    implicit val distributiveInstance = Representable.distributive[Pair]
+    implicit val distributiveInstance: Distributive[Pair] = Representable.distributive[Pair](reprPair)
     checkAll("Pair[Int]", DistributiveTests[Pair].distributive[Int, Int, Int, Option, MiniInt => *])
   }
 

--- a/tests/src/test/scala/cats/tests/SemigroupKSuite.scala
+++ b/tests/src/test/scala/cats/tests/SemigroupKSuite.scala
@@ -1,20 +1,19 @@
 package cats.tests
 
-import cats.SemigroupK
+import cats.Alternative
+import cats.{Align, SemigroupK}
 import cats.data.{Chain, Validated}
 import cats.laws.discipline.AlignTests
 import cats.laws.discipline.arbitrary._
 
 class SemigroupKSuite extends CatsSuite {
-  {
-    implicit val listwrapperSemigroupK = ListWrapper.alternative
-    implicit val listwrapperAlign = SemigroupK.align[ListWrapper]
-    checkAll("SemigroupK[ListWrapper].align", AlignTests[ListWrapper].align[Int, Int, Int, Int])
+  implicit val listwrapperSemigroupK: Alternative[ListWrapper] = ListWrapper.alternative
+  implicit val listwrapperAlign: Align[ListWrapper] = SemigroupK.align[ListWrapper]
+  checkAll("SemigroupK[ListWrapper].align", AlignTests[ListWrapper].align[Int, Int, Int, Int])
 
-    implicit val validatedAlign = SemigroupK.align[Validated[String, *]]
-    checkAll("SemigroupK[Validated].align", AlignTests[Validated[String, *]].align[Int, Int, Int, Int])
+  implicit val validatedAlign: Align[Validated[String, *]] = SemigroupK.align[Validated[String, *]]
+  checkAll("SemigroupK[Validated].align", AlignTests[Validated[String, *]].align[Int, Int, Int, Int])
 
-    implicit val chainAlign = SemigroupK.align[Chain]
-    checkAll("SemigroupK[Chain].align", AlignTests[Chain].align[Int, Int, Int, Int])
-  }
+  implicit val chainAlign: Align[Chain] = SemigroupK.align[Chain]
+  checkAll("SemigroupK[Chain].align", AlignTests[Chain].align[Int, Int, Int, Int])
 }

--- a/tests/src/test/scala/cats/tests/SortedMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/SortedMapSuite.scala
@@ -13,11 +13,12 @@ import cats.laws.discipline.{
   TraverseTests
 }
 import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 
 import scala.collection.immutable.SortedMap
 
 class SortedMapSuite extends CatsSuite {
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[SortedMap[Int, *]]
+  implicit val iso: Isomorphisms[SortedMap[Int, *]] = Isomorphisms.invariant[SortedMap[Int, *]]
 
   checkAll("SortedMap[Int, Int]", SemigroupalTests[SortedMap[Int, *]].semigroupal[Int, Int, Int])
   checkAll("Semigroupal[SortedMap[Int, *]]", SerializableTests.serializable(Semigroupal[SortedMap[Int, *]]))

--- a/tests/src/test/scala/cats/tests/SortedSetSuite.scala
+++ b/tests/src/test/scala/cats/tests/SortedSetSuite.scala
@@ -11,7 +11,7 @@ import cats.laws.discipline.{FoldableTests, SemigroupKTests, SemigroupalTests, S
 import scala.collection.immutable.SortedSet
 
 class SortedSetSuite extends CatsSuite {
-  implicit val iso = SortedSetIsomorphism
+  implicit val iso: Isomorphisms[SortedSet] = SortedSetIsomorphism
 
   checkAll("SortedSet[Int]", SemigroupKTests[SortedSet].semigroupK[Int])
   checkAll("SortedSet[Int]", SemigroupalTests[SortedSet].semigroupal[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/SyntaxSuite.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxSuite.scala
@@ -63,7 +63,7 @@ object SyntaxSuite
 
   def testMonoid[A: Monoid]: Unit = {
     val x = mock[A]
-    implicit val y = mock[Eq[A]]
+    implicit val y: Eq[A] = mock[Eq[A]]
     val z: Boolean = x.isEmpty
   }
 
@@ -495,7 +495,7 @@ object SyntaxSuite
     val padZipped = fa.padZip(fb)
     val padZippedWith = fa.padZipWith(fb)(f2)
 
-    implicit val sa = mock[Semigroup[A]]
+    implicit val sa: Semigroup[A] = mock[Semigroup[A]]
     val fa2 = fa.alignCombine(fa)
   }
 

--- a/tests/src/test/scala/cats/tests/TrySuite.scala
+++ b/tests/src/test/scala/cats/tests/TrySuite.scala
@@ -27,7 +27,7 @@ class TrySuite extends CatsSuite {
   checkAll("Monad[Try]", SerializableTests.serializable(Monad[Try]))
 
   {
-    implicit val F = ListWrapper.semigroup[Int]
+    implicit val F: Semigroup[ListWrapper[Int]] = ListWrapper.semigroup[Int]
 
     checkAll("Try[ListWrapper[Int]]", SemigroupTests[Try[ListWrapper[Int]]].semigroup)
     checkAll("Semigroup[Try[ListWrapper[Int]]", SerializableTests.serializable(Semigroup[Try[ListWrapper[Int]]]))

--- a/tests/src/test/scala/cats/tests/Tuple2KSuite.scala
+++ b/tests/src/test/scala/cats/tests/Tuple2KSuite.scala
@@ -6,10 +6,11 @@ import cats.Contravariant
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.kernel.laws.discipline.{EqTests, OrderTests, PartialOrderTests}
 
 class Tuple2KSuite extends CatsSuite {
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Tuple2K[Option, List, *]]
+  implicit val iso: Isomorphisms[Tuple2K[Option, List, *]] = Isomorphisms.invariant[Tuple2K[Option, List, *]]
   checkAll("Tuple2K[Eval, Eval, *]", DeferTests[Tuple2K[Eval, Eval, *]].defer[Int])
   checkAll("Tuple2K[Option, List, Int]", SemigroupalTests[λ[α => Tuple2K[Option, List, α]]].semigroupal[Int, Int, Int])
   checkAll("Semigroupal[Tuple2K[Option, List, Int]]",
@@ -36,14 +37,14 @@ class Tuple2KSuite extends CatsSuite {
   checkAll("Show[Tuple2K[Option, Option, Int]]", SerializableTests.serializable(Show[Tuple2K[Option, Option, Int]]))
 
   {
-    implicit val monoidK = ListWrapper.monoidK
+    implicit val monoidK: MonoidK[ListWrapper] = ListWrapper.monoidK
     checkAll("Tuple2K[ListWrapper, ListWrapper, *]", MonoidKTests[Tuple2K[ListWrapper, ListWrapper, *]].monoidK[Int])
     checkAll("MonoidK[Tuple2K[ListWrapper, ListWrapper, *]]",
              SerializableTests.serializable(MonoidK[Tuple2K[ListWrapper, ListWrapper, *]]))
   }
 
   {
-    implicit val semigroupK = ListWrapper.semigroupK
+    implicit val semigroupK: SemigroupK[ListWrapper] = ListWrapper.semigroupK
     checkAll("Tuple2K[ListWrapper, ListWrapper, *]",
              SemigroupKTests[Tuple2K[ListWrapper, ListWrapper, *]].semigroupK[Int])
     checkAll("SemigroupK[Tuple2K[ListWrapper, ListWrapper, *]]",
@@ -51,8 +52,9 @@ class Tuple2KSuite extends CatsSuite {
   }
 
   {
-    implicit val apply = ListWrapper.applyInstance
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[Tuple2K[ListWrapper, ListWrapper, *]]
+    implicit val apply: Apply[ListWrapper] = ListWrapper.applyInstance
+    implicit val iso: Isomorphisms[Tuple2K[ListWrapper, ListWrapper, *]] =
+      Isomorphisms.invariant[Tuple2K[ListWrapper, ListWrapper, *]]
     checkAll("Tuple2K[ListWrapper, ListWrapper, *]",
              ApplyTests[Tuple2K[ListWrapper, ListWrapper, *]].apply[Int, Int, Int])
     checkAll("Apply[Tuple2K[ListWrapper, ListWrapper, *]]",
@@ -60,8 +62,6 @@ class Tuple2KSuite extends CatsSuite {
   }
 
   {
-    implicit val optionApply = Apply[Option]
-    implicit val validatedApply = Apply[Validated[Int, *]]
     checkAll("Tuple2K[Option, Validated[Int, *], *]",
              CommutativeApplyTests[Tuple2K[Option, Validated[Int, *], *]].commutativeApply[Int, Int, Int])
     checkAll("Apply[Tuple2K[Option, Validated[Int, *], *]]",
@@ -76,7 +76,7 @@ class Tuple2KSuite extends CatsSuite {
   }
 
   {
-    implicit val functor = ListWrapper.functor
+    implicit val functor: Functor[ListWrapper] = ListWrapper.functor
     checkAll("Tuple2K[ListWrapper, ListWrapper, *]",
              FunctorTests[Tuple2K[ListWrapper, ListWrapper, *]].functor[Int, Int, Int])
     checkAll("Functor[Tuple2K[ListWrapper, ListWrapper, *]]",
@@ -84,8 +84,9 @@ class Tuple2KSuite extends CatsSuite {
   }
 
   {
-    implicit val monad = ListWrapper.monad
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[Tuple2K[ListWrapper, ListWrapper, *]]
+    implicit val monad: Monad[ListWrapper] = ListWrapper.monad
+    implicit val iso: Isomorphisms[Tuple2K[ListWrapper, ListWrapper, *]] =
+      Isomorphisms.invariant[Tuple2K[ListWrapper, ListWrapper, *]]
     checkAll("Tuple2K[ListWrapper, ListWrapper, *]",
              MonadTests[Tuple2K[ListWrapper, ListWrapper, *]].monad[Int, Int, Int])
     checkAll("Monad[Tuple2K[ListWrapper, ListWrapper, *]]",
@@ -93,7 +94,7 @@ class Tuple2KSuite extends CatsSuite {
   }
 
   {
-    implicit val foldable = ListWrapper.foldable
+    implicit val foldable: Foldable[ListWrapper] = ListWrapper.foldable
     checkAll("Tuple2K[ListWrapper, ListWrapper, *]",
              FoldableTests[Tuple2K[ListWrapper, ListWrapper, *]].foldable[Int, Int])
     checkAll("Foldable[Tuple2K[ListWrapper, ListWrapper, *]]",
@@ -101,7 +102,7 @@ class Tuple2KSuite extends CatsSuite {
   }
 
   {
-    implicit val traverse = ListWrapper.traverse
+    implicit val traverse: Traverse[ListWrapper] = ListWrapper.traverse
     checkAll("Tuple2K[ListWrapper, ListWrapper, *]",
              TraverseTests[Tuple2K[ListWrapper, ListWrapper, *]].traverse[Int, Int, Int, Int, Option, Option])
     checkAll("Traverse[Tuple2K[ListWrapper, ListWrapper, *]]",
@@ -109,8 +110,9 @@ class Tuple2KSuite extends CatsSuite {
   }
 
   {
-    implicit val alternative = ListWrapper.alternative
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[Tuple2K[ListWrapper, ListWrapper, *]]
+    implicit val alternative: Alternative[ListWrapper] = ListWrapper.alternative
+    implicit val iso: Isomorphisms[Tuple2K[ListWrapper, ListWrapper, *]] =
+      Isomorphisms.invariant[Tuple2K[ListWrapper, ListWrapper, *]]
     checkAll("Tuple2K[ListWrapper, ListWrapper, *]",
              AlternativeTests[Tuple2K[ListWrapper, ListWrapper, *]].alternative[Int, Int, Int])
     checkAll("Alternative[Tuple2K[ListWrapper, ListWrapper, *]]",
@@ -118,9 +120,9 @@ class Tuple2KSuite extends CatsSuite {
   }
 
   {
-    implicit val E = ListWrapper.eqv[Int]
-    implicit val O = ListWrapper.order[Int]
-    implicit val P = ListWrapper.partialOrder[Int]
+    implicit val E: Eq[ListWrapper[Int]] = ListWrapper.eqv[Int]
+    implicit val O: Order[ListWrapper[Int]] = ListWrapper.order[Int]
+    implicit val P: PartialOrder[ListWrapper[Int]] = ListWrapper.partialOrder[Int]
 
     checkAll("Tuple2K[ListWrapper, ListWrapper, Int]", EqTests[Tuple2K[ListWrapper, ListWrapper, Int]].eqv)
     checkAll("Tuple2K[ListWrapper, ListWrapper, Int]", OrderTests[Tuple2K[ListWrapper, ListWrapper, Int]].order)

--- a/tests/src/test/scala/cats/tests/TupleSuite.scala
+++ b/tests/src/test/scala/cats/tests/TupleSuite.scala
@@ -5,12 +5,13 @@ import data.NonEmptyList
 
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import Helpers.CSemi
 
 class TupleSuite extends CatsSuite {
 
-  implicit val iso1 = SemigroupalTests.Isomorphisms.invariant[(NonEmptyList[Int], *)]
-  implicit val iso2 = SemigroupalTests.Isomorphisms.invariant[(String, *)]
+  implicit val iso1: Isomorphisms[(NonEmptyList[Int], *)] = Isomorphisms.invariant[(NonEmptyList[Int], *)]
+  implicit val iso2: Isomorphisms[(String, *)] = Isomorphisms.invariant[(String, *)]
 
   checkAll("Tuple2", BitraverseTests[Tuple2].bitraverse[Option, Int, Int, Int, String, String, String])
   checkAll("Bitraverse[Tuple2]", SerializableTests.serializable(Bitraverse[Tuple2]))

--- a/tests/src/test/scala/cats/tests/ValidatedSuite.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedSuite.scala
@@ -6,20 +6,22 @@ import cats.data.Validated.{Invalid, Valid}
 import cats.laws.discipline._
 import org.scalacheck.Arbitrary._
 import cats.laws.discipline.SemigroupKTests
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline.arbitrary._
 import cats.kernel.laws.discipline.{EqTests, MonoidTests, OrderTests, PartialOrderTests, SemigroupTests}
 
 import scala.util.Try
 
 class ValidatedSuite extends CatsSuite {
-  implicit val iso = SemigroupalTests.Isomorphisms.invariant[Validated[String, *]]
+  implicit val iso: Isomorphisms[Validated[String, *]] = Isomorphisms.invariant[Validated[String, *]]
   checkAll("Validated[String, Int]", SemigroupalTests[Validated[String, *]].semigroupal[Int, Int, Int])
   checkAll("Semigroupal[Validated[String,*]]", SerializableTests.serializable(Semigroupal[Validated[String, *]]))
 
   checkAll("Validated[*, *]", BitraverseTests[Validated].bitraverse[Option, Int, Int, Int, String, String, String])
   checkAll("Bitraverse[Validated]", SerializableTests.serializable(Bitraverse[Validated]))
 
-  implicit val eq0 = EitherT.catsDataEqForEitherT[Validated[String, *], String, Int]
+  implicit val eq0: Eq[EitherT[Validated[String, *], String, Int]] =
+    EitherT.catsDataEqForEitherT[Validated[String, *], String, Int]
 
   checkAll("Validated[String, Int]",
            ApplicativeErrorTests[Validated[String, *], String].applicativeError[Int, Int, Int])
@@ -45,15 +47,15 @@ class ValidatedSuite extends CatsSuite {
   checkAll("Align[Validated[Int, *]]", SerializableTests.serializable(Align[Validated[Int, *]]))
 
   {
-    implicit val L = ListWrapper.semigroup[String]
+    implicit val L: Semigroup[ListWrapper[String]] = ListWrapper.semigroup[String]
     checkAll("Validated[ListWrapper[String], *]", SemigroupKTests[Validated[ListWrapper[String], *]].semigroupK[Int])
     checkAll("SemigroupK[Validated[ListWrapper[String], *]]",
              SerializableTests.serializable(SemigroupK[Validated[ListWrapper[String], *]]))
   }
 
   {
-    implicit val S = ListWrapper.partialOrder[String]
-    implicit val I = ListWrapper.partialOrder[Int]
+    implicit val S: PartialOrder[ListWrapper[String]] = ListWrapper.partialOrder[String]
+    implicit val I: PartialOrder[ListWrapper[Int]] = ListWrapper.partialOrder[Int]
     checkAll("Validated[ListWrapper[String], ListWrapper[Int]]",
              PartialOrderTests[Validated[ListWrapper[String], ListWrapper[Int]]].partialOrder)
     checkAll(
@@ -63,8 +65,8 @@ class ValidatedSuite extends CatsSuite {
   }
 
   {
-    implicit val S = ListWrapper.eqv[String]
-    implicit val I = ListWrapper.eqv[Int]
+    implicit val S: Eq[ListWrapper[String]] = ListWrapper.eqv[String]
+    implicit val I: Eq[ListWrapper[Int]] = ListWrapper.eqv[Int]
     checkAll("Validated[ListWrapper[String], ListWrapper[Int]]",
              EqTests[Validated[ListWrapper[String], ListWrapper[Int]]].eqv)
     checkAll("Eq[Validated[ListWrapper[String], ListWrapper[Int]]]",

--- a/tests/src/test/scala/cats/tests/WriterTSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterTSuite.scala
@@ -6,6 +6,7 @@ import cats.kernel.Semigroup
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.kernel.laws.discipline.{EqTests, MonoidTests, SemigroupTests}
 
 class WriterTSuite extends CatsSuite {
@@ -162,7 +163,7 @@ class WriterTSuite extends CatsSuite {
              SerializableTests.serializable(Bifunctor[WriterT[ListWrapper, *, *]]))
   }
 
-  implicit val iso = SemigroupalTests.Isomorphisms
+  implicit val iso: Isomorphisms[WriterT[ListWrapper, ListWrapper[Int], *]] = Isomorphisms
     .invariant[WriterT[ListWrapper, ListWrapper[Int], *]](WriterT.catsDataCoflatMapForWriterT(ListWrapper.functor))
 
   // We have varying instances available depending on `F` and `L`.
@@ -361,8 +362,10 @@ class WriterTSuite extends CatsSuite {
   {
     // F has an Applicative and L has a Monoid
     implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
-    implicit val app = WriterT.catsDataApplicativeForWriterT[Validated[String, *], ListWrapper[Int]]
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[WriterT[Validated[String, *], ListWrapper[Int], *]]
+    implicit val app: Applicative[WriterT[Validated[String, *], ListWrapper[Int], *]] =
+      WriterT.catsDataApplicativeForWriterT[Validated[String, *], ListWrapper[Int]]
+    implicit val iso: Isomorphisms[WriterT[Validated[String, *], ListWrapper[Int], *]] =
+      Isomorphisms.invariant[WriterT[Validated[String, *], ListWrapper[Int], *]]
     implicit def eq1[A: Eq]: Eq[WriterT[Validated[String, *], ListWrapper[Int], A]] =
       WriterT.catsDataEqForWriterT[Validated[String, *], ListWrapper[Int], A]
     implicit val eq2: Eq[EitherT[WriterT[Validated[String, *], ListWrapper[Int], *], String, Int]] =
@@ -383,8 +386,10 @@ class WriterTSuite extends CatsSuite {
   {
     // F has an ApplicativeError and L has a Monoid
     implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
-    implicit val appErr = WriterT.catsDataApplicativeErrorForWriterT[Validated[String, *], ListWrapper[Int], String]
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[WriterT[Validated[String, *], ListWrapper[Int], *]]
+    implicit val appErr: ApplicativeError[WriterT[Validated[String, *], ListWrapper[Int], *], String] =
+      WriterT.catsDataApplicativeErrorForWriterT[Validated[String, *], ListWrapper[Int], String]
+    implicit val iso: Isomorphisms[WriterT[Validated[String, *], ListWrapper[Int], *]] =
+      Isomorphisms.invariant[WriterT[Validated[String, *], ListWrapper[Int], *]]
     checkAll(
       "WriterT[Validated[String, *], ListWrapper[Int], *]",
       ApplicativeErrorTests[WriterT[Validated[String, *], ListWrapper[Int], *], String].applicativeError[Int, Int, Int]
@@ -398,7 +403,8 @@ class WriterTSuite extends CatsSuite {
   {
     // F has a MonadError and L has a Monoid
     implicit val L: Monoid[ListWrapper[Int]] = ListWrapper.monoid[Int]
-    implicit val iso = SemigroupalTests.Isomorphisms.invariant[WriterT[Option, ListWrapper[Int], *]]
+    implicit val iso: Isomorphisms[WriterT[Option, ListWrapper[Int], *]] =
+      Isomorphisms.invariant[WriterT[Option, ListWrapper[Int], *]]
     implicit val eq0: Eq[EitherT[WriterT[Option, ListWrapper[Int], *], Unit, Int]] =
       EitherT.catsDataEqForEitherT[WriterT[Option, ListWrapper[Int], *], Unit, Int]
 
@@ -428,7 +434,7 @@ class WriterTSuite extends CatsSuite {
 
   {
     // F has an Invariant
-    implicit val evidence = ListWrapper.invariant
+    implicit val evidence: Invariant[ListWrapper] = ListWrapper.invariant
     Invariant[ListWrapper]
     Invariant[WriterT[ListWrapper, Int, *]]
 


### PR DESCRIPTION
Dotty doesn't like local implicit vals without type annotations. I'm finally getting back to Dotty cross-building for tests after doing this for core and laws a few weeks back. In my view these changes are an improvement even on Scala 2.

The only non-trivial change is in `RepresentableSuite`, where there was some kind of weird code like this:

```scala
implicit val bimonadInstance = Representable.bimonad[Pair, Boolean]
```

The issue here is that `Representable.bimonad` has a `Representable[Pair]` constraint, and the `Representable[Pair]` instance has a `Functor[Pair]` constraint. But `bimonadInstance` is a `Functor[Pair]`. If you leave off the type annotation Scala is fine with this (because Scala), but if you put it on you get forward reference errors from the compiler. I've worked around this by invoking the `Representable[X]` in an outer scope and assigning it to a non-implicit val.

I've also removed the single bracket in `SemigroupKSuite` because some other weird stuff was happening that seems entirely unrelated to what's being tested there.