### PR TITLE
More Dotty compat stuff in tests

### DIFF
--- a/tests/src/test/scala/cats/tests/AsSuite.scala
+++ b/tests/src/test/scala/cats/tests/AsSuite.scala
@@ -14,7 +14,7 @@ class AsSuite extends CatsSuite {
     fa.foldLeft(Map.empty[A, B])(subst(_ + _))
   }
 
-  implicit def arbAs[A, B](implicit ev: A <~< B) = Arbitrary(Gen.const(ev))
+  implicit def arbAs[A, B](implicit ev: A <~< B): Arbitrary[A <~< B] = Arbitrary(Gen.const(ev))
   implicit def eq[A, B]: Eq[As[A, B]] = Eq.fromUniversalEquals
 
   test("narrow an input of a function2") {

--- a/tests/src/test/scala/cats/tests/EvalSuite.scala
+++ b/tests/src/test/scala/cats/tests/EvalSuite.scala
@@ -195,8 +195,8 @@ class EvalSuite extends CatsSuite {
       Arbitrary(
         Gen.oneOf(arbitrary[A => A].map(OMap(_)),
                   arbitrary[A => Eval[A]].map(OFlatMap(_)),
-                  Gen.const(OMemoize[A]),
-                  Gen.const(ODefer[A]))
+                  Gen.const(OMemoize[A]()),
+                  Gen.const(ODefer[A]()))
       )
 
     def build[A](leaf: () => Eval[A], os: Vector[O[A]]): DeepEval[A] = {

--- a/tests/src/test/scala/cats/tests/FoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/FoldableSuite.scala
@@ -560,7 +560,7 @@ class FoldableEitherKSuite extends FoldableSuite[EitherK[Option, Option, *]]("ei
   def iterator[T](eitherK: EitherK[Option, Option, T]) = eitherK.run.bimap(_.iterator, _.iterator).merge
 }
 
-class FoldableIorSuite extends FoldableSuite[Int Ior *]("ior") {
+class FoldableIorSuite extends FoldableSuite[Ior[Int, *]]("ior") {
   def iterator[T](ior: Int Ior T) =
     ior.fold(_ => None.iterator, b => Some(b).iterator, (_, b) => Some(b).iterator)
 }

--- a/tests/src/test/scala/cats/tests/IorSuite.scala
+++ b/tests/src/test/scala/cats/tests/IorSuite.scala
@@ -20,18 +20,18 @@ class IorSuite extends CatsSuite {
   implicit val iso: Isomorphisms[Ior[String, *]] = Isomorphisms.invariant[Ior[String, *]]
 
   checkAll("Ior[String, Int]", SemigroupalTests[Ior[String, *]].semigroupal[Int, Int, Int])
-  checkAll("Semigroupal[String Ior *]]", SerializableTests.serializable(Semigroupal[String Ior *]))
+  checkAll("Semigroupal[Ior[String, *]]", SerializableTests.serializable(Semigroupal[Ior[String, *]]))
 
   implicit val eq0: Eq[EitherT[Ior[String, *], String, Int]] = EitherT.catsDataEqForEitherT[Ior[String, *], String, Int]
 
-  checkAll("Ior[String, Int]", MonadErrorTests[String Ior *, String].monadError[Int, Int, Int])
-  checkAll("MonadError[String Ior *]", SerializableTests.serializable(MonadError[String Ior *, String]))
+  checkAll("Ior[String, Int]", MonadErrorTests[Ior[String, *], String].monadError[Int, Int, Int])
+  checkAll("MonadError[SIor[String, *]]", SerializableTests.serializable(MonadError[Ior[String, *], String]))
 
-  checkAll("Ior[String, Int] with Option", TraverseTests[String Ior *].traverse[Int, Int, Int, Int, Option, Option])
-  checkAll("Traverse[String Ior *]", SerializableTests.serializable(Traverse[String Ior *]))
-  checkAll("* Ior *", BifunctorTests[Ior].bifunctor[Int, Int, Int, String, String, String])
+  checkAll("Ior[String, Int] with Option", TraverseTests[Ior[String, *]].traverse[Int, Int, Int, Int, Option, Option])
+  checkAll("Traverse[Ior[String, *]]", SerializableTests.serializable(Traverse[Ior[String, *]]))
+  checkAll("Ior[*, *]", BifunctorTests[Ior].bifunctor[Int, Int, Int, String, String, String])
 
-  checkAll("Ior[*, *]", BitraverseTests[Ior].bitraverse[Option, Int, Int, Int, String, String, String])
+  checkAll("BitraverseTests Ior[*, *]", BitraverseTests[Ior].bitraverse[Option, Int, Int, Int, String, String, String])
   checkAll("Bitraverse[Ior]", SerializableTests.serializable(Bitraverse[Ior]))
 
   checkAll("Semigroup[Ior[A: Semigroup, B: Semigroup]]", SemigroupTests[Ior[List[Int], List[Int]]].semigroup)

--- a/tests/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/KleisliSuite.scala
@@ -157,7 +157,7 @@ class KleisliSuite extends CatsSuite {
            SerializableTests.serializable(Contravariant[Kleisli[Option, *, Int]]))
 
   test("Functor[Kleisli[F, Int, *]] is not ambiguous when an ApplicativeError and a FlatMap are in scope for F") {
-    def shouldCompile1[F[_]: ApplicativeError[*[_], E]: FlatMap, E]: Functor[Kleisli[F, Int, *]] =
+    def shouldCompile1[F[_], E](implicit F: ApplicativeError[F, E], FM: FlatMap[F]): Functor[Kleisli[F, Int, *]] =
       Functor[Kleisli[F, Int, *]]
   }
 

--- a/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
@@ -300,17 +300,17 @@ class NonEmptyVectorSuite extends CatsSuite {
         // A bug in scala 2.10 allows private constructors to be accessed.
         // We should still ensure that on scala 2.11 and up we cannot construct the
         // object directly. see: https://issues.scala-lang.org/browse/SI-6601
-        "val bad: NonEmptyVector[Int] = new NonEmptyVector(Vector(1))" shouldNot compile
+        assertDoesNotCompile("val bad: NonEmptyVector[Int] = new NonEmptyVector(Vector(1))")
       }
     }
   }
 
   test("Cannot create a new NonEmptyVector[Int] from apply with a Vector[Int]") {
-    "val bad: NonEmptyVector[Int] = NonEmptyVector(Vector(1))" shouldNot compile
+    assertDoesNotCompile("val bad: NonEmptyVector[Int] = NonEmptyVector(Vector(1))")
   }
 
   test("Cannot create a new NonEmptyVector[Int] from apply with a an empty Vector") {
-    "val bad: NonEmptyVector[Int] = NonEmptyVector(Vector.empty[Int])" shouldNot compile
+    assertDoesNotCompile("val bad: NonEmptyVector[Int] = NonEmptyVector(Vector.empty[Int])")
   }
 
   test("NonEmptyVector#distinct is consistent with Vector#distinct") {


### PR DESCRIPTION
Okay, I think I'm really close to cross-compiling the Cats tests on Dotty, and I'm pretty sure this is the last batch of Scala 2-friendly changes that could be merged into master right now. (The rest of the changes are stubs for ScalaTest macros and explicit type parameters for cases where Dotty's type inference is worse than Scala 2's, which I'm working on feature requests for.)

Note that I've changed a few instances of `"code" shouldNot compile` to `assertDoesNotCompile("code")`, which is both more consistent with Cats's style elsewhere (e.g. using `assertTypeError` instead of `shouldNot typeCheck`) and easier to temporarily stub for Dotty. In my view this is a strict improvement even on Scala 2 (but I hate ScalaTest's matchers in general).