### PR TITLE
Update discipline-scalatest

### DIFF
--- a/alleycats-tests/shared/src/test/scala/alleycats/tests/AlleycatsSuite.scala
+++ b/alleycats-tests/shared/src/test/scala/alleycats/tests/AlleycatsSuite.scala
@@ -8,7 +8,7 @@ import cats.syntax.{AllSyntax, EqOps}
 import cats.tests.StrictCatsEquality
 import org.scalatest.funsuite.AnyFunSuiteLike
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import org.typelevel.discipline.scalatest.Discipline
+import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest.matchers.should.Matchers
@@ -23,7 +23,7 @@ trait AlleycatsSuite
     extends AnyFunSuiteLike
     with Matchers
     with ScalaCheckDrivenPropertyChecks
-    with Discipline
+    with FunSuiteDiscipline
     with TestSettings
     with AllInstances
     with AllSyntax

--- a/build.sbt
+++ b/build.sbt
@@ -23,7 +23,7 @@ val scalatestplusScalaCheckVersion = "3.1.0.1"
 
 val disciplineVersion = "1.0.2"
 
-val disciplineScalatestVersion = "1.0.0-RC2"
+val disciplineScalatestVersion = "1.0.0-RC4"
 
 val kindProjectorVersion = "0.11.0"
 

--- a/docs/src/main/tut/typeclasses/lawtesting.md
+++ b/docs/src/main/tut/typeclasses/lawtesting.md
@@ -84,7 +84,7 @@ this conversion for two test frameworks: `ScalaTest` and `Specs2`.
 
 * If you are using `Specs2`, extend your test class with `org.typelevel.discipline.specs2.Discipline` (provided by `discipline-specs2`).
 
-* If you are using `ScalaTest`, extend your test class with `org.typelevel.discipline.scalatest.Discipline` (provided by `discipline-scalatest`) and `org.scalatest.funsuite.AnyFunSuiteLike`.
+* If you are using `ScalaTest`, extend your test class with `org.typelevel.discipline.scalatest.FunSuiteDiscipline` (provided by `discipline-scalatest`) and `org.scalatest.funsuite.AnyFunSuiteLike`.
 
 * For other test frameworks, you need to resort to their integration with `ScalaCheck` to test
 the `ScalaCheck` `Properties` provided by `cats-laws`.
@@ -95,10 +95,11 @@ The following example is for ScalaTest.
 import cats.implicits._
 import cats.laws.discipline.FunctorTests
 import org.scalatest.funsuite.AnyFunSuite
-import org.typelevel.discipline.scalatest.Discipline
+import org.scalatestplus.scalacheck.Checkers
+import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 import arbitraries._
 
-class TreeLawTests extends AnyFunSuite with Discipline {
+class TreeLawTests extends AnyFunSuite with FunSuiteDiscipline with Checkers {
   checkAll("Tree.FunctorLaws", FunctorTests[Tree].functor[Int, Int, String])
 }
 ```
@@ -106,7 +107,7 @@ class TreeLawTests extends AnyFunSuite with Discipline {
 * `cats.implicits._` imports the instances we need for `Eq[Tree[Int]]`, which the laws use to compare trees.
 * `FunctorTests` contains the functor laws.
 * `AnyFunSuite` defines the style of ScalaTest.
-* `Discipline` provides `checkAll`, and must be mixed into `AnyFunSuite`
+* `FunSuiteDiscipline` provides `checkAll`, and must be mixed into `AnyFunSuite`
 * `arbitraries._` imports the `Arbitrary[Tree[_]]` instances needed to check the laws.
 
 Alternatively, you can use the `CatsSuite` provided by [Cats-testkit-scalatest](https://github.com/typelevel/cats-testkit-scalatest),
@@ -161,10 +162,11 @@ import cats.implicits._
 import cats.kernel.laws.discipline.SemigroupTests
 import cats.laws.discipline.FunctorTests
 import org.scalatest.funsuite.AnyFunSuite
-import org.typelevel.discipline.scalatest.Discipline
+import org.scalatestplus.scalacheck.Checkers
+import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 import arbitraries._
 
-class TreeLawTests extends AnyFunSuite with Discipline {
+class TreeLawTests extends AnyFunSuite with FunSuiteDiscipline with Checkers {
   checkAll("Tree[Int].SemigroupLaws", SemigroupTests[Tree[Int]].semigroup)
   checkAll("Tree.FunctorLaws", FunctorTests[Tree].functor[Int, Int, String])
 }

--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -134,10 +134,7 @@ object KernelCheck {
     }
 }
 
-class Tests extends AnyFunSuiteLike with FunSuiteDiscipline with ScalaVersionSpecificTests with Checkers {
-
-  import KernelCheck._
-
+class TestsConfig extends Checkers {
   // The ScalaCheck defaults (100,100) are too high for Scala.js.
   final val PropMaxSize: PosZInt = if (Platform.isJs) 10 else 100
   final val PropMinSuccessful: PosInt = if (Platform.isJs) 10 else 100
@@ -145,6 +142,11 @@ class Tests extends AnyFunSuiteLike with FunSuiteDiscipline with ScalaVersionSpe
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = PropMinSuccessful, sizeRange = PropMaxSize, workers = PropWorkers)
+}
+
+class Tests extends TestsConfig with AnyFunSuiteLike with FunSuiteDiscipline with ScalaVersionSpecificTests {
+
+  import KernelCheck._
 
   {
     // needed for Cogen[Map[...]]

--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -5,11 +5,12 @@ import cats.kernel.instances.all._
 import cats.kernel.laws.discipline._
 import cats.platform.Platform
 
-import org.typelevel.discipline.scalatest.Discipline
+import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import Arbitrary.arbitrary
 import org.scalactic.anyvals.{PosInt, PosZInt}
 import org.scalatest.funsuite.AnyFunSuiteLike
+import org.scalatestplus.scalacheck.Checkers
 
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.collection.immutable.{BitSet, Queue, SortedMap, SortedSet}
@@ -133,7 +134,7 @@ object KernelCheck {
     }
 }
 
-class Tests extends AnyFunSuiteLike with Discipline with ScalaVersionSpecificTests {
+class Tests extends AnyFunSuiteLike with FunSuiteDiscipline with ScalaVersionSpecificTests with Checkers {
 
   import KernelCheck._
 

--- a/laws/src/test/scala/cats/laws/discipline/MonadTestsTests.scala
+++ b/laws/src/test/scala/cats/laws/discipline/MonadTestsTests.scala
@@ -5,9 +5,10 @@ package discipline
 import cats.instances.all._
 import cats.laws.discipline.arbitrary._
 import org.scalatest.funsuite.AnyFunSuiteLike
-import org.typelevel.discipline.scalatest.Discipline
+import org.scalatestplus.scalacheck.Checkers
+import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 
-class MonadTestsTests extends AnyFunSuiteLike with Discipline {
+class MonadTestsTests extends AnyFunSuiteLike with FunSuiteDiscipline with Checkers {
   // We don't use `stackUnsafeMonad` in our laws checking for instances in Cats,
   // so we confirm here that the laws pass for `Eval` (the monad instance for
   // which is actually stack safe, like all other monad instances in Cats.)

--- a/tests/src/test/scala/cats/tests/AndThenSuite.scala
+++ b/tests/src/test/scala/cats/tests/AndThenSuite.scala
@@ -8,8 +8,9 @@ import cats.arrow._
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
 import cats.platform.Platform
+import org.scalatestplus.scalacheck.Checkers
 
-class AndThenSuite extends CatsSuite {
+class AndThenSuite extends CatsSuite with Checkers {
   checkAll("AndThen[MiniInt, Int]", SemigroupalTests[AndThen[MiniInt, *]].semigroupal[Int, Int, Int])
   checkAll("Semigroupal[AndThen[Int, *]]", SerializableTests.serializable(Semigroupal[AndThen[Int, *]]))
 

--- a/tests/src/test/scala/cats/tests/CatsSuite.scala
+++ b/tests/src/test/scala/cats/tests/CatsSuite.scala
@@ -9,7 +9,7 @@ import org.scalatest.funsuite.AnyFunSuiteLike
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.Configuration
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
-import org.typelevel.discipline.scalatest.Discipline
+import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 
 trait TestSettings extends Configuration with Matchers {
 
@@ -35,7 +35,7 @@ trait CatsSuite
     extends AnyFunSuiteLike
     with Matchers
     with ScalaCheckDrivenPropertyChecks
-    with Discipline
+    with FunSuiteDiscipline
     with TestSettings
     with AllInstances
     with AllInstancesBinCompat0

--- a/tests/src/test/scala/cats/tests/ParallelSuite.scala
+++ b/tests/src/test/scala/cats/tests/ParallelSuite.scala
@@ -8,7 +8,8 @@ import org.scalatest.funsuite.AnyFunSuiteLike
 import cats.laws.discipline.{ApplicativeErrorTests, MiniInt, NonEmptyParallelTests, ParallelTests, SerializableTests}
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
-import org.typelevel.discipline.scalatest.Discipline
+import org.scalatestplus.scalacheck.Checkers
+import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 import scala.collection.immutable.SortedSet
 import kernel.compat.scalaVersionSpecific._
 
@@ -498,7 +499,7 @@ class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest with Sc
   }
 }
 
-trait ApplicativeErrorForEitherTest extends AnyFunSuiteLike with Discipline {
+trait ApplicativeErrorForEitherTest extends AnyFunSuiteLike with FunSuiteDiscipline with Checkers {
 
   import cats.instances.either._
   import cats.instances.string._


### PR DESCRIPTION
Okay, trying this again, with [1.0.0-RC4](https://github.com/typelevel/discipline-scalatest/releases/tag/v1.0.0-RC4).

-----

Update: the NPEs were because of an initialization issue in `cats.kernel.laws.Test`, which was happening because the implicit `PropertyCheckConfiguration` is now being resolved where `checkAll` is called instead of in discipline-scalatest (where previously it always used `generatorDrivenConfig`).

Unfortunately ScalaTest's `org.scalatest.prop.Configuration` defines `generatorDrivenConfig` as a `val`, so we can't just slap a `lazy` on the override. Instead I've added a configuration class that makes the initialization work out right.

This is the only place this issue showed up either here or in [Circe](https://github.com/circe/circe/pull/1369), which I've also updated to discipline-scalatest 1.0.0-RC4, and I think it's likely to be rare—it's only showing up here because of the kind of unusual arrangement of Scala-version-specific tests.

I also think the new behavior is the correct behavior. If the user was writing tests in terms of `check` directly, the implicit configuration would be resolved at the point where they call `check`—it wouldn't just use `generatorDrivenConfig` automatically. In my view our `checkAll` should do the same.

(I'll note the issue in the final 1.0.0 release notes.)