### PR TITLE
Fix compiler warnings in tests

### DIFF
--- a/tests/src/test/scala/cats/tests/ContravariantSuite.scala
+++ b/tests/src/test/scala/cats/tests/ContravariantSuite.scala
@@ -4,7 +4,6 @@ package tests
 import cats.data.Const
 import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
 import cats.laws.discipline.{ContravariantMonoidalTests, ExhaustiveCheck, MiniInt}
-import org.scalactic.CanEqual
 import org.scalacheck.{Arbitrary, Cogen}
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
@@ -13,8 +12,6 @@ class ContravariantSuite extends CatsSuite {
 
   test("narrow equals contramap(identity)") {
     implicit val constInst: Contravariant[Const[Int, *]] = Const.catsDataContravariantForConst[Int]
-    implicit val canEqual: CanEqual[cats.data.Const[Int, Some[Int]], cats.data.Const[Int, Some[Int]]] =
-      StrictCatsEquality.lowPriorityConversionCheckedConstraint
     forAll { (i: Int) =>
       val const: Const[Int, Option[Int]] = Const[Int, Option[Int]](i)
       val narrowed: Const[Int, Some[Int]] = constInst.narrow[Option[Int], Some[Int]](const)

--- a/tests/src/test/scala/cats/tests/ReducibleSuite.scala
+++ b/tests/src/test/scala/cats/tests/ReducibleSuite.scala
@@ -111,7 +111,7 @@ class ReducibleSuiteAdditional extends CatsSuite {
     val n = 100000
     val xs = NES(Right(0), Stream.from(1).map(i => if (i < n) Right(i) else Left(i)))
 
-    assert(xs.reduceA === Left(n))
+    xs.reduceA should ===(Left(n))
   }
 }
 


### PR DESCRIPTION
The tests have been warning on these two issues for a while. The first is because of a [ScalaTest bug](https://github.com/scalatest/scalatest/issues/961), but it's easy to work around. The second is a deprecation warning for some code that's no longer necessary.

