### PR TITLE
Avoid syntax methods in implementations in cats-core

### DIFF
--- a/bench/src/main/scala/cats/bench/EitherKMapBench.scala
+++ b/bench/src/main/scala/cats/bench/EitherKMapBench.scala
@@ -1,0 +1,33 @@
+package cats.bench
+
+import cats.Functor
+import cats.data.EitherK
+import cats.implicits._
+import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
+
+@State(Scope.Benchmark)
+class EitherKMapBench {
+  def map1[F[_], G[_], A, B](e: EitherK[F, G, A])(f: A => B)(implicit F: Functor[F], G: Functor[G]): EitherK[F, G, B] =
+    EitherK(e.run.bimap(F.lift(f), G.lift(f)))
+
+  def map2[F[_], G[_], A, B](e: EitherK[F, G, A])(f: A => B)(implicit F: Functor[F], G: Functor[G]): EitherK[F, G, B] =
+    EitherK(
+      e.run match {
+        case Right(ga) => Right(G.map(ga)(f))
+        case Left(fa)  => Left(F.map(fa)(f))
+      }
+    )
+
+  type EK = EitherK[List, Option, Int]
+
+  val value1 = EitherK[List, Option, Int](Right(Some(0)))
+  val value2 = EitherK[List, Option, Int](Right(None))
+  val value3 = EitherK[List, Option, Int](Left(List(1, 2)))
+  val f: Int => Int = _ + 1
+
+  @Benchmark
+  def incMap1: (EK, EK, EK) = (map1(value1)(f), map1(value2)(f), map1(value3)(f))
+
+  @Benchmark
+  def incMap2: (EK, EK, EK) = (map2(value1)(f), map2(value2)(f), map2(value3)(f))
+}

--- a/bench/src/main/scala/cats/bench/ValidatedBench.scala
+++ b/bench/src/main/scala/cats/bench/ValidatedBench.scala
@@ -13,14 +13,12 @@ class ValidatedBench {
 
   def bimapPointfull[E, A, EE, AA](v: Validated[E, A])(fe: E => EE, fa: A => AA): Validated[EE, AA] =
     v match {
-      case Valid(a) => Valid(fa(a))
+      case Valid(a)   => Valid(fa(a))
       case Invalid(e) => Invalid(fe(e))
     }
 
   @Benchmark
   def pointfull: Validated[Int, Int] = bimapPointfull(x)(_.length, _ + 1)
-
-
   @Benchmark
   def pointfree: Validated[Int, Int] = bimapPointfree(x)(_.length, _ + 1)
 }

--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -2,8 +2,6 @@ package cats
 
 import scala.annotation.tailrec
 
-import cats.syntax.all._
-
 /**
  * Eval is a monad which controls evaluation.
  *
@@ -416,7 +414,7 @@ sealed abstract private[cats] class EvalInstances extends EvalInstances0 {
   implicit def catsOrderForEval[A: Order]: Order[Eval[A]] =
     new Order[Eval[A]] {
       def compare(lx: Eval[A], ly: Eval[A]): Int =
-        lx.value.compare(ly.value)
+        Order[A].compare(lx.value, ly.value)
     }
 
   implicit def catsGroupForEval[A: Group]: Group[Eval[A]] =
@@ -443,7 +441,7 @@ sealed abstract private[cats] class EvalInstances0 extends EvalInstances1 {
   implicit def catsPartialOrderForEval[A: PartialOrder]: PartialOrder[Eval[A]] =
     new PartialOrder[Eval[A]] {
       def partialCompare(lx: Eval[A], ly: Eval[A]): Double =
-        lx.value.partialCompare(ly.value)
+        PartialOrder[A].partialCompare(lx.value, ly.value)
     }
 
   implicit def catsMonoidForEval[A: Monoid]: Monoid[Eval[A]] =
@@ -454,7 +452,7 @@ sealed abstract private[cats] class EvalInstances1 {
   implicit def catsEqForEval[A: Eq]: Eq[Eval[A]] =
     new Eq[Eval[A]] {
       def eqv(lx: Eval[A], ly: Eval[A]): Boolean =
-        lx.value === ly.value
+        Eq[A].eqv(lx.value, ly.value)
     }
 
   implicit def catsSemigroupForEval[A: Semigroup]: Semigroup[Eval[A]] =
@@ -464,7 +462,7 @@ sealed abstract private[cats] class EvalInstances1 {
 trait EvalSemigroup[A] extends Semigroup[Eval[A]] {
   implicit def algebra: Semigroup[A]
   def combine(lx: Eval[A], ly: Eval[A]): Eval[A] =
-    for { x <- lx; y <- ly } yield x |+| y
+    for { x <- lx; y <- ly } yield algebra.combine(x, y)
 }
 
 trait EvalMonoid[A] extends Monoid[Eval[A]] with EvalSemigroup[A] {
@@ -475,7 +473,7 @@ trait EvalMonoid[A] extends Monoid[Eval[A]] with EvalSemigroup[A] {
 trait EvalGroup[A] extends Group[Eval[A]] with EvalMonoid[A] {
   implicit def algebra: Group[A]
   def inverse(lx: Eval[A]): Eval[A] =
-    lx.map(_.inverse())
+    lx.map(algebra.inverse)
   override def remove(lx: Eval[A], ly: Eval[A]): Eval[A] =
-    for { x <- lx; y <- ly } yield x |-| y
+    for { x <- lx; y <- ly } yield algebra.remove(x, y)
 }

--- a/core/src/main/scala/cats/Reducible.scala
+++ b/core/src/main/scala/cats/Reducible.scala
@@ -257,8 +257,6 @@ import simulacrum.{noop, typeclass}
    * }}}
    */
   def nonEmptyPartition[A, B, C](fa: F[A])(f: A => Either[B, C]): Ior[NonEmptyList[B], NonEmptyList[C]] = {
-    import cats.syntax.either._
-
     def g(a: A, eval: Eval[Ior[NonEmptyList[B], NonEmptyList[C]]]): Eval[Ior[NonEmptyList[B], NonEmptyList[C]]] =
       eval.map(ior =>
         (f(a), ior) match {
@@ -269,7 +267,12 @@ import simulacrum.{noop, typeclass}
         }
       )
 
-    reduceRightTo(fa)(a => f(a).bimap(NonEmptyList.one, NonEmptyList.one).toIor)(g).value
+    reduceRightTo(fa)(a =>
+      f(a) match {
+        case Right(c) => Ior.right(NonEmptyList.one(c))
+        case Left(b)  => Ior.left(NonEmptyList.one(b))
+      }
+    )(g).value
   }
 
   override def isEmpty[A](fa: F[A]): Boolean = false

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -2,7 +2,7 @@ package cats
 package data
 
 import cats.instances.either._
-import cats.syntax.either._
+import cats.syntax.EitherUtil
 
 /**
  * Transformer for `Either`, allowing the effect of an arbitrary type constructor `F` to be combined with the
@@ -128,7 +128,7 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
   def orElse[C, BB >: B](default: => EitherT[F, C, BB])(implicit F: Monad[F]): EitherT[F, C, BB] =
     EitherT(F.flatMap(value) {
       case Left(_)      => default.value
-      case r @ Right(_) => F.pure(r.leftCast)
+      case r @ Right(_) => F.pure(EitherUtil.leftCast(r))
     })
 
   /**
@@ -145,7 +145,14 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
    * }}}
    */
   def recover(pf: PartialFunction[A, B])(implicit F: Functor[F]): EitherT[F, A, B] =
-    EitherT(F.map(value)(_.recover(pf)))
+    EitherT(
+      F.map(value) { eab =>
+        eab match {
+          case Left(a) if pf.isDefinedAt(a) => Right(pf(a))
+          case _                            => eab
+        }
+      }
+    )
 
   /**
    * Example:
@@ -259,7 +266,14 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
    * }}}
    */
   def ensure[AA >: A](onFailure: => AA)(f: B => Boolean)(implicit F: Functor[F]): EitherT[F, AA, B] =
-    EitherT(F.map(value)(_.ensure(onFailure)(f)))
+    EitherT(
+      F.map(value) { eab =>
+        eab match {
+          case Left(_)  => eab
+          case Right(b) => if (f(b)) eab else Left(onFailure)
+        }
+      }
+    )
 
   /**
    * Example:
@@ -277,7 +291,14 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
    * }}}
    */
   def ensureOr[AA >: A](onFailure: B => AA)(f: B => Boolean)(implicit F: Functor[F]): EitherT[F, AA, B] =
-    EitherT(F.map(value)(_.ensureOr(onFailure)(f)))
+    EitherT(
+      F.map(value) { eab =>
+        eab match {
+          case Left(_)  => eab
+          case Right(b) => if (f(b)) eab else Left(onFailure(b))
+        }
+      }
+    )
 
   /**
    * Example:
@@ -304,7 +325,10 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
    * }}}
    */
   def to[G[_]](implicit F: Functor[F], G: Alternative[G]): F[G[B]] =
-    F.map(value)(_.to[G])
+    F.map(value) {
+      case Right(b) => G.pure(b)
+      case Left(_)  => G.empty
+    }
 
   /**
    * Example:
@@ -319,7 +343,10 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
    * }}}
    */
   def collectRight(implicit FA: Alternative[F], FM: Monad[F]): F[B] =
-    FM.flatMap(value)(_.to[F])
+    FM.flatMap(value) {
+      case Right(b) => FA.pure(b)
+      case Left(_)  => FA.empty
+    }
 
   /**
    * Example:
@@ -334,7 +361,12 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
    * }}}
    */
   def bimap[C, D](fa: A => C, fb: B => D)(implicit F: Functor[F]): EitherT[F, C, D] =
-    EitherT(F.map(value)(_.bimap(fa, fb)))
+    EitherT(
+      F.map(value) {
+        case Right(b) => Right(fb(b))
+        case Left(a)  => Left(fa(a))
+      }
+    )
 
   def bitraverse[G[_], C, D](f: A => G[C], g: B => G[D])(implicit traverseF: Traverse[F],
                                                          applicativeG: Applicative[G]): G[EitherT[F, C, D]] =
@@ -351,7 +383,7 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
 
   def flatMap[AA >: A, D](f: B => EitherT[F, AA, D])(implicit F: Monad[F]): EitherT[F, AA, D] =
     EitherT(F.flatMap(value) {
-      case l @ Left(_) => F.pure(l.rightCast)
+      case l @ Left(_) => F.pure(EitherUtil.rightCast(l))
       case Right(b)    => f(b).value
     })
 
@@ -379,7 +411,7 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
   def leftFlatMap[BB >: B, C](f: A => EitherT[F, C, BB])(implicit F: Monad[F]): EitherT[F, C, BB] =
     EitherT(F.flatMap(value) {
       case Left(a)      => f(a).value
-      case r @ Right(_) => F.pure(r.leftCast)
+      case r @ Right(_) => F.pure(EitherUtil.leftCast(r))
     })
 
   def leftSemiflatMap[D](f: A => F[D])(implicit F: Monad[F]): EitherT[F, D, B] =
@@ -388,7 +420,7 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
         F.map(f(a)) { d =>
           Left(d)
         }
-      case r @ Right(_) => F.pure(r.leftCast)
+      case r @ Right(_) => F.pure(EitherUtil.leftCast(r))
     })
 
   /** Combine `leftSemiflatMap` and `semiflatMap` together.
@@ -429,10 +461,16 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
     applicativeG.map(traverseF.traverse(value)(axb => Traverse[Either[A, *]].traverse(axb)(f)))(EitherT.apply)
 
   def foldLeft[C](c: C)(f: (C, B) => C)(implicit F: Foldable[F]): C =
-    F.foldLeft(value, c)((c, axb) => axb.foldLeft(c)(f))
+    F.foldLeft(value, c) {
+      case (c, Right(b)) => f(c, b)
+      case (c, Left(_))  => c
+    }
 
   def foldRight[C](lc: Eval[C])(f: (B, Eval[C]) => Eval[C])(implicit F: Foldable[F]): Eval[C] =
-    F.foldRight(value, lc)((axb, lc) => axb.foldRight(lc)(f))
+    F.foldRight(value, lc) {
+      case (Right(b), lc) => f(b, lc)
+      case (Left(_), lc)  => lc
+    }
 
   def merge[AA >: A](implicit ev: B <:< AA, F: Functor[F]): F[AA] = F.map(value)(_.fold(identity, ev.apply))
 
@@ -475,16 +513,28 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
    * }}}
    */
   def combine(that: EitherT[F, A, B])(implicit F: Apply[F], B: Semigroup[B]): EitherT[F, A, B] =
-    EitherT(F.map2(this.value, that.value)(_.combine(_)))
+    EitherT(
+      F.map2(this.value, that.value) {
+        case (Right(b1), Right(b2)) => Right(B.combine(b1, b2))
+        case (left @ Left(_), _)    => left
+        case (_, left @ Left(_))    => left
+      }
+    )
 
   def toValidated(implicit F: Functor[F]): F[Validated[A, B]] =
     F.map(value)(Validated.fromEither)
 
   def toValidatedNel(implicit F: Functor[F]): F[ValidatedNel[A, B]] =
-    F.map(value)(_.toValidatedNel)
+    F.map(value) {
+      case Right(b) => Validated.valid(b)
+      case Left(a)  => Validated.invalidNel(a)
+    }
 
   def toValidatedNec(implicit F: Functor[F]): F[ValidatedNec[A, B]] =
-    F.map(value)(_.toValidatedNec)
+    F.map(value) {
+      case Right(b) => Validated.valid(b)
+      case Left(a)  => Validated.invalidNec(a)
+    }
 
   /** Run this value as a `[[Validated]]` against the function and convert it back to an `[[EitherT]]`.
    *
@@ -554,13 +604,23 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
    * Transform this `EitherT[F, A, B]` into a `[[Nested]][F, ValidatedNel[A, *], B]`.
    */
   def toNestedValidatedNel(implicit F: Functor[F]): Nested[F, ValidatedNel[A, *], B] =
-    Nested[F, ValidatedNel[A, *], B](F.map(value)(_.toValidatedNel))
+    Nested[F, ValidatedNel[A, *], B](
+      F.map(value) {
+        case Right(b) => Validated.valid(b)
+        case Left(a)  => Validated.invalidNel(a)
+      }
+    )
 
   /**
    * Transform this `EitherT[F, A, B]` into a `[[Nested]][F, ValidatedNec[A, *], B]`.
    */
   def toNestedValidatedNec(implicit F: Functor[F]): Nested[F, ValidatedNec[A, *], B] =
-    Nested[F, ValidatedNec[A, *], B](F.map(value)(_.toValidatedNec))
+    Nested[F, ValidatedNec[A, *], B](
+      F.map(value) {
+        case Right(b) => Validated.valid(b)
+        case Left(a)  => Validated.invalidNec(a)
+      }
+    )
 }
 
 object EitherT extends EitherTInstances {
@@ -720,7 +780,14 @@ object EitherT extends EitherTInstances {
    */
   final private[data] class FromOptionPartiallyApplied[F[_]](private val dummy: Boolean = true) extends AnyVal {
     def apply[E, A](opt: Option[A], ifNone: => E)(implicit F: Applicative[F]): EitherT[F, E, A] =
-      EitherT(F.pure(Either.fromOption(opt, ifNone)))
+      EitherT(
+        F.pure(
+          opt match {
+            case Some(a) => Right(a)
+            case None    => Left(ifNone)
+          }
+        )
+      )
   }
 
   /** Transforms an `F[Option]` into an `EitherT`, using the second argument if the `Option` is a `None`.
@@ -734,7 +801,12 @@ object EitherT extends EitherTInstances {
    * }}}
    */
   final def fromOptionF[F[_], E, A](fopt: F[Option[A]], ifNone: => E)(implicit F: Functor[F]): EitherT[F, E, A] =
-    EitherT(F.map(fopt)(opt => Either.fromOption(opt, ifNone)))
+    EitherT(
+      F.map(fopt) {
+        case Some(a) => Right(a)
+        case None    => Left(ifNone)
+      }
+    )
 
   /**  If the condition is satisfied, return the given `A` in `Right`
    *  lifted into the specified `Applicative`, otherwise, return the

--- a/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
@@ -3,8 +3,6 @@ package data
 
 import cats.arrow.{Profunctor, Strong}
 
-import cats.syntax.either._
-
 /**
  * Represents a stateful computation in a context `F[_]`, from state `SA` to state `SB`,
  *  with an initial environment `E`, an accumulated log `L` and a result `A`.
@@ -671,7 +669,10 @@ sealed abstract private[data] class RWSTMonad[F[_], E, L, S]
         case (currL, currS, currA) =>
           F.map(f(currA).run(e, currS)) {
             case (nextL, nextS, ab) =>
-              ab.bimap((L.combine(currL, nextL), nextS, _), (L.combine(currL, nextL), nextS, _))
+              ab match {
+                case Right(b) => Right((L.combine(currL, nextL), nextS, b))
+                case Left(a)  => Left((L.combine(currL, nextL), nextS, a))
+              }
           }
       }
     }

--- a/core/src/main/scala/cats/data/IorT.scala
+++ b/core/src/main/scala/cats/data/IorT.scala
@@ -2,8 +2,6 @@ package cats
 package data
 
 import cats.arrow.FunctionK
-import cats.syntax.either._
-import cats.syntax.option._
 
 final case class IorT[F[_], A, B](value: F[Ior[A, B]]) {
 
@@ -294,7 +292,8 @@ object IorT extends IorTInstances {
    * Uses the [[http://typelevel.org/cats/guidelines.html#partially-applied-type-params Partially Applied Type Params technique]] for ergonomics.
    */
   final private[data] class FromEitherPartiallyApplied[F[_]](private val dummy: Boolean = true) extends AnyVal {
-    def apply[E, A](either: Either[E, A])(implicit F: Applicative[F]): IorT[F, E, A] = IorT(F.pure(either.toIor))
+    def apply[E, A](either: Either[E, A])(implicit F: Applicative[F]): IorT[F, E, A] =
+      IorT(F.pure(Ior.fromEither(either)))
   }
 
   /**
@@ -320,14 +319,14 @@ object IorT extends IorTInstances {
    * }}}
    */
   final def fromEitherF[F[_], E, A](feither: F[Either[E, A]])(implicit F: Functor[F]): IorT[F, E, A] =
-    IorT(F.map(feither)(_.toIor))
+    IorT(F.map(feither)(Ior.fromEither))
 
   /**
    * Uses the [[http://typelevel.org/cats/guidelines.html#partially-applied-type-params Partially Applied Type Params technique]] for ergonomics.
    */
   final private[data] class FromOptionPartiallyApplied[F[_]](private val dummy: Boolean = true) extends AnyVal {
     def apply[E, A](option: Option[A], ifNone: => E)(implicit F: Applicative[F]): IorT[F, E, A] =
-      IorT(F.pure(option.toRightIor(ifNone)))
+      IorT(F.pure(option.fold[Ior[E, A]](Ior.left(ifNone))(Ior.right)))
   }
 
   /**
@@ -358,7 +357,7 @@ object IorT extends IorTInstances {
    * }}}
    */
   final def fromOptionF[F[_], E, A](foption: F[Option[A]], ifNone: => E)(implicit F: Functor[F]): IorT[F, E, A] =
-    IorT(F.map(foption)(_.toRightIor(ifNone)))
+    IorT(F.map(foption)(_.fold[Ior[E, A]](Ior.left(ifNone))(Ior.right)))
 
   /**
    * Uses the [[http://typelevel.org/cats/guidelines.html#partially-applied-type-params Partially Applied Type Params technique]] for ergonomics.

--- a/core/src/main/scala/cats/data/NonEmptySet.scala
+++ b/core/src/main/scala/cats/data/NonEmptySet.scala
@@ -19,7 +19,6 @@ package data
 
 import cats.instances.sortedSet._
 import cats.kernel._
-import cats.syntax.order._
 
 import scala.collection.immutable._
 import kernel.compat.scalaVersionSpecific._
@@ -437,7 +436,7 @@ sealed abstract private[data] class NonEmptySetOrder[A] extends Order[NonEmptySe
   implicit override def A0: Order[A]
 
   override def compare(x: NonEmptySet[A], y: NonEmptySet[A]): Int =
-    x.toSortedSet.compare(y.toSortedSet)
+    Order[SortedSet[A]].compare(x.toSortedSet, y.toSortedSet)
 }
 
 sealed private[data] trait NonEmptySetEq[A] extends Eq[NonEmptySet[A]] {

--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -252,12 +252,9 @@ sealed abstract private[data] class OneAndLowPriority0 extends OneAndLowPriority
   implicit def catsDataNonEmptyTraverseForOneAnd[F[_]](implicit F: Traverse[F],
                                                        F2: Alternative[F]): NonEmptyTraverse[OneAnd[F, *]] =
     new NonEmptyReducible[OneAnd[F, *], F] with NonEmptyTraverse[OneAnd[F, *]] {
-      def nonEmptyTraverse[G[_], A, B](fa: OneAnd[F, A])(f: (A) => G[B])(implicit G: Apply[G]): G[OneAnd[F, B]] = {
-        import cats.syntax.apply._
-
+      def nonEmptyTraverse[G[_], A, B](fa: OneAnd[F, A])(f: (A) => G[B])(implicit G: Apply[G]): G[OneAnd[F, B]] =
         fa.map(a => Apply[G].map(f(a))(OneAnd(_, F2.empty[B])))(F)
-          .reduceLeft(((acc, a) => (acc, a).mapN((x: OneAnd[F, B], y: OneAnd[F, B]) => x.combine(y))))
-      }
+          .reduceLeft(((acc, a) => G.map2(acc, a)((x: OneAnd[F, B], y: OneAnd[F, B]) => x.combine(y))))
 
       override def traverse[G[_], A, B](fa: OneAnd[F, A])(f: (A) => G[B])(implicit G: Applicative[G]): G[OneAnd[F, B]] =
         G.map2Eval(f(fa.head), Always(F.traverse(fa.tail)(f)))(OneAnd(_, _)).value

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -2,7 +2,6 @@ package cats
 package data
 
 import cats.instances.option.{catsStdInstancesForOption => optionInstance, catsStdTraverseFilterForOption}
-import cats.syntax.either._
 
 /**
  * `OptionT[F[_], A]` is a light wrapper on an `F[Option[A]]` with some
@@ -424,7 +423,7 @@ private[data] trait OptionTMonad[F[_]] extends Monad[OptionT[F, *]] {
     OptionT(
       F.tailRecM(a)(a0 =>
         F.map(f(a0).value)(
-          _.fold(Either.right[A, Option[B]](None))(_.map(b => Some(b): Option[B]))
+          _.fold[Either[A, Option[B]]](Right(None))(_.map(b => Some(b): Option[B]))
         )
       )
     )

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -4,7 +4,6 @@ package data
 import cats.Foldable
 import cats.kernel.instances.tuple._
 import cats.kernel.CommutativeMonoid
-import cats.syntax.semigroup._
 
 final case class WriterT[F[_], L, V](run: F[(L, V)]) {
 
@@ -20,7 +19,7 @@ final case class WriterT[F[_], L, V](run: F[(L, V)]) {
    * }}}
    */
   def tell(l: L)(implicit functorF: Functor[F], semigroupL: Semigroup[L]): WriterT[F, L, V] =
-    mapWritten(_ |+| l)
+    mapWritten(semigroupL.combine(_, l))
 
   /**
    * Example:


### PR DESCRIPTION
This weekend I ran into a [Dotty bug](https://github.com/lampepfl/dotty/issues/8035) that turned up because of our use of `cats.syntax` methods in `cats.data`. The issues are easy enough to work around, but it's a good reminder that value classes are a mess and we might want to avoid extension methods in our own implementations.

This PR replaces all use of `cats.syntax` extension methods in `cats/*.scala` and `cats/data/*.scala`. Most of the replacements have a fairly neutral effect on readability, like using `Ior.fromEither` instead of `_.toIor`, or `algebra.remove(x, y)` instead of `x |-| y`, etc. In these cases we get to avoid some indirection and exposure to value class nonsense without bloating the code.

In a few cases the non-syntax version is a significantly more verbose—in particular we use `bimap` on `Either` a lot in `cats.data`. This is one case where the syntax method does have a non-trivial runtime cost. I've added a benchmark for two implementations of `map` for `EitherK`: the current one:

```scala
EitherK(e.run.bimap(F.lift(f), G.lift(f)))
```

…and one that doesn't use the `bimap` extension method:

```scala
EitherK(
  e.run match {
    case Right(ga) => Right(G.map(ga)(f))
    case Left(fa)  => Left(F.map(fa)(f))
  }
)
```
The non-syntax one gets 30% more throughput in this benchmark:

```scala
EitherKMapBench.incMap1  thrpt   20  19348653.553 ±  75679.278  ops/s
EitherKMapBench.incMap2  thrpt   20  25152245.244 ± 161475.884  ops/s
```
Given that the faster one is still arguably _more_ readable, even if it's a little more verbose, I think avoiding `bimap` in our own implementations is reasonable.