### PR TITLE
Make Id covariant

### DIFF
--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -33,16 +33,16 @@ package object cats {
    */
   type Id[+A] = A
   type Endo[A] = A => A
-  implicit val catsInstancesForId: Bimonad[λ[A => A]]
-    with CommutativeMonad[λ[A => A]]
-    with Comonad[λ[A => A]]
-    with NonEmptyTraverse[λ[A => A]]
-    with Distributive[λ[A => A]] =
-    new Bimonad[λ[A => A]]
-      with CommutativeMonad[λ[A => A]]
-      with Comonad[λ[A => A]]
-      with NonEmptyTraverse[λ[A => A]]
-      with Distributive[λ[A => A]] {
+  implicit val catsInstancesForId: Bimonad[({ type L[+x] = x })#L]
+    with CommutativeMonad[({ type L[+x] = x })#L]
+    with Comonad[({ type L[+x] = x })#L]
+    with NonEmptyTraverse[({ type L[+x] = x })#L]
+    with Distributive[({ type L[+x] = x })#L] =
+    new Bimonad[({ type L[+x] = x })#L]
+      with CommutativeMonad[({ type L[+x] = x })#L]
+      with Comonad[({ type L[+x] = x })#L]
+      with NonEmptyTraverse[({ type L[+x] = x })#L]
+      with Distributive[({ type L[+x] = x })#L] {
       def pure[A](a: A): A = a
       def extract[A](a: A): A = a
       def flatMap[A, B](a: A)(f: A => B): B = f(a)
@@ -88,8 +88,8 @@ package object cats {
   /**
    * Witness for: Id[A] <-> Unit => A
    */
-  implicit val catsRepresentableForId: Representable.Aux[λ[A => A], Unit] =
-    new Representable[λ[A => A]] {
+  implicit val catsRepresentableForId: Representable.Aux[({ type L[+x] = x })#L, Unit] =
+    new Representable[({ type L[+x] = x })#L] {
       override type Representation = Unit
       override val F: Functor[Id] = Functor[Id]
 
@@ -98,7 +98,8 @@ package object cats {
       override def index[A](f: Id[A]): Unit => A = (_: Unit) => f
     }
 
-  implicit val catsParallelForId: Parallel.Aux[λ[A => A], λ[A => A]] = Parallel.identity[λ[A => A]]
+  implicit val catsParallelForId: Parallel.Aux[({ type L[+x] = x })#L, ({ type L[+x] = x })#L] =
+    Parallel.identity[({ type L[+x] = x })#L]
 
   type Eq[A] = cats.kernel.Eq[A]
   type PartialOrder[A] = cats.kernel.PartialOrder[A]

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -34,6 +34,7 @@ package object cats {
   type Id[+A] = A
 
   // Workaround for a compiler bug that should be fixed soon.
+  // See https://github.com/scala/scala/pull/8651 for details.
   private type IdWrapper = { type L[+A] = A }
 
   type Endo[A] = A => A

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -32,17 +32,21 @@ package object cats {
    * encodes pure unary function application.
    */
   type Id[+A] = A
+
+  // Workaround for a compiler bug that should be fixed soon.
+  private type IdWrapper = { type L[+A] = A }
+
   type Endo[A] = A => A
-  implicit val catsInstancesForId: Bimonad[({ type L[+x] = x })#L]
-    with CommutativeMonad[({ type L[+x] = x })#L]
-    with Comonad[({ type L[+x] = x })#L]
-    with NonEmptyTraverse[({ type L[+x] = x })#L]
-    with Distributive[({ type L[+x] = x })#L] =
-    new Bimonad[({ type L[+x] = x })#L]
-      with CommutativeMonad[({ type L[+x] = x })#L]
-      with Comonad[({ type L[+x] = x })#L]
-      with NonEmptyTraverse[({ type L[+x] = x })#L]
-      with Distributive[({ type L[+x] = x })#L] {
+  implicit val catsInstancesForId: Bimonad[IdWrapper#L]
+    with CommutativeMonad[IdWrapper#L]
+    with Comonad[IdWrapper#L]
+    with NonEmptyTraverse[IdWrapper#L]
+    with Distributive[IdWrapper#L] =
+    new Bimonad[IdWrapper#L]
+      with CommutativeMonad[IdWrapper#L]
+      with Comonad[IdWrapper#L]
+      with NonEmptyTraverse[IdWrapper#L]
+      with Distributive[IdWrapper#L] {
       def pure[A](a: A): A = a
       def extract[A](a: A): A = a
       def flatMap[A, B](a: A)(f: A => B): B = f(a)
@@ -88,8 +92,8 @@ package object cats {
   /**
    * Witness for: Id[A] <-> Unit => A
    */
-  implicit val catsRepresentableForId: Representable.Aux[({ type L[+x] = x })#L, Unit] =
-    new Representable[({ type L[+x] = x })#L] {
+  implicit val catsRepresentableForId: Representable.Aux[IdWrapper#L, Unit] =
+    new Representable[IdWrapper#L] {
       override type Representation = Unit
       override val F: Functor[Id] = Functor[Id]
 
@@ -98,8 +102,8 @@ package object cats {
       override def index[A](f: Id[A]): Unit => A = (_: Unit) => f
     }
 
-  implicit val catsParallelForId: Parallel.Aux[({ type L[+x] = x })#L, ({ type L[+x] = x })#L] =
-    Parallel.identity[({ type L[+x] = x })#L]
+  implicit val catsParallelForId: Parallel.Aux[IdWrapper#L, IdWrapper#L] =
+    Parallel.identity[Id]
 
   type Eq[A] = cats.kernel.Eq[A]
   type PartialOrder[A] = cats.kernel.PartialOrder[A]

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -31,11 +31,18 @@ package object cats {
    * type `A` to get a pure value of type `B`. That is, the instance
    * encodes pure unary function application.
    */
-  type Id[A] = A
+  type Id[+A] = A
   type Endo[A] = A => A
-  implicit val catsInstancesForId
-    : Bimonad[Id] with CommutativeMonad[Id] with Comonad[Id] with NonEmptyTraverse[Id] with Distributive[Id] =
-    new Bimonad[Id] with CommutativeMonad[Id] with Comonad[Id] with NonEmptyTraverse[Id] with Distributive[Id] {
+  implicit val catsInstancesForId: Bimonad[λ[A => A]]
+    with CommutativeMonad[λ[A => A]]
+    with Comonad[λ[A => A]]
+    with NonEmptyTraverse[λ[A => A]]
+    with Distributive[λ[A => A]] =
+    new Bimonad[λ[A => A]]
+      with CommutativeMonad[λ[A => A]]
+      with Comonad[λ[A => A]]
+      with NonEmptyTraverse[λ[A => A]]
+      with Distributive[λ[A => A]] {
       def pure[A](a: A): A = a
       def extract[A](a: A): A = a
       def flatMap[A, B](a: A)(f: A => B): B = f(a)
@@ -81,16 +88,17 @@ package object cats {
   /**
    * Witness for: Id[A] <-> Unit => A
    */
-  implicit val catsRepresentableForId: Representable.Aux[Id, Unit] = new Representable[Id] {
-    override type Representation = Unit
-    override val F: Functor[Id] = Functor[Id]
+  implicit val catsRepresentableForId: Representable.Aux[λ[A => A], Unit] =
+    new Representable[λ[A => A]] {
+      override type Representation = Unit
+      override val F: Functor[Id] = Functor[Id]
 
-    override def tabulate[A](f: Unit => A): Id[A] = f(())
+      override def tabulate[A](f: Unit => A): Id[A] = f(())
 
-    override def index[A](f: Id[A]): Unit => A = (_: Unit) => f
-  }
+      override def index[A](f: Id[A]): Unit => A = (_: Unit) => f
+    }
 
-  implicit val catsParallelForId: Parallel.Aux[Id, Id] = Parallel.identity
+  implicit val catsParallelForId: Parallel.Aux[λ[A => A], λ[A => A]] = Parallel.identity[λ[A => A]]
 
   type Eq[A] = cats.kernel.Eq[A]
   type PartialOrder[A] = cats.kernel.PartialOrder[A]


### PR DESCRIPTION
Making `Id` covariant was [discussed briefly in 2015](https://github.com/typelevel/cats/pull/186#issuecomment-74051456):

> Should Id be covariant? I ask mainly because you say,
>>    We can freely treat values of type A as values of type Id[A], and vice-versa.
>
> which is only strictly true if it is.

As far as I know this was never followed up on, but I just ran into [an issue while trying to cross-build the Cats tests on Dotty](https://github.com/lampepfl/dotty/issues/8049#issue-552831428) where implicit conversions for `Id` weren't being found because it's invariant. Making it covariant would fix this problem (and also just generally seems like the right thing to do, even if the Dotty team decides that the issue is a bug and fixes it on the Dotty side).

Unfortunately if we make `Id` covariant we hit a weird Scala 2 bug when defining instances for it, which minimized looks like this:

```scala
scala> trait Tc[F[_]]
defined trait Tc

scala> object X {
     |   type Id[+A] = A
     |   val x: Tc[Id] = new Tc[Id] {}
     | }
<console>:15: error: covariant type Id occurs in invariant position in type => Tc[X.Id] of value x
         val x: Tc[Id] = new Tc[Id] {}
             ^
```
And it gets even weirder:
```scala
scala> val x: Tc[Id] = new Tc[Id] {}
x: Tc[Id] = $anon$1@673c4f6e

scala> object X { type Id[+A] = A; new Tc[Id] {} }
defined object X
```

There's some explanation by @smarter in a [conversation from this afternoon on Gitter](https://gitter.im/typelevel/cats-dev?at=5e271431075a19397ce055b1).

Update: @smarter also has [a fix](https://github.com/scala/scala/pull/8651) for the issue.

We can work around this by changing the `Id` instances to `λ[A => A]`. ~~We could also use `({ type L[+A] => A })#L` or the weird ``λ[`+A` => A]`` thing but `λ[A => A]` seems to work fine.~~ Update: Scala 2 doesn't care if the variance doesn't match, but Dotty does, so I've gone with `({ type L[+A] => A })#L` for now.

No other changes are necessary, and we can verify that these instances are available without imports:

```scala
scala> cats.Monad[cats.Id]
res0: cats.Monad[cats.Id] = cats.package$$anon$1@9a00a50

scala> cats.Parallel[cats.Id, cats.Id]
res1: cats.Parallel.Aux[cats.Id,cats.Id] = cats.Parallel$$anon$2@12376480

scala> cats.Parallel[cats.Id]
res2: cats.Parallel.Aux[cats.Id,cats.package.catsParallelForId.F] = cats.Parallel$$anon$2@12376480
```

In the longer run, we're going to come up against another change in Dotty (this one definitely [not a bug](https://github.com/lampepfl/dotty/issues/8048)) that means that these type class instances for `Id` won't be available in implicit scope—they'll have to be imported explicitly.

There are a few ways we could address this. The first would be to do nothing and expect users to import `cats._` if they need these instances. We could also create a new `cats.instances.id` that they could be imported from more idiomatically (also making them available in `cats.instances.all` and `cats.implicits`).

In my view the best approach would be to provide these instances in the type class companion objects, which would ensure that they're in implicit scope on both Scala 2 and Dotty. This is something I've already done in #3043, but we could do it separately if necessary.

