### PR TITLE
Optimize traverse

### DIFF
--- a/bench/src/main/scala/cats/bench/TraverseBench.scala
+++ b/bench/src/main/scala/cats/bench/TraverseBench.scala
@@ -1,0 +1,157 @@
+package cats.bench
+
+import cats.{Always, Applicative, Eval, Traverse}
+import cats.instances.either._
+import cats.instances.list._
+import cats.instances.vector._
+import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
+
+@State(Scope.Benchmark)
+class TraverseListBench {
+  val instance: Traverse[List] = Traverse[List]
+  val f: Int => Either[Int, Int] = Right(_)
+
+  val xs1: List[Int] = (1 to 10).toList
+  val xs2: List[Int] = (1 to 100).toList
+  val xs3: List[Int] = (1 to 1000).toList
+  val xs4: List[Int] = (1 to 10000).toList
+
+  def traverseCats[G[_], A, B](fa: List[A])(f: A => G[B])(implicit G: Applicative[G]): G[List[B]] =
+    instance
+      .foldRight[A, G[List[B]]](fa, Always(G.pure(List.empty))) { (a, lglb) =>
+        G.map2Eval(f(a), lglb)(_ :: _)
+      }
+      .value
+
+  def traverseFoldRight[G[_], A, B](fa: List[A])(f: A => G[B])(implicit G: Applicative[G]): G[List[B]] =
+    fa.foldRight[Eval[G[List[B]]]](Always(G.pure(Nil))) {
+        case (h, t) => G.map2Eval(f(h), Eval.defer(t))(_ :: _)
+      }
+      .value
+
+  def traverseRec[G[_], A, B](fa: List[A])(f: A => G[B])(implicit G: Applicative[G]): G[List[B]] = {
+    def loop(fa: List[A]): Eval[G[List[B]]] = fa match {
+      case h :: t => G.map2Eval(f(h), Eval.defer(loop(t)))(_ :: _)
+      case Nil    => Eval.now(G.pure(Nil))
+    }
+    loop(fa).value
+  }
+
+  @Benchmark def traverseCats1: Either[Int, List[Int]] = traverseCats(xs1)(f)
+  @Benchmark def traverseCats2: Either[Int, List[Int]] = traverseCats(xs2)(f)
+  @Benchmark def traverseCats3: Either[Int, List[Int]] = traverseCats(xs3)(f)
+  @Benchmark def traverseCats4: Either[Int, List[Int]] = traverseCats(xs4)(f)
+
+  @Benchmark def traverseFoldRight1: Either[Int, List[Int]] = traverseFoldRight(xs1)(f)
+  @Benchmark def traverseFoldRight2: Either[Int, List[Int]] = traverseFoldRight(xs2)(f)
+  @Benchmark def traverseFoldRight3: Either[Int, List[Int]] = traverseFoldRight(xs3)(f)
+  @Benchmark def traverseFoldRight4: Either[Int, List[Int]] = traverseFoldRight(xs4)(f)
+
+  @Benchmark def traverseRec1: Either[Int, List[Int]] = traverseRec(xs1)(f)
+  @Benchmark def traverseRec2: Either[Int, List[Int]] = traverseRec(xs2)(f)
+  @Benchmark def traverseRec3: Either[Int, List[Int]] = traverseRec(xs3)(f)
+  @Benchmark def traverseRec4: Either[Int, List[Int]] = traverseRec(xs4)(f)
+}
+
+@State(Scope.Benchmark)
+class TraverseVectorBench {
+  val instance: Traverse[Vector] = Traverse[Vector]
+  val f: Int => Either[Int, Int] = Right(_)
+
+  val xs1: Vector[Int] = (1 to 10).toVector
+  val xs2: Vector[Int] = (1 to 100).toVector
+  val xs3: Vector[Int] = (1 to 1000).toVector
+  val xs4: Vector[Int] = (1 to 10000).toVector
+
+  def traverseCats[G[_], A, B](fa: Vector[A])(f: A => G[B])(implicit G: Applicative[G]): G[Vector[B]] =
+    instance
+      .foldRight[A, G[Vector[B]]](fa, Always(G.pure(Vector.empty))) { (a, lgvb) =>
+        G.map2Eval(f(a), lgvb)(_ +: _)
+      }
+      .value
+
+  def traverseFoldRight[G[_], A, B](fa: Vector[A])(f: A => G[B])(implicit G: Applicative[G]): G[Vector[B]] =
+    fa.foldRight[Eval[G[Vector[B]]]](Always(G.pure(Vector.empty))) {
+        case (h, t) => G.map2Eval(f(h), Eval.defer(t))(_ +: _)
+      }
+      .value
+
+  def traverseRec[G[_], A, B](fa: Vector[A])(f: A => G[B])(implicit G: Applicative[G]): G[Vector[B]] = {
+    def loop(i: Int): Eval[G[Vector[B]]] =
+      if (i < fa.length) G.map2Eval(f(fa(i)), Eval.defer(loop(i + 1)))(_ +: _) else Eval.now(G.pure(Vector.empty))
+    loop(0).value
+  }
+
+  def traverseIter[G[_], A, B](fa: Vector[A])(f: A => G[B])(implicit G: Applicative[G]): G[Vector[B]] = {
+    var i = fa.length - 1
+    var current: Eval[G[Vector[B]]] = Eval.now(G.pure(Vector.empty))
+
+    while (i >= 0) {
+      current = G.map2Eval(f(fa(i)), current)(_ +: _)
+      i -= 1
+    }
+
+    current.value
+  }
+
+  def traverseFoldRightViaList[G[_], A, B](fa: Vector[A])(f: A => G[B])(implicit G: Applicative[G]): G[Vector[B]] =
+    G.map(
+      fa.foldRight[Eval[G[List[B]]]](Always(G.pure(Nil))) {
+          case (h, t) => G.map2Eval(f(h), Eval.defer(t))(_ :: _)
+        }
+        .value
+    )(_.toVector)
+
+  def traverseRecViaList[G[_], A, B](fa: Vector[A])(f: A => G[B])(implicit G: Applicative[G]): G[Vector[B]] = {
+    def loop(i: Int): Eval[G[List[B]]] =
+      if (i < fa.length) G.map2Eval(f(fa(i)), Eval.defer(loop(i + 1)))(_ :: _) else Eval.now(G.pure(Nil))
+    G.map(loop(0).value)(_.toVector)
+  }
+
+  def traverseIterViaList[G[_], A, B](fa: Vector[A])(f: A => G[B])(implicit G: Applicative[G]): G[Vector[B]] = {
+    var i = fa.length - 1
+    var current: Eval[G[List[B]]] = Eval.now(G.pure(Nil))
+
+    while (i >= 0) {
+      current = G.map2Eval(f(fa(i)), current)(_ :: _)
+      i -= 1
+    }
+
+    G.map(current.value)(_.toVector)
+  }
+
+  @Benchmark def traverseCats1: Either[Int, Vector[Int]] = traverseCats(xs1)(f)
+  @Benchmark def traverseCats2: Either[Int, Vector[Int]] = traverseCats(xs2)(f)
+  @Benchmark def traverseCats3: Either[Int, Vector[Int]] = traverseCats(xs3)(f)
+  @Benchmark def traverseCats4: Either[Int, Vector[Int]] = traverseCats(xs4)(f)
+
+  @Benchmark def traverseFoldRight1: Either[Int, Vector[Int]] = traverseFoldRight(xs1)(f)
+  @Benchmark def traverseFoldRight2: Either[Int, Vector[Int]] = traverseFoldRight(xs2)(f)
+  @Benchmark def traverseFoldRight3: Either[Int, Vector[Int]] = traverseFoldRight(xs3)(f)
+  @Benchmark def traverseFoldRight4: Either[Int, Vector[Int]] = traverseFoldRight(xs4)(f)
+
+  @Benchmark def traverseRec1: Either[Int, Vector[Int]] = traverseRec(xs1)(f)
+  @Benchmark def traverseRec2: Either[Int, Vector[Int]] = traverseRec(xs2)(f)
+  @Benchmark def traverseRec3: Either[Int, Vector[Int]] = traverseRec(xs3)(f)
+  @Benchmark def traverseRec4: Either[Int, Vector[Int]] = traverseRec(xs4)(f)
+
+  @Benchmark def traverseIter1: Either[Int, Vector[Int]] = traverseIter(xs1)(f)
+  @Benchmark def traverseIter2: Either[Int, Vector[Int]] = traverseIter(xs2)(f)
+  @Benchmark def traverseIter3: Either[Int, Vector[Int]] = traverseIter(xs3)(f)
+  @Benchmark def traverseIter4: Either[Int, Vector[Int]] = traverseIter(xs4)(f)
+
+  @Benchmark def traverseFoldRightViaList1: Either[Int, Vector[Int]] = traverseFoldRightViaList(xs1)(f)
+  @Benchmark def traverseFoldRightViaList2: Either[Int, Vector[Int]] = traverseFoldRightViaList(xs2)(f)
+  @Benchmark def traverseFoldRightViaList3: Either[Int, Vector[Int]] = traverseFoldRightViaList(xs3)(f)
+  @Benchmark def traverseFoldRightViaList4: Either[Int, Vector[Int]] = traverseFoldRightViaList(xs4)(f)
+
+  @Benchmark def traverseRecViaList1: Either[Int, Vector[Int]] = traverseRecViaList(xs1)(f)
+  @Benchmark def traverseRecViaList2: Either[Int, Vector[Int]] = traverseRecViaList(xs2)(f)
+  @Benchmark def traverseRecViaList3: Either[Int, Vector[Int]] = traverseRecViaList(xs3)(f)
+  @Benchmark def traverseRecViaList4: Either[Int, Vector[Int]] = traverseRecViaList(xs4)(f)
+
+  @Benchmark def traverseIterViaList1: Either[Int, Vector[Int]] = traverseIterViaList(xs1)(f)
+  @Benchmark def traverseIterViaList2: Either[Int, Vector[Int]] = traverseIterViaList(xs2)(f)
+  @Benchmark def traverseIterViaList3: Either[Int, Vector[Int]] = traverseIterViaList(xs3)(f)
+  @Benchmark def traverseIterViaList4: Either[Int, Vector[Int]] = traverseIterViaList(xs4)(f)
+}

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -73,10 +73,13 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
       override def foldMap[A, B](fa: List[A])(f: A => B)(implicit B: Monoid[B]): B =
         B.combineAll(fa.iterator.map(f))
 
-      def traverse[G[_], A, B](fa: List[A])(f: A => G[B])(implicit G: Applicative[G]): G[List[B]] =
-        foldRight[A, G[List[B]]](fa, Always(G.pure(List.empty))) { (a, lglb) =>
-          G.map2Eval(f(a), lglb)(_ :: _)
-        }.value
+      def traverse[G[_], A, B](fa: List[A])(f: A => G[B])(implicit G: Applicative[G]): G[List[B]] = {
+        def loop(fa: List[A]): Eval[G[List[B]]] = fa match {
+          case h :: t => G.map2Eval(f(h), Eval.defer(loop(t)))(_ :: _)
+          case Nil    => Eval.now(G.pure(Nil))
+        }
+        loop(fa).value
+      }
 
       def functor: Functor[List] = this
 


### PR DESCRIPTION
tl;dr: Traversing a `List` or `Vector` is probably the most common operation people do with this library, and the current implementations for these types have some room for optimization, with the changes in this PR giving up to 20% more throughput for `List` and 201% for `Vector`.

I've put together a benchmark that compares the current `traverse` for `List` with two new implementations:

```scala
def traverseFoldRight[G[_], A, B](fa: List[A])(f: A => G[B])(implicit G: Applicative[G]): G[List[B]] =
  fa.foldRight[Eval[G[List[B]]]](Always(G.pure(Nil))) {
      case (h, t) => G.map2Eval(f(h), Eval.defer(t))(_ :: _)
    }
    .value

def traverseRec[G[_], A, B](fa: List[A])(f: A => G[B])(implicit G: Applicative[G]): G[List[B]] = {
  def loop(fa: List[A]): Eval[G[List[B]]] = fa match {
    case h :: t => G.map2Eval(f(h), Eval.defer(loop(t)))(_ :: _)
    case Nil    => Eval.now(G.pure(Nil))
  }
  loop(fa).value
}
```
The first uses the standard library's `foldRight` with an explicit `Eval` accumulator, instead of the `Eval`-based `foldRight` on `Foldable`. The second effectively just inlines the call the Cat's `foldRight` in the current implementation.

Both of these seem substantially faster than the current implementation when traversing with `Right(_)` (results shown for list sizes 10<sup>1</sup>, 10<sup>2</sup>, 10<sup>3</sup>, and 10<sup>4</sup>; higher numbers are better; all results are shown for Scala 2.13, but 2.12 is similar):

```
Benchmark                                       Mode  Cnt        Score       Error  Units
TraverseListBench.traverseCats1                thrpt   20  2522518.924 ±  4088.634  ops/s
TraverseListBench.traverseCats2                thrpt   20   284154.249 ±  1386.556  ops/s
TraverseListBench.traverseCats3                thrpt   20    26490.162 ±   764.213  ops/s
TraverseListBench.traverseCats4                thrpt   20     2645.683 ±     2.779  ops/s
TraverseListBench.traverseFoldRight1           thrpt   20  3109083.857 ± 10545.898  ops/s
TraverseListBench.traverseFoldRight2           thrpt   20   325352.357 ±   482.879  ops/s
TraverseListBench.traverseFoldRight3           thrpt   20    26009.438 ±    89.164  ops/s
TraverseListBench.traverseFoldRight4           thrpt   20     2609.019 ±    15.222  ops/s
TraverseListBench.traverseRec1                 thrpt   20  3053589.800 ±  8292.173  ops/s
TraverseListBench.traverseRec2                 thrpt   20   340495.016 ±   803.026  ops/s
TraverseListBench.traverseRec3                 thrpt   20    30449.658 ±    58.876  ops/s
TraverseListBench.traverseRec4                 thrpt   20     2945.153 ±     3.059  ops/s
```
The `loop` implementation also allocates less:
```
Benchmark                                                Mode  Cnt        Score        Error   Units
TraverseListBench.traverseCats1:gc.alloc.rate.norm      thrpt    5     2056.000 ±      0.001    B/op
TraverseListBench.traverseCats2:gc.alloc.rate.norm      thrpt    5    18616.000 ±      0.001    B/op
TraverseListBench.traverseCats3:gc.alloc.rate.norm      thrpt    5   198168.002 ±      0.001    B/op
TraverseListBench.traverseCats4:gc.alloc.rate.norm      thrpt    5  1998168.018 ±      0.012    B/op
TraverseListBench.traverseRec1:gc.alloc.rate.norm       thrpt    5     1728.000 ±      0.001    B/op
TraverseListBench.traverseRec2:gc.alloc.rate.norm       thrpt    5    16848.000 ±      0.001    B/op
TraverseListBench.traverseRec3:gc.alloc.rate.norm       thrpt    5   182016.001 ±      0.001    B/op
TraverseListBench.traverseRec4:gc.alloc.rate.norm       thrpt    5  1838016.016 ±      0.009    B/op
```
The results for a more complex parsing operation in `ValidatedNel` are similar.

I've done a similar comparison for `Vector`, but with an additional new candidate:

```scala
def traverseIter[G[_], A, B](fa: Vector[A])(f: A => G[B])(implicit G: Applicative[G]): G[Vector[B]] = {
  var i = fa.length - 1
  var current: Eval[G[Vector[B]]] = Eval.now(G.pure(Vector.empty))

  while (i >= 0) {
    current = G.map2Eval(f(fa(i)), current)(_ +: _)
    i -= 1
  }

  current.value
}
```

I've also included implementations of all three new approaches for `Vector` that accumulate the result in a `List` and then convert at the end.

```

Benchmark                                       Mode  Cnt        Score       Error  Units
TraverseVectorBench.traverseCats1              thrpt   20  1716229.387 ± 12903.229  ops/s
TraverseVectorBench.traverseCats2              thrpt   20    98885.248 ±   187.467  ops/s
TraverseVectorBench.traverseCats3              thrpt   20     8095.486 ±    86.914  ops/s
TraverseVectorBench.traverseCats4              thrpt   20      786.319 ±     9.118  ops/s
TraverseVectorBench.traverseFoldRight1         thrpt   20  1940918.153 ±  4653.590  ops/s
TraverseVectorBench.traverseFoldRight2         thrpt   20    99467.268 ±   151.832  ops/s
TraverseVectorBench.traverseFoldRight3         thrpt   20     7906.035 ±    25.461  ops/s
TraverseVectorBench.traverseFoldRight4         thrpt   20      768.825 ±     4.546  ops/s
TraverseVectorBench.traverseFoldRightViaList1  thrpt   20  2444454.783 ± 27744.679  ops/s
TraverseVectorBench.traverseFoldRightViaList2  thrpt   20   250501.174 ±  1286.555  ops/s
TraverseVectorBench.traverseFoldRightViaList3  thrpt   20    22235.074 ±    55.709  ops/s
TraverseVectorBench.traverseFoldRightViaList4  thrpt   20     2195.451 ±     3.826  ops/s
TraverseVectorBench.traverseIter1              thrpt   20  1845529.178 ±  1799.628  ops/s
TraverseVectorBench.traverseIter2              thrpt   20    98067.794 ±   408.574  ops/s
TraverseVectorBench.traverseIter3              thrpt   20     8032.515 ±    49.259  ops/s
TraverseVectorBench.traverseIter4              thrpt   20      765.116 ±     3.384  ops/s
TraverseVectorBench.traverseIterViaList1       thrpt   20  2409083.473 ±  2141.445  ops/s
TraverseVectorBench.traverseIterViaList2       thrpt   20   255852.261 ±   488.992  ops/s
TraverseVectorBench.traverseIterViaList3       thrpt   20    22926.371 ±   134.168  ops/s
TraverseVectorBench.traverseIterViaList4       thrpt   20     2160.138 ±     2.741  ops/s
TraverseVectorBench.traverseRec1               thrpt   20  1994461.861 ± 12887.488  ops/s
TraverseVectorBench.traverseRec2               thrpt   20   101952.832 ±   233.014  ops/s
TraverseVectorBench.traverseRec3               thrpt   20     8120.346 ±    82.347  ops/s
TraverseVectorBench.traverseRec4               thrpt   20      792.459 ±    28.741  ops/s
TraverseVectorBench.traverseRecViaList1        thrpt   20  2628040.643 ± 35243.584  ops/s
TraverseVectorBench.traverseRecViaList2        thrpt   20   279305.281 ±   381.740  ops/s
TraverseVectorBench.traverseRecViaList3        thrpt   20    24388.417 ±    40.075  ops/s
TraverseVectorBench.traverseRecViaList4        thrpt   20     2728.899 ±     2.560  ops/s
```

Again the `loop` implementation is fastest (but the version that accumulates in a list, not the one that builds a vector directly).

I've made these changes for `List`, `Vector`, and 2.13's `ArraySeq`, but not for `Chain`, `Stream`, or `LazyList`.