### PR TITLE
Remove machinist from colophon microsite page

### DIFF
--- a/docs/src/main/tut/colophon.md
+++ b/docs/src/main/tut/colophon.md
@@ -14,7 +14,6 @@ and we'd encourage you to check out these projects and consider
 integrating them into your own projects.
 
  * [simulacrum](https://github.com/typelevel/simulacrum) for minimizing type class boilerplate
- * [machinist](https://github.com/typelevel/machinist) for optimizing implicit operators
  * [scalacheck](http://scalacheck.org) for property-based testing
  * [discipline](https://github.com/typelevel/discipline) for encoding and testing laws
  * [kind-projector](https://github.com/typelevel/kind-projector) for type lambda syntax


### PR DESCRIPTION
Machinist is an archived project and has been removed from the cats project with [PR 2925](https://github.com/typelevel/cats/pull/2925) on 1 Jul 2019.

To avoid confusion, it should be removed from the colophon page in my opinion as well.


