### PR TITLE
Update readme with latest cats-core version

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.2")
 And then create the Cats dependency, by adding the following to your `build.sbt`:
 
 ```scala
-libraryDependencies += "org.typelevel" %% "cats-core" % "2.0.0"
+libraryDependencies += "org.typelevel" %% "cats-core" % "2.1.0"
 ```
 
 This will pull in the cats-core module. If you require some other


### PR DESCRIPTION
I noticed the readme suggest cats-core 2.0.0 as the sbt dependency, but since 2.1.0 is already out we might as well use that one. If for some reason this is not the case, please ignore this PR.