### PR TITLE
Use unlimited MathContext for BigDecimal arithmetic

### DIFF
--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -314,9 +314,6 @@ class Tests extends TestsConfig with AnyFunSuiteLike with FunSuiteDiscipline wit
   checkAll("Hash[Queue[Int]", HashTests[Queue[Int]].hash)
 
   {
-    // default Arbitrary[BigDecimal] is a bit too intense :/
-    implicit val arbBigDecimal: Arbitrary[BigDecimal] =
-      Arbitrary(arbitrary[Double].map(n => BigDecimal(n.toString)))
     checkAll("Order[BigDecimal]", OrderTests[BigDecimal].order)
     checkAll("CommutativeGroup[BigDecimal]", CommutativeGroupTests[BigDecimal].commutativeGroup)
     checkAll("CommutativeGroup[BigDecimal]", SerializableTests.serializable(CommutativeGroup[BigDecimal]))

--- a/kernel/src/main/scala/cats/kernel/instances/BigDecimalInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/BigDecimalInstances.scala
@@ -10,9 +10,10 @@ trait BigDecimalInstances {
 
 class BigDecimalGroup extends CommutativeGroup[BigDecimal] {
   val empty: BigDecimal = BigDecimal(0)
-  def combine(x: BigDecimal, y: BigDecimal): BigDecimal = x + y
-  def inverse(x: BigDecimal): BigDecimal = -x
-  override def remove(x: BigDecimal, y: BigDecimal): BigDecimal = x - y
+  def combine(x: BigDecimal, y: BigDecimal): BigDecimal = new BigDecimal(x.bigDecimal.add(y.bigDecimal), x.mc)
+  def inverse(x: BigDecimal): BigDecimal = new BigDecimal(x.bigDecimal.negate(), x.mc)
+  override def remove(x: BigDecimal, y: BigDecimal): BigDecimal =
+    new BigDecimal(x.bigDecimal.subtract(y.bigDecimal), x.mc)
 }
 
 class BigDecimalOrder extends Order[BigDecimal] with Hash[BigDecimal] {

--- a/kernel/src/main/scala/cats/kernel/instances/BigDecimalInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/BigDecimalInstances.scala
@@ -8,6 +8,14 @@ trait BigDecimalInstances {
     new BigDecimalGroup
 }
 
+/**
+ * Note that combining, removing, and inverting `BigDecimal` values will use unlimited precision
+ * operations.
+ *
+ * This matches the behavior of Scala 2.12 and earlier versions, but not Scala 2.13, which means
+ * that `+` and `|+|` (or `sum` and `combineAll`) may not agree if you are working with values with
+ * limited-precision `MathContext`s.
+ */
 class BigDecimalGroup extends CommutativeGroup[BigDecimal] {
   val empty: BigDecimal = BigDecimal(0)
   def combine(x: BigDecimal, y: BigDecimal): BigDecimal = new BigDecimal(x.bigDecimal.add(y.bigDecimal), x.mc)


### PR DESCRIPTION
Scala 2.13 changes the behavior of arithmetic on `BigDecimal` so that the `MathContext` of the first operand is used (instead of always using `UNLIMITED`, which is what was done in previous Scala versions; see [this issue](https://github.com/scala/bug/issues/11590) for some discussion of the change).

While this change is arguably the right thing to do in the standard library (assuming we're stuck with the mistake of carrying around a context in the first place), I think I've convinced myself that it's the wrong thing to do in Cats's instances. For one thing the 2.13 change means that operations from these instances are no longer commutative or even associative, even for fairly simple cases:

```scala
import cats.kernel.instances.bigDecimal._, cats.syntax.semigroup._

val x = BigDecimal("1e20")(java.math.MathContext.UNLIMITED)
val y = BigDecimal("1e-20")
```
And then:
```scala
scala> (x |+| y) == (y |+| x)
res0: Boolean = false

scala> (x |+| (y |+| x)) == ((x |+| y) |+| x)
res1: Boolean = false
```
…while on 2.12 both of these results are `true`.

These issues don't turn up when we're checking the laws right now, because we have this instance in `cats.kernel.laws.Tests`:

```scala
   // default Arbitrary[BigDecimal] is a bit too intense :/
    implicit val arbBigDecimal: Arbitrary[BigDecimal] =
      Arbitrary(arbitrary[Double].map(n => BigDecimal(n.toString)))
```
This workaround seems to me like a bad idea to start with, and for more complex test cases it's not enough, anyway (see for example the issue @johnynek [ran into](https://github.com/typelevel/cats/pull/3279#issuecomment-581068548) in #3279).

This PR changes the implementations of all of the operations that require contexts back to the 2.12 behavior (it has no effect on 2.12). I've also removed the custom `Arbitrary[BigDecimal]` in the cats-kernel-laws tests. It precedes 2.13 (it was introduced in #1319 in 2016), but removing it doesn't seem to cause problems in a few test runs I've just done on both 2.12 and 2.13. If it turns out that we needed it to avoid flakiness I'll revert that part.