### PR TITLE
Replace instance trait inheritance with imports in tests

### DIFF
--- a/alleycats-tests/js/src/test/scala/alleycats/tests/TestSettings.scala
+++ b/alleycats-tests/js/src/test/scala/alleycats/tests/TestSettings.scala
@@ -1,5 +1,4 @@
-package alleycats
-package tests
+package alleycats.tests
 
 import org.scalactic.anyvals.{PosInt, PosZDouble, PosZInt}
 import org.scalatest.matchers.should.Matchers

--- a/alleycats-tests/jvm/src/test/scala/alleycats/tests/TestSettings.scala
+++ b/alleycats-tests/jvm/src/test/scala/alleycats/tests/TestSettings.scala
@@ -1,5 +1,4 @@
-package alleycats
-package tests
+package alleycats.tests
 
 import org.scalactic.anyvals.{PosInt, PosZDouble, PosZInt}
 import org.scalatest.matchers.should.Matchers

--- a/alleycats-tests/shared/src/test/scala/alleycats/tests/AlleycatsSuite.scala
+++ b/alleycats-tests/shared/src/test/scala/alleycats/tests/AlleycatsSuite.scala
@@ -3,7 +3,6 @@ package alleycats.tests
 import alleycats.std.MapInstances
 import cats._
 import cats.instances.all._
-import cats.syntax.EqOps
 import cats.tests.StrictCatsEquality
 import org.scalatest.funsuite.AnyFunSuiteLike
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
@@ -28,10 +27,6 @@ trait AlleycatsSuite
     with MapInstances {
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     checkConfiguration
-
-  // disable Eq syntax (by making `catsSyntaxEq` not implicit), since it collides
-  // with scalactic's equality
-  def catsSyntaxEq[A: Eq](a: A): EqOps[A] = new EqOps[A](a)
 
   implicit def EqIterable[A: Eq]: Eq[Iterable[A]] = Eq.by(_.toList)
 }

--- a/alleycats-tests/shared/src/test/scala/alleycats/tests/AlleycatsSuite.scala
+++ b/alleycats-tests/shared/src/test/scala/alleycats/tests/AlleycatsSuite.scala
@@ -1,10 +1,9 @@
-package alleycats
-package tests
+package alleycats.tests
 
 import alleycats.std.MapInstances
 import cats._
-import cats.instances.AllInstances
-import cats.syntax.{AllSyntax, EqOps}
+import cats.instances.all._
+import cats.syntax.EqOps
 import cats.tests.StrictCatsEquality
 import org.scalatest.funsuite.AnyFunSuiteLike
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
@@ -12,7 +11,6 @@ import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 import org.scalacheck.{Arbitrary, Gen}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalatest.matchers.should.Matchers
-
 import scala.util.{Failure, Success, Try}
 
 /**
@@ -25,8 +23,6 @@ trait AlleycatsSuite
     with ScalaCheckDrivenPropertyChecks
     with FunSuiteDiscipline
     with TestSettings
-    with AllInstances
-    with AllSyntax
     with TestInstances
     with StrictCatsEquality
     with MapInstances {
@@ -35,7 +31,7 @@ trait AlleycatsSuite
 
   // disable Eq syntax (by making `catsSyntaxEq` not implicit), since it collides
   // with scalactic's equality
-  override def catsSyntaxEq[A: Eq](a: A): EqOps[A] = new EqOps[A](a)
+  def catsSyntaxEq[A: Eq](a: A): EqOps[A] = new EqOps[A](a)
 
   implicit def EqIterable[A: Eq]: Eq[Iterable[A]] = Eq.by(_.toList)
 }

--- a/alleycats-tests/shared/src/test/scala/alleycats/tests/IterableTests.scala
+++ b/alleycats-tests/shared/src/test/scala/alleycats/tests/IterableTests.scala
@@ -1,8 +1,8 @@
-package alleycats
-package tests
+package alleycats.tests
 
-import cats.{Eval, Foldable}
 import alleycats.std.all._
+import cats.{Eval, Foldable}
+import cats.instances.all._
 import cats.laws.discipline.FoldableTests
 
 class IterableTests extends AlleycatsSuite {

--- a/alleycats-tests/shared/src/test/scala/alleycats/tests/MapSuite.scala
+++ b/alleycats-tests/shared/src/test/scala/alleycats/tests/MapSuite.scala
@@ -1,8 +1,9 @@
 package alleycats.tests
 
-import cats.laws.discipline.arbitrary._
-import cats.laws.discipline.{SerializableTests, TraverseFilterTests}
 import cats.Traverse
+import cats.instances.all._
+import cats.laws.discipline.{SerializableTests, TraverseFilterTests}
+import cats.laws.discipline.arbitrary._
 
 class MapSuite extends AlleycatsSuite {
   checkAll("Traverse[Map[Int, *]]", SerializableTests.serializable(Traverse[Map[Int, *]]))

--- a/alleycats-tests/shared/src/test/scala/alleycats/tests/SetSuite.scala
+++ b/alleycats-tests/shared/src/test/scala/alleycats/tests/SetSuite.scala
@@ -1,12 +1,12 @@
 package alleycats.tests
 
 import alleycats.laws.discipline._
-import cats.Foldable
-import cats.kernel.laws.discipline.SerializableTests
-import cats.laws.discipline.arbitrary._
-import cats.laws.discipline.TraverseFilterTests
-
 import alleycats.std.all._
+import cats.Foldable
+import cats.instances.all._
+import cats.kernel.laws.discipline.SerializableTests
+import cats.laws.discipline.TraverseFilterTests
+import cats.laws.discipline.arbitrary._
 
 class SetSuite extends AlleycatsSuite {
   checkAll("FlatMapRec[Set]", FlatMapRecTests[Set].tailRecM[Int])

--- a/free/src/test/scala/cats/free/CofreeSuite.scala
+++ b/free/src/test/scala/cats/free/CofreeSuite.scala
@@ -1,7 +1,9 @@
-package cats
-package free
+package cats.free
 
+import cats.{~>, Comonad, Eval, Id, Reducible, Traverse}
 import cats.data.{NonEmptyList, OptionT}
+import cats.instances.all._
+import cats.kernel.Eq
 import cats.laws.discipline.{ComonadTests, ReducibleTests, SerializableTests, TraverseTests}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.syntax.list._

--- a/free/src/test/scala/cats/free/ContravariantCoyonedaSuite.scala
+++ b/free/src/test/scala/cats/free/ContravariantCoyonedaSuite.scala
@@ -1,10 +1,11 @@
-package cats
-package free
+package cats.free
 
+import cats.{~>, Contravariant}
 import cats.arrow.FunctionK
-import cats.tests.CatsSuite
+import cats.instances.all._
+import cats.kernel.Eq
 import cats.laws.discipline.{ContravariantTests, SerializableTests}
-
+import cats.tests.CatsSuite
 import org.scalacheck.{Arbitrary}
 
 class ContravariantCoyonedaSuite extends CatsSuite {

--- a/free/src/test/scala/cats/free/CoyonedaSuite.scala
+++ b/free/src/test/scala/cats/free/CoyonedaSuite.scala
@@ -1,10 +1,11 @@
-package cats
-package free
+package cats.free
 
-import cats.tests.CatsSuite
+import cats.Functor
 import cats.arrow.FunctionK
+import cats.instances.all._
+import cats.kernel.Eq
 import cats.laws.discipline.{FunctorTests, SerializableTests}
-
+import cats.tests.CatsSuite
 import org.scalacheck.Arbitrary
 
 class CoyonedaSuite extends CatsSuite {

--- a/free/src/test/scala/cats/free/FreeApplicativeSuite.scala
+++ b/free/src/test/scala/cats/free/FreeApplicativeSuite.scala
@@ -7,7 +7,7 @@ import cats.instances.all._
 import cats.kernel.Eq
 import cats.laws.discipline.{ApplicativeTests, SerializableTests}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
-import cats.syntax.all._
+import cats.syntax.apply._
 import cats.tests.CatsSuite
 import org.scalacheck.{Arbitrary, Gen}
 

--- a/free/src/test/scala/cats/free/FreeApplicativeSuite.scala
+++ b/free/src/test/scala/cats/free/FreeApplicativeSuite.scala
@@ -1,12 +1,14 @@
-package cats
-package free
+package cats.free
 
-import cats.tests.CatsSuite
+import cats.{~>, Applicative, Apply, Id}
 import cats.arrow.FunctionK
+import cats.data.State
+import cats.instances.all._
+import cats.kernel.Eq
 import cats.laws.discipline.{ApplicativeTests, SerializableTests}
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
-import cats.data.State
-
+import cats.syntax.all._
+import cats.tests.CatsSuite
 import org.scalacheck.{Arbitrary, Gen}
 
 class FreeApplicativeSuite extends CatsSuite {

--- a/free/src/test/scala/cats/free/FreeInvariantMonoidalSuite.scala
+++ b/free/src/test/scala/cats/free/FreeInvariantMonoidalSuite.scala
@@ -7,7 +7,8 @@ import cats.instances.all._
 import cats.laws.discipline.{InvariantMonoidalTests, MiniInt, SerializableTests}
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
-import cats.syntax.all._
+import cats.syntax.invariant._
+import cats.syntax.semigroupal._
 import cats.tests.BinCodecInvariantMonoidalSuite._
 import cats.tests.CatsSuite
 import org.scalacheck.{Arbitrary, Gen}

--- a/free/src/test/scala/cats/free/FreeInvariantMonoidalSuite.scala
+++ b/free/src/test/scala/cats/free/FreeInvariantMonoidalSuite.scala
@@ -1,13 +1,16 @@
-package cats
-package tests
+package cats.free
 
+import cats.{Id, InvariantMonoidal}
 import cats.arrow.FunctionK
-import cats.free.FreeInvariantMonoidal
+import cats.kernel.Eq
+import cats.instances.all._
 import cats.laws.discipline.{InvariantMonoidalTests, MiniInt, SerializableTests}
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
-import org.scalacheck.{Arbitrary, Gen}
+import cats.syntax.all._
 import cats.tests.BinCodecInvariantMonoidalSuite._
+import cats.tests.CatsSuite
+import org.scalacheck.{Arbitrary, Gen}
 
 class FreeInvariantMonoidalSuite extends CatsSuite {
   implicit def freeInvariantMonoidalArbitrary[F[_], A](implicit F: Arbitrary[F[A]],

--- a/free/src/test/scala/cats/free/FreeSuite.scala
+++ b/free/src/test/scala/cats/free/FreeSuite.scala
@@ -1,15 +1,17 @@
-package cats
-package free
+package cats.free
 
+import cats.{:<:, Foldable, Functor, Id, Monad, Traverse}
 import cats.arrow.FunctionK
 import cats.data.EitherK
+import cats.instances.all._
+import cats.kernel.Eq
 import cats.laws.discipline.{DeferTests, FoldableTests, MonadTests, SerializableTests, TraverseTests}
 import cats.laws.discipline.arbitrary.catsLawsArbitraryForFn0
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
+import cats.syntax.all._
 import cats.tests.CatsSuite
-
 import org.scalacheck.{Arbitrary, Cogen, Gen}
-import Arbitrary.arbFunction1
+import org.scalacheck.Arbitrary.arbFunction1
 
 class FreeSuite extends CatsSuite {
   import FreeSuite._

--- a/free/src/test/scala/cats/free/FreeSuite.scala
+++ b/free/src/test/scala/cats/free/FreeSuite.scala
@@ -8,7 +8,7 @@ import cats.kernel.Eq
 import cats.laws.discipline.{DeferTests, FoldableTests, MonadTests, SerializableTests, TraverseTests}
 import cats.laws.discipline.arbitrary.catsLawsArbitraryForFn0
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
-import cats.syntax.all._
+import cats.syntax.apply._
 import cats.tests.CatsSuite
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import org.scalacheck.Arbitrary.arbFunction1

--- a/free/src/test/scala/cats/free/FreeTSuite.scala
+++ b/free/src/test/scala/cats/free/FreeTSuite.scala
@@ -5,7 +5,8 @@ import cats.arrow.FunctionK
 import cats.data._
 import cats.instances.all._
 import cats.laws.discipline._
-import cats.syntax.all._
+import cats.syntax.applicative._
+import cats.syntax.either._
 import cats.tests.CatsSuite
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 

--- a/free/src/test/scala/cats/free/FreeTSuite.scala
+++ b/free/src/test/scala/cats/free/FreeTSuite.scala
@@ -1,12 +1,12 @@
-package cats
-package free
+package cats.free
 
 import cats._
 import cats.arrow.FunctionK
 import cats.data._
+import cats.instances.all._
 import cats.laws.discipline._
+import cats.syntax.all._
 import cats.tests.CatsSuite
-import cats.instances.option._
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 
 class FreeTSuite extends CatsSuite {

--- a/free/src/test/scala/cats/free/YonedaSuite.scala
+++ b/free/src/test/scala/cats/free/YonedaSuite.scala
@@ -1,9 +1,10 @@
-package cats
-package free
+package cats.free
 
-import cats.tests.CatsSuite
+import cats.Functor
+import cats.instances.all._
+import cats.kernel.Eq
 import cats.laws.discipline.{FunctorTests, SerializableTests}
-
+import cats.tests.CatsSuite
 import org.scalacheck.Arbitrary
 
 class YonedaSuite extends CatsSuite {

--- a/js/src/test/scala/cats/tests/FutureTests.scala
+++ b/js/src/test/scala/cats/tests/FutureTests.scala
@@ -1,19 +1,19 @@
-package cats
-package js
-package tests
+package cats.js.tests
 
-import cats.kernel.laws.discipline.{MonoidTests => MonoidLawTests, SemigroupTests => SemigroupLawTests}
-import cats.laws.discipline._
+import cats.Comonad
+import cats.instances.all._
 import cats.js.instances.Await
 import cats.js.instances.future.futureComonad
+import cats.kernel.Eq
+import cats.kernel.laws.discipline.{MonoidTests => MonoidLawTests, SemigroupTests => SemigroupLawTests}
+import cats.laws.discipline._
+import cats.laws.discipline.arbitrary._
+import cats.syntax.all._
 import cats.tests.{CatsSuite, ListWrapper}
-
-import scala.concurrent.{ExecutionContextExecutor, Future}
-import scala.concurrent.duration._
-
 import org.scalacheck.{Arbitrary, Cogen}
 import org.scalacheck.Arbitrary.arbitrary
-import cats.laws.discipline.arbitrary._
+import scala.concurrent.{ExecutionContextExecutor, Future}
+import scala.concurrent.duration._
 
 class FutureTests extends CatsSuite {
   // Replaces Scala.js's `JSExecutionContext.runNow`, which is removed in 1.0.
@@ -46,7 +46,7 @@ class FutureTests extends CatsSuite {
   implicit val throwableEq: Eq[Throwable] =
     Eq.by[Throwable, String](_.toString)
 
-  implicit val comonad: Comonad[Future] = futureComonad(timeout)
+  val comonad: Comonad[Future] = futureComonad(timeout)
 
   // Need non-fatal Throwables for Future recoverWith/handleError
   implicit val nonFatalArbitrary: Arbitrary[Throwable] =
@@ -59,7 +59,7 @@ class FutureTests extends CatsSuite {
     Cogen[Unit].contramap(_ => ())
 
   checkAll("Future[Int]", MonadErrorTests[Future, Throwable].monadError[Int, Int, Int])
-  checkAll("Future[Int]", ComonadTests[Future].comonad[Int, Int, Int])
+  checkAll("Future[Int]", ComonadTests[Future](comonad).comonad[Int, Int, Int])
   checkAll("Future", MonadTests[Future].monad[Int, Int, Int])
 
   {

--- a/js/src/test/scala/cats/tests/FutureTests.scala
+++ b/js/src/test/scala/cats/tests/FutureTests.scala
@@ -8,7 +8,7 @@ import cats.kernel.Eq
 import cats.kernel.laws.discipline.{MonoidTests => MonoidLawTests, SemigroupTests => SemigroupLawTests}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.either._
 import cats.tests.{CatsSuite, ListWrapper}
 import org.scalacheck.{Arbitrary, Cogen}
 import org.scalacheck.Arbitrary.arbitrary

--- a/jvm/src/test/scala/cats/tests/FutureSuite.scala
+++ b/jvm/src/test/scala/cats/tests/FutureSuite.scala
@@ -1,18 +1,18 @@
-package cats
-package jvm
-package tests
+package cats.jvm.tests
 
+import cats.instances.all._
+import cats.kernel.{Eq, Semigroup}
 import cats.kernel.laws.discipline.{MonoidTests => MonoidLawTests, SemigroupTests => SemigroupLawTests}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
+import cats.syntax.all._
 import cats.tests.{CatsSuite, ListWrapper}
-
-import scala.concurrent.{Await, Future}
-import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
 import org.scalacheck.{Arbitrary, Cogen}
 import org.scalacheck.Arbitrary.arbitrary
 import org.scalacheck.rng.Seed
+import scala.concurrent.{Await, Future}
+import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 class FutureSuite extends CatsSuite {
   val timeout = 3.seconds

--- a/jvm/src/test/scala/cats/tests/FutureSuite.scala
+++ b/jvm/src/test/scala/cats/tests/FutureSuite.scala
@@ -5,7 +5,7 @@ import cats.kernel.{Eq, Semigroup}
 import cats.kernel.laws.discipline.{MonoidTests => MonoidLawTests, SemigroupTests => SemigroupLawTests}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.either._
 import cats.tests.{CatsSuite, ListWrapper}
 import org.scalacheck.{Arbitrary, Cogen}
 import org.scalacheck.Arbitrary.arbitrary

--- a/testkit/src/main/scala/cats/tests/Helpers.scala
+++ b/testkit/src/main/scala/cats/tests/Helpers.scala
@@ -1,11 +1,8 @@
-package cats
-package tests
+package cats.tests
 
+import cats.kernel._
 import org.scalacheck.{Arbitrary, Cogen}
-import Arbitrary.arbitrary
-
-import cats.kernel.{CommutativeGroup, CommutativeMonoid, CommutativeSemigroup}
-import cats.kernel.{Band, BoundedSemilattice, Semilattice}
+import org.scalacheck.Arbitrary.arbitrary
 
 /**
  * Helpers provides new concrete types where we control exactly which

--- a/tests/src/test/scala-2.12/cats/tests/NonEmptyStreamSuite.scala
+++ b/tests/src/test/scala-2.12/cats/tests/NonEmptyStreamSuite.scala
@@ -8,7 +8,9 @@ import cats.kernel.laws.discipline.{EqTests, SemigroupTests}
 import cats.laws.discipline._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.foldable._
+import cats.syntax.reducible._
+import cats.syntax.show._
 
 class NonEmptyStreamSuite extends CatsSuite {
   // Lots of collections here.. telling ScalaCheck to calm down a bit

--- a/tests/src/test/scala-2.12/cats/tests/NonEmptyStreamSuite.scala
+++ b/tests/src/test/scala-2.12/cats/tests/NonEmptyStreamSuite.scala
@@ -1,12 +1,14 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Comonad, Eval, Functor, Monad, NonEmptyTraverse, Now, Reducible, SemigroupK, Show}
 import cats.data.{NonEmptyStream, OneAnd}
-import cats.instances.stream._
+import cats.instances.all._
+import cats.kernel.Semigroup
 import cats.kernel.laws.discipline.{EqTests, SemigroupTests}
-import cats.laws.discipline.arbitrary._
-import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
+import cats.laws.discipline.arbitrary._
+import cats.syntax.all._
 
 class NonEmptyStreamSuite extends CatsSuite {
   // Lots of collections here.. telling ScalaCheck to calm down a bit

--- a/tests/src/test/scala-2.12/cats/tests/ScalaVersionSpecific.scala
+++ b/tests/src/test/scala-2.12/cats/tests/ScalaVersionSpecific.scala
@@ -1,5 +1,4 @@
-package cats
-package tests
+package cats.tests
 
 trait ScalaVersionSpecificFoldableSuite
 trait ScalaVersionSpecificParallelSuite

--- a/tests/src/test/scala-2.13+/cats/tests/ArraySeqSuite.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/ArraySeqSuite.scala
@@ -14,7 +14,7 @@ import cats.laws.discipline.{
   TraverseTests
 }
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.show._
 import scala.collection.immutable.ArraySeq
 
 class ArraySeqSuite extends CatsSuite {

--- a/tests/src/test/scala-2.13+/cats/tests/ArraySeqSuite.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/ArraySeqSuite.scala
@@ -1,6 +1,8 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Align, Alternative, CoflatMap, Monad, MonoidK, Traverse, TraverseFilter}
+import cats.instances.all._
+import cats.kernel.{Eq, Hash, Monoid, Order, PartialOrder}
 import cats.kernel.laws.discipline.{EqTests, HashTests, MonoidTests, OrderTests, PartialOrderTests}
 import cats.laws.discipline.{
   AlignTests,
@@ -12,7 +14,7 @@ import cats.laws.discipline.{
   TraverseTests
 }
 import cats.laws.discipline.arbitrary._
-
+import cats.syntax.all._
 import scala.collection.immutable.ArraySeq
 
 class ArraySeqSuite extends CatsSuite {

--- a/tests/src/test/scala-2.13+/cats/tests/LazyListSuite.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/LazyListSuite.scala
@@ -15,7 +15,7 @@ import cats.laws.discipline.{
   TraverseTests
 }
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.show._
 import org.scalatest.funsuite.AnyFunSuiteLike
 
 class LazyListSuite extends CatsSuite {

--- a/tests/src/test/scala-2.13+/cats/tests/LazyListSuite.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/LazyListSuite.scala
@@ -1,6 +1,8 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Align, Alternative, CoflatMap, Monad, Semigroupal, Traverse, TraverseFilter}
+import cats.data.ZipLazyList
+import cats.instances.all._
 import cats.laws.discipline.{
   AlignTests,
   AlternativeTests,
@@ -12,8 +14,8 @@ import cats.laws.discipline.{
   TraverseFilterTests,
   TraverseTests
 }
-import cats.data.ZipLazyList
 import cats.laws.discipline.arbitrary._
+import cats.syntax.all._
 import org.scalatest.funsuite.AnyFunSuiteLike
 
 class LazyListSuite extends CatsSuite {

--- a/tests/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
@@ -1,10 +1,13 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Align, Bimonad, SemigroupK, Show, Traverse}
 import cats.data.{NonEmptyLazyList, NonEmptyLazyListOps}
+import cats.instances.all._
+import cats.kernel.{Eq, Hash, Order, PartialOrder, Semigroup}
 import cats.kernel.laws.discipline.{EqTests, HashTests, OrderTests, PartialOrderTests, SemigroupTests}
 import cats.laws.discipline.{AlignTests, BimonadTests, NonEmptyTraverseTests, SemigroupKTests, SerializableTests}
 import cats.laws.discipline.arbitrary._
+import cats.syntax.all._
 
 class NonEmptyLazyListSuite extends NonEmptyCollectionSuite[LazyList, NonEmptyLazyList, NonEmptyLazyListOps] {
   protected def toList[A](value: NonEmptyLazyList[A]): List[A] = value.toList

--- a/tests/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
@@ -7,7 +7,8 @@ import cats.kernel.{Eq, Hash, Order, PartialOrder, Semigroup}
 import cats.kernel.laws.discipline.{EqTests, HashTests, OrderTests, PartialOrderTests, SemigroupTests}
 import cats.laws.discipline.{AlignTests, BimonadTests, NonEmptyTraverseTests, SemigroupKTests, SerializableTests}
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.either._
+import cats.syntax.foldable._
 
 class NonEmptyLazyListSuite extends NonEmptyCollectionSuite[LazyList, NonEmptyLazyList, NonEmptyLazyListOps] {
   protected def toList[A](value: NonEmptyLazyList[A]): List[A] = value.toList

--- a/tests/src/test/scala-2.13+/cats/tests/ScalaVersionSpecific.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/ScalaVersionSpecific.scala
@@ -5,7 +5,10 @@ import cats.data.NonEmptyLazyList
 import cats.instances.all._
 import cats.laws.discipline.{NonEmptyParallelTests, ParallelTests}
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.either._
+import cats.syntax.foldable._
+import cats.syntax.parallel._
+import cats.syntax.traverse._
 
 trait ScalaVersionSpecificFoldableSuite { self: FoldableSuiteAdditional =>
   test("Foldable[LazyList].foldM stack safety") {

--- a/tests/src/test/scala-2.13+/cats/tests/ScalaVersionSpecific.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/ScalaVersionSpecific.scala
@@ -1,10 +1,11 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Eval, Foldable, Id, Now}
 import cats.data.NonEmptyLazyList
-import cats.instances.lazyList._
+import cats.instances.all._
 import cats.laws.discipline.{NonEmptyParallelTests, ParallelTests}
 import cats.laws.discipline.arbitrary._
+import cats.syntax.all._
 
 trait ScalaVersionSpecificFoldableSuite { self: FoldableSuiteAdditional =>
   test("Foldable[LazyList].foldM stack safety") {

--- a/tests/src/test/scala/cats/tests/AlgebraInvariantSuite.scala
+++ b/tests/src/test/scala/cats/tests/AlgebraInvariantSuite.scala
@@ -1,7 +1,7 @@
-package cats
-package tests
+package cats.tests
 
-import cats.Invariant
+import cats.{CommutativeApplicative, CommutativeApply, Invariant, InvariantMonoidal}
+import cats.instances._
 import cats.kernel._
 import cats.kernel.laws.discipline.{SemigroupTests, MonoidTests, GroupTests, _}
 import cats.laws.discipline.{
@@ -11,15 +11,27 @@ import cats.laws.discipline.{
   MiniInt,
   SerializableTests
 }
-import MiniInt._
+import cats.laws.discipline.MiniInt._
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
+import cats.syntax.all._
 import org.scalacheck.{Arbitrary, Gen}
 
-class AlgebraInvariantSuite extends CatsSuite {
+class AlgebraInvariantSuite
+    extends CatsSuite
+    with AllInstances
+    with AllInstancesBinCompat0
+    with AllInstancesBinCompat1
+    with AllInstancesBinCompat2
+    with AllInstancesBinCompat3
+    with AllInstancesBinCompat4
+    with AllInstancesBinCompat5
+    with AllInstancesBinCompat6 {
   // working around https://github.com/typelevel/cats/issues/2701
   implicit private val eqSetBooleanTuple: Eq[(Set[Boolean], Set[Boolean])] = Eq.fromUniversalEquals
   implicit private val eqSetBooleanBooleanTuple: Eq[(Set[Boolean], Boolean)] = Eq.fromUniversalEquals
+
+  catsLawsEqForBand[Set[Boolean]]
 
   // https://github.com/typelevel/cats/issues/2725
   implicit private def commutativeMonoidForSemigroup[A](

--- a/tests/src/test/scala/cats/tests/AlgebraInvariantSuite.scala
+++ b/tests/src/test/scala/cats/tests/AlgebraInvariantSuite.scala
@@ -14,7 +14,8 @@ import cats.laws.discipline.{
 import cats.laws.discipline.MiniInt._
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.invariant._
+import cats.syntax.order._
 import org.scalacheck.{Arbitrary, Gen}
 
 class AlgebraInvariantSuite

--- a/tests/src/test/scala/cats/tests/AlignSuite.scala
+++ b/tests/src/test/scala/cats/tests/AlignSuite.scala
@@ -1,6 +1,7 @@
 package cats.tests
 
 import cats.Align
+import cats.instances.all._
 import cats.kernel.laws.discipline.SemigroupTests
 
 class AlignSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/AlternativeSuite.scala
+++ b/tests/src/test/scala/cats/tests/AlternativeSuite.scala
@@ -1,5 +1,7 @@
-package cats
-package tests
+package cats.tests
+
+import cats.Alternative
+import cats.instances.all._
 
 class AlternativeSuite extends CatsSuite {
   test("unite") {

--- a/tests/src/test/scala/cats/tests/AndThenSuite.scala
+++ b/tests/src/test/scala/cats/tests/AndThenSuite.scala
@@ -1,12 +1,13 @@
-package cats
-package tests
+package cats.tests
 
-import cats.data._
+import cats.{Contravariant, ContravariantMonoidal, Monad, Semigroupal}
+import cats.arrow.{ArrowChoice, Choice, CommutativeArrow}
+import cats.data.AndThen
+import cats.instances.all._
 import cats.kernel.laws.discipline.SerializableTests
 import cats.laws.discipline._
-import cats.arrow._
-import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.eq._
 import cats.platform.Platform
 import org.scalatestplus.scalacheck.Checkers
 

--- a/tests/src/test/scala/cats/tests/ApplicativeErrorSuite.scala
+++ b/tests/src/test/scala/cats/tests/ApplicativeErrorSuite.scala
@@ -4,7 +4,9 @@ import cats.ApplicativeError
 import cats.data.EitherT
 import cats.instances.all._
 import cats.kernel.Eq
-import cats.syntax.all._
+import cats.syntax.applicativeError._
+import cats.syntax.either._
+import cats.syntax.option._
 
 class ApplicativeErrorSuite extends CatsSuite {
   val failed: Option[Int] =

--- a/tests/src/test/scala/cats/tests/ApplicativeErrorSuite.scala
+++ b/tests/src/test/scala/cats/tests/ApplicativeErrorSuite.scala
@@ -1,7 +1,10 @@
-package cats
-package tests
+package cats.tests
 
+import cats.ApplicativeError
 import cats.data.EitherT
+import cats.instances.all._
+import cats.kernel.Eq
+import cats.syntax.all._
 
 class ApplicativeErrorSuite extends CatsSuite {
   val failed: Option[Int] =

--- a/tests/src/test/scala/cats/tests/ApplicativeSuite.scala
+++ b/tests/src/test/scala/cats/tests/ApplicativeSuite.scala
@@ -7,7 +7,7 @@ import cats.kernel.Monoid
 import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.{AlignTests, CoflatMapTests}
-import cats.syntax.all._
+import cats.syntax.applicative._
 
 class ApplicativeSuite extends CatsSuite {
 

--- a/tests/src/test/scala/cats/tests/ApplicativeSuite.scala
+++ b/tests/src/test/scala/cats/tests/ApplicativeSuite.scala
@@ -1,12 +1,13 @@
-package cats
-package tests
+package cats.tests
 
-import cats.Applicative
-import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
+import cats.{Align, Applicative, Apply, CoflatMap}
 import cats.data.{Const, Validated}
+import cats.instances.all._
+import cats.kernel.Monoid
+import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
 import cats.laws.discipline.arbitrary._
-import cats.laws.discipline.CoflatMapTests
-import cats.laws.discipline.AlignTests
+import cats.laws.discipline.{AlignTests, CoflatMapTests}
+import cats.syntax.all._
 
 class ApplicativeSuite extends CatsSuite {
 

--- a/tests/src/test/scala/cats/tests/AsSuite.scala
+++ b/tests/src/test/scala/cats/tests/AsSuite.scala
@@ -1,11 +1,12 @@
-package cats
-package tests
+package cats.tests
 
+import cats.kernel.Eq
 import cats.laws.discipline.{CategoryTests, SerializableTests}
 import org.scalacheck.{Arbitrary, Gen}
 import cats.arrow.Category
+
 class AsSuite extends CatsSuite {
-  import evidence._
+  import cats.evidence._
 
   def toMap[A, B, X](fa: List[X])(implicit ev: X <~< (A, B)): Map[A, B] = {
     type RequiredFunc = (Map[A, B], X) => Map[A, B]

--- a/tests/src/test/scala/cats/tests/BifoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/BifoldableSuite.scala
@@ -1,7 +1,9 @@
-package cats
-package tests
+package cats.tests
 
+import cats.Bifoldable
+import cats.instances.all._
 import cats.laws.discipline.{BifoldableTests, SerializableTests}
+import cats.syntax.all._
 
 class BifoldableSuite extends CatsSuite {
   type EitherEither[A, B] = Either[Either[A, B], Either[A, B]]

--- a/tests/src/test/scala/cats/tests/BifoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/BifoldableSuite.scala
@@ -3,7 +3,7 @@ package cats.tests
 import cats.Bifoldable
 import cats.instances.all._
 import cats.laws.discipline.{BifoldableTests, SerializableTests}
-import cats.syntax.all._
+import cats.syntax.either._
 
 class BifoldableSuite extends CatsSuite {
   type EitherEither[A, B] = Either[Either[A, B], Either[A, B]]

--- a/tests/src/test/scala/cats/tests/BifunctorSuite.scala
+++ b/tests/src/test/scala/cats/tests/BifunctorSuite.scala
@@ -1,7 +1,7 @@
-package cats
-package tests
+package cats.tests
 
-import cats.Bifunctor
+import cats.{Bifunctor, Functor}
+import cats.instances.all._
 import cats.laws.discipline.{BifunctorTests, FunctorTests, SerializableTests}
 
 class BifunctorSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/BinCodecInvariantMonoidalSuite.scala
+++ b/tests/src/test/scala/cats/tests/BinCodecInvariantMonoidalSuite.scala
@@ -1,14 +1,14 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{InvariantMonoidal, InvariantSemigroupal}
+import cats.implicits._
+import cats.kernel.{Eq, Monoid, Semigroup}
+import cats.kernel.compat.scalaVersionSpecific._
+import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.{ExhaustiveCheck, InvariantMonoidalTests, MiniInt, SerializableTests}
-import cats.implicits._
-import cats.Eq
-import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
 import org.scalacheck.{Arbitrary, Gen}
-import kernel.compat.scalaVersionSpecific._
 
 @suppressUnusedImportWarningForScalaVersionSpecific
 object BinCodecInvariantMonoidalSuite {

--- a/tests/src/test/scala/cats/tests/BinestedSuite.scala
+++ b/tests/src/test/scala/cats/tests/BinestedSuite.scala
@@ -8,7 +8,8 @@ import cats.instances.all._
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
-import cats.syntax.all._
+import cats.syntax.bifunctor._
+import cats.syntax.binested._
 
 class BinestedSuite extends CatsSuite {
   // we have a lot of generated lists of lists in these tests. We have to tell

--- a/tests/src/test/scala/cats/tests/BinestedSuite.scala
+++ b/tests/src/test/scala/cats/tests/BinestedSuite.scala
@@ -1,12 +1,14 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Bifoldable, Bifunctor, Bitraverse, Foldable, Functor, Traverse}
 import cats.arrow.Profunctor
 import cats.data.Binested
-
+import cats.kernel.Eq
+import cats.instances.all._
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
+import cats.syntax.all._
 
 class BinestedSuite extends CatsSuite {
   // we have a lot of generated lists of lists in these tests. We have to tell

--- a/tests/src/test/scala/cats/tests/BitSetSuite.scala
+++ b/tests/src/test/scala/cats/tests/BitSetSuite.scala
@@ -1,8 +1,9 @@
 package cats.tests
 
+import cats.instances.all._
+import cats.syntax.all._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
-
 import scala.collection.immutable.BitSet
 
 class BitSetSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/BitSetSuite.scala
+++ b/tests/src/test/scala/cats/tests/BitSetSuite.scala
@@ -1,7 +1,7 @@
 package cats.tests
 
 import cats.instances.all._
-import cats.syntax.all._
+import cats.syntax.show._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary
 import scala.collection.immutable.BitSet

--- a/tests/src/test/scala/cats/tests/BitraverseSuite.scala
+++ b/tests/src/test/scala/cats/tests/BitraverseSuite.scala
@@ -1,6 +1,7 @@
-package cats
-package tests
+package cats.tests
 
+import cats.Bitraverse
+import cats.instances.all._
 import cats.laws.discipline.{BitraverseTests, SerializableTests}
 
 class BitraverseSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/CategorySuite.scala
+++ b/tests/src/test/scala/cats/tests/CategorySuite.scala
@@ -1,9 +1,9 @@
-package cats
-package tests
+package cats.tests
 
-import cats.kernel.laws.discipline.MonoidTests
-
+import cats.Endo
 import cats.arrow.Category
+import cats.instances.all._
+import cats.kernel.laws.discipline.MonoidTests
 import cats.laws.discipline.{MiniInt, MonoidKTests, SerializableTests}
 import cats.laws.discipline.eq.catsLawsEqForFn1Exhaustive
 import cats.laws.discipline.arbitrary.{catsLawsArbitraryForMiniInt, catsLawsCogenForMiniInt}

--- a/tests/src/test/scala/cats/tests/CatsEquality.scala
+++ b/tests/src/test/scala/cats/tests/CatsEquality.scala
@@ -1,6 +1,6 @@
-package cats
-package tests
+package cats.tests
 
+import cats.kernel.Eq
 import org.scalactic._
 import TripleEqualsSupport.AToBEquivalenceConstraint
 import TripleEqualsSupport.BToAEquivalenceConstraint

--- a/tests/src/test/scala/cats/tests/CatsSuite.scala
+++ b/tests/src/test/scala/cats/tests/CatsSuite.scala
@@ -1,8 +1,6 @@
 package cats.tests
 
-import cats.kernel.Eq
 import cats.platform.Platform
-import cats.syntax._
 import org.scalactic.anyvals.{PosInt, PosZDouble, PosZInt}
 import org.scalatest.funsuite.AnyFunSuiteLike
 import org.scalatest.matchers.should.Matchers
@@ -40,10 +38,6 @@ trait CatsSuite
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     checkConfiguration
-
-  // disable Eq syntax (by making `catsSyntaxEq` not implicit), since it collides
-  // with scalactic's equality
-  def catsSyntaxEq[A: Eq](a: A): EqOps[A] = new EqOps[A](a)
 
   def even(i: Int): Boolean = i % 2 == 0
 

--- a/tests/src/test/scala/cats/tests/CatsSuite.scala
+++ b/tests/src/test/scala/cats/tests/CatsSuite.scala
@@ -1,7 +1,6 @@
-package cats
-package tests
+package cats.tests
 
-import cats.instances._
+import cats.kernel.Eq
 import cats.platform.Platform
 import cats.syntax._
 import org.scalactic.anyvals.{PosInt, PosZDouble, PosZInt}
@@ -37,22 +36,6 @@ trait CatsSuite
     with ScalaCheckDrivenPropertyChecks
     with FunSuiteDiscipline
     with TestSettings
-    with AllInstances
-    with AllInstancesBinCompat0
-    with AllInstancesBinCompat1
-    with AllInstancesBinCompat2
-    with AllInstancesBinCompat3
-    with AllInstancesBinCompat4
-    with AllInstancesBinCompat5
-    with AllInstancesBinCompat6
-    with AllSyntax
-    with AllSyntaxBinCompat0
-    with AllSyntaxBinCompat1
-    with AllSyntaxBinCompat2
-    with AllSyntaxBinCompat3
-    with AllSyntaxBinCompat4
-    with AllSyntaxBinCompat5
-    with AllSyntaxBinCompat6
     with StrictCatsEquality {
 
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
@@ -60,7 +43,7 @@ trait CatsSuite
 
   // disable Eq syntax (by making `catsSyntaxEq` not implicit), since it collides
   // with scalactic's equality
-  override def catsSyntaxEq[A: Eq](a: A): EqOps[A] = new EqOps[A](a)
+  def catsSyntaxEq[A: Eq](a: A): EqOps[A] = new EqOps[A](a)
 
   def even(i: Int): Boolean = i % 2 == 0
 

--- a/tests/src/test/scala/cats/tests/ChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/ChainSuite.scala
@@ -17,7 +17,8 @@ import cats.laws.discipline.{
   TraverseTests
 }
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.foldable._
+import cats.syntax.semigroup._
 
 class ChainSuite extends CatsSuite {
   checkAll("Chain[Int]", AlternativeTests[Chain].alternative[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/ChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/ChainSuite.scala
@@ -1,9 +1,12 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Align, Alternative, CoflatMap, Monad, Show, Traverse, TraverseFilter}
 import cats.data.Chain
 import cats.data.Chain.==:
 import cats.data.Chain.`:==`
+import cats.instances.all._
+import cats.kernel.{Eq, Hash, Monoid, Order, PartialOrder}
+import cats.kernel.laws.discipline.{EqTests, HashTests, MonoidTests, OrderTests, PartialOrderTests}
 import cats.laws.discipline.{
   AlignTests,
   AlternativeTests,
@@ -13,8 +16,8 @@ import cats.laws.discipline.{
   TraverseFilterTests,
   TraverseTests
 }
-import cats.kernel.laws.discipline.{EqTests, HashTests, MonoidTests, OrderTests, PartialOrderTests}
 import cats.laws.discipline.arbitrary._
+import cats.syntax.all._
 
 class ChainSuite extends CatsSuite {
   checkAll("Chain[Int]", AlternativeTests[Chain].alternative[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/CokleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/CokleisliSuite.scala
@@ -1,9 +1,10 @@
-package cats
-package tests
+package cats.tests
 
-import cats.Contravariant
+import cats.{Contravariant, Id, Monad, MonoidK, SemigroupK, Semigroupal}
 import cats.arrow._
 import cats.data.{Cokleisli, NonEmptyList}
+import cats.instances.all._
+import cats.kernel.Eq
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/ComposeSuite.scala
+++ b/tests/src/test/scala/cats/tests/ComposeSuite.scala
@@ -1,11 +1,13 @@
-package cats
-package tests
+package cats.tests
 
-import cats.kernel.laws.discipline.SemigroupTests
+import cats.Endo
 import cats.arrow.Compose
+import cats.instances.all._
+import cats.kernel.laws.discipline.SemigroupTests
 import cats.laws.discipline.{MiniInt, SemigroupKTests, SerializableTests}
 import cats.laws.discipline.eq.catsLawsEqForFn1Exhaustive
 import cats.laws.discipline.arbitrary._
+import cats.syntax.all._
 
 class ComposeSuite extends CatsSuite {
   val functionCompose = Compose[Function1]

--- a/tests/src/test/scala/cats/tests/ComposeSuite.scala
+++ b/tests/src/test/scala/cats/tests/ComposeSuite.scala
@@ -7,7 +7,7 @@ import cats.kernel.laws.discipline.SemigroupTests
 import cats.laws.discipline.{MiniInt, SemigroupKTests, SerializableTests}
 import cats.laws.discipline.eq.catsLawsEqForFn1Exhaustive
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.compose._
 
 class ComposeSuite extends CatsSuite {
   val functionCompose = Compose[Function1]

--- a/tests/src/test/scala/cats/tests/ConstSuite.scala
+++ b/tests/src/test/scala/cats/tests/ConstSuite.scala
@@ -1,6 +1,9 @@
-package cats
-package tests
+package cats.tests
 
+import cats._
+import cats.data.{Const, NonEmptyList}
+import cats.instances.all._
+import cats.kernel.Semigroup
 import cats.kernel.laws.discipline.{
   EqTests,
   LowerBoundedTests,
@@ -10,10 +13,10 @@ import cats.kernel.laws.discipline.{
   SemigroupTests,
   UpperBoundedTests
 }
-import cats.data.{Const, NonEmptyList}
 import cats.laws.discipline._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline.arbitrary._
+import cats.syntax.all._
 import cats.tests.Helpers.{CMono, CSemi}
 
 class ConstSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/ConstSuite.scala
+++ b/tests/src/test/scala/cats/tests/ConstSuite.scala
@@ -16,7 +16,7 @@ import cats.kernel.laws.discipline.{
 import cats.laws.discipline._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.show._
 import cats.tests.Helpers.{CMono, CSemi}
 
 class ConstSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/ContTSuite.scala
+++ b/tests/src/test/scala/cats/tests/ContTSuite.scala
@@ -1,7 +1,9 @@
-package cats
-package tests
+package cats.tests
 
+import cats.Eval
 import cats.data.ContT
+import cats.instances.all._
+import cats.kernel.Eq
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import org.scalacheck.{Arbitrary, Gen}

--- a/tests/src/test/scala/cats/tests/ContravariantSuite.scala
+++ b/tests/src/test/scala/cats/tests/ContravariantSuite.scala
@@ -1,12 +1,14 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Contravariant, ContravariantMonoidal, ContravariantSemigroupal}
 import cats.data.Const
+import cats.instances.all._
+import cats.kernel.{Eq, Monoid, Semigroup}
 import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
 import cats.laws.discipline.{ContravariantMonoidalTests, ExhaustiveCheck, MiniInt}
-import org.scalacheck.{Arbitrary, Cogen}
-import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.eq._
+import org.scalacheck.{Arbitrary, Cogen}
 
 class ContravariantSuite extends CatsSuite {
 

--- a/tests/src/test/scala/cats/tests/DurationSuite.scala
+++ b/tests/src/test/scala/cats/tests/DurationSuite.scala
@@ -1,8 +1,8 @@
-package cats
-package tests
+package cats.tests
 
+import cats.Show
+import cats.instances.all._
 import cats.laws.discipline.SerializableTests
-
 import scala.concurrent.duration.{Duration, DurationInt}
 
 class DurationSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/EitherKSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherKSuite.scala
@@ -1,8 +1,9 @@
 package cats.tests
 
 import cats._
-import cats.kernel.laws.discipline.EqTests
 import cats.data.EitherK
+import cats.instances.all._
+import cats.kernel.laws.discipline.EqTests
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/EitherSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherSuite.scala
@@ -7,7 +7,7 @@ import cats.instances.all._
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
-import cats.syntax.all._
+import cats.syntax.either._
 import org.scalatest.funsuite.AnyFunSuiteLike
 import scala.util.Try
 

--- a/tests/src/test/scala/cats/tests/EitherSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherSuite.scala
@@ -1,13 +1,14 @@
-package cats
-package tests
+package cats.tests
 
+import cats._
 import cats.data.{EitherT, NonEmptyChain, NonEmptyList, NonEmptySet, Validated}
-import cats.laws.discipline._
 import cats.kernel.laws.discipline.{EqTests, MonoidTests, OrderTests, PartialOrderTests, SemigroupTests}
-import org.scalatest.funsuite.AnyFunSuiteLike
+import cats.instances.all._
+import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
-
+import cats.syntax.all._
+import org.scalatest.funsuite.AnyFunSuiteLike
 import scala.util.Try
 
 class EitherSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/EitherTSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherTSuite.scala
@@ -1,12 +1,13 @@
-package cats
-package tests
+package cats.tests
 
+import cats._
 import cats.data.{EitherT, State}
+import cats.instances.all._
+import cats.kernel.laws.discipline.{EqTests, MonoidTests, OrderTests, PartialOrderTests, SemigroupTests}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
-import cats.kernel.laws.discipline.{EqTests, MonoidTests, OrderTests, PartialOrderTests, SemigroupTests}
-
+import cats.syntax.all._
 import scala.util.{Failure, Success, Try}
 
 class EitherTSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/EitherTSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherTSuite.scala
@@ -7,7 +7,9 @@ import cats.kernel.laws.discipline.{EqTests, MonoidTests, OrderTests, PartialOrd
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
-import cats.syntax.all._
+import cats.syntax.applicative._
+import cats.syntax.applicativeError._
+import cats.syntax.either._
 import scala.util.{Failure, Success, Try}
 
 class EitherTSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/EqSuite.scala
+++ b/tests/src/test/scala/cats/tests/EqSuite.scala
@@ -1,6 +1,8 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Contravariant, ContravariantMonoidal, ContravariantSemigroupal, Invariant, Semigroupal}
+import cats.instances.all._
+import cats.kernel.Eq
 import cats.kernel.laws.discipline.SerializableTests
 import cats.laws.discipline.{ContravariantMonoidalTests, MiniInt}
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/EquivSuite.scala
+++ b/tests/src/test/scala/cats/tests/EquivSuite.scala
@@ -1,6 +1,7 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Contravariant, ContravariantMonoidal, ContravariantSemigroupal, Invariant, Semigroupal}
+import cats.instances.all._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/EvalSuite.scala
+++ b/tests/src/test/scala/cats/tests/EvalSuite.scala
@@ -1,6 +1,7 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Bimonad, CommutativeMonad, Eval, Reducible}
+import cats.instances.all._
 import cats.laws.ComonadLaws
 import cats.laws.discipline.{
   BimonadTests,
@@ -11,6 +12,7 @@ import cats.laws.discipline.{
   SerializableTests
 }
 import cats.laws.discipline.arbitrary._
+import cats.kernel.{Eq, Monoid, Order, PartialOrder, Semigroup}
 import cats.kernel.laws.discipline.{EqTests, GroupTests, MonoidTests, OrderTests, PartialOrderTests, SemigroupTests}
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import org.scalacheck.Arbitrary.arbitrary

--- a/tests/src/test/scala/cats/tests/ExtraRegressionSuite.scala
+++ b/tests/src/test/scala/cats/tests/ExtraRegressionSuite.scala
@@ -1,6 +1,7 @@
-package cats
-package tests
+package cats.tests
 
+import cats.Show
+import cats.instances.all._
 import ExtraRegressionSuite._
 
 class ExtraRegressionSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/FiniteDurationSuite.scala
+++ b/tests/src/test/scala/cats/tests/FiniteDurationSuite.scala
@@ -1,8 +1,8 @@
-package cats
-package tests
+package cats.tests
 
+import cats.Show
+import cats.instances.all._
 import cats.laws.discipline.SerializableTests
-
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 
 class FiniteDurationSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/FoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/FoldableSuite.scala
@@ -6,7 +6,13 @@ import cats.instances.all._
 import cats.kernel.{Eq, Monoid}
 import cats.kernel.compat.scalaVersionSpecific._
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.alternative._
+import cats.syntax.either._
+import cats.syntax.foldable._
+import cats.syntax.functor._
+import cats.syntax.list._
+import cats.syntax.reducible._
+import cats.syntax.semigroupk._
 import org.scalacheck.Arbitrary
 import scala.collection.immutable.{SortedMap, SortedSet}
 import scala.util.Try

--- a/tests/src/test/scala/cats/tests/FoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/FoldableSuite.scala
@@ -1,13 +1,15 @@
-package cats
-package tests
+package cats.tests
 
-import org.scalacheck.Arbitrary
-import scala.util.Try
-import scala.collection.immutable.{SortedMap, SortedSet}
+import cats.{Eval, Foldable, Id, Now}
+import cats.data.{Const, EitherK, IdT, Ior, Nested, NonEmptyList, NonEmptyStream, NonEmptyVector, OneAnd, Validated}
 import cats.instances.all._
-import cats.data._
+import cats.kernel.{Eq, Monoid}
+import cats.kernel.compat.scalaVersionSpecific._
 import cats.laws.discipline.arbitrary._
-import kernel.compat.scalaVersionSpecific._
+import cats.syntax.all._
+import org.scalacheck.Arbitrary
+import scala.collection.immutable.{SortedMap, SortedSet}
+import scala.util.Try
 
 @suppressUnusedImportWarningForScalaVersionSpecific
 abstract class FoldableSuite[F[_]: Foldable](name: String)(implicit ArbFInt: Arbitrary[F[Int]],

--- a/tests/src/test/scala/cats/tests/FuncSuite.scala
+++ b/tests/src/test/scala/cats/tests/FuncSuite.scala
@@ -1,9 +1,10 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Applicative, Apply, Contravariant, Functor, Semigroupal, Show}
 import cats.data.{AppFunc, Func}
-import Func.appFunc
-import cats.Contravariant
+import cats.data.Func.appFunc
+import cats.instances.all._
+import cats.kernel.Eq
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms

--- a/tests/src/test/scala/cats/tests/FunctionKSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctionKSuite.scala
@@ -1,9 +1,10 @@
-package cats
-package tests
+package cats.tests
 
+import cats.Id
 import cats.arrow.FunctionK
 import cats.data.EitherK
 import cats.data.NonEmptyList
+import cats.instances.all._
 import cats.laws.discipline.arbitrary._
 
 class FunctionKSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/FunctionSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctionSuite.scala
@@ -1,7 +1,21 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{
+  Applicative,
+  Bimonad,
+  Contravariant,
+  ContravariantMonoidal,
+  Defer,
+  Distributive,
+  Endo,
+  Id,
+  Monad,
+  MonoidK,
+  Semigroupal
+}
 import cats.arrow.{ArrowChoice, Choice, CommutativeArrow}
+import cats.instances.all._
+import cats.kernel._
 import cats.kernel.laws.HashLaws
 import cats.kernel.laws.discipline.{
   BandTests,
@@ -19,11 +33,10 @@ import cats.kernel.laws.discipline.{
   SerializableTests
 }
 import cats.laws.discipline._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
-import cats.laws.discipline.SemigroupalTests.Isomorphisms
-import cats.kernel.{CommutativeGroup, CommutativeMonoid, CommutativeSemigroup}
-import cats.kernel.{Band, BoundedSemilattice, Semilattice}
+import cats.syntax.all._
 import org.scalacheck.Gen
 
 class FunctionSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/FunctionSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctionSuite.scala
@@ -36,7 +36,7 @@ import cats.laws.discipline._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.foldable._
 import org.scalacheck.Gen
 
 class FunctionSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/FunctorSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctorSuite.scala
@@ -1,5 +1,8 @@
-package cats
-package tests
+package cats.tests
+
+import cats.Functor
+import cats.instances.all._
+import cats.syntax.all._
 
 class FunctorSuite extends CatsSuite {
   test("void replaces values with unit preserving structure") {

--- a/tests/src/test/scala/cats/tests/FunctorSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctorSuite.scala
@@ -2,7 +2,7 @@ package cats.tests
 
 import cats.Functor
 import cats.instances.all._
-import cats.syntax.all._
+import cats.syntax.functor._
 
 class FunctorSuite extends CatsSuite {
   test("void replaces values with unit preserving structure") {

--- a/tests/src/test/scala/cats/tests/GroupSuite.scala
+++ b/tests/src/test/scala/cats/tests/GroupSuite.scala
@@ -1,6 +1,7 @@
-package cats
-package tests
+package cats.tests
 
+import cats.instances.all._
+import cats.kernel.Group
 import cats.kernel.laws.discipline.GroupTests
 
 class GroupSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/HashSuite.scala
+++ b/tests/src/test/scala/cats/tests/HashSuite.scala
@@ -1,5 +1,9 @@
-package cats
-package tests
+package cats.tests
+
+import cats.{Contravariant, Invariant}
+import cats.instances.all._
+import cats.kernel.Hash
+import cats.syntax.all._
 
 class HashSuite extends CatsSuite {
 

--- a/tests/src/test/scala/cats/tests/HashSuite.scala
+++ b/tests/src/test/scala/cats/tests/HashSuite.scala
@@ -3,7 +3,7 @@ package cats.tests
 import cats.{Contravariant, Invariant}
 import cats.instances.all._
 import cats.kernel.Hash
-import cats.syntax.all._
+import cats.syntax.hash._
 
 class HashSuite extends CatsSuite {
 

--- a/tests/src/test/scala/cats/tests/IdSuite.scala
+++ b/tests/src/test/scala/cats/tests/IdSuite.scala
@@ -1,6 +1,7 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Bimonad, CommutativeMonad, Id, Reducible, Traverse}
+import cats.instances.all._
 import cats.laws.discipline._
 
 class IdSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/IdTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IdTSuite.scala
@@ -1,12 +1,13 @@
-package cats
-package tests
+package cats.tests
 
+import cats._
 import cats.data.{Const, IdT, NonEmptyList}
+import cats.instances.all._
 import cats.kernel.laws.discipline.{EqTests, OrderTests}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
-import Helpers.CSemi
+import cats.tests.Helpers.CSemi
 
 class IdTSuite extends CatsSuite {
 

--- a/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTSuite.scala
@@ -1,14 +1,16 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{~>, Bifunctor, Contravariant, Eval, Functor, Id, Monad, MonadError, SemigroupK}
+import cats.arrow.{Profunctor, Strong}
 import cats.data.{EitherT, IRWST, IndexedReaderWriterStateT, ReaderWriterState, ReaderWriterStateT}
-
+import cats.instances.all._
+import cats.kernel.{Eq, Monoid}
 import cats.laws.discipline._
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
+import cats.syntax.all._
 import org.scalacheck.Arbitrary
-import cats.arrow.{Profunctor, Strong}
 
 class ReaderWriterStateTSuite extends CatsSuite {
   import ReaderWriterStateTSuite._

--- a/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTSuite.scala
@@ -9,7 +9,9 @@ import cats.laws.discipline._
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
-import cats.syntax.all._
+import cats.syntax.apply._
+import cats.syntax.semigroup._
+import cats.syntax.traverse._
 import org.scalacheck.Arbitrary
 
 class ReaderWriterStateTSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
@@ -10,7 +10,9 @@ import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
 import cats.platform.Platform
-import cats.syntax.all._
+import cats.syntax.apply._
+import cats.syntax.flatMap._
+import cats.syntax.traverse._
 
 class IndexedStateTSuite extends CatsSuite {
 

--- a/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
@@ -1,15 +1,16 @@
-package cats
-package tests
+package cats.tests
 
+import cats._
 import cats.arrow.{Profunctor, Strong}
 import cats.data.{EitherT, IndexedStateT, State, StateT}
-import cats.arrow.Profunctor
-import cats.kernel.instances.tuple._
+import cats.instances.all._
+import cats.kernel.Eq
 import cats.laws.discipline._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
-import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.platform.Platform
+import cats.syntax.all._
 
 class IndexedStateTSuite extends CatsSuite {
 

--- a/tests/src/test/scala/cats/tests/InjectKSuite.scala
+++ b/tests/src/test/scala/cats/tests/InjectKSuite.scala
@@ -1,8 +1,10 @@
-package cats
+package cats.tests
 
+import cats.{:<:, Functor, InjectK}
 import cats.data.EitherK
+import cats.kernel.Eq
+import cats.instances.all._
 import cats.laws.discipline.InjectKTests
-import cats.tests.CatsSuite
 import org.scalacheck._
 
 class InjectKSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/InjectSuite.scala
+++ b/tests/src/test/scala/cats/tests/InjectSuite.scala
@@ -1,7 +1,8 @@
-package cats
+package cats.tests
 
+import cats.Inject
+import cats.instances.all._
 import cats.laws.discipline.InjectTests
-import cats.tests.CatsSuite
 
 class InjectSuite extends CatsSuite {
 

--- a/tests/src/test/scala/cats/tests/IorSuite.scala
+++ b/tests/src/test/scala/cats/tests/IorSuite.scala
@@ -1,6 +1,9 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Bitraverse, MonadError, Semigroupal, Show, Traverse}
+import cats.data.{EitherT, Ior, NonEmptyChain, NonEmptyList, NonEmptySet}
+import cats.instances.all._
+import cats.kernel.{Eq, Semigroup}
 import cats.kernel.laws.discipline.SemigroupTests
 import cats.laws.discipline.{
   BifunctorTests,
@@ -10,9 +13,8 @@ import cats.laws.discipline.{
   SerializableTests,
   TraverseTests
 }
-import cats.data.{EitherT, Ior, NonEmptyChain, NonEmptyList, NonEmptySet}
-import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
+import cats.laws.discipline.arbitrary._
 import org.scalacheck.Arbitrary._
 
 class IorSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/IorTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IorTSuite.scala
@@ -1,7 +1,9 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{~>, Bifunctor, Eval, Foldable, Functor, Id, Monad, MonadError, Traverse}
 import cats.data.{Ior, IorT}
+import cats.instances.all._
+import cats.kernel.{Eq, Monoid, Semigroup}
 import cats.kernel.laws.discipline.{EqTests, MonoidTests, SemigroupTests}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/IsSuite.scala
+++ b/tests/src/test/scala/cats/tests/IsSuite.scala
@@ -1,14 +1,13 @@
-package cats
-package tests
+package cats.tests
 
 import cats.arrow._
+import cats.evidence.{Is, Leibniz}
+import cats.kernel.Eq
 import cats.kernel.laws.discipline.SerializableTests
 import cats.laws.discipline.CategoryTests
 import org.scalacheck.{Arbitrary, Gen}
 
 class IsSuite extends CatsSuite {
-  import evidence._
-
   implicit def arbIs[A, B](implicit ev: A Is B): Arbitrary[A Is B] = Arbitrary(Gen.const(ev))
   implicit def eqIs[A, B]: Eq[A Is B] = Eq.fromUniversalEquals
 

--- a/tests/src/test/scala/cats/tests/KernelContravariantSuite.scala
+++ b/tests/src/test/scala/cats/tests/KernelContravariantSuite.scala
@@ -1,6 +1,8 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Contravariant, ContravariantSemigroupal, Invariant, Semigroupal}
+import cats.instances.all._
+import cats.kernel.{Eq, Hash, Order, PartialOrder}
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/KleisliSuite.scala
@@ -1,17 +1,18 @@
-package cats
-package tests
+package cats.tests
 
-import cats.Contravariant
+import cats._
 import cats.arrow._
 import cats.data.{Const, EitherT, Kleisli, Reader, ReaderT}
+import cats.instances.all._
+import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
-import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
 import cats.laws.discipline.{DeferTests, MonoidKTests, SemigroupKTests}
+import cats.syntax.all._
 import cats.platform.Platform
-import Helpers.CSemi
+import cats.tests.Helpers.CSemi
 
 class KleisliSuite extends CatsSuite {
   implicit def kleisliEq[F[_], A, B](implicit ev: Eq[A => F[B]]): Eq[Kleisli[F, A, B]] =

--- a/tests/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/KleisliSuite.scala
@@ -10,7 +10,9 @@ import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline.{DeferTests, MonoidKTests, SemigroupKTests}
-import cats.syntax.all._
+import cats.syntax.flatMap._
+import cats.syntax.functor._
+import cats.syntax.traverse._
 import cats.platform.Platform
 import cats.tests.Helpers.CSemi
 

--- a/tests/src/test/scala/cats/tests/ListSuite.scala
+++ b/tests/src/test/scala/cats/tests/ListSuite.scala
@@ -1,7 +1,8 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Align, Alternative, CoflatMap, Monad, Semigroupal, Traverse, TraverseFilter}
 import cats.data.{NonEmptyList, ZipList}
+import cats.instances.all._
 import cats.laws.discipline.{
   AlignTests,
   AlternativeTests,
@@ -14,6 +15,7 @@ import cats.laws.discipline.{
   TraverseTests
 }
 import cats.laws.discipline.arbitrary._
+import cats.syntax.all._
 import org.scalatest.funsuite.AnyFunSuiteLike
 
 class ListSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/ListSuite.scala
+++ b/tests/src/test/scala/cats/tests/ListSuite.scala
@@ -15,7 +15,8 @@ import cats.laws.discipline.{
   TraverseTests
 }
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.list._
+import cats.syntax.show._
 import org.scalatest.funsuite.AnyFunSuiteLike
 
 class ListSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/MapSuite.scala
+++ b/tests/src/test/scala/cats/tests/MapSuite.scala
@@ -1,6 +1,9 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Align, FlatMap, FunctorFilter, MonoidK, Semigroupal, Show, UnorderedTraverse}
+import cats.arrow.Compose
+import cats.instances.all._
+import cats.kernel.instances.StaticMethods.wrapMutableMap
 import cats.laws.discipline.{
   AlignTests,
   ComposeTests,
@@ -12,8 +15,7 @@ import cats.laws.discipline.{
   UnorderedTraverseTests
 }
 import cats.laws.discipline.arbitrary._
-import cats.arrow.Compose
-import cats.kernel.instances.StaticMethods.wrapMutableMap
+import cats.syntax.all._
 
 class MapSuite extends CatsSuite {
 

--- a/tests/src/test/scala/cats/tests/MapSuite.scala
+++ b/tests/src/test/scala/cats/tests/MapSuite.scala
@@ -15,7 +15,7 @@ import cats.laws.discipline.{
   UnorderedTraverseTests
 }
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.show._
 
 class MapSuite extends CatsSuite {
 

--- a/tests/src/test/scala/cats/tests/MiniIntSuite.scala
+++ b/tests/src/test/scala/cats/tests/MiniIntSuite.scala
@@ -1,12 +1,11 @@
-package cats
-package tests
+package cats.tests
 
-import cats.laws.discipline.MiniInt
-import MiniInt._
-import cats.laws.discipline.arbitrary._
-import cats.kernel.{BoundedSemilattice, CommutativeGroup, CommutativeMonoid}
+import cats.instances.all._
+import cats.kernel.{BoundedSemilattice, CommutativeGroup, CommutativeMonoid, Hash, Order}
 import cats.kernel.laws.discipline._
-
+import cats.laws.discipline.MiniInt
+import cats.laws.discipline.MiniInt._
+import cats.laws.discipline.arbitrary._
 import org.scalacheck.Gen
 
 class MiniIntSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/MonadErrorSuite.scala
+++ b/tests/src/test/scala/cats/tests/MonadErrorSuite.scala
@@ -2,7 +2,8 @@ package cats.tests
 
 import cats.instances.all._
 import cats.kernel.Eq
-import cats.syntax.all._
+import cats.syntax.applicativeError._
+import cats.syntax.monadError._
 import scala.util.{Failure, Success, Try}
 
 class MonadErrorSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/MonadErrorSuite.scala
+++ b/tests/src/test/scala/cats/tests/MonadErrorSuite.scala
@@ -1,6 +1,8 @@
-package cats
-package tests
+package cats.tests
 
+import cats.instances.all._
+import cats.kernel.Eq
+import cats.syntax.all._
 import scala.util.{Failure, Success, Try}
 
 class MonadErrorSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/MonadSuite.scala
+++ b/tests/src/test/scala/cats/tests/MonadSuite.scala
@@ -3,7 +3,8 @@ package cats.tests
 import cats.{Id, Monad}
 import cats.data.{IndexedStateT, StateT}
 import cats.instances.all._
-import cats.syntax.all._
+import cats.syntax.apply._
+import cats.syntax.monad._
 import org.scalacheck.Gen
 
 class MonadSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/MonadSuite.scala
+++ b/tests/src/test/scala/cats/tests/MonadSuite.scala
@@ -1,7 +1,9 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Id, Monad}
 import cats.data.{IndexedStateT, StateT}
+import cats.instances.all._
+import cats.syntax.all._
 import org.scalacheck.Gen
 
 class MonadSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/MonoidSuite.scala
+++ b/tests/src/test/scala/cats/tests/MonoidSuite.scala
@@ -1,5 +1,8 @@
-package cats
-package tests
+package cats.tests
+
+import cats.{Invariant, InvariantSemigroupal}
+import cats.instances.all._
+import cats.kernel.Monoid
 
 class MonoidSuite extends CatsSuite {
   {

--- a/tests/src/test/scala/cats/tests/NestedSuite.scala
+++ b/tests/src/test/scala/cats/tests/NestedSuite.scala
@@ -1,9 +1,8 @@
-package cats
-package tests
+package cats.tests
 
-import cats.Functor
+import cats._
 import cats.data._
-
+import cats.instances.all._
 import cats.laws.discipline._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms._
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/NonEmptyChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyChainSuite.scala
@@ -7,7 +7,8 @@ import cats.kernel.{Eq, Order, PartialOrder, Semigroup}
 import cats.kernel.laws.discipline.{EqTests, OrderTests, PartialOrderTests, SemigroupTests}
 import cats.laws.discipline.{AlignTests, BimonadTests, NonEmptyTraverseTests, SemigroupKTests, SerializableTests}
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.either._
+import cats.syntax.foldable._
 
 class NonEmptyChainSuite extends NonEmptyCollectionSuite[Chain, NonEmptyChain, NonEmptyChainOps] {
   protected def toList[A](value: NonEmptyChain[A]): List[A] = value.toChain.toList

--- a/tests/src/test/scala/cats/tests/NonEmptyChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyChainSuite.scala
@@ -1,10 +1,13 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Align, Bimonad, SemigroupK, Show, Traverse}
 import cats.data.{Chain, NonEmptyChain, NonEmptyChainOps}
+import cats.instances.all._
+import cats.kernel.{Eq, Order, PartialOrder, Semigroup}
 import cats.kernel.laws.discipline.{EqTests, OrderTests, PartialOrderTests, SemigroupTests}
 import cats.laws.discipline.{AlignTests, BimonadTests, NonEmptyTraverseTests, SemigroupKTests, SerializableTests}
 import cats.laws.discipline.arbitrary._
+import cats.syntax.all._
 
 class NonEmptyChainSuite extends NonEmptyCollectionSuite[Chain, NonEmptyChain, NonEmptyChainOps] {
   protected def toList[A](value: NonEmptyChain[A]): List[A] = value.toChain.toList

--- a/tests/src/test/scala/cats/tests/NonEmptyCollectionSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyCollectionSuite.scala
@@ -1,6 +1,7 @@
 package cats.tests
 
 import cats.data.NonEmptyCollection
+import cats.instances.all._
 import org.scalacheck.Arbitrary
 
 abstract class NonEmptyCollectionSuite[U[+_], NE[+_], NEC[x] <: NonEmptyCollection[x, U, NE]](

--- a/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
@@ -1,10 +1,11 @@
-package cats
-package tests
+package cats.tests
 
-import cats.kernel.laws.discipline.{EqTests, OrderTests, PartialOrderTests, SemigroupTests}
-
+import cats.{Align, Bimonad, Eval, NonEmptyTraverse, Now, Reducible, SemigroupK, Show}
 import cats.data.{NonEmptyList, NonEmptyMap, NonEmptySet, NonEmptyVector}
 import cats.data.NonEmptyList.ZipNonEmptyList
+import cats.instances.all._
+import cats.kernel.{Eq, Order, PartialOrder, Semigroup}
+import cats.kernel.laws.discipline.{EqTests, OrderTests, PartialOrderTests, SemigroupTests}
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.{
   AlignTests,
@@ -15,8 +16,8 @@ import cats.laws.discipline.{
   SemigroupKTests,
   SerializableTests
 }
-import scala.collection.immutable.SortedMap
-import scala.collection.immutable.SortedSet
+import cats.syntax.all._
+import scala.collection.immutable.{SortedMap, SortedSet}
 
 class NonEmptyListSuite extends NonEmptyCollectionSuite[List, NonEmptyList, NonEmptyList] {
   protected def toList[A](value: NonEmptyList[A]): List[A] = value.toList

--- a/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
@@ -16,7 +16,9 @@ import cats.laws.discipline.{
   SemigroupKTests,
   SerializableTests
 }
-import cats.syntax.all._
+import cats.syntax.foldable._
+import cats.syntax.reducible._
+import cats.syntax.show._
 import scala.collection.immutable.{SortedMap, SortedSet}
 
 class NonEmptyListSuite extends NonEmptyCollectionSuite[List, NonEmptyList, NonEmptyList] {

--- a/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
@@ -1,11 +1,12 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Align, Eval, Foldable, Now, SemigroupK, Show}
+import cats.data.{NonEmptyList, NonEmptyMap}
+import cats.kernel.laws.discipline.{SerializableTests => _, _}
+import cats.instances.all._
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
-import cats.data._
-import cats.kernel.laws.discipline.{SerializableTests => _, _}
-
+import cats.syntax.all._
 import scala.collection.immutable.SortedMap
 
 class NonEmptyMapSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
@@ -6,7 +6,10 @@ import cats.kernel.laws.discipline.{SerializableTests => _, _}
 import cats.instances.all._
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.foldable._
+import cats.syntax.functor._
+import cats.syntax.show._
+import cats.syntax.reducible._
 import scala.collection.immutable.SortedMap
 
 class NonEmptyMapSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/NonEmptySetSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptySetSuite.scala
@@ -1,12 +1,13 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Eval, Now, Reducible, SemigroupK, Show}
+import cats.data.NonEmptySet
+import cats.instances.all._
+import cats.kernel.{Eq, Order, PartialOrder, Semilattice}
+import cats.kernel.laws.discipline.{EqTests, HashTests, OrderTests, SemilatticeTests}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
-import cats.data.NonEmptySet
-import cats.kernel.Semilattice
-import cats.kernel.laws.discipline.{EqTests, HashTests, OrderTests, SemilatticeTests}
-
+import cats.syntax.all._
 import scala.collection.immutable.SortedSet
 
 class NonEmptySetSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/NonEmptySetSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptySetSuite.scala
@@ -7,7 +7,9 @@ import cats.kernel.{Eq, Order, PartialOrder, Semilattice}
 import cats.kernel.laws.discipline.{EqTests, HashTests, OrderTests, SemilatticeTests}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.foldable._
+import cats.syntax.reducible._
+import cats.syntax.show._
 import scala.collection.immutable.SortedSet
 
 class NonEmptySetSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
@@ -1,11 +1,26 @@
-package cats
-package tests
+package cats.tests
 
-import cats.data.NonEmptyVector.ZipNonEmptyVector
-
-import cats.kernel.laws.discipline.{EqTests, SemigroupTests}
-
+import cats.{
+  Align,
+  Bimonad,
+  CommutativeApply,
+  Comonad,
+  Eval,
+  Foldable,
+  Functor,
+  Monad,
+  NonEmptyTraverse,
+  Now,
+  Reducible,
+  SemigroupK,
+  Show,
+  Traverse
+}
 import cats.data.NonEmptyVector
+import cats.data.NonEmptyVector.ZipNonEmptyVector
+import cats.instances.all._
+import cats.kernel.Semigroup
+import cats.kernel.laws.discipline.{EqTests, SemigroupTests}
 import cats.laws.discipline.{
   AlignTests,
   BimonadTests,
@@ -18,7 +33,7 @@ import cats.laws.discipline.{
 }
 import cats.laws.discipline.arbitrary._
 import cats.platform.Platform
-
+import cats.syntax.all._
 import scala.util.Properties
 
 class NonEmptyVectorSuite extends NonEmptyCollectionSuite[Vector, NonEmptyVector, NonEmptyVector] {

--- a/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
@@ -33,7 +33,9 @@ import cats.laws.discipline.{
 }
 import cats.laws.discipline.arbitrary._
 import cats.platform.Platform
-import cats.syntax.all._
+import cats.syntax.foldable._
+import cats.syntax.reducible._
+import cats.syntax.show._
 import scala.util.Properties
 
 class NonEmptyVectorSuite extends NonEmptyCollectionSuite[Vector, NonEmptyVector, NonEmptyVector] {

--- a/tests/src/test/scala/cats/tests/OneAndSuite.scala
+++ b/tests/src/test/scala/cats/tests/OneAndSuite.scala
@@ -6,7 +6,7 @@ import cats.instances.all._
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
-import cats.syntax.all._
+import cats.syntax.foldable._
 
 class OneAndSuite extends CatsSuite {
   // Lots of collections here.. telling ScalaCheck to calm down a bit

--- a/tests/src/test/scala/cats/tests/OneAndSuite.scala
+++ b/tests/src/test/scala/cats/tests/OneAndSuite.scala
@@ -1,10 +1,12 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Alternative, Applicative, Foldable, Functor, Monad, SemigroupK, Traverse}
 import cats.data.OneAnd
+import cats.instances.all._
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
+import cats.syntax.all._
 
 class OneAndSuite extends CatsSuite {
   // Lots of collections here.. telling ScalaCheck to calm down a bit

--- a/tests/src/test/scala/cats/tests/OpSuite.scala
+++ b/tests/src/test/scala/cats/tests/OpSuite.scala
@@ -1,8 +1,9 @@
-package cats
-package tests
+package cats.tests
 
 import cats.arrow._
 import cats.data.{Kleisli, Op}
+import cats.instances.all._
+import cats.kernel.Eq
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/OptionSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionSuite.scala
@@ -1,9 +1,11 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Alternative, CoflatMap, CommutativeMonad, Eval, Later, MonadError, Semigroupal, Traverse, TraverseFilter}
+import cats.instances.all._
 import cats.laws.{ApplicativeLaws, CoflatMapLaws, FlatMapLaws, MonadLaws}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
+import cats.syntax.all._
 
 class OptionSuite extends CatsSuite {
   checkAll("Option[Int]", SemigroupalTests[Option].semigroupal[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/OptionSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionSuite.scala
@@ -5,7 +5,9 @@ import cats.instances.all._
 import cats.laws.{ApplicativeLaws, CoflatMapLaws, FlatMapLaws, MonadLaws}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.apply._
+import cats.syntax.option._
+import cats.syntax.show._
 
 class OptionSuite extends CatsSuite {
   checkAll("Option[Int]", SemigroupalTests[Option].semigroupal[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/OptionTSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionTSuite.scala
@@ -8,7 +8,8 @@ import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
-import cats.syntax.all._
+import cats.syntax.either._
+import cats.syntax.monadError._
 
 class OptionTSuite extends CatsSuite {
   implicit val iso: Isomorphisms[OptionT[ListWrapper, *]] = Isomorphisms

--- a/tests/src/test/scala/cats/tests/OptionTSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionTSuite.scala
@@ -1,13 +1,14 @@
-package cats
-package tests
+package cats.tests
 
+import cats._
 import cats.data.{Const, IdT, OptionT}
-import cats.kernel.{Monoid, Semigroup}
+import cats.instances.all._
 import cats.kernel.laws.discipline.{EqTests, MonoidTests, OrderTests, PartialOrderTests, SemigroupTests}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
+import cats.syntax.all._
 
 class OptionTSuite extends CatsSuite {
   implicit val iso: Isomorphisms[OptionT[ListWrapper, *]] = Isomorphisms

--- a/tests/src/test/scala/cats/tests/OptionWrapper.scala
+++ b/tests/src/test/scala/cats/tests/OptionWrapper.scala
@@ -1,9 +1,9 @@
-package cats
-package tests
+package cats.tests
 
+import cats.Functor
 import cats.laws.discipline.ExhaustiveCheck
-
-import org.scalacheck.{Arbitrary, Cogen}, Arbitrary.arbitrary
+import org.scalacheck.{Arbitrary, Cogen}
+import org.scalacheck.Arbitrary.arbitrary
 
 /**
  * Similar to [[ListWrapper]], but using `Option` instead of `List` limits the size of the structure, which can be

--- a/tests/src/test/scala/cats/tests/OrderSuite.scala
+++ b/tests/src/test/scala/cats/tests/OrderSuite.scala
@@ -1,11 +1,14 @@
-package cats
-package tests
+package cats.tests
 
-import Helpers.Ord
+import cats.{Contravariant, ContravariantMonoidal, Invariant}
+import cats.instances.all._
+import cats.kernel.{Order, PartialOrder}
 import cats.kernel.laws.discipline.{OrderTests, SerializableTests}
 import cats.laws.discipline.{ContravariantMonoidalTests, MiniInt}
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
+import cats.syntax.all._
+import cats.tests.Helpers.Ord
 
 class OrderSuite extends CatsSuite {
   {

--- a/tests/src/test/scala/cats/tests/OrderSuite.scala
+++ b/tests/src/test/scala/cats/tests/OrderSuite.scala
@@ -7,7 +7,7 @@ import cats.kernel.laws.discipline.{OrderTests, SerializableTests}
 import cats.laws.discipline.{ContravariantMonoidalTests, MiniInt}
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
-import cats.syntax.all._
+import cats.syntax.order._
 import cats.tests.Helpers.Ord
 
 class OrderSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/OrderingSuite.scala
+++ b/tests/src/test/scala/cats/tests/OrderingSuite.scala
@@ -1,6 +1,7 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Contravariant, ContravariantMonoidal, ContravariantSemigroupal, Invariant, Semigroupal}
+import cats.instances.all._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/ParallelSuite.scala
+++ b/tests/src/test/scala/cats/tests/ParallelSuite.scala
@@ -1,17 +1,18 @@
-package cats
-package tests
+package cats.tests
 
 import cats._
-import cats.data.NonEmptyList.ZipNonEmptyList
 import cats.data._
-import org.scalatest.funsuite.AnyFunSuiteLike
+import cats.data.NonEmptyList.ZipNonEmptyList
+import cats.instances.all._
+import cats.kernel.compat.scalaVersionSpecific._
 import cats.laws.discipline.{ApplicativeErrorTests, MiniInt, NonEmptyParallelTests, ParallelTests, SerializableTests}
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
+import cats.syntax.all._
+import org.scalatest.funsuite.AnyFunSuiteLike
 import org.scalatestplus.scalacheck.Checkers
 import org.typelevel.discipline.scalatest.FunSuiteDiscipline
 import scala.collection.immutable.SortedSet
-import kernel.compat.scalaVersionSpecific._
 
 @suppressUnusedImportWarningForScalaVersionSpecific
 class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest with ScalaVersionSpecificParallelSuite {

--- a/tests/src/test/scala/cats/tests/ParallelSuite.scala
+++ b/tests/src/test/scala/cats/tests/ParallelSuite.scala
@@ -8,7 +8,14 @@ import cats.kernel.compat.scalaVersionSpecific._
 import cats.laws.discipline.{ApplicativeErrorTests, MiniInt, NonEmptyParallelTests, ParallelTests, SerializableTests}
 import cats.laws.discipline.eq._
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.bifunctor._
+import cats.syntax.bitraverse._
+import cats.syntax.either._
+import cats.syntax.flatMap._
+import cats.syntax.foldable._
+import cats.syntax.option._
+import cats.syntax.parallel._
+import cats.syntax.traverse._
 import org.scalatest.funsuite.AnyFunSuiteLike
 import org.scalatestplus.scalacheck.Checkers
 import org.typelevel.discipline.scalatest.FunSuiteDiscipline

--- a/tests/src/test/scala/cats/tests/PartialOrderSuite.scala
+++ b/tests/src/test/scala/cats/tests/PartialOrderSuite.scala
@@ -1,12 +1,15 @@
-package cats
-package tests
+package cats.tests
 
-import Helpers.POrd
+import cats.{Contravariant, ContravariantMonoidal, Invariant}
+import cats.instances.all._
+import cats.kernel.PartialOrder
 import cats.kernel.laws.discipline.SerializableTests
 import cats.laws.discipline.{ContravariantMonoidalTests, MiniInt}
-import org.scalatest.Assertion
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
+import cats.syntax.all._
+import cats.tests.Helpers.POrd
+import org.scalatest.Assertion
 
 class PartialOrderSuite extends CatsSuite {
 

--- a/tests/src/test/scala/cats/tests/PartialOrderSuite.scala
+++ b/tests/src/test/scala/cats/tests/PartialOrderSuite.scala
@@ -7,7 +7,7 @@ import cats.kernel.laws.discipline.SerializableTests
 import cats.laws.discipline.{ContravariantMonoidalTests, MiniInt}
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
-import cats.syntax.all._
+import cats.syntax.partialOrder._
 import cats.tests.Helpers.POrd
 import org.scalatest.Assertion
 

--- a/tests/src/test/scala/cats/tests/PartialOrderingSuite.scala
+++ b/tests/src/test/scala/cats/tests/PartialOrderingSuite.scala
@@ -1,6 +1,7 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Contravariant, ContravariantMonoidal, ContravariantSemigroupal, Invariant, Semigroupal}
+import cats.instances.all._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/QueueSuite.scala
+++ b/tests/src/test/scala/cats/tests/QueueSuite.scala
@@ -11,7 +11,7 @@ import cats.laws.discipline.{
   TraverseFilterTests,
   TraverseTests
 }
-import cats.syntax.all._
+import cats.syntax.show._
 import scala.collection.immutable.Queue
 
 class QueueSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/QueueSuite.scala
+++ b/tests/src/test/scala/cats/tests/QueueSuite.scala
@@ -1,7 +1,7 @@
-package cats
-package tests
+package cats.tests
 
-import scala.collection.immutable.Queue
+import cats.{Alternative, CoflatMap, Monad, Semigroupal, Traverse, TraverseFilter}
+import cats.instances.all._
 import cats.laws.discipline.{
   AlternativeTests,
   CoflatMapTests,
@@ -11,6 +11,8 @@ import cats.laws.discipline.{
   TraverseFilterTests,
   TraverseTests
 }
+import cats.syntax.all._
+import scala.collection.immutable.Queue
 
 class QueueSuite extends CatsSuite {
   checkAll("Queue[Int]", SemigroupalTests[Queue].semigroupal[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/ReducibleSuite.scala
+++ b/tests/src/test/scala/cats/tests/ReducibleSuite.scala
@@ -4,7 +4,11 @@ import cats.{Eval, NonEmptyReducible, Now, Reducible}
 import cats.data.NonEmptyList
 import cats.kernel.Eq
 import cats.instances.all._
-import cats.syntax.all._
+import cats.syntax.either._
+import cats.syntax.foldable._
+import cats.syntax.list._
+import cats.syntax.option._
+import cats.syntax.reducible._
 import org.scalacheck.Arbitrary
 
 class ReducibleSuiteAdditional extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/ReducibleSuite.scala
+++ b/tests/src/test/scala/cats/tests/ReducibleSuite.scala
@@ -1,8 +1,11 @@
-package cats
-package tests
+package cats.tests
 
-import org.scalacheck.Arbitrary
+import cats.{Eval, NonEmptyReducible, Now, Reducible}
 import cats.data.NonEmptyList
+import cats.kernel.Eq
+import cats.instances.all._
+import cats.syntax.all._
+import org.scalacheck.Arbitrary
 
 class ReducibleSuiteAdditional extends CatsSuite {
 

--- a/tests/src/test/scala/cats/tests/RegressionSuite.scala
+++ b/tests/src/test/scala/cats/tests/RegressionSuite.scala
@@ -1,10 +1,13 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Apply, Monad, MonadError, StackSafeMonad, Traverse}
 import cats.data.{Const, NonEmptyList, StateT}
+import cats.instances.all._
+import cats.kernel.Eq
+import cats.kernel.compat.scalaVersionSpecific._
+import cats.syntax.all._
 import scala.collection.mutable
 import scala.collection.immutable.SortedMap
-import kernel.compat.scalaVersionSpecific._
 
 @suppressUnusedImportWarningForScalaVersionSpecific
 class RegressionSuite extends CatsSuite with ScalaVersionSpecificRegressionSuite {
@@ -149,7 +152,7 @@ class RegressionSuite extends CatsSuite with ScalaVersionSpecificRegressionSuite
   }
 
   test("#2022 EitherT syntax no long works the old way") {
-    import data._
+    import cats.data._
 
     EitherT.right[String](Option(1)).handleErrorWith((_: String) => EitherT.pure(2))
 

--- a/tests/src/test/scala/cats/tests/RegressionSuite.scala
+++ b/tests/src/test/scala/cats/tests/RegressionSuite.scala
@@ -5,7 +5,11 @@ import cats.data.{Const, NonEmptyList, StateT}
 import cats.instances.all._
 import cats.kernel.Eq
 import cats.kernel.compat.scalaVersionSpecific._
-import cats.syntax.all._
+import cats.syntax.applicativeError._
+import cats.syntax.either._
+import cats.syntax.foldable._
+import cats.syntax.monadError._
+import cats.syntax.traverse._
 import scala.collection.mutable
 import scala.collection.immutable.SortedMap
 

--- a/tests/src/test/scala/cats/tests/RepresentableStoreSuite.scala
+++ b/tests/src/test/scala/cats/tests/RepresentableStoreSuite.scala
@@ -2,6 +2,7 @@ package cats.tests
 
 import cats.Comonad
 import cats.data.{RepresentableStore, Store}
+import cats.instances.all._
 import cats.kernel.Eq
 import cats.laws.discipline.{ComonadTests, SerializableTests}
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/RepresentableSuite.scala
+++ b/tests/src/test/scala/cats/tests/RepresentableSuite.scala
@@ -15,7 +15,7 @@ import cats.laws.discipline.{
   RepresentableTests,
   SerializableTests
 }
-import cats.syntax.all._
+import cats.syntax.representable._
 import org.scalacheck.Arbitrary
 
 class RepresentableSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/RepresentableSuite.scala
+++ b/tests/src/test/scala/cats/tests/RepresentableSuite.scala
@@ -1,5 +1,9 @@
 package cats.tests
 
+import cats.{Bimonad, Distributive, Eq, Eval, Id, Monad, Representable}
+import cats.data.Kleisli
+import cats.instances.all._
+import cats.kernel.Monoid
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
@@ -11,9 +15,8 @@ import cats.laws.discipline.{
   RepresentableTests,
   SerializableTests
 }
-import cats.{Bimonad, Distributive, Eq, Eval, Id, Monad, Monoid, Representable}
+import cats.syntax.all._
 import org.scalacheck.Arbitrary
-import cats.data.Kleisli
 
 class RepresentableSuite extends CatsSuite {
 

--- a/tests/src/test/scala/cats/tests/SemigroupKSuite.scala
+++ b/tests/src/test/scala/cats/tests/SemigroupKSuite.scala
@@ -1,8 +1,8 @@
 package cats.tests
 
-import cats.Alternative
-import cats.{Align, SemigroupK}
+import cats.{Align, Alternative, SemigroupK}
 import cats.data.{Chain, Validated}
+import cats.instances.all._
 import cats.laws.discipline.AlignTests
 import cats.laws.discipline.arbitrary._
 

--- a/tests/src/test/scala/cats/tests/SemigroupSuite.scala
+++ b/tests/src/test/scala/cats/tests/SemigroupSuite.scala
@@ -1,6 +1,7 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Invariant, InvariantMonoidal, Semigroupal}
+import cats.kernel.Semigroup
 import org.scalatest._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.funsuite._

--- a/tests/src/test/scala/cats/tests/SetSuite.scala
+++ b/tests/src/test/scala/cats/tests/SetSuite.scala
@@ -1,10 +1,12 @@
-package cats
-package tests
+package cats.tests
 
-import cats.kernel.laws.discipline.MonoidTests
+import cats.{MonoidK, Show, UnorderedTraverse}
 import cats.data.Validated
+import cats.instances.all._
+import cats.kernel.laws.discipline.MonoidTests
 import cats.laws.discipline.{MonoidKTests, SerializableTests, UnorderedTraverseTests}
 import cats.laws.discipline.arbitrary._
+import cats.syntax.all._
 
 class SetSuite extends CatsSuite {
   checkAll("Set[Int]", MonoidTests[Set[Int]].monoid)

--- a/tests/src/test/scala/cats/tests/SetSuite.scala
+++ b/tests/src/test/scala/cats/tests/SetSuite.scala
@@ -6,7 +6,7 @@ import cats.instances.all._
 import cats.kernel.laws.discipline.MonoidTests
 import cats.laws.discipline.{MonoidKTests, SerializableTests, UnorderedTraverseTests}
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.show._
 
 class SetSuite extends CatsSuite {
   checkAll("Set[Int]", MonoidTests[Set[Int]].monoid)

--- a/tests/src/test/scala/cats/tests/ShowSuite.scala
+++ b/tests/src/test/scala/cats/tests/ShowSuite.scala
@@ -1,14 +1,15 @@
-package cats
-package tests
+package cats.tests
 
-import java.util.concurrent.TimeUnit
-
+import cats.{Contravariant, Show}
 import cats.Show.ContravariantShow
-import cats.laws.discipline.arbitrary._
+import cats.kernel.Order
+import cats.instances.all._
+import cats.syntax.all._
 import cats.laws.discipline.{ContravariantTests, MiniInt, SerializableTests}
+import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
+import java.util.concurrent.TimeUnit
 import org.scalatest.funsuite.AnyFunSuiteLike
-
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
 class ShowSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/ShowSuite.scala
+++ b/tests/src/test/scala/cats/tests/ShowSuite.scala
@@ -4,7 +4,7 @@ import cats.{Contravariant, Show}
 import cats.Show.ContravariantShow
 import cats.kernel.Order
 import cats.instances.all._
-import cats.syntax.all._
+import cats.syntax.show._
 import cats.laws.discipline.{ContravariantTests, MiniInt, SerializableTests}
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/SortedMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/SortedMapSuite.scala
@@ -15,7 +15,7 @@ import cats.laws.discipline.{
 }
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.show._
 import scala.collection.immutable.SortedMap
 
 class SortedMapSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/SortedMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/SortedMapSuite.scala
@@ -1,7 +1,8 @@
-package cats
-package tests
+package cats.tests
 
-import cats.kernel.CommutativeMonoid
+import cats.{Align, FlatMap, MonoidK, Semigroupal, Show, Traverse, TraverseFilter}
+import cats.instances.all._
+import cats.kernel.{CommutativeMonoid, Monoid}
 import cats.kernel.laws.discipline.{CommutativeMonoidTests, HashTests, MonoidTests}
 import cats.laws.discipline.{
   AlignTests,
@@ -12,9 +13,9 @@ import cats.laws.discipline.{
   TraverseFilterTests,
   TraverseTests
 }
-import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
-
+import cats.laws.discipline.arbitrary._
+import cats.syntax.all._
 import scala.collection.immutable.SortedMap
 
 class SortedMapSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/SortedSetSuite.scala
+++ b/tests/src/test/scala/cats/tests/SortedSetSuite.scala
@@ -1,13 +1,15 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{SemigroupK, Semigroupal, Show}
+import cats.instances.all._
+import cats.kernel.{Order, PartialOrder}
 import cats.kernel.laws.discipline.{BoundedSemilatticeTests, HashTests, OrderTests, PartialOrderTests}
 import cats.kernel.{BoundedSemilattice, Semilattice}
 import cats.laws._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.{FoldableTests, SemigroupKTests, SemigroupalTests, SerializableTests}
-
+import cats.syntax.all._
 import scala.collection.immutable.SortedSet
 
 class SortedSetSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/SortedSetSuite.scala
+++ b/tests/src/test/scala/cats/tests/SortedSetSuite.scala
@@ -9,7 +9,7 @@ import cats.laws._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.{FoldableTests, SemigroupKTests, SemigroupalTests, SerializableTests}
-import cats.syntax.all._
+import cats.syntax.show._
 import scala.collection.immutable.SortedSet
 
 class SortedSetSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/SplitSuite.scala
+++ b/tests/src/test/scala/cats/tests/SplitSuite.scala
@@ -1,7 +1,7 @@
 package cats.tests
 
 import cats.instances.all._
-import cats.syntax.all._
+import cats.syntax.arrow._
 
 class SplitSuite extends CatsSuite {
   test("syntax") {

--- a/tests/src/test/scala/cats/tests/SplitSuite.scala
+++ b/tests/src/test/scala/cats/tests/SplitSuite.scala
@@ -1,5 +1,7 @@
-package cats
-package tests
+package cats.tests
+
+import cats.instances.all._
+import cats.syntax.all._
 
 class SplitSuite extends CatsSuite {
   test("syntax") {

--- a/tests/src/test/scala/cats/tests/Spooky.scala
+++ b/tests/src/test/scala/cats/tests/Spooky.scala
@@ -1,5 +1,4 @@
-package cats
-package tests
+package cats.tests
 
 /**
  * Class for spooky side-effects and action-at-a-distance.

--- a/tests/src/test/scala/cats/tests/StreamSuite.scala
+++ b/tests/src/test/scala/cats/tests/StreamSuite.scala
@@ -1,6 +1,8 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Align, Alternative, CoflatMap, Monad, Semigroupal, Traverse, TraverseFilter}
+import cats.data.ZipStream
+import cats.instances.all._
 import cats.laws.discipline.{
   AlignTests,
   AlternativeTests,
@@ -12,8 +14,8 @@ import cats.laws.discipline.{
   TraverseFilterTests,
   TraverseTests
 }
-import cats.data.ZipStream
 import cats.laws.discipline.arbitrary._
+import cats.syntax.all._
 import org.scalatest.funsuite.AnyFunSuiteLike
 
 class StreamSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/StreamSuite.scala
+++ b/tests/src/test/scala/cats/tests/StreamSuite.scala
@@ -15,7 +15,7 @@ import cats.laws.discipline.{
   TraverseTests
 }
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.show._
 import org.scalatest.funsuite.AnyFunSuiteLike
 
 class StreamSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/SyntaxSuite.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxSuite.scala
@@ -1,21 +1,12 @@
-package cats
-package tests
+package cats.tests
 
-import scala.collection.immutable.SortedSet
-import scala.collection.immutable.SortedMap
+import cats._
 import cats.arrow.Compose
 import cats.data.{Binested, Nested, NonEmptyChain, NonEmptyList, NonEmptySet}
-import cats.instances.{
-  AllInstances,
-  AllInstancesBinCompat0,
-  AllInstancesBinCompat1,
-  AllInstancesBinCompat2,
-  AllInstancesBinCompat3,
-  AllInstancesBinCompat4,
-  AllInstancesBinCompat5,
-  AllInstancesBinCompat6
-}
-import cats.syntax.AllSyntaxBinCompat
+//import cats.kernel.{Eq, Group, Monoid, Order, PartialOrder, Semigroup}
+import cats.instances.all._
+import cats.syntax.all._
+import scala.collection.immutable.{SortedMap, SortedSet}
 
 /**
  * Test that our syntax implicits are working.
@@ -35,16 +26,7 @@ import cats.syntax.AllSyntaxBinCompat
  *
  * None of these tests should ever run, or do any runtime checks.
  */
-object SyntaxSuite
-    extends AllSyntaxBinCompat
-    with AllInstances
-    with AllInstancesBinCompat0
-    with AllInstancesBinCompat1
-    with AllInstancesBinCompat2
-    with AllInstancesBinCompat3
-    with AllInstancesBinCompat4
-    with AllInstancesBinCompat5
-    with AllInstancesBinCompat6 {
+object SyntaxSuite {
 
   // pretend we have a value of type A
   def mock[A]: A = ???

--- a/tests/src/test/scala/cats/tests/SyntaxSuite.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxSuite.scala
@@ -3,7 +3,6 @@ package cats.tests
 import cats._
 import cats.arrow.Compose
 import cats.data.{Binested, Nested, NonEmptyChain, NonEmptyList, NonEmptySet}
-//import cats.kernel.{Eq, Group, Monoid, Order, PartialOrder, Semigroup}
 import cats.instances.all._
 import cats.syntax.all._
 import scala.collection.immutable.{SortedMap, SortedSet}

--- a/tests/src/test/scala/cats/tests/TailRecSuite.scala
+++ b/tests/src/test/scala/cats/tests/TailRecSuite.scala
@@ -1,12 +1,12 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Defer, Monad}
+import cats.instances.all._
+import cats.kernel.Eq
+import cats.laws.discipline.{DeferTests, MonadTests, SerializableTests}
 import scala.util.control.TailCalls.{done, tailcall, TailRec}
 import org.scalacheck.{Arbitrary, Cogen, Gen}
-
-import Arbitrary.arbitrary
-
-import cats.laws.discipline.{DeferTests, MonadTests, SerializableTests}
+import org.scalacheck.Arbitrary.arbitrary
 
 class TailRecSuite extends CatsSuite {
 

--- a/tests/src/test/scala/cats/tests/TraverseSuite.scala
+++ b/tests/src/test/scala/cats/tests/TraverseSuite.scala
@@ -1,10 +1,10 @@
-package cats
-package tests
+package cats.tests
 
-import org.scalacheck.Arbitrary
-
+import cats.{Applicative, Eval, Traverse}
 import cats.instances.all._
-import kernel.compat.scalaVersionSpecific._
+import cats.kernel.compat.scalaVersionSpecific._
+import cats.syntax.all._
+import org.scalacheck.Arbitrary
 
 @suppressUnusedImportWarningForScalaVersionSpecific
 abstract class TraverseSuite[F[_]: Traverse](name: String)(implicit ArbFInt: Arbitrary[F[Int]]) extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/TraverseSuite.scala
+++ b/tests/src/test/scala/cats/tests/TraverseSuite.scala
@@ -3,7 +3,9 @@ package cats.tests
 import cats.{Applicative, Eval, Traverse}
 import cats.instances.all._
 import cats.kernel.compat.scalaVersionSpecific._
-import cats.syntax.all._
+import cats.syntax.foldable._
+import cats.syntax.functor._
+import cats.syntax.traverse._
 import org.scalacheck.Arbitrary
 
 @suppressUnusedImportWarningForScalaVersionSpecific
@@ -23,7 +25,7 @@ abstract class TraverseSuite[F[_]: Traverse](name: String)(implicit ArbFInt: Arb
 
   test(s"Traverse[$name].traverseWithIndexM") {
     forAll { (fa: F[Int], fn: ((Int, Int)) => (Int, Int)) =>
-      val left = fa.traverseWithIndexM((a, i) => fn((a, i))).map(_.toList)
+      val left = fa.traverseWithIndexM((a, i) => fn((a, i))).fmap(_.toList)
       val (xs, values) = fa.toList.zipWithIndex.map(fn).unzip
       left should ===((xs.combineAll, values))
     }

--- a/tests/src/test/scala/cats/tests/TrySuite.scala
+++ b/tests/src/test/scala/cats/tests/TrySuite.scala
@@ -7,7 +7,8 @@ import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
 import cats.laws.{ApplicativeLaws, CoflatMapLaws, FlatMapLaws, MonadLaws}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.apply._
+import cats.syntax.show._
 import scala.util.{Success, Try}
 
 class TrySuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/TrySuite.scala
+++ b/tests/src/test/scala/cats/tests/TrySuite.scala
@@ -1,11 +1,13 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{CoflatMap, Eval, Later, Monad, MonadError, Semigroupal, Traverse}
+import cats.instances.all._
+import cats.kernel.{Eq, Monoid, Semigroup}
 import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
 import cats.laws.{ApplicativeLaws, CoflatMapLaws, FlatMapLaws, MonadLaws}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
-
+import cats.syntax.all._
 import scala.util.{Success, Try}
 
 class TrySuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/Tuple2KSuite.scala
+++ b/tests/src/test/scala/cats/tests/Tuple2KSuite.scala
@@ -1,13 +1,13 @@
-package cats
-package tests
+package cats.tests
 
+import cats._
 import cats.data.{Const, Tuple2K, Validated}
-import cats.Contravariant
+import cats.instances.all._
+import cats.kernel.laws.discipline.{EqTests, OrderTests, PartialOrderTests}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
-import cats.kernel.laws.discipline.{EqTests, OrderTests, PartialOrderTests}
 
 class Tuple2KSuite extends CatsSuite {
   implicit val iso: Isomorphisms[Tuple2K[Option, List, *]] = Isomorphisms.invariant[Tuple2K[Option, List, *]]

--- a/tests/src/test/scala/cats/tests/TupleSuite.scala
+++ b/tests/src/test/scala/cats/tests/TupleSuite.scala
@@ -18,7 +18,7 @@ import cats.kernel.{Eq, Order}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
-import cats.syntax.all._
+import cats.syntax.show._
 import cats.tests.Helpers.CSemi
 
 class TupleSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/TupleSuite.scala
+++ b/tests/src/test/scala/cats/tests/TupleSuite.scala
@@ -1,12 +1,25 @@
-package cats
-package tests
+package cats.tests
 
-import data.NonEmptyList
-
+import cats.{
+  Bitraverse,
+  CommutativeFlatMap,
+  CommutativeMonad,
+  Comonad,
+  ContravariantSemigroupal,
+  FlatMap,
+  Monad,
+  Reducible,
+  Show,
+  Traverse
+}
+import cats.data.NonEmptyList
+import cats.instances.all._
+import cats.kernel.{Eq, Order}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
-import Helpers.CSemi
+import cats.syntax.all._
+import cats.tests.Helpers.CSemi
 
 class TupleSuite extends CatsSuite {
 

--- a/tests/src/test/scala/cats/tests/UnorderedFoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/UnorderedFoldableSuite.scala
@@ -4,7 +4,7 @@ import cats.UnorderedFoldable
 import cats.instances.all._
 import cats.kernel.CommutativeMonoid
 import cats.laws.discipline.UnorderedFoldableTests
-import cats.syntax.all._
+import cats.syntax.unorderedFoldable._
 import org.scalacheck.Arbitrary
 
 sealed abstract class UnorderedFoldableSuite[F[_]](name: String)(implicit ArbFString: Arbitrary[F[String]],

--- a/tests/src/test/scala/cats/tests/UnorderedFoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/UnorderedFoldableSuite.scala
@@ -1,10 +1,11 @@
-package cats
-package tests
+package cats.tests
 
-import org.scalacheck.Arbitrary
+import cats.UnorderedFoldable
 import cats.instances.all._
 import cats.kernel.CommutativeMonoid
 import cats.laws.discipline.UnorderedFoldableTests
+import cats.syntax.all._
+import org.scalacheck.Arbitrary
 
 sealed abstract class UnorderedFoldableSuite[F[_]](name: String)(implicit ArbFString: Arbitrary[F[String]],
                                                                  ArbFInt: Arbitrary[F[Int]])

--- a/tests/src/test/scala/cats/tests/UnorderedTraverseSuite.scala
+++ b/tests/src/test/scala/cats/tests/UnorderedTraverseSuite.scala
@@ -1,5 +1,8 @@
-package cats
-package tests
+package cats.tests
+
+import cats.Id
+import cats.instances.all._
+import cats.syntax.all._
 
 class UnorderedTraverseSuite extends CatsSuite {
   test("UnorderedTraverse[Set[Int]].unorderedTraverse via syntax") {

--- a/tests/src/test/scala/cats/tests/UnorderedTraverseSuite.scala
+++ b/tests/src/test/scala/cats/tests/UnorderedTraverseSuite.scala
@@ -2,7 +2,7 @@ package cats.tests
 
 import cats.Id
 import cats.instances.all._
-import cats.syntax.all._
+import cats.syntax.unorderedTraverse._
 
 class UnorderedTraverseSuite extends CatsSuite {
   test("UnorderedTraverse[Set[Int]].unorderedTraverse via syntax") {

--- a/tests/src/test/scala/cats/tests/ValidatedSuite.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedSuite.scala
@@ -20,7 +20,9 @@ import cats.laws.discipline._
 import cats.laws.discipline.SemigroupKTests
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.apply._
+import cats.syntax.either._
+import cats.syntax.validated._
 import org.scalacheck.Arbitrary._
 import scala.util.Try
 

--- a/tests/src/test/scala/cats/tests/ValidatedSuite.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedSuite.scala
@@ -1,15 +1,27 @@
-package cats
-package tests
+package cats.tests
 
-import cats.data._
+import cats.{
+  Align,
+  Applicative,
+  ApplicativeError,
+  Bitraverse,
+  CommutativeApplicative,
+  SemigroupK,
+  Semigroupal,
+  Show,
+  Traverse
+}
+import cats.data.{EitherT, Ior, NonEmptyChain, NonEmptyList, Validated, ValidatedNel}
 import cats.data.Validated.{Invalid, Valid}
+import cats.instances.all._
+import cats.kernel.{Eq, Order, PartialOrder, Semigroup}
+import cats.kernel.laws.discipline.{EqTests, MonoidTests, OrderTests, PartialOrderTests, SemigroupTests}
 import cats.laws.discipline._
-import org.scalacheck.Arbitrary._
 import cats.laws.discipline.SemigroupKTests
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline.arbitrary._
-import cats.kernel.laws.discipline.{EqTests, MonoidTests, OrderTests, PartialOrderTests, SemigroupTests}
-
+import cats.syntax.all._
+import org.scalacheck.Arbitrary._
 import scala.util.Try
 
 class ValidatedSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/VectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/VectorSuite.scala
@@ -1,7 +1,8 @@
-package cats
-package tests
+package cats.tests
 
+import cats.{Align, Alternative, CoflatMap, Monad, Semigroupal, Traverse, TraverseFilter}
 import cats.data.{NonEmptyVector, ZipVector}
+import cats.instances.all._
 import cats.laws.discipline.{
   AlignTests,
   AlternativeTests,
@@ -14,6 +15,7 @@ import cats.laws.discipline.{
   TraverseTests
 }
 import cats.laws.discipline.arbitrary._
+import cats.syntax.all._
 import org.scalatest.funsuite.AnyFunSuiteLike
 
 class VectorSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/VectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/VectorSuite.scala
@@ -15,7 +15,8 @@ import cats.laws.discipline.{
   TraverseTests
 }
 import cats.laws.discipline.arbitrary._
-import cats.syntax.all._
+import cats.syntax.show._
+import cats.syntax.vector._
 import org.scalatest.funsuite.AnyFunSuiteLike
 
 class VectorSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/WordCountSuite.scala
+++ b/tests/src/test/scala/cats/tests/WordCountSuite.scala
@@ -1,8 +1,8 @@
-package cats
-package tests
+package cats.tests
 
-import cats.data.{AppFunc, Const, Func}
-import Func.appFunc
+import cats.data.{AppFunc, Const}
+import cats.data.Func.appFunc
+import cats.instances.all._
 
 /*
  * This an example of applicative function composition.

--- a/tests/src/test/scala/cats/tests/WriterSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterSuite.scala
@@ -1,7 +1,8 @@
-package cats
-package tests
+package cats.tests
 
 import cats.data.Writer
+import cats.instances.all._
+import cats.syntax.all._
 
 class WriterSuite extends CatsSuite {
   test("pure syntax creates a writer with an empty log") {

--- a/tests/src/test/scala/cats/tests/WriterSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterSuite.scala
@@ -2,7 +2,8 @@ package cats.tests
 
 import cats.data.Writer
 import cats.instances.all._
-import cats.syntax.all._
+import cats.syntax.applicative._
+import cats.syntax.writer._
 
 class WriterSuite extends CatsSuite {
   test("pure syntax creates a writer with an empty log") {

--- a/tests/src/test/scala/cats/tests/WriterTSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterTSuite.scala
@@ -1,13 +1,14 @@
-package cats
-package tests
+package cats.tests
 
+import cats._
 import cats.data.{Const, EitherT, Validated, Writer, WriterT}
-import cats.kernel.Semigroup
+import cats.instances.all._
+import cats.kernel.laws.discipline.{EqTests, MonoidTests, SemigroupTests}
 import cats.laws.discipline._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
-import cats.laws.discipline.SemigroupalTests.Isomorphisms
-import cats.kernel.laws.discipline.{EqTests, MonoidTests, SemigroupTests}
+import cats.syntax.all._
 
 class WriterTSuite extends CatsSuite {
   type Logged[A] = Writer[ListWrapper[Int], A]

--- a/tests/src/test/scala/cats/tests/WriterTSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterTSuite.scala
@@ -8,7 +8,7 @@ import cats.laws.discipline._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
-import cats.syntax.all._
+import cats.syntax.option._
 
 class WriterTSuite extends CatsSuite {
   type Logged[A] = Writer[ListWrapper[Int], A]


### PR DESCRIPTION
This PR does several things to clean up the Cats tests (the first addresses #3262):

1. Uses imports instead of inheritance to bring instances and syntax into scope.
2. Uses imports instead of nested packaging to bring definitions in `cats` / `alleycats` into scope.
3. Sorts imports consistently.
4. Fixes a few minor packaging inconsistencies (like some of the cats-free tests being in `cats.tests` and others in `cats.free`).

The issue is that the tests are currently set up in a way that saves a few imports, but at the expense of not exercising normal library usage (see #3262 for an example of this causing problems).

After this change the tests do a better job of reflecting what users actually do (e.g. they don't nest stuff inside `package cats` and they don't extend a giant stack of 14 `AllInstancesBinCompatX` traits).

## Compile times

Speeding up test compilation was a non-goal for this change, but I was curious and it seems a little faster (consistently 76s vs. 82s for `testsJVM/test:compile` after `testsJVM/test:clean` on 2.12 on my desktop).

## ~The WIP part~

Update: the `catsSyntaxEq` "override" did work just fine, even after switching to imports, but I went ahead and changed to more granular imports for `cats.syntax` anyway, since trying it out turned up two existing bugs (fixed separately in #3305 and #3306). I don't see any point in switching to granular imports for `cats.instances` since these will probably be gone entirely very soon.

~I'm opening this so I don't lose track of it, but I still want to make sure the change doesn't cause problems with respect to the `===` situation (previously we were overriding `catsSyntaxEq` to make it non-explicit, and now might need to change all of the `cats.syntax.all` imports to exclude it instead).~

There's also one test class (`AlgebraInvariantSuite`) where some function instances needed in the tests weren't resolving correctly when I switched to imports, so I'm still using the instance traits there. I'll try to take a closer look at it, but I think it's something specific to `cats.laws.discipline.eq` and I'm not too worried about it.