### PR TITLE
Add cats.syntax.hash

### DIFF
--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -31,6 +31,7 @@ package object syntax {
   object functor extends FunctorSyntax
   object functorFilter extends FunctorFilterSyntax
   object group extends GroupSyntax
+  object hash extends HashSyntax
   object invariant extends InvariantSyntax
   object ior extends IorSyntax
   object list extends ListSyntax with ListSyntaxBinCompat0


### PR DESCRIPTION
This seems to have been an oversight. We're not really testing these at the moment, but #3304 will help with that (it's why I noticed this was missing).
