### PR TITLE
Make cats.syntax.flatMap include untilDefinedM

### DIFF
--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -26,7 +26,7 @@ package object syntax {
   object contravariantMonoidal extends ContravariantMonoidalSyntax
   object either extends EitherSyntax with EitherSyntaxBinCompat0
   object eq extends EqSyntax
-  object flatMap extends FlatMapSyntax
+  object flatMap extends FlatMapSyntax with FlatMapOptionSyntax
   object foldable extends FoldableSyntax with FoldableSyntaxBinCompat0 with FoldableSyntaxBinCompat1
   object functor extends FunctorSyntax
   object functorFilter extends FunctorFilterSyntax


### PR DESCRIPTION
`untilDefinedM` is a method on `FlatMap` and should be available via `cats.syntax.flatMap`, but it's not:

```scala
scala> import cats.instances.list._, cats.syntax.flatMap._
import cats.instances.list._
import cats.syntax.flatMap._

scala> List(Option(1)).untilDefinedM
<console>:18: error: value untilDefinedM is not a member of List[Option[Int]]
       List(Option(1)).untilDefinedM
                       ^
```
It is in `all`:
```scala
scala> import cats.instances.list._, cats.syntax.all._
import cats.instances.list._
import cats.syntax.all._

scala> List(Option(1)).untilDefinedM
res0: List[Int] = List(1)
```
This change just fixes this oversight. Like #3305 it's not currently tested, but will be in #3304.