### PR TITLE
Clean up some NonEmpty stuff

### DIFF
--- a/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
+++ b/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
@@ -219,7 +219,14 @@ class NonEmptyLazyListOps[A](private val value: NonEmptyLazyList[A]) extends Any
    * Finds the first element of this `NonEmptyLazyList` for which the given partial
    * function is defined, and applies the partial function to it.
    */
-  final def collectLazyList[B](pf: PartialFunction[A, B]): Option[B] = toLazyList.collectFirst(pf)
+  @deprecated("Use collectFirst", "2.2.0-M1")
+  final def collectLazyList[B](pf: PartialFunction[A, B]): Option[B] = collectFirst(pf)
+
+  /**
+   * Finds the first element of this `NonEmptyLazyList` for which the given partial
+   * function is defined, and applies the partial function to it.
+   */
+  final def collectFirst[B](pf: PartialFunction[A, B]): Option[B] = toLazyList.collectFirst(pf)
 
   /**
    * Filters all elements of this NonEmptyLazyList that do not satisfy the given predicate.

--- a/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
+++ b/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
@@ -54,7 +54,9 @@ object NonEmptyLazyList extends NonEmptyLazyListInstances {
     new NonEmptyLazyListOps(value)
 }
 
-class NonEmptyLazyListOps[A](private val value: NonEmptyLazyList[A]) extends AnyVal {
+class NonEmptyLazyListOps[A](private val value: NonEmptyLazyList[A])
+    extends AnyVal
+    with NonEmptyCollection[A, LazyList, NonEmptyLazyList] {
 
   /**
    * Converts this NonEmptyLazyList to a `LazyList`

--- a/core/src/main/scala/cats/data/NonEmptyChain.scala
+++ b/core/src/main/scala/cats/data/NonEmptyChain.scala
@@ -53,7 +53,9 @@ private[data] object NonEmptyChainImpl extends NonEmptyChainInstances with Scala
     new NonEmptyChainOps(value)
 }
 
-class NonEmptyChainOps[A](private val value: NonEmptyChain[A]) extends AnyVal {
+class NonEmptyChainOps[A](private val value: NonEmptyChain[A])
+    extends AnyVal
+    with NonEmptyCollection[A, Chain, NonEmptyChain] {
 
   /**
    * Converts this chain to a `Chain`

--- a/core/src/main/scala/cats/data/NonEmptyCollection.scala
+++ b/core/src/main/scala/cats/data/NonEmptyCollection.scala
@@ -1,0 +1,40 @@
+package cats.data
+
+import cats.Show
+import cats.kernel.{Order, Semigroup}
+
+private[cats] trait NonEmptyCollection[+A, U[+_], NE[+_]] extends Any {
+  def head: A
+  def tail: U[A]
+  def last: A
+  def init: U[A]
+
+  def iterator: Iterator[A]
+
+  def map[B](f: A => B): NE[B]
+  def reverse: NE[A]
+  def prepend[AA >: A](a: AA): NE[AA]
+  def append[AA >: A](a: AA): NE[AA]
+
+  def filter(f: A => Boolean): U[A]
+  def filterNot(p: A => Boolean): U[A]
+  def collect[B](pf: PartialFunction[A, B]): U[B]
+  def find(p: A => Boolean): Option[A]
+  def exists(p: A => Boolean): Boolean
+  def forall(p: A => Boolean): Boolean
+
+  def foldLeft[B](b: B)(f: (B, A) => B): B
+  def reduce[AA >: A](implicit S: Semigroup[AA]): AA
+
+  def zipWith[B, C](b: NE[B])(f: (A, B) => C): NE[C]
+  def zipWithIndex: NE[(A, Int)]
+
+  def distinct[AA >: A](implicit O: Order[AA]): NE[AA]
+  def sortBy[B](f: A => B)(implicit B: Order[B]): NE[A]
+  def sorted[AA >: A](implicit AA: Order[AA]): NE[AA]
+  def groupByNem[B](f: A => B)(implicit B: Order[B]): NonEmptyMap[B, NE[A]]
+  def toNem[T, V](implicit ev: A <:< (T, V), order: Order[T]): NonEmptyMap[T, V]
+  def toNes[B >: A](implicit order: Order[B]): NonEmptySet[B]
+
+  def show[AA >: A](implicit AA: Show[AA]): String
+}

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -13,7 +13,7 @@ import scala.collection.mutable.ListBuffer
  * A data type which represents a non empty list of A, with
  * single element (head) and optional structure (tail).
  */
-final case class NonEmptyList[+A](head: A, tail: List[A]) {
+final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollection[A, List, NonEmptyList] {
 
   /**
    * Return the head and tail into a single list

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -55,6 +55,8 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) {
     case t   => head :: t.init
   }
 
+  final def iterator: Iterator[A] = toList.iterator
+
   /**
    * The size of this NonEmptyList
    *

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -16,7 +16,9 @@ import kernel.compat.scalaVersionSpecific._
  * `NonEmptyVector`. However, due to https://issues.scala-lang.org/browse/SI-6601, on
  * Scala 2.10, this may be bypassed due to a compiler bug.
  */
-final class NonEmptyVector[+A] private (val toVector: Vector[A]) extends AnyVal {
+final class NonEmptyVector[+A] private (val toVector: Vector[A])
+    extends AnyVal
+    with NonEmptyCollection[A, Vector, NonEmptyVector] {
 
   /** Gets the element at the index, if it exists */
   def get(i: Int): Option[A] =

--- a/tests/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
@@ -101,6 +101,12 @@ class NonEmptyLazyListSuite extends CatsSuite {
     Either.catchNonFatal(NonEmptyLazyList.fromLazyListUnsafe(LazyList.empty[Int])).isLeft should ===(true)
   }
 
+  test("fromLazyListAppend is consistent with LazyList#:+") {
+    forAll { (lli: LazyList[Int], i: Int) =>
+      NonEmptyLazyList.fromLazyListAppend(lli, i).toLazyList should ===(lli :+ i)
+    }
+  }
+
   test("fromSeq . toList . iterator is id") {
     forAll { (ci: NonEmptyLazyList[Int]) =>
       NonEmptyLazyList.fromSeq(ci.iterator.toList) should ===(Option(ci))

--- a/tests/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
@@ -1,12 +1,14 @@
 package cats
 package tests
 
-import cats.data.NonEmptyLazyList
+import cats.data.{NonEmptyLazyList, NonEmptyLazyListOps}
 import cats.kernel.laws.discipline.{EqTests, HashTests, OrderTests, PartialOrderTests, SemigroupTests}
 import cats.laws.discipline.{AlignTests, BimonadTests, NonEmptyTraverseTests, SemigroupKTests, SerializableTests}
 import cats.laws.discipline.arbitrary._
 
-class NonEmptyLazyListSuite extends CatsSuite {
+class NonEmptyLazyListSuite extends NonEmptyCollectionSuite[LazyList, NonEmptyLazyList, NonEmptyLazyListOps] {
+  def toList[A](value: NonEmptyLazyList[A]): List[A] = value.toList
+  def underlyingToList[A](underlying: LazyList[A]): List[A] = underlying.toList
 
   checkAll("NonEmptyLazyList[Int]", SemigroupTests[NonEmptyLazyList[Int]].semigroup)
   checkAll(s"Semigroup[NonEmptyLazyList]", SerializableTests.serializable(Semigroup[NonEmptyLazyList[Int]]))

--- a/tests/src/test/scala/cats/tests/ChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/ChainSuite.scala
@@ -161,6 +161,24 @@ class ChainSuite extends CatsSuite {
     }
   }
 
+  test("zipWithIndex is consistent with toList.zipWithIndex") {
+    forAll { (ci: Chain[Int]) =>
+      ci.zipWithIndex.toList should ===(ci.toList.zipWithIndex)
+    }
+  }
+
+  test("sortBy is consistent with toList.sortBy") {
+    forAll { (ci: Chain[Int], f: Int => String) =>
+      ci.sortBy(f).toList should ===(ci.toList.sortBy(f))
+    }
+  }
+
+  test("sorted is consistent with toList.sorted") {
+    forAll { (ci: Chain[Int]) =>
+      ci.sorted.toList should ===(ci.toList.sorted)
+    }
+  }
+
   test("reverse . reverse is id") {
     forAll { (ci: Chain[Int]) =>
       ci.reverse.reverse should ===(ci)

--- a/tests/src/test/scala/cats/tests/NonEmptyChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyChainSuite.scala
@@ -1,12 +1,15 @@
 package cats
 package tests
 
-import cats.data.{Chain, NonEmptyChain}
+import cats.data.{Chain, NonEmptyChain, NonEmptyChainOps}
 import cats.kernel.laws.discipline.{EqTests, OrderTests, PartialOrderTests, SemigroupTests}
 import cats.laws.discipline.{AlignTests, BimonadTests, NonEmptyTraverseTests, SemigroupKTests, SerializableTests}
 import cats.laws.discipline.arbitrary._
 
-class NonEmptyChainSuite extends CatsSuite {
+class NonEmptyChainSuite extends NonEmptyCollectionSuite[Chain, NonEmptyChain, NonEmptyChainOps] {
+  def toList[A](value: NonEmptyChain[A]): List[A] = value.toChain.toList
+  def underlyingToList[A](underlying: Chain[A]): List[A] = underlying.toList
+
   checkAll("NonEmptyChain[Int]", SemigroupKTests[NonEmptyChain].semigroupK[Int])
   checkAll("SemigroupK[NonEmptyChain]", SerializableTests.serializable(SemigroupK[NonEmptyChain]))
 

--- a/tests/src/test/scala/cats/tests/NonEmptyCollectionSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyCollectionSuite.scala
@@ -1,0 +1,158 @@
+package cats.tests
+
+import cats.data.NonEmptyCollection
+import org.scalacheck.Arbitrary
+
+abstract class NonEmptyCollectionSuite[U[+_], NE[+_], NEC[x] <: NonEmptyCollection[x, U, NE]](
+  implicit arbitraryU: Arbitrary[U[Int]],
+  arbitraryNE: Arbitrary[NE[Int]],
+  ev: NE[Int] => NEC[Int],
+  evPair: NE[(Int, Int)] => NEC[(Int, Int)]
+) extends CatsSuite {
+  def toList[A](value: NE[A]): List[A]
+  def underlyingToList[A](underlying: U[A]): List[A]
+
+  test("head is consistent with iterator.toList.head") {
+    forAll { (is: NE[Int]) =>
+      is.head should ===(is.iterator.toList.head)
+    }
+  }
+
+  test("tail is consistent with iterator.toList.tail") {
+    forAll { (is: NE[Int]) =>
+      underlyingToList(is.tail) should ===(is.iterator.toList.tail)
+    }
+  }
+
+  test("last is consistent with iterator.toList.last") {
+    forAll { (is: NE[Int]) =>
+      is.last should ===(is.iterator.toList.last)
+    }
+  }
+
+  test("init is consistent with iterator.toList.init") {
+    forAll { (is: NE[Int]) =>
+      underlyingToList(is.init) should ===(is.iterator.toList.init)
+    }
+  }
+
+  test("map is consistent with iterator.toList.map") {
+    forAll { (is: NE[Int], f: Int => String) =>
+      toList(is.map(f)) should ===(is.iterator.toList.map(f))
+    }
+  }
+
+  test("reverse is consistent with iterator.toList.reverse") {
+    forAll { (is: NE[Int]) =>
+      toList(is.reverse) should ===(is.iterator.toList.reverse)
+    }
+  }
+
+  test("prepend is consistent with iterator.toList.::") {
+    forAll { (is: NE[Int], i: Int) =>
+      toList(is.prepend(i)) should ===(i :: is.iterator.toList)
+    }
+  }
+
+  test("append is consistent with iterator.toList.::") {
+    forAll { (is: NE[Int], i: Int) =>
+      toList(is.append(i)) should ===(is.iterator.toList :+ i)
+    }
+  }
+
+  test("filter is consistent with iterator.toList.filter") {
+    forAll { (is: NE[Int], pred: Int => Boolean) =>
+      underlyingToList(is.filter(pred)) should ===(is.iterator.toList.filter(pred))
+    }
+  }
+
+  test("filterNot is consistent with iterator.toList.filterNot") {
+    forAll { (is: NE[Int], pred: Int => Boolean) =>
+      underlyingToList(is.filterNot(pred)) should ===(is.iterator.toList.filterNot(pred))
+    }
+  }
+
+  test("collect is consistent with iterator.toList.collect") {
+    forAll { (is: NE[Int], pf: PartialFunction[Int, String]) =>
+      underlyingToList(is.collect(pf)) should ===(is.iterator.toList.collect(pf))
+    }
+  }
+
+  test("find is consistent with iterator.toList.find") {
+    forAll { (is: NE[Int], pred: Int => Boolean) =>
+      is.find(pred) should ===(is.iterator.toList.find(pred))
+    }
+  }
+
+  test("exists is consistent with iterator.toList.exists") {
+    forAll { (is: NE[Int], pred: Int => Boolean) =>
+      is.exists(pred) should ===(is.iterator.toList.exists(pred))
+    }
+  }
+
+  test("forall is consistent with iterator.toList.forall") {
+    forAll { (is: NE[Int], pred: Int => Boolean) =>
+      is.forall(pred) should ===(is.iterator.toList.forall(pred))
+    }
+  }
+
+  test("foldLeft is consistent with iterator.toList.foldLeft") {
+    forAll { (is: NE[Int], b: String, f: (String, Int) => String) =>
+      is.foldLeft(b)(f) should ===(is.iterator.toList.foldLeft(b)(f))
+    }
+  }
+
+  test("reduce is consistent with iterator.toList.sum") {
+    forAll { (is: NE[Int]) =>
+      is.reduce should ===(is.iterator.toList.sum)
+    }
+  }
+
+  test("zipWith is consistent with iterator.toList.zip") {
+    forAll { (is: NE[Int], other: NE[Int], f: (Int, Int) => String) =>
+      toList(is.zipWith(other)(f)) should ===(is.iterator.toList.zip(other.iterator.toList).map(Function.tupled(f)))
+    }
+  }
+
+  test("zipWithIndex is consistent with iterator.toList.zipWithIndex") {
+    forAll { (is: NE[Int]) =>
+      toList(is.zipWithIndex) should ===(is.iterator.toList.zipWithIndex)
+    }
+  }
+
+  test("distinct is consistent with iterator.toList.distinct") {
+    forAll { (is: NE[Int]) =>
+      toList(is.distinct) should ===(is.iterator.toList.distinct)
+    }
+  }
+
+  test("sortBy is consistent with iterator.toList.sortBy") {
+    forAll { (is: NE[Int], f: Int => String) =>
+      toList(is.sortBy(f)) should ===(is.iterator.toList.sortBy(f))
+    }
+  }
+
+  test("sorted is consistent with iterator.toList.sorted") {
+    forAll { (is: NE[Int]) =>
+      toList(is.sorted) should ===(is.iterator.toList.sorted)
+    }
+  }
+
+  test("groupByNem is consistent with iterator.toList.groupBy") {
+    forAll { (is: NE[Int], f: Int => String) =>
+      is.groupByNem(f).toSortedMap.map { case (k, v) => (k, toList(v)) } should ===(is.iterator.toList.groupBy(f))
+    }
+  }
+
+  test("toNem is consistent with iterator.toMap") {
+    forAll { (is: NE[Int]) =>
+      is.zipWithIndex.toNem.toSortedMap should ===(is.zipWithIndex.iterator.toMap)
+    }
+  }
+
+  test("toNes is consistent with iterator.toSet") {
+    forAll { (is: NE[Int]) =>
+      is.toNes.toSortedSet should ===(is.iterator.toSet)
+    }
+  }
+}

--- a/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
@@ -18,7 +18,10 @@ import cats.laws.discipline.{
 import scala.collection.immutable.SortedMap
 import scala.collection.immutable.SortedSet
 
-class NonEmptyListSuite extends CatsSuite {
+class NonEmptyListSuite extends NonEmptyCollectionSuite[List, NonEmptyList, NonEmptyList] {
+  def toList[A](value: NonEmptyList[A]): List[A] = value.toList
+  def underlyingToList[A](underlying: List[A]): List[A] = underlying
+
   // Lots of collections here.. telling ScalaCheck to calm down a bit
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = 20, sizeRange = 5)

--- a/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
@@ -21,7 +21,10 @@ import cats.platform.Platform
 
 import scala.util.Properties
 
-class NonEmptyVectorSuite extends CatsSuite {
+class NonEmptyVectorSuite extends NonEmptyCollectionSuite[Vector, NonEmptyVector, NonEmptyVector] {
+  def toList[A](value: NonEmptyVector[A]): List[A] = value.toList
+  def underlyingToList[A](underlying: Vector[A]): List[A] = underlying.toList
+
   // Lots of collections here.. telling ScalaCheck to calm down a bit
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =
     PropertyCheckConfiguration(minSuccessful = 20, sizeRange = 5)


### PR DESCRIPTION
Unfortunately `cats.data` is kind of a disaster, in part because all of the `NonEmptyX` types are unrelated and don't implement any particular interface. This means that not only do we have four different ways to encode non-empty collections, each of our implementations has a fairly arbitrary grab-bag of methods attached to it.

This PR adds several "missing" methods:

* New for `Chain`: `sortBy`, `sorted`, `zipWithIndex`.
* New for `NonEmptyChain`: `sortBy`, `sorted`, `zipWithIndex`, `groupByNem`, `toNem`, `toNes`, `show`.
* New for `NonEmptyLazyList`:  `sortBy`, `sorted`, `groupBy`, `groupByNem`, `toNem`, `toNes`, `show`.
* New for `NonEmptyList`: `iterator`.
* New for `NonEmptyVector`: `iterator`, `groupBy`, `groupByNem`, `toNem`, `toNes`.


This PR also introduces a new `NonEmptyCollection` interface that is implemented by `NonEmptyChain`, `NonEmptyLazyList`, `NonEmptyList`, and `NonEmptyVector`. It's roughly a union of the methods of these types, and the additions above were what was necessary to fill out these implementations. It's implemented as a universal trait, and does not interfere with value classes.

It's worth noting that `NonEmptyCollection` is not part of the public Cats API. The goal is to help us maintain consistency (and as a side effect to make testing easier), not to provide a user-facing abstraction. The user only sees a more consistent set of methods across these types.

I've also fixed one misnamed method on `NonEmptyLazyList`: `collectLazyList` (now deprecated) is clearly a typo for `collectFirst`.

It's worth noting that some methods that should be on `NonEmptyCollection` can't be, because of mistakes that we've made in the past. For example, `NonEmptyChain` has a `groupBy` that returns a `NonEmptyMap`, while the other `NonEmptyX` collections call that method `groupByNem` and have `groupBy` return a `SortedSet`. Also `Chain` has `length` and `size` methods that return a `Long` (?), while `NonEmptyChain` has a `Long`-returning `length`, but no `size` (??), while the other `NonEmptyX` collections have a `length` that returns an `Int` (and some of them have a `size: Int`). I can't wait for `cats.data` to be banished to its own module in Cats 3.
