### PR TITLE
Introduce reduceOption for UnorderedFoldable and minimum/maximum(By)Option 

### DIFF
--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -183,7 +183,7 @@ import Foldable.sentinel
    *
    * @see [[maximumOption]] for maximum instead of minimum.
    */
-  def minimumOption[A](fa: F[A])(implicit A: Order[A]): Option[A] =
+  override def minimumOption[A](fa: F[A])(implicit A: Order[A]): Option[A] =
     reduceLeftOption(fa)(A.min)
 
   /**
@@ -197,7 +197,7 @@ import Foldable.sentinel
    *
    * @see [[minimumOption]] for minimum instead of maximum.
    */
-  def maximumOption[A](fa: F[A])(implicit A: Order[A]): Option[A] =
+  override def maximumOption[A](fa: F[A])(implicit A: Order[A]): Option[A] =
     reduceLeftOption(fa)(A.max)
 
   /**
@@ -211,7 +211,7 @@ import Foldable.sentinel
    *
    * @see [[maximumByOption]] for maximum instead of minimum.
    */
-  def minimumByOption[A, B: Order](fa: F[A])(f: A => B): Option[A] =
+  override def minimumByOption[A, B: Order](fa: F[A])(f: A => B): Option[A] =
     minimumOption(fa)(Order.by(f))
 
   /**
@@ -225,7 +225,7 @@ import Foldable.sentinel
    *
    * @see [[minimumByOption]] for minimum instead of maximum.
    */
-  def maximumByOption[A, B: Order](fa: F[A])(f: A => B): Option[A] =
+  override def maximumByOption[A, B: Order](fa: F[A])(f: A => B): Option[A] =
     maximumOption(fa)(Order.by(f))
 
   /**

--- a/core/src/main/scala/cats/UnorderedFoldable.scala
+++ b/core/src/main/scala/cats/UnorderedFoldable.scala
@@ -73,6 +73,50 @@ import simulacrum.{noop, typeclass}
   @noop
   def count[A](fa: F[A])(p: A => Boolean): Long =
     unorderedFoldMap(fa)(a => if (p(a)) 1L else 0L)
+
+  /**
+   * Find the minimum `A` item in this structure according to the `Order[A]`.
+   *
+   * @return `None` if the structure is empty, otherwise the minimum element
+   * wrapped in a `Some`.
+   *
+   * @see [[maximumOption]] for maximum instead of minimum.
+   */
+  def minimumOption[A: Order](fa: F[A]): Option[A] =
+    unorderedReduceOption(fa)(UnorderedFoldable.minCommutativeSemigroup)
+
+  /**
+   * Find the maximum `A` item in this structure according to the `Order[A]`.
+   *
+   * @return `None` if the structure is empty, otherwise the maximum element
+   * wrapped in a `Some`.
+   *
+   * @see [[minimumOption]] for minimum instead of maximum.
+   */
+  def maximumOption[A: Order](fa: F[A]): Option[A] =
+    unorderedReduceOption(fa)(UnorderedFoldable.maxCommutativeSemigroup)
+
+  /**
+   * Find the minimum `A` item in this structure according to an `Order.by(f)`.
+   *
+   * @return `None` if the structure is empty, otherwise the minimum element
+   * wrapped in a `Some`.
+   *
+   * @see [[maximumByOption]] for maximum instead of minimum.
+   */
+  def minimumByOption[A, B: Order](fa: F[A])(f: A => B): Option[A] =
+    minimumOption(fa)(Order.by(f))
+
+  /**
+   * Find the maximum `A` item in this structure according to an `Order.by(f)`.
+   *
+   * @return `None` if the structure is empty, otherwise the maximum element
+   * wrapped in a `Some`.
+   *
+   * @see [[minimumByOption]] for minimum instead of maximum.
+   */
+  def maximumByOption[A, B: Order](fa: F[A])(f: A => B): Option[A] =
+    maximumOption(fa)(Order.by(f))
 }
 
 object UnorderedFoldable {
@@ -94,5 +138,13 @@ object UnorderedFoldable {
         case true  => ly
         case false => Eval.False
       }
+  }
+
+  private def minCommutativeSemigroup[A: Order]: CommutativeSemigroup[A] = new CommutativeSemigroup[A] {
+    override def combine(x: A, y: A): A = Order.min(x, y)
+  }
+
+  private def maxCommutativeSemigroup[A: Order]: CommutativeSemigroup[A] = new CommutativeSemigroup[A] {
+    override def combine(x: A, y: A): A = Order.max(x, y)
   }
 }

--- a/core/src/main/scala/cats/UnorderedFoldable.scala
+++ b/core/src/main/scala/cats/UnorderedFoldable.scala
@@ -1,7 +1,8 @@
 package cats
 
 import cats.instances.long._
-import cats.kernel.CommutativeMonoid
+import cats.kernel.{CommutativeMonoid, CommutativeSemigroup}
+import cats.syntax.option._
 import simulacrum.{noop, typeclass}
 
 /**
@@ -13,6 +14,9 @@ import simulacrum.{noop, typeclass}
 
   def unorderedFold[A: CommutativeMonoid](fa: F[A]): A =
     unorderedFoldMap(fa)(identity)
+
+  def unorderedReduceOption[A](fa: F[A])(implicit A: CommutativeSemigroup[A]): Option[A] =
+    unorderedFoldMap(fa)(_.some)(cats.instances.option.catsKernelStdCommutativeMonoidForOption(A))
 
   /**
    * Returns true if there are no elements. Otherwise false.

--- a/laws/src/main/scala/cats/laws/UnorderedFoldableLaws.scala
+++ b/laws/src/main/scala/cats/laws/UnorderedFoldableLaws.scala
@@ -9,6 +9,9 @@ trait UnorderedFoldableLaws[F[_]] {
   def unorderedFoldConsistentWithUnorderedFoldMap[A: CommutativeMonoid](fa: F[A]): IsEq[A] =
     F.unorderedFoldMap(fa)(identity) <-> F.unorderedFold(fa)
 
+  def unorderedReduceOptionConsistentWithUnorderedFold[A: CommutativeMonoid](fa: F[A]): IsEq[Option[A]] =
+    F.unorderedReduceOption(fa) <-> (if (F.isEmpty(fa)) None else Some(F.unorderedFold(fa)))
+
   def forallConsistentWithExists[A](fa: F[A], p: A => Boolean): Boolean =
     if (F.forall(fa)(p)) {
       val negationExists = F.exists(fa)(a => !(p(a)))

--- a/laws/src/main/scala/cats/laws/discipline/UnorderedFoldableTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/UnorderedFoldableTests.scala
@@ -18,11 +18,15 @@ trait UnorderedFoldableTests[F[_]] extends Laws {
                                                     A: CommutativeMonoid[A],
                                                     B: CommutativeMonoid[B],
                                                     EqFA: Eq[A],
-                                                    EqFB: Eq[B]): RuleSet =
+                                                    EqFB: Eq[B],
+                                                    EqOptionA: Eq[Option[A]]): RuleSet =
     new DefaultRuleSet(
       name = "unorderedFoldable",
       parent = None,
       "unorderedFold consistent with unorderedFoldMap" -> forAll(laws.unorderedFoldConsistentWithUnorderedFoldMap[A] _),
+      "unorderedReduceOption consistent with unorderedFold" -> forAll(
+        laws.unorderedReduceOptionConsistentWithUnorderedFold[A] _
+      ),
       "forall consistent with exists" -> forAll(laws.forallConsistentWithExists[A] _),
       "forall true if empty" -> forAll(laws.forallEmpty[A] _),
       "nonEmpty reference" -> forAll(laws.nonEmptyRef[A] _),

--- a/laws/src/main/scala/cats/laws/discipline/UnorderedTraverseTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/UnorderedTraverseTests.scala
@@ -23,7 +23,8 @@ trait UnorderedTraverseTests[F[_]] extends UnorderedFoldableTests[F] {
     EqB: Eq[B],
     EqXYFC: Eq[X[Y[F[C]]]],
     EqXFB: Eq[X[F[B]]],
-    EqYFB: Eq[Y[F[B]]]
+    EqYFB: Eq[Y[F[B]]],
+    EqOptionA: Eq[Option[A]]
   ): RuleSet = {
     implicit def EqXFBYFB: Eq[(X[F[B]], Y[F[B]])] = new Eq[(X[F[B]], Y[F[B]])] {
       override def eqv(x: (X[F[B]], Y[F[B]]), y: (X[F[B]], Y[F[B]])): Boolean =


### PR DESCRIPTION
This PR first introduces the following methods for `UnorderedFoldable`,

*  `unorderedReduceOption`. By lifting a `CommutativeSemigroup[A]` into a `CommutativeMonoid[Option[A]]` in the standard way. 

* `minimumOption`, `maximumOption`, `minimumByOption`, `maximumByOption`. Via `unorderedReduceOption` by defining the appropriate semigroups for min and max. 

It also includes a law to test the consistency between `unorderedReduceOption` and `unorderedFold`.

**Observations:**

The second part of the PR regarding min/max operations is the object of issue https://github.com/typelevel/cats/issues/2715. I've since realised there is another (wip) PR to address it https://github.com/typelevel/cats/pull/3132. I've opted to leave my tentative solution in this PR anyway since it follows a different approach, via `unorderedReduceOption`. This is more in line with the corresponding implementations in `Foldable` via `reduceLeftOption`.

My tentative implementation for the min/max however appears to suffer from the same issues described in https://github.com/typelevel/cats/issues/2715. Namely that the min/max operations in `Foldable` require override, which if I understand correctly affects simulacrum generation of syntax ops. Indeed I could tell syntax wasn't working when I tried it, but don't know much about simulacrum. I could try to fix this but would need some guidance here. 
