### PR TITLE
Update discipline-scalatest

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,11 +19,11 @@ isTravisBuild in Global := sys.env.get("TRAVIS").isDefined
 
 val scalaCheckVersion = "1.14.3"
 
-val scalatestplusScalaCheckVersion = "3.1.1.0"
+val scalatestplusScalaCheckVersion = "3.1.1.1"
 
 val disciplineVersion = "1.0.2"
 
-val disciplineScalatestVersion = "1.0.0"
+val disciplineScalatestVersion = "1.0.1"
 
 val kindProjectorVersion = "0.11.0"
 


### PR DESCRIPTION
Just published discipline-scalatest and Simulacrum for Scala.js 1.0.0, so after this is merged we can backport it and publish Cats 2.1.0 for Scala.js 1.0.0 as well.
