### PR TITLE
Make scala.js 1.0 the default

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,5 +1,5 @@
 val scalaJSVersion =
-  Option(System.getenv("SCALAJS_VERSION")).getOrElse("0.6.32")
+  Option(System.getenv("SCALAJS_VERSION")).getOrElse("1.0.0")
 
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 addSbtPlugin("com.github.gseitz" %% "sbt-release" % "1.0.13")

--- a/scripts/scala.js-1.0-publish.sh
+++ b/scripts/scala.js-1.0-publish.sh
@@ -2,11 +2,11 @@
 
 # For temporary use while cross-publishing for Scala.js 0.6 and 1.0.
 
-SCALAJS_VERSION=1.0.0-RC2 sbt +kernelJS/publishSigned
-SCALAJS_VERSION=1.0.0-RC2 sbt +kernelLawsJS/publishSigned
-SCALAJS_VERSION=1.0.0-RC2 sbt +coreJS/publishSigned
-SCALAJS_VERSION=1.0.0-RC2 sbt +lawsJS/publishSigned
-SCALAJS_VERSION=1.0.0-RC2 sbt +freeJS/publishSigned
-SCALAJS_VERSION=1.0.0-RC2 sbt +testkitJS/publishSigned
-SCALAJS_VERSION=1.0.0-RC2 sbt +alleycatsCoreJS/publishSigned
-SCALAJS_VERSION=1.0.0-RC2 sbt +alleycatsLawsJS/publishSigned
+SCALAJS_VERSION=0.6.32 sbt +kernelJS/publishSigned
+SCALAJS_VERSION=0.6.32 sbt +kernelLawsJS/publishSigned
+SCALAJS_VERSION=0.6.32 sbt +coreJS/publishSigned
+SCALAJS_VERSION=0.6.32 sbt +lawsJS/publishSigned
+SCALAJS_VERSION=0.6.32 sbt +freeJS/publishSigned
+SCALAJS_VERSION=0.6.32 sbt +testkitJS/publishSigned
+SCALAJS_VERSION=0.6.32 sbt +alleycatsCoreJS/publishSigned
+SCALAJS_VERSION=0.6.32 sbt +alleycatsLawsJS/publishSigned


### PR DESCRIPTION
I propose that scala.js becomes the default going forward but you can still publish for 0.6.x