### PR TITLE
Add semiflatTap and leftSemiflatTap functions to EitherT

### DIFF
--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -447,6 +447,12 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
         }
     })
 
+  def semiflatTap[C](f: B => F[C])(implicit F: Monad[F]): EitherT[F, A, B] =
+    semiflatMap(b => Monad[F].as(f(b), b))
+
+  def leftSemiflatTap[C](f: A => F[C])(implicit F: Monad[F]): EitherT[F, A, B] =
+    leftSemiflatMap(a => Monad[F].as(f(a), a))
+
   def compare(that: EitherT[F, A, B])(implicit o: Order[F[Either[A, B]]]): Int =
     o.compare(value, that.value)
 

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -448,10 +448,10 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
     })
 
   def semiflatTap[C](f: B => F[C])(implicit F: Monad[F]): EitherT[F, A, B] =
-    semiflatMap(b => Monad[F].as(f(b), b))
+    semiflatMap(b => F.as(f(b), b))
 
   def leftSemiflatTap[C](f: A => F[C])(implicit F: Monad[F]): EitherT[F, A, B] =
-    leftSemiflatMap(a => Monad[F].as(f(a), a))
+    leftSemiflatMap(a => F.as(f(a), a))
 
   def compare(that: EitherT[F, A, B])(implicit o: Order[F[Either[A, B]]]): Int =
     o.compare(value, that.value)

--- a/tests/src/test/scala/cats/tests/EitherTSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherTSuite.scala
@@ -1,13 +1,12 @@
 package cats
 package tests
 
-import cats.Bifunctor
-import cats.data.EitherT
-
+import cats.data.{EitherT, State}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.kernel.laws.discipline.{EqTests, MonoidTests, OrderTests, PartialOrderTests, SemigroupTests}
+
 import scala.util.{Failure, Success, Try}
 
 class EitherTSuite extends CatsSuite {
@@ -538,6 +537,43 @@ class EitherTSuite extends CatsSuite {
   test("leftSemiflatmap consistent with swap and the semiflatMap") {
     forAll { (eithert: EitherT[List, String, Int], f: String => List[String]) =>
       eithert.leftSemiflatMap(f) should ===(eithert.swap.semiflatMap(a => f(a)).swap)
+    }
+  }
+
+  test("semiflatTap does not change the return value") {
+    type TestEffect[A] = State[List[Int], A]
+    forAll { (eithert: EitherT[TestEffect, String, Int], f: Int => TestEffect[Int], initial: List[Int]) =>
+      eithert.semiflatTap(v => f(v)).value.runA(initial) should ===(eithert.value.runA(initial))
+    }
+  }
+
+  test("semiflatTap runs the effect") {
+    type TestEffect[A] = State[List[Int], A]
+    forAll { (eithert: EitherT[TestEffect, String, Int], f: Int => TestEffect[Int], initial: List[Int]) =>
+      eithert.semiflatTap(v => f(v)).value.runS(initial) should ===(eithert.semiflatMap(f).value.runS(initial))
+    }
+  }
+
+  test("leftSemiflatTap does not change the return value") {
+    type TestEffect[A] = State[List[Int], A]
+    forAll { (eithert: EitherT[TestEffect, String, Int], f: String => TestEffect[Int], initial: List[Int]) =>
+      eithert.leftSemiflatTap(v => f(v)).value.runA(initial) should ===(eithert.value.runA(initial))
+    }
+  }
+
+  test("leftSemiflatTap runs the effect") {
+    type TestEffect[A] = State[List[Int], A]
+    forAll { (eithert: EitherT[TestEffect, String, Int], f: String => TestEffect[Int], initial: List[Int]) =>
+      eithert.leftSemiflatTap(v => f(v)).value.runS(initial) should ===(eithert.leftSemiflatMap(f).value.runS(initial))
+    }
+  }
+
+  test("leftSemiflatTap consistent with swap and the semiflatTap") {
+    type TestEffect[A] = State[List[Int], A]
+    forAll { (eithert: EitherT[TestEffect, String, Int], f: String => TestEffect[Int], initial: List[Int]) =>
+      eithert.leftSemiflatTap(v => f(v)).value.runA(initial) should ===(
+        eithert.swap.semiflatTap(v => f(v)).swap.value.runA(initial)
+      )
     }
   }
 


### PR DESCRIPTION
`semiflatTaps` functions on `EitherT` are highly useful when you have some e.g. `Logger[F]` abstractions and you don't want to lift it to `EitherT[F,A,B]`