### PR TITLE
Scala version 2.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,8 @@ jobs:
     - stage: test
       env: TEST="docs"
       install: gem install jekyll -v 4.0.0
-      script: sbt docs/makeMicrosite
+      script: sbt  docs/makeMicrosite
+      scala: *scala_version_212
 
     - stage: test
       env: TEST="scalafix"

--- a/build.sbt
+++ b/build.sbt
@@ -50,7 +50,7 @@ def scalaVersionSpecificFolders(srcName: String, srcBaseDir: java.io.File, scala
 
 lazy val commonScalaVersionSettings = Seq(
   crossScalaVersions := (crossScalaVersionsFromTravis in Global).value,
-  scalaVersion := crossScalaVersions.value.find(_.contains("2.12")).get
+  scalaVersion := crossScalaVersions.value.find(_.contains("2.13")).get
 )
 
 commonScalaVersionSettings


### PR DESCRIPTION
I've noticed that the project's scala version is still `2.12`. I'm not sure if there's a reason for that. If it's not just an overlook I'm happy to close this PR.

