### PR TITLE
Add parentheses for Dotty

### DIFF
--- a/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTSuite.scala
@@ -329,7 +329,7 @@ class ReaderWriterStateTSuite extends CatsSuite {
   }
 
   test("pure + listen + map(_._1) + runEmptyA is identity") {
-    forAll { i: Int =>
+    forAll { (i: Int) =>
       IndexedReaderWriterStateT
         .pure[Id, String, String, Int, Int](i)
         .listen
@@ -339,7 +339,7 @@ class ReaderWriterStateTSuite extends CatsSuite {
   }
 
   test("tell + listen + map(_._2) + runEmptyA is identity") {
-    forAll { s: String =>
+    forAll { (s: String) =>
       IndexedReaderWriterStateT
         .tell[Id, String, String, Int](s)
         .listen


### PR DESCRIPTION
Trivial change: some missing parentheses slipped in and when I just tried to update the Dotty cross-building it failed here. (I'll be glad when we have Dotty cross-building in CI and don't have to worry about little stuff like this.)