### PR TITLE
Re-encode relationships to avoid implicit conversion functions

### DIFF
--- a/tests/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
@@ -7,8 +7,9 @@ import cats.laws.discipline.{AlignTests, BimonadTests, NonEmptyTraverseTests, Se
 import cats.laws.discipline.arbitrary._
 
 class NonEmptyLazyListSuite extends NonEmptyCollectionSuite[LazyList, NonEmptyLazyList, NonEmptyLazyListOps] {
-  def toList[A](value: NonEmptyLazyList[A]): List[A] = value.toList
-  def underlyingToList[A](underlying: LazyList[A]): List[A] = underlying.toList
+  protected def toList[A](value: NonEmptyLazyList[A]): List[A] = value.toList
+  protected def underlyingToList[A](underlying: LazyList[A]): List[A] = underlying.toList
+  protected def toNonEmptyCollection[A](nea: NonEmptyLazyList[A]): NonEmptyLazyListOps[A] = nea
 
   checkAll("NonEmptyLazyList[Int]", SemigroupTests[NonEmptyLazyList[Int]].semigroup)
   checkAll(s"Semigroup[NonEmptyLazyList]", SerializableTests.serializable(Semigroup[NonEmptyLazyList[Int]]))

--- a/tests/src/test/scala/cats/tests/NonEmptyChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyChainSuite.scala
@@ -7,8 +7,9 @@ import cats.laws.discipline.{AlignTests, BimonadTests, NonEmptyTraverseTests, Se
 import cats.laws.discipline.arbitrary._
 
 class NonEmptyChainSuite extends NonEmptyCollectionSuite[Chain, NonEmptyChain, NonEmptyChainOps] {
-  def toList[A](value: NonEmptyChain[A]): List[A] = value.toChain.toList
-  def underlyingToList[A](underlying: Chain[A]): List[A] = underlying.toList
+  protected def toList[A](value: NonEmptyChain[A]): List[A] = value.toChain.toList
+  protected def underlyingToList[A](underlying: Chain[A]): List[A] = underlying.toList
+  protected def toNonEmptyCollection[A](nea: NonEmptyChain[A]): NonEmptyChainOps[A] = nea
 
   checkAll("NonEmptyChain[Int]", SemigroupKTests[NonEmptyChain].semigroupK[Int])
   checkAll("SemigroupK[NonEmptyChain]", SerializableTests.serializable(SemigroupK[NonEmptyChain]))

--- a/tests/src/test/scala/cats/tests/NonEmptyCollectionSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyCollectionSuite.scala
@@ -5,12 +5,14 @@ import org.scalacheck.Arbitrary
 
 abstract class NonEmptyCollectionSuite[U[+_], NE[+_], NEC[x] <: NonEmptyCollection[x, U, NE]](
   implicit arbitraryU: Arbitrary[U[Int]],
-  arbitraryNE: Arbitrary[NE[Int]],
-  ev: NE[Int] => NEC[Int],
-  evPair: NE[(Int, Int)] => NEC[(Int, Int)]
+  arbitraryNE: Arbitrary[NE[Int]]
 ) extends CatsSuite {
-  def toList[A](value: NE[A]): List[A]
-  def underlyingToList[A](underlying: U[A]): List[A]
+  protected def toList[A](value: NE[A]): List[A]
+  protected def underlyingToList[A](underlying: U[A]): List[A]
+
+  // Necessary because of the non-inheritance-based encoding of some non-empty collections.
+  protected def toNonEmptyCollection[A](nea: NE[A]): NEC[A]
+  implicit private def convertToNonEmptyCollection[A](nea: NE[A]): NEC[A] = toNonEmptyCollection(nea)
 
   test("head is consistent with iterator.toList.head") {
     forAll { (is: NE[Int]) =>

--- a/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
@@ -19,8 +19,9 @@ import scala.collection.immutable.SortedMap
 import scala.collection.immutable.SortedSet
 
 class NonEmptyListSuite extends NonEmptyCollectionSuite[List, NonEmptyList, NonEmptyList] {
-  def toList[A](value: NonEmptyList[A]): List[A] = value.toList
-  def underlyingToList[A](underlying: List[A]): List[A] = underlying
+  protected def toList[A](value: NonEmptyList[A]): List[A] = value.toList
+  protected def underlyingToList[A](underlying: List[A]): List[A] = underlying
+  protected def toNonEmptyCollection[A](nea: NonEmptyList[A]): NonEmptyList[A] = nea
 
   // Lots of collections here.. telling ScalaCheck to calm down a bit
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =

--- a/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
@@ -22,8 +22,9 @@ import cats.platform.Platform
 import scala.util.Properties
 
 class NonEmptyVectorSuite extends NonEmptyCollectionSuite[Vector, NonEmptyVector, NonEmptyVector] {
-  def toList[A](value: NonEmptyVector[A]): List[A] = value.toList
-  def underlyingToList[A](underlying: Vector[A]): List[A] = underlying.toList
+  protected def toList[A](value: NonEmptyVector[A]): List[A] = value.toList
+  protected def underlyingToList[A](underlying: Vector[A]): List[A] = underlying.toList
+  protected def toNonEmptyCollection[A](nea: NonEmptyVector[A]): NonEmptyVector[A] = nea
 
   // Lots of collections here.. telling ScalaCheck to calm down a bit
   implicit override val generatorDrivenConfig: PropertyCheckConfiguration =


### PR DESCRIPTION
This change only affects test code that I added recently, so it should be fairly uncontroversial.

In #3307 I introduced some abstraction for `NonEmptyX` testing, since there were a lot of inconsistencies and gaps not just in the interfaces themselves, but also in their tests.

In that change I encoded the relationship between the non-empty type and the type that has its operations as a couple of implicit parameters:

```scala
  ev: NE[Int] => NEC[Int],
  evPair: NE[(Int, Int)] => NEC[(Int, Int)]
```

I couldn't use `<:<` because for `NonEmpty` types that use the newtype encoding, `NE` isn't actually a subtype of `NEC` (e.g. `NonEmptyChain` and `NonEmptyChainOps`).

The issue is that this encoding in the tests doesn't work on Dotty, and in any case is a little inelegant—if for example we want to work with additional `NE[x]` values in the future, we'd need new `evX` parameters here.

I've changed `NonEmptyCollectionSuite` to use a new abstract method instead:

```scala
protected def toNonEmptyCollection[A](nea: NE[A]): NEC[A]
```

This fixes the tests on Dotty and provides a bit of extra future-proofing even on Scala 2.