### PR TITLE
Use ArraySeq.untagged instead of ClassTag[Nothing]

### DIFF
--- a/core/src/main/scala-2.13+/cats/instances/arraySeq.scala
+++ b/core/src/main/scala-2.13+/cats/instances/arraySeq.scala
@@ -56,11 +56,11 @@ private[cats] object ArraySeqInstances {
       }
 
       override def map2[A, B, Z](fa: ArraySeq[A], fb: ArraySeq[B])(f: (A, B) => Z): ArraySeq[Z] =
-        if (fb.isEmpty) ArraySeq.empty // do O(1) work if fb is empty
+        if (fb.isEmpty) ArraySeq.untagged.empty // do O(1) work if fb is empty
         else fa.flatMap(a => fb.map(b => f(a, b))) // already O(1) if fa is empty
 
       override def map2Eval[A, B, Z](fa: ArraySeq[A], fb: Eval[ArraySeq[B]])(f: (A, B) => Z): Eval[ArraySeq[Z]] =
-        if (fa.isEmpty) Eval.now(ArraySeq.empty) // no need to evaluate fb
+        if (fa.isEmpty) Eval.now(ArraySeq.untagged.empty) // no need to evaluate fb
         else fb.map(fb => map2(fa, fb)(f))
 
       def foldLeft[A, B](fa: ArraySeq[A], b: B)(f: (B, A) => B): B =


### PR DESCRIPTION
Another fairly trivial change that fixes Dotty breakage and avoids some arguably weird behavior on Scala 2. The code this touches has never been released and in any case these changes shouldn't affect the behavior of these implementations.

On Scala 2 you can write something like this:

```scala
scala> import scala.collection.immutable.ArraySeq
import scala.collection.immutable.ArraySeq

scala> def empty[A]: ArraySeq[A] = ArraySeq.empty
empty: [A]=> scala.collection.immutable.ArraySeq[A]
```
But it doesn't work on Dotty:

```scala
scala> import scala.collection.immutable.ArraySeq                                                                                                                                                                                            

scala> def empty[A]: ArraySeq[A] = ArraySeq.empty
1 |def empty[A]: ArraySeq[A] = ArraySeq.empty
  |                                          ^
  |                                          No ClassTag available for A
```
Which is similar to what happens on Scala 2 if you don't let the type parameter get inferred:
```scala
scala> def empty[A]: ArraySeq[A] = ArraySeq.empty[A]
                                                 ^
       error: No ClassTag available for A
```
I think what's happening on Scala 2 is that `Nothing` is inferred and this implicit `ClassTag[Nothing]` is plugged in:

```scala
scala> implicitly[reflect.ClassTag[Nothing]]
res0: scala.reflect.ClassTag[Nothing] = Nothing
```
Dotty's `scala.reflect` doesn't provide this instance:

```scala
scala> implicitly[reflect.ClassTag[Nothing]]                                                                                                                                                                                                 
1 |implicitly[reflect.ClassTag[Nothing]]
  |                                     ^
  |                                     No ClassTag available for Nothing
```

Changes to these two lines fixes the issue on Dotty by using the  `untagged` factory, which uses a `ClassTag[Any]` behind the scenes.

