### PR TITLE
Specific commutativity and associativity tests for BigDecimal

### DIFF
--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -313,11 +313,9 @@ class Tests extends TestsConfig with AnyFunSuiteLike with FunSuiteDiscipline wit
   checkAll("Hash[SortedMap[Int, String]]", HashTests[SortedMap[Int, String]].hash)
   checkAll("Hash[Queue[Int]", HashTests[Queue[Int]].hash)
 
-  {
-    checkAll("Order[BigDecimal]", OrderTests[BigDecimal].order)
-    checkAll("CommutativeGroup[BigDecimal]", CommutativeGroupTests[BigDecimal].commutativeGroup)
-    checkAll("CommutativeGroup[BigDecimal]", SerializableTests.serializable(CommutativeGroup[BigDecimal]))
-  }
+  checkAll("Order[BigDecimal]", OrderTests[BigDecimal].order)
+  checkAll("CommutativeGroup[BigDecimal]", CommutativeGroupTests[BigDecimal].commutativeGroup)
+  checkAll("CommutativeGroup[BigDecimal]", SerializableTests.serializable(CommutativeGroup[BigDecimal]))
 
   test("CommutativeGroup[BigDecimal]'s combine should be associative for known problematic cases (#3303)") {
     import java.math.MathContext

--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -319,6 +319,27 @@ class Tests extends TestsConfig with AnyFunSuiteLike with FunSuiteDiscipline wit
     checkAll("CommutativeGroup[BigDecimal]", SerializableTests.serializable(CommutativeGroup[BigDecimal]))
   }
 
+  test("CommutativeGroup[BigDecimal]'s combine should be associative for known problematic cases (#3303)") {
+    import java.math.MathContext
+
+    val one = BigDecimal("1", MathContext.DECIMAL32)
+    val small = BigDecimal("0.00001111111", MathContext.DECIMAL32)
+    val xs = one :: List.fill(10)(small)
+    val combineRight = xs.reduceRight(CommutativeGroup[BigDecimal].combine)
+    val combineLeft = xs.reduceLeft(CommutativeGroup[BigDecimal].combine)
+
+    assert(combineRight === combineLeft)
+  }
+
+  test("CommutativeGroup[BigDecimal]'s combine should be commutative for known problematic cases (#3303)") {
+    import java.math.MathContext
+
+    val one = BigDecimal("1")
+    val small = BigDecimal("1e-7", MathContext.DECIMAL32)
+
+    assert(CommutativeGroup[BigDecimal].combine(one, small) === CommutativeGroup[BigDecimal].combine(small, one))
+  }
+
   checkAll("Band[(Int, Int)]", BandTests[(Int, Int)].band)
   checkAll("Band[(Int, Int)]", SerializableTests.serializable(Band[(Int, Int)]))
 


### PR DESCRIPTION
Before the fix in #3303 we were seeing occasional failed tests on Scala 2.13, and we haven't seen any since then, but I should have added some tests that specifically highlighted the fix, to make sure the instance don't accidentally get changed back, etc.

In this PR I've added two specific cases where commutativity and associativity didn't hold for the old `|+|` for `BigDecimal` on Scala 2.13, which simply called the standard library's `+`:

```scala
import java.math.MathContext

val one = BigDecimal("1", MathContext.DECIMAL32)
val small = BigDecimal("0.00001111111", MathContext.DECIMAL32)
val xs = one :: List.fill(10)(small)
```
And then:
```scala
scala> xs.reduceLeft(_ + _)
res0: scala.math.BigDecimal = 1.000110

scala> xs.reduceRight(_ + _)
res1: scala.math.BigDecimal = 1.000111
```
And for commutativity:
```scala
scala> import java.math.MathContext
import java.math.MathContext

scala> val one = BigDecimal("1")
one: scala.math.BigDecimal = 1

scala> val small = BigDecimal("1e-7", MathContext.DECIMAL32)
small: scala.math.BigDecimal = 1E-7

scala> one + small
res0: scala.math.BigDecimal = 1.0000001

scala> small + one
res1: scala.math.BigDecimal = 1.000000
```
