### PR TITLE
Update Scalafmt to 2.4.2

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -7,3 +7,4 @@ assumeStandardLibraryStripMargin = true
 danglingParentheses = true
 rewrite.rules = [AvoidInfix, SortImports, RedundantBraces, RedundantParens, SortModifiers]
 docstrings = JavaDoc
+newlines.afterCurlyLambda = preserve

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version=2.3.2
+version=2.4.2
 align.openParenCallSite = true
 align.openParenDefnSite = true
 maxColumn = 120

--- a/alleycats-core/src/main/scala/alleycats/std/map.scala
+++ b/alleycats-core/src/main/scala/alleycats/std/map.scala
@@ -15,9 +15,9 @@ trait MapInstances {
         val gba: Eval[G[Map[K, B]]] = Always(G.pure(Map.empty))
         val gbb = Foldable
           .iterateRight(fa, gba) { (kv, lbuf) =>
-            G.map2Eval(f(kv._2), lbuf)({ (b, buf) =>
+            G.map2Eval(f(kv._2), lbuf) { (b, buf) =>
               buf + (kv._1 -> b)
-            })
+            }
           }
           .value
         G.map(gbb)(_.toMap)
@@ -67,9 +67,9 @@ trait MapInstances {
         val gba: Eval[G[Map[K, B]]] = Always(G.pure(Map.empty))
         Foldable
           .iterateRight(fa, gba) { (kv, lbuf) =>
-            G.map2Eval(f(kv._2), lbuf)({ (ob, buf) =>
+            G.map2Eval(f(kv._2), lbuf) { (ob, buf) =>
               ob.fold(buf)(b => buf + (kv._1 -> b))
-            })
+            }
           }
           .value
       }

--- a/core/src/main/scala/cats/data/Cokleisli.scala
+++ b/core/src/main/scala/cats/data/Cokleisli.scala
@@ -123,14 +123,14 @@ private[data] class CokleisliMonad[F[_], A] extends Monad[Cokleisli[F, A, *]] {
     fa.map(f)
 
   def tailRecM[B, C](b: B)(fn: B => Cokleisli[F, A, Either[B, C]]): Cokleisli[F, A, C] =
-    Cokleisli({ (fa: F[A]) =>
+    Cokleisli { (fa: F[A]) =>
       @tailrec
       def loop(c: Cokleisli[F, A, Either[B, C]]): C = c.run(fa) match {
         case Right(c) => c
         case Left(bb) => loop(fn(bb))
       }
       loop(fn(b))
-    })
+    }
 
 }
 

--- a/core/src/main/scala/cats/data/Func.scala
+++ b/core/src/main/scala/cats/data/Func.scala
@@ -107,9 +107,9 @@ sealed abstract class AppFunc[F[_], A, B] extends Func[F, A, B] { self =>
 
   def compose[G[_], C](g: AppFunc[G, C, A]): AppFunc[Nested[G, F, *], C, B] = {
     implicit val gfApplicative: Applicative[Nested[G, F, *]] = Nested.catsDataApplicativeForNested[G, F](g.F, F)
-    Func.appFunc[Nested[G, F, *], C, B]({ (c: C) =>
+    Func.appFunc[Nested[G, F, *], C, B] { (c: C) =>
       Nested(g.F.map(g.run(c))(self.run))
-    })
+    }
   }
 
   def andThen[G[_], C](g: AppFunc[G, B, C]): AppFunc[Nested[F, G, *], A, C] =

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -598,9 +598,9 @@ private[data] trait KleisliFlatMap[F[_], A] extends FlatMap[Kleisli[F, A, *]] wi
     fa.flatMap(f)
 
   def tailRecM[B, C](b: B)(f: B => Kleisli[F, A, Either[B, C]]): Kleisli[F, A, C] =
-    Kleisli[F, A, C]({ a =>
-      F.tailRecM(b) { f(_).run(a) }
-    })
+    Kleisli[F, A, C] { a =>
+      F.tailRecM(b)(f(_).run(a))
+    }
 }
 
 private[data] trait KleisliApplicative[F[_], A] extends Applicative[Kleisli[F, A, *]] with KleisliApply[F, A] {

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -200,7 +200,7 @@ final case class WriterT[F[_], L, V](run: F[(L, V)]) {
    * }}}
    */
   def mapBoth[M, U](f: (L, V) => (M, U))(implicit functorF: Functor[F]): WriterT[F, M, U] =
-    WriterT { functorF.map(run)(f.tupled) }
+    WriterT(functorF.map(run)(f.tupled))
 
   /**
    * Example:

--- a/core/src/main/scala/cats/instances/map.scala
+++ b/core/src/main/scala/cats/instances/map.scala
@@ -28,9 +28,9 @@ trait MapInstances extends cats.kernel.instances.MapInstances {
         val gba: Eval[G[Map[K, B]]] = Always(G.pure(Map.empty))
         val gbb = Foldable
           .iterateRight(fa, gba) { (kv, lbuf) =>
-            G.map2Eval(f(kv._2), lbuf)({ (b, buf) =>
+            G.map2Eval(f(kv._2), lbuf) { (b, buf) =>
               buf + (kv._1 -> b)
-            })
+            }
           }
           .value
         G.map(gbb)(_.toMap)

--- a/core/src/main/scala/cats/instances/sortedMap.scala
+++ b/core/src/main/scala/cats/instances/sortedMap.scala
@@ -38,9 +38,9 @@ trait SortedMapInstances extends SortedMapInstances2 {
         val gba: Eval[G[SortedMap[K, B]]] = Always(G.pure(SortedMap.empty(Order[K].toOrdering)))
         Foldable
           .iterateRight(fa, gba) { (kv, lbuf) =>
-            G.map2Eval(f(kv._2), lbuf)({ (b, buf) =>
+            G.map2Eval(f(kv._2), lbuf) { (b, buf) =>
               buf + (kv._1 -> b)
-            })
+            }
           }
           .value
       }
@@ -186,9 +186,9 @@ private[instances] trait SortedMapInstancesBinCompat0 {
         val gba: Eval[G[SortedMap[K, B]]] = Always(G.pure(SortedMap.empty))
         Foldable
           .iterateRight(fa, gba) { (kv, lbuf) =>
-            G.map2Eval(f(kv._2), lbuf)({ (ob, buf) =>
+            G.map2Eval(f(kv._2), lbuf) { (ob, buf) =>
               ob.fold(buf)(b => buf + (kv._1 -> b))
-            })
+            }
           }
           .value
       }

--- a/core/src/main/scala/cats/syntax/monadError.scala
+++ b/core/src/main/scala/cats/syntax/monadError.scala
@@ -36,5 +36,7 @@ final class MonadErrorOps[F[_], E, A](private val fa: F[A]) extends AnyVal {
 
 final class MonadErrorRethrowOps[F[_], E, A](private val fea: F[Either[E, A]]) extends AnyVal {
   def rethrow(implicit F: MonadError[F, _ >: E]): F[A] =
-    F.flatMap(fea)(_.fold(F.raiseError, F.pure)) // dup from the type class impl, due to https://github.com/scala/bug/issues/11562. Once fixed should be able to replace with `F.rethrow(fea)`
+    F.flatMap(fea)(
+      _.fold(F.raiseError, F.pure)
+    ) // dup from the type class impl, due to https://github.com/scala/bug/issues/11562. Once fixed should be able to replace with `F.rethrow(fea)`
 }

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -16,7 +16,7 @@ object Boilerplate {
     def block(args: Any*): String = {
       val interpolated = sc.standardInterpolator(treatEscapes, args)
       val rawLines = interpolated.split('\n')
-      val trimmedLines = rawLines.map { _.dropWhile(_.isWhitespace) }
+      val trimmedLines = rawLines.map(_.dropWhile(_.isWhitespace))
       trimmedLines.mkString("\n")
     }
   }
@@ -65,8 +65,8 @@ object Boilerplate {
           acc.map(_.tail)
         else {
           val pre = contents.head.takeWhile(_.startsWith("|"))
-          val instances = contents.flatMap { _.dropWhile(_.startsWith("|")).takeWhile(_.startsWith("-")) }
-          val next = contents.map { _.dropWhile(_.startsWith("|")).dropWhile(_.startsWith("-")) }
+          val instances = contents.flatMap(_.dropWhile(_.startsWith("|")).takeWhile(_.startsWith("-")))
+          val next = contents.map(_.dropWhile(_.startsWith("|")).dropWhile(_.startsWith("-")))
           expandInstances(next, acc ++ pre ++ instances)
         }
 
@@ -174,14 +174,14 @@ object Boilerplate {
       val tpes = synTypes.map { tpe =>
         s"F[$tpe]"
       }
-      val fargs = (0 until arity).map { "f" + _ }
+      val fargs = (0 until arity).map("f" + _)
       val fparams = (fargs.zip(tpes)).map { case (v, t) => s"$v:$t" }.mkString(", ")
 
       val a = arity / 2
       val b = arity - a
 
-      val fArgsA = (0 until a).map { "f" + _ }.mkString(",")
-      val fArgsB = (a until arity).map { "f" + _ }.mkString(",")
+      val fArgsA = (0 until a).map("f" + _).mkString(",")
+      val fArgsB = (a until arity).map("f" + _).mkString(",")
       val argsA = (0 until a)
         .map { n =>
           "a" + n + ":A" + n
@@ -198,7 +198,7 @@ object Boilerplate {
         } else {
           s"ap$n"
         }
-      def allArgs = (0 until arity).map { "a" + _ }.mkString(",")
+      def allArgs = (0 until arity).map("a" + _).mkString(",")
 
       val apply =
         block"""
@@ -253,7 +253,7 @@ object Boilerplate {
       val tpes = synTypes.map { tpe =>
         s"M[$tpe]"
       }
-      val fargs = (0 until arity).map { "m" + _ }
+      val fargs = (0 until arity).map("m" + _)
       val fparams = (fargs.zip(tpes)).map { case (v, t) => s"$v:$t" }.mkString(", ")
       val fargsS = fargs.mkString(", ")
       val nestedExpansion = ParallelNestedExpansions(arity)
@@ -286,7 +286,7 @@ object Boilerplate {
       val tpes = synTypes.map { tpe =>
         s"M[$tpe]"
       }
-      val fargs = (0 until arity).map { "m" + _ }
+      val fargs = (0 until arity).map("m" + _)
       val fparams = (fargs.zip(tpes)).map { case (v, t) => s"$v:$t" }.mkString(", ")
       val fargsS = fargs.mkString(", ")
       val nestedExpansion = ParallelNestedExpansions(arity)
@@ -319,7 +319,7 @@ object Boilerplate {
       val tpes = synTypes.map { tpe =>
         s"F[$tpe]"
       }
-      val fargs = (0 until arity).map { "f" + _ }
+      val fargs = (0 until arity).map("f" + _)
       val fparams = (fargs.zip(tpes)).map { case (v, t) => s"$v:$t" }.mkString(", ")
       val fargsS = fargs.mkString(", ")
 

--- a/tests/src/test/scala/cats/tests/AndThenSuite.scala
+++ b/tests/src/test/scala/cats/tests/AndThenSuite.scala
@@ -59,7 +59,7 @@ class AndThenSuite extends CatsSuite with Checkers {
 
   test("andThen is stack safe") {
     val count = if (Platform.isJvm) 500000 else 1000
-    val fs = (0 until count).map(_ => { (i: Int) => i + 1 })
+    val fs = (0 until count).map(_ => (i: Int) => i + 1)
     val result = fs.foldLeft(AndThen((x: Int) => x))(_.andThen(_))(42)
 
     result shouldEqual (count + 42)
@@ -67,7 +67,7 @@ class AndThenSuite extends CatsSuite with Checkers {
 
   test("compose is stack safe") {
     val count = if (Platform.isJvm) 500000 else 1000
-    val fs = (0 until count).map(_ => { (i: Int) => i + 1 })
+    val fs = (0 until count).map(_ => (i: Int) => i + 1)
     val result = fs.foldLeft(AndThen((x: Int) => x))(_.compose(_))(42)
 
     result shouldEqual (count + 42)

--- a/tests/src/test/scala/cats/tests/EitherSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherSuite.scala
@@ -99,13 +99,13 @@ class EitherSuite extends CatsSuite {
 
   test("catchOnly lets non-matching exceptions escape") {
     val _ = intercept[NumberFormatException] {
-      Either.catchOnly[IndexOutOfBoundsException] { "foo".toInt }
+      Either.catchOnly[IndexOutOfBoundsException]("foo".toInt)
     }
   }
 
   test("catchNonFatal catches non-fatal exceptions") {
-    assert(Either.catchNonFatal { "foo".toInt }.isLeft)
-    assert(Either.catchNonFatal { throw new Throwable("blargh") }.isLeft)
+    assert(Either.catchNonFatal("foo".toInt).isLeft)
+    assert(Either.catchNonFatal(throw new Throwable("blargh")).isLeft)
   }
 
   test("fromTry is left for failed Try") {

--- a/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTSuite.scala
@@ -231,16 +231,21 @@ class ReaderWriterStateTSuite extends CatsSuite {
   }
 
   test("flatMap and flatMapF+tell are consistent") {
-    forAll { (rwst: ReaderWriterStateT[Option, String, String, String, Int], f: Int => Option[Int], initial: String, context: String, log: String) =>
-      val flatMap = rwst.flatMap { a =>
-        ReaderWriterStateT { (e, s) =>
-          f(a).map((log, s, _))
+    forAll {
+      (rwst: ReaderWriterStateT[Option, String, String, String, Int],
+       f: Int => Option[Int],
+       initial: String,
+       context: String,
+       log: String) =>
+        val flatMap = rwst.flatMap { a =>
+          ReaderWriterStateT { (e, s) =>
+            f(a).map((log, s, _))
+          }
         }
-      }
 
-      val flatMapF = rwst.flatMapF(f).tell(log)
+        val flatMapF = rwst.flatMapF(f).tell(log)
 
-      flatMap.run(context, initial) should ===(flatMapF.run(context, initial))
+        flatMap.run(context, initial) should ===(flatMapF.run(context, initial))
     }
   }
 

--- a/tests/src/test/scala/cats/tests/RegressionSuite.scala
+++ b/tests/src/test/scala/cats/tests/RegressionSuite.scala
@@ -13,13 +13,13 @@ class RegressionSuite extends CatsSuite with ScalaVersionSpecificRegressionSuite
   // not stack safe, very minimal, not for actual use
   case class State[S, A](run: S => (A, S)) { self =>
     def map[B](f: A => B): State[S, B] =
-      State({ s =>
+      State { s =>
         val (a, s2) = self.run(s); (f(a), s2)
-      })
+      }
     def flatMap[B](f: A => State[S, B]): State[S, B] =
-      State({ s =>
+      State { s =>
         val (a, s2) = self.run(s); f(a).run(s2)
-      })
+      }
   }
 
   object State {

--- a/tests/src/test/scala/cats/tests/ValidatedSuite.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedSuite.scala
@@ -79,18 +79,18 @@ class ValidatedSuite extends CatsSuite {
   }
 
   test("catchOnly catches matching exceptions") {
-    assert(Validated.catchOnly[NumberFormatException] { "foo".toInt }.isInstanceOf[Invalid[NumberFormatException]])
+    assert(Validated.catchOnly[NumberFormatException]("foo".toInt).isInstanceOf[Invalid[NumberFormatException]])
   }
 
   test("catchOnly lets non-matching exceptions escape") {
     val _ = intercept[NumberFormatException] {
-      Validated.catchOnly[IndexOutOfBoundsException] { "foo".toInt }
+      Validated.catchOnly[IndexOutOfBoundsException]("foo".toInt)
     }
   }
 
   test("catchNonFatal catches non-fatal exceptions") {
-    assert(Validated.catchNonFatal { "foo".toInt }.isInvalid)
-    assert(Validated.catchNonFatal { throw new Throwable("blargh") }.isInvalid)
+    assert(Validated.catchNonFatal("foo".toInt).isInvalid)
+    assert(Validated.catchNonFatal(throw new Throwable("blargh")).isInvalid)
   }
 
   test("fromTry is invalid for failed try") {


### PR DESCRIPTION
This is a more conservative version of #3315 that still rewrites `{ }` to `( )` for single-line expressions, but doesn't remove newlines in cases like this, [which was my primary complaint about the default config in 2.4.2](https://github.com/typelevel/cats/pull/3315#issuecomment-590907872):

```scala
  forAll { (nes: NonEmptySet[Int]) =>
    nes.reduce should ===(nes.fold)
  }
```
In #3315 that got rewritten to the following, which obscures what's being tested, at least to my eyes:

```scala
  forAll((nes: NonEmptySet[Int]) => nes.reduce should ===(nes.fold))
```

Instead of `+495 −1,432` it's `+58, −50`, so quite a bit less dramatic, and the changes look more reasonable to me.
