### PR TITLE
Backport #3126 Remove `Order` constraint from `Hash` instance for SortedSet

### DIFF
--- a/core/src/main/scala/cats/instances/all.scala
+++ b/core/src/main/scala/cats/instances/all.scala
@@ -69,3 +69,4 @@ trait AllInstancesBinCompat7
     with VectorInstancesBinCompat1
     with EitherInstancesBinCompat0
     with StreamInstancesBinCompat1
+    with SortedSetInstancesBinCompat2

--- a/core/src/main/scala/cats/instances/package.scala
+++ b/core/src/main/scala/cats/instances/package.scala
@@ -36,7 +36,11 @@ package object instances {
       with SortedMapInstancesBinCompat0
       with SortedMapInstancesBinCompat1
       with SortedMapInstancesBinCompat2
-  object sortedSet extends SortedSetInstances with SortedSetInstancesBinCompat0 with SortedSetInstancesBinCompat1
+  object sortedSet
+      extends SortedSetInstances
+      with SortedSetInstancesBinCompat0
+      with SortedSetInstancesBinCompat1
+      with SortedSetInstancesBinCompat2
   object stream extends StreamInstances with StreamInstancesBinCompat0 with StreamInstancesBinCompat1
   object string extends StringInstances
   object try_ extends TryInstances

--- a/core/src/main/scala/cats/instances/sortedSet.scala
+++ b/core/src/main/scala/cats/instances/sortedSet.scala
@@ -2,8 +2,9 @@ package cats
 package instances
 
 import cats.kernel.{BoundedSemilattice, Hash, Order}
-import scala.collection.immutable.SortedSet
+
 import scala.annotation.tailrec
+import scala.collection.immutable.SortedSet
 
 trait SortedSetInstances extends SortedSetInstances1 {
 
@@ -73,7 +74,7 @@ trait SortedSetInstances extends SortedSetInstances1 {
 private[instances] trait SortedSetInstances1 {
   @deprecated("Use cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet", "2.0.0-RC2")
   private[instances] def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
-    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A]
+    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A](Hash[A])
 
   @deprecated("Use cats.kernel.instances.sortedSet.catsKernelStdSemilatticeForSortedSet", "2.0.0-RC2")
   def catsKernelStdSemilatticeForSortedSet[A: Order]: BoundedSemilattice[SortedSet[A]] =
@@ -92,9 +93,9 @@ private[instances] trait SortedSetInstancesBinCompat0 {
 }
 
 private[instances] trait SortedSetInstancesBinCompat1 extends LowPrioritySortedSetInstancesBinCompat1 {
-  // TODO: Remove when this is no longer necessary for binary compatibility.
-  implicit override def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
-    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A]
+  @deprecated("Use cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet", "2.0.0-RC2")
+  override def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
+    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet(Hash[A])
 }
 
 private[instances] trait LowPrioritySortedSetInstancesBinCompat1
@@ -103,8 +104,14 @@ private[instances] trait LowPrioritySortedSetInstancesBinCompat1
   implicit override def catsKernelStdOrderForSortedSet[A: Order]: Order[SortedSet[A]] =
     cats.kernel.instances.sortedSet.catsKernelStdOrderForSortedSet[A]
 
+  @deprecated("Use cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet", "2.0.0-RC2")
   override def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
-    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A]
+    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet(Hash[A])
+}
+
+private[instances] trait SortedSetInstancesBinCompat2 extends SortedSetInstancesBinCompat1 {
+  implicit def catsKernelStdHashForSortedSet[A: Hash]: Hash[SortedSet[A]] =
+    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A](Hash[A])
 }
 
 @deprecated("Use cats.kernel.instances.SortedSetHash", "2.0.0-RC2")

--- a/core/src/main/scala/cats/instances/sortedSet.scala
+++ b/core/src/main/scala/cats/instances/sortedSet.scala
@@ -93,6 +93,7 @@ private[instances] trait SortedSetInstancesBinCompat0 {
 }
 
 private[instances] trait SortedSetInstancesBinCompat1 extends LowPrioritySortedSetInstancesBinCompat1 {
+  // TODO: Remove when this is no longer necessary for binary compatibility.
   @deprecated("Use cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet", "2.0.0-RC2")
   override def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
     cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet(Hash[A])

--- a/kernel/src/main/scala/cats/kernel/instances/AllInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/AllInstances.scala
@@ -36,3 +36,5 @@ trait AllInstances
 private[instances] trait AllInstancesBinCompat0 extends FiniteDurationInstances
 
 private[instances] trait AllInstancesBinCompat1 extends SortedMapInstances with SortedSetInstances
+
+private[instances] trait AllInstancesBinCompat2 extends SortedSetInstances2

--- a/kernel/src/main/scala/cats/kernel/instances/all/package.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/all/package.scala
@@ -1,4 +1,8 @@
 package cats.kernel
 package instances
 
-package object all extends AllInstances with AllInstancesBinCompat0 with AllInstancesBinCompat1
+package object all
+    extends AllInstances
+    with AllInstancesBinCompat0
+    with AllInstancesBinCompat1
+    with AllInstancesBinCompat2

--- a/kernel/src/main/scala/cats/kernel/instances/sortedSet/package.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/sortedSet/package.scala
@@ -1,4 +1,4 @@
 package cats.kernel
 package instances
 
-package object sortedSet extends SortedSetInstances
+package object sortedSet extends SortedSetInstances with SortedSetInstances2


### PR DESCRIPTION
addresses #3143 
