### PR TITLE
Add Align lawful tests for Option instance

### DIFF
--- a/tests/src/test/scala/cats/tests/OptionSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionSuite.scala
@@ -27,6 +27,9 @@ class OptionSuite extends CatsSuite {
   checkAll("Option with Unit", MonadErrorTests[Option, Unit].monadError[Int, Int, Int])
   checkAll("MonadError[Option, Unit]", SerializableTests.serializable(MonadError[Option, Unit]))
 
+  checkAll("Option[Int]", AlignTests[Option].align[Int, Int, Int, Int])
+  checkAll("Align[Option]", SerializableTests.serializable(Align[Option]))
+
   test("show") {
     none[Int].show should ===("None")
     1.some.show should ===("Some(1)")

--- a/tests/src/test/scala/cats/tests/OptionSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionSuite.scala
@@ -1,6 +1,6 @@
 package cats.tests
 
-import cats.{Alternative, CoflatMap, CommutativeMonad, Eval, Later, MonadError, Semigroupal, Traverse, TraverseFilter}
+import cats.{Align, Alternative, CoflatMap, CommutativeMonad, Eval, Later, MonadError, Semigroupal, Traverse, TraverseFilter}
 import cats.instances.all._
 import cats.laws.{ApplicativeLaws, CoflatMapLaws, FlatMapLaws, MonadLaws}
 import cats.laws.discipline._

--- a/tests/src/test/scala/cats/tests/OptionSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionSuite.scala
@@ -1,13 +1,13 @@
 package cats.tests
 
-import cats.{Align, Alternative, CoflatMap, CommutativeMonad, Eval, Later, MonadError, Semigroupal, Traverse, TraverseFilter}
 import cats.instances.all._
-import cats.laws.{ApplicativeLaws, CoflatMapLaws, FlatMapLaws, MonadLaws}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
+import cats.laws.{ApplicativeLaws, CoflatMapLaws, FlatMapLaws, MonadLaws}
 import cats.syntax.apply._
 import cats.syntax.option._
 import cats.syntax.show._
+import cats.{Align, Alternative, CoflatMap, CommutativeMonad, Eval, Later, MonadError, Semigroupal, Traverse, TraverseFilter}
 
 class OptionSuite extends CatsSuite {
   checkAll("Option[Int]", SemigroupalTests[Option].semigroupal[Int, Int, Int])

--- a/tests/src/test/scala/cats/tests/OptionSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionSuite.scala
@@ -7,7 +7,18 @@ import cats.laws.{ApplicativeLaws, CoflatMapLaws, FlatMapLaws, MonadLaws}
 import cats.syntax.apply._
 import cats.syntax.option._
 import cats.syntax.show._
-import cats.{Align, Alternative, CoflatMap, CommutativeMonad, Eval, Later, MonadError, Semigroupal, Traverse, TraverseFilter}
+import cats.{
+  Align,
+  Alternative,
+  CoflatMap,
+  CommutativeMonad,
+  Eval,
+  Later,
+  MonadError,
+  Semigroupal,
+  Traverse,
+  TraverseFilter
+}
 
 class OptionSuite extends CatsSuite {
   checkAll("Option[Int]", SemigroupalTests[Option].semigroupal[Int, Int, Int])


### PR DESCRIPTION
while back-porting `Align` to Scala 2.11, noticed we are missing tests for `Option` instance.


