### PR TITLE
Change review policy for PRs that don't target master

### DIFF
--- a/PROCESS.md
+++ b/PROCESS.md
@@ -18,6 +18,15 @@ When fixing typos, improving documentation or minor build fix only
 one sign-off is required (although for major edits waiting for two
  may be preferable).
 
+In some cases pull requests that don't target the master branch may be
+merged with a single sign-off from a maintainer (as long as they
+aren't also the author of the pull request). For example, backporting
+changes from master to the `scala_2.11` branch generally shouldn't
+require multiple reviews. If either the pull request author or a Cats
+maintainer thinks that a specific change should receive multiple
+approvals even though it doesn't target the master branch, their
+request should be respected.
+
 For serious emergencies or work on the build which can't easily be
 reviewed or tested, pushing directly to master may be OK (but is
 definitely not encouraged). In these cases it's best to comment in


### PR DESCRIPTION
I originally proposed this policy change [on Gitter](https://gitter.im/typelevel/cats-dev?at=5e68b7c7e203784a559e5cca):

> I'd like to propose that we lower the review requirement for non-master PRs in Cats.
> 
> Specifically Gagandeep has put a huge amount of effort into backporting 2.1 changes for Scala 2.11, and these contributions have been getting merged very slowly: https://github.com/typelevel/cats/pulls?q=is%3Apr+author%3Agagandeepkalra+backport
> 
> There are currently 10 open. I've reviewed all of them, and in a few cases we've gone through several iterations to get them right.
>
> I know backport branches like this are a low priority for most maintainers (including me), but they can be very important for contributors like Gagandeep, and I think it would be reasonable to say PRs against these branches only need one non-author +1 to merge.

…but on second thought it seems easiest just to make the change as a PR and we can discuss it here.


