### PR TITLE
Merge 2.1.x after 2.1.1 release

### DIFF
--- a/scripts/scala.js-1.0-publish.sh
+++ b/scripts/scala.js-1.0-publish.sh
@@ -2,11 +2,12 @@
 
 # For temporary use while cross-publishing for Scala.js 0.6 and 1.0.
 
-SCALAJS_VERSION=1.0.0-RC2 sbt +kernelJS/publishSigned
-SCALAJS_VERSION=1.0.0-RC2 sbt +kernelLawsJS/publishSigned
-SCALAJS_VERSION=1.0.0-RC2 sbt +coreJS/publishSigned
-SCALAJS_VERSION=1.0.0-RC2 sbt +lawsJS/publishSigned
-SCALAJS_VERSION=1.0.0-RC2 sbt +freeJS/publishSigned
-SCALAJS_VERSION=1.0.0-RC2 sbt +testkitJS/publishSigned
-SCALAJS_VERSION=1.0.0-RC2 sbt +alleycatsCoreJS/publishSigned
-SCALAJS_VERSION=1.0.0-RC2 sbt +alleycatsLawsJS/publishSigned
+SCALAJS_VERSION=1.0.0 sbt +macrosJS/publishSigned
+SCALAJS_VERSION=1.0.0 sbt +kernelJS/publishSigned
+SCALAJS_VERSION=1.0.0 sbt +kernelLawsJS/publishSigned
+SCALAJS_VERSION=1.0.0 sbt +coreJS/publishSigned
+SCALAJS_VERSION=1.0.0 sbt +lawsJS/publishSigned
+SCALAJS_VERSION=1.0.0 sbt +freeJS/publishSigned
+SCALAJS_VERSION=1.0.0 sbt +testkitJS/publishSigned
+SCALAJS_VERSION=1.0.0 sbt +alleycatsCoreJS/publishSigned
+SCALAJS_VERSION=1.0.0 sbt +alleycatsLawsJS/publishSigned

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.1.1-SNAPSHOT"
+version in ThisBuild := "2.1.2-SNAPSHOT"


### PR DESCRIPTION
First, if you're merging this, please don't squash or rebase! This change is to keep master and the current release branch in sync, and rebasing would mean e.g. that the `v2.1.1` release tag isn't included in the history on master.

The issue is that I forgot to merge the `2.1.x` branch back into master when I published 2.1.1 a couple of weeks ago. This isn't a big deal, but it does mean that the `version.sbt` and the Scala.js 1.0 release script in master are out of date. This PR just does the merge, resolving some conflicts from things I had to backport in order to support Scala.js 1.0.0 in 2.1.1.