### PR TITLE
add pos and seek to RepresentableStore

### DIFF
--- a/core/src/main/scala/cats/data/RepresentableStore.scala
+++ b/core/src/main/scala/cats/data/RepresentableStore.scala
@@ -19,6 +19,16 @@ final case class RepresentableStore[F[_], S, A](fa: F[A], index: S)(implicit R: 
   lazy val extract: A = peek(index)
 
   /**
+   * Extract the "index"
+   */
+  lazy val pos: S = index
+
+  /**
+   * Set the "index"
+   */
+  def seek(s: S): RepresentableStore[F, S, A] = copy(index = s)
+
+  /**
    * Duplicate the store structure
    */
   lazy val coflatten: RepresentableStore[F, S, RepresentableStore[F, S, A]] =

--- a/tests/src/test/scala/cats/tests/RepresentableStoreSuite.scala
+++ b/tests/src/test/scala/cats/tests/RepresentableStoreSuite.scala
@@ -53,4 +53,16 @@ class RepresentableStoreSuite extends CatsSuite {
       store.extract should ===(f(s))
     }
   }
+
+  test("pos and index are consistent") {
+    forAll { (store: Store[String, String]) =>
+      store.pos should ===(store.index)
+    }
+  }
+
+  test("seek changes pos") {
+    forAll { (store: Store[String, String], s: String) =>
+      store.seek(s).pos should ===(s)
+    }
+  }
 }

--- a/tests/src/test/scala/cats/tests/RepresentableStoreSuite.scala
+++ b/tests/src/test/scala/cats/tests/RepresentableStoreSuite.scala
@@ -65,4 +65,13 @@ class RepresentableStoreSuite extends CatsSuite {
       store.seek(s).pos should ===(s)
     }
   }
+
+  test("seek and peek are consistent") {
+    forAll { (store: Store[String, String], s: String) =>
+      val fromSeek = store.seek(s)
+      val fromPeek = store.coflatten.peek(s)
+      fromSeek.pos should ===(fromPeek.pos)
+      fromSeek.extract should ===(fromPeek.extract)
+    }
+  }
 }


### PR DESCRIPTION
This adds a couple of helper functions to `RepresentableStore`, ported from the `ComonadStore` Haskell typeclass.
Thanks for your work!