### PR TITLE
Restrict attemptNarrow to subtypes of Throwable

### DIFF
--- a/core/src/main/scala/cats/ApplicativeError.scala
+++ b/core/src/main/scala/cats/ApplicativeError.scala
@@ -80,7 +80,7 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
   /**
    * Similar to [[attempt]], but it only handles errors of type `EE`.
    */
-  def attemptNarrow[EE, A](fa: F[A])(implicit tag: ClassTag[EE], ev: EE <:< E): F[Either[EE, A]] =
+  def attemptNarrow[EE <: Throwable, A](fa: F[A])(implicit tag: ClassTag[EE], ev: EE <:< E): F[Either[EE, A]] =
     recover(map(fa)(Right[EE, A](_): Either[EE, A])) { case e: EE => Left[EE, A](e) }
 
   /**

--- a/core/src/main/scala/cats/syntax/applicativeError.scala
+++ b/core/src/main/scala/cats/syntax/applicativeError.scala
@@ -51,7 +51,9 @@ final class ApplicativeErrorOps[F[_], E, A](private val fa: F[A]) extends AnyVal
   def attempt(implicit F: ApplicativeError[F, E]): F[Either[E, A]] =
     F.attempt(fa)
 
-  def attemptNarrow[EE](implicit F: ApplicativeError[F, E], tag: ClassTag[EE], ev: EE <:< E): F[Either[EE, A]] =
+  def attemptNarrow[EE <: Throwable](implicit F: ApplicativeError[F, E],
+                                     tag: ClassTag[EE],
+                                     ev: EE <:< E): F[Either[EE, A]] =
     F.attemptNarrow[EE, A](fa)
 
   def attemptT(implicit F: ApplicativeError[F, E]): EitherT[F, E, A] =

--- a/tests/src/test/scala/cats/tests/ApplicativeErrorSuite.scala
+++ b/tests/src/test/scala/cats/tests/ApplicativeErrorSuite.scala
@@ -29,7 +29,7 @@ class ApplicativeErrorSuite extends CatsSuite {
   }
 
   test("attemptNarrow[EE] syntax creates an F[Either[EE, A]]") {
-    trait Err
+    trait Err extends Throwable
     case class ErrA() extends Err
     case class ErrB() extends Err
 
@@ -44,7 +44,7 @@ class ApplicativeErrorSuite extends CatsSuite {
   }
 
   test("attemptNarrow works for parametrized types") {
-    trait T[A]
+    trait T[A] extends Throwable
     case object Str extends T[String]
     case class Num(i: Int) extends T[Int]
 
@@ -61,7 +61,7 @@ class ApplicativeErrorSuite extends CatsSuite {
     assertTypeError("e2.attemptNarrow[Num]")
 
     val e3: Either[List[T[String]], Unit] = List(Str).asLeft[Unit]
-    e3.attemptNarrow[List[Str.type]] should ===(e3.asRight[List[T[String]]])
+    assertTypeError("e3.attemptNarrow[List[Str.type]]")
     assertTypeError("e3.attemptNarrow[List[Num]]")
   }
 


### PR DESCRIPTION
This change makes it impossible to call `attemptNarrow` with a type parameter that isn't `Throwable` or one of its subtypes. This makes it slightly less easy to shoot yourself in the foot with it (see #3360), while still supporting its most common use cases.

The change doesn't break binary compatibility, but definitely does break source compatibility. It only breaks dangerous code, though, so I think that's fine for 2.2.0.

Personally I'd prefer to scrap it entirely (by making it package-private), since even in this restricted form it breaks parametricity in a way that feels un-Cats-like. I've chosen this route because of the precedent of `catchOnly`, which does a similar thing with runtime reflection but makes it relatively safe by restricting to `Throwable`.

