### PR TITLE
Prepend a Vector to a NonEmptyVector

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -118,8 +118,9 @@ final class NonEmptyVector[+A] private (val toVector: Vector[A])
   /**
    * Prepend a `Vector` to this, producing a new `NonEmptyVector`.
    */
-  def prependVec[AA >: A](vector: Vector[AA]): NonEmptyVector[AA] = 
+  def prependVec[AA >: A](vector: Vector[AA]): NonEmptyVector[AA] =
     NonEmptyVector.fromVector(vector).fold[NonEmptyVector[AA]](this)(_.concatNev(this))
+
   /**
    * Alias for [[prepend]]
    */

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -118,8 +118,8 @@ final class NonEmptyVector[+A] private (val toVector: Vector[A])
   /**
    * Prepend a `Vector` to this, producing a new `NonEmptyVector`.
    */
-  def prependVec[AA >: A](vector: Vector[AA]): NonEmptyVector[AA] =
-    NonEmptyVector.fromVector(vector).fold[NonEmptyVector[AA]](this)(_.concatNev(this))
+  def prependVector[AA >: A](vector: Vector[AA]): NonEmptyVector[AA] =
+    new NonEmptyVector(vector ++ this.toVector)
 
   /**
    * Alias for [[prepend]]

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -116,6 +116,11 @@ final class NonEmptyVector[+A] private (val toVector: Vector[A])
   def prepend[AA >: A](a: AA): NonEmptyVector[AA] = new NonEmptyVector(a +: toVector)
 
   /**
+   * Prepend a `Vector` to this, producing a new `NonEmptyVector`.
+   */
+  def prependVec[AA >: A](vector: Vector[AA]): NonEmptyVector[AA] = 
+    NonEmptyVector.fromVector(vector).fold[NonEmptyVector[AA]](this)(_.concatNev(this))
+  /**
    * Alias for [[prepend]]
    */
   def +:[AA >: A](a: AA): NonEmptyVector[AA] = prepend(a)

--- a/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
@@ -247,15 +247,15 @@ class NonEmptyVectorSuite extends NonEmptyCollectionSuite[Vector, NonEmptyVector
     }
   }
 
-  test("prependVec with a NonEmptyVector is the same as concatNec") {
+  test("prependVector with a NonEmptyVector is the same as concatNec") {
     forAll { (nonEmptyVector1: NonEmptyVector[Int], nonEmptyVector2: NonEmptyVector[Int]) =>
-      nonEmptyVector2.prependVec(nonEmptyVector1.toVector) should ===(nonEmptyVector1.concatNev(nonEmptyVector2))
+      nonEmptyVector2.prependVector(nonEmptyVector1.toVector) should ===(nonEmptyVector1.concatNev(nonEmptyVector2))
     }
   }
 
-  test("prependVec with an empty Vector is the same as the original NonEmptyVector") {
+  test("prependVector with an empty Vector is the same as the original NonEmptyVector") {
     forAll { (nonEmptyVector: NonEmptyVector[Int]) =>
-      nonEmptyVector.prependVec(Vector.empty) should ===(nonEmptyVector)
+      nonEmptyVector.prependVector(Vector.empty) should ===(nonEmptyVector)
     }
   }
 

--- a/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
@@ -249,13 +249,13 @@ class NonEmptyVectorSuite extends NonEmptyCollectionSuite[Vector, NonEmptyVector
 
   test("prependVec with a NonEmptyVector is the same as concatNec") {
     forAll { (nonEmptyVector1: NonEmptyVector[Int], nonEmptyVector2: NonEmptyVector[Int]) =>
-      nonEmptyVector2.prependVec(nonEmptyVector1.toVector) should === (nonEmptyVector1.concatNev(nonEmptyVector2))
+      nonEmptyVector2.prependVec(nonEmptyVector1.toVector) should ===(nonEmptyVector1.concatNev(nonEmptyVector2))
     }
   }
 
   test("prependVec with an empty Vector is the same as the original NonEmptyVector") {
     forAll { (nonEmptyVector: NonEmptyVector[Int]) =>
-      nonEmptyVector.prependVec(Vector.empty) should === (nonEmptyVector)
+      nonEmptyVector.prependVec(Vector.empty) should ===(nonEmptyVector)
     }
   }
 

--- a/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
@@ -247,6 +247,18 @@ class NonEmptyVectorSuite extends NonEmptyCollectionSuite[Vector, NonEmptyVector
     }
   }
 
+  test("prependVec with a NonEmptyVector is the same as concatNec") {
+    forAll { (nonEmptyVector1: NonEmptyVector[Int], nonEmptyVector2: NonEmptyVector[Int]) =>
+      nonEmptyVector2.prependVec(nonEmptyVector1.toVector) should === (nonEmptyVector1.concatNev(nonEmptyVector2))
+    }
+  }
+
+  test("prependVec with an empty Vector is the same as the original NonEmptyVector") {
+    forAll { (nonEmptyVector: NonEmptyVector[Int]) =>
+      nonEmptyVector.prependVec(Vector.empty) should === (nonEmptyVector)
+    }
+  }
+
   test("NonEmptyVector#of on varargs is consistent with NonEmptyVector#apply on Vector") {
     forAll { (head: Int, tail: Vector[Int]) =>
       NonEmptyVector.of(head, tail: _*) should ===(NonEmptyVector(head, tail))


### PR DESCRIPTION
I needed to implement this recently and was surprised it didn't already exist.

Thank you for contributing to Cats!

This is a kind reminder to run `sbt +prePR` and commit the changed files, if any, before submitting.


