### PR TITLE
Add unit test to verify Chain.zipWithIndex stack safety

### DIFF
--- a/tests/src/test/scala/cats/tests/ChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/ChainSuite.scala
@@ -177,6 +177,12 @@ class ChainSuite extends CatsSuite {
     }
   }
 
+  test("zipWithIndex is stack-safe for a large chain constructed using concatenations") {
+    val list = List.fill(10000)(1)
+    val chain = list.foldLeft(Chain.empty[Int]) { case (acc, next) => acc.concat(Chain(next)) }
+    chain.zipWithIndex.toList === (list.zipWithIndex)
+  }
+
   test("sortBy is consistent with toList.sortBy") {
     forAll { (ci: Chain[Int], f: Int => String) =>
       assert(ci.sortBy(f).toList === (ci.toList.sortBy(f)))


### PR DESCRIPTION
Noticed while poking around to add `zipAll` that `zipWithIndex` on `Chain` (also called from `NonEmptyChain`) isn’t tail recursive. It’ll blow the stack if the chain is built from many `concat`s meaning we have a highly nested `Append` structure. E.g.

```
scala> List.fill(10000)(1).foldLeft(Chain(1)) { case (acc, next) => acc.concat(Chain(next)) }.zipWithIndex
java.lang.StackOverflowError
  at scala.collection.AbstractIterable.<init>(Iterable.scala:56)
  at scala.collection.AbstractSeq.<init>(Seq.scala:45)
```

This wasn’t caught by tests as the arbitrary instances generate only small collections - I guess this was a conscious decision?

Either way worth flagging 😄 

Edit: has since been fixed in https://github.com/typelevel/cats/pull/3533 so this change only adds a unit test. Changed title to reflect that.