### PR TITLE
Remove cats.instances from tests

### DIFF
--- a/tests/src/test/scala-2.13+/cats/tests/ArraySeqSuite.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/ArraySeqSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.{Align, Alternative, CoflatMap, Monad, MonoidK, Traverse, TraverseFilter}
-import cats.instances.all._
 import cats.kernel.{Eq, Hash, Monoid, Order, PartialOrder}
 import cats.kernel.laws.discipline.{EqTests, HashTests, MonoidTests, OrderTests, PartialOrderTests}
 import cats.laws.discipline.{

--- a/tests/src/test/scala-2.13+/cats/tests/LazyListSuite.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/LazyListSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.{Align, Alternative, CoflatMap, Monad, Semigroupal, Traverse, TraverseFilter}
 import cats.data.ZipLazyList
-import cats.instances.all._
 import cats.laws.discipline.{
   AlignTests,
   AlternativeTests,

--- a/tests/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.{Align, Bimonad, SemigroupK, Show, Traverse}
 import cats.data.{NonEmptyLazyList, NonEmptyLazyListOps}
-import cats.instances.all._
 import cats.kernel.{Eq, Hash, Order, PartialOrder, Semigroup}
 import cats.kernel.laws.discipline.{EqTests, HashTests, OrderTests, PartialOrderTests, SemigroupTests}
 import cats.laws.discipline.{AlignTests, BimonadTests, NonEmptyTraverseTests, SemigroupKTests, SerializableTests}

--- a/tests/src/test/scala/cats/tests/AlgebraInvariantSuite.scala
+++ b/tests/src/test/scala/cats/tests/AlgebraInvariantSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.{CommutativeApplicative, CommutativeApply, Invariant, InvariantMonoidal}
-import cats.instances._
 import cats.kernel._
 import cats.kernel.laws.discipline.{SemigroupTests, MonoidTests, GroupTests, _}
 import cats.laws.discipline.{
@@ -19,15 +18,7 @@ import cats.syntax.order._
 import org.scalacheck.{Arbitrary, Gen}
 
 class AlgebraInvariantSuite
-    extends CatsSuite
-    with AllInstances
-    with AllInstancesBinCompat0
-    with AllInstancesBinCompat1
-    with AllInstancesBinCompat2
-    with AllInstancesBinCompat3
-    with AllInstancesBinCompat4
-    with AllInstancesBinCompat5
-    with AllInstancesBinCompat6 {
+    extends CatsSuite {
   // working around https://github.com/typelevel/cats/issues/2701
   implicit private val eqSetBooleanTuple: Eq[(Set[Boolean], Set[Boolean])] = Eq.fromUniversalEquals
   implicit private val eqSetBooleanBooleanTuple: Eq[(Set[Boolean], Boolean)] = Eq.fromUniversalEquals

--- a/tests/src/test/scala/cats/tests/AlgebraInvariantSuite.scala
+++ b/tests/src/test/scala/cats/tests/AlgebraInvariantSuite.scala
@@ -17,8 +17,7 @@ import cats.syntax.invariant._
 import cats.syntax.order._
 import org.scalacheck.{Arbitrary, Gen}
 
-class AlgebraInvariantSuite
-    extends CatsSuite {
+class AlgebraInvariantSuite extends CatsSuite {
   // working around https://github.com/typelevel/cats/issues/2701
   implicit private val eqSetBooleanTuple: Eq[(Set[Boolean], Set[Boolean])] = Eq.fromUniversalEquals
   implicit private val eqSetBooleanBooleanTuple: Eq[(Set[Boolean], Boolean)] = Eq.fromUniversalEquals

--- a/tests/src/test/scala/cats/tests/AlignSuite.scala
+++ b/tests/src/test/scala/cats/tests/AlignSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.Align
-import cats.instances.all._
 import cats.kernel.laws.discipline.SemigroupTests
 
 class AlignSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/AlternativeSuite.scala
+++ b/tests/src/test/scala/cats/tests/AlternativeSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.Alternative
-import cats.instances.all._
 
 class AlternativeSuite extends CatsSuite {
   test("unite") {

--- a/tests/src/test/scala/cats/tests/AndThenSuite.scala
+++ b/tests/src/test/scala/cats/tests/AndThenSuite.scala
@@ -3,7 +3,6 @@ package cats.tests
 import cats.{Contravariant, ContravariantMonoidal, Monad, Semigroupal}
 import cats.arrow.{ArrowChoice, Choice, CommutativeArrow}
 import cats.data.AndThen
-import cats.instances.all._
 import cats.kernel.laws.discipline.SerializableTests
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/ApplicativeErrorSuite.scala
+++ b/tests/src/test/scala/cats/tests/ApplicativeErrorSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.ApplicativeError
 import cats.data.EitherT
-import cats.instances.all._
 import cats.kernel.Eq
 import cats.syntax.applicativeError._
 import cats.syntax.either._

--- a/tests/src/test/scala/cats/tests/ApplicativeSuite.scala
+++ b/tests/src/test/scala/cats/tests/ApplicativeSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.{Align, Applicative, Apply, CoflatMap}
 import cats.data.{Const, Validated}
-import cats.instances.all._
 import cats.kernel.Monoid
 import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/BifoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/BifoldableSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.Bifoldable
-import cats.instances.all._
 import cats.laws.discipline.{BifoldableTests, SerializableTests}
 import cats.syntax.either._
 

--- a/tests/src/test/scala/cats/tests/BifunctorSuite.scala
+++ b/tests/src/test/scala/cats/tests/BifunctorSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.{Bifunctor, Functor}
-import cats.instances.all._
 import cats.laws.discipline.{BifunctorTests, FunctorTests, SerializableTests}
 
 class BifunctorSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/BinestedSuite.scala
+++ b/tests/src/test/scala/cats/tests/BinestedSuite.scala
@@ -4,7 +4,6 @@ import cats.{Bifoldable, Bifunctor, Bitraverse, Foldable, Functor, Traverse}
 import cats.arrow.Profunctor
 import cats.data.Binested
 import cats.kernel.Eq
-import cats.instances.all._
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/BitSetSuite.scala
+++ b/tests/src/test/scala/cats/tests/BitSetSuite.scala
@@ -1,6 +1,5 @@
 package cats.tests
 
-import cats.instances.all._
 import cats.syntax.show._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Arbitrary.arbitrary

--- a/tests/src/test/scala/cats/tests/BitraverseSuite.scala
+++ b/tests/src/test/scala/cats/tests/BitraverseSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.Bitraverse
-import cats.instances.all._
 import cats.laws.discipline.{BitraverseTests, SerializableTests}
 
 class BitraverseSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/CategorySuite.scala
+++ b/tests/src/test/scala/cats/tests/CategorySuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.Endo
 import cats.arrow.Category
-import cats.instances.all._
 import cats.kernel.laws.discipline.MonoidTests
 import cats.laws.discipline.{MiniInt, MonoidKTests, SerializableTests}
 import cats.laws.discipline.eq.catsLawsEqForFn1Exhaustive

--- a/tests/src/test/scala/cats/tests/ChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/ChainSuite.scala
@@ -4,7 +4,6 @@ import cats.{Align, Alternative, CoflatMap, Monad, Show, Traverse, TraverseFilte
 import cats.data.Chain
 import cats.data.Chain.==:
 import cats.data.Chain.`:==`
-import cats.instances.all._
 import cats.kernel.{Eq, Hash, Monoid, Order, PartialOrder}
 import cats.kernel.laws.discipline.{EqTests, HashTests, MonoidTests, OrderTests, PartialOrderTests}
 import cats.laws.discipline.{

--- a/tests/src/test/scala/cats/tests/CokleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/CokleisliSuite.scala
@@ -3,7 +3,6 @@ package cats.tests
 import cats.{Contravariant, Id, Monad, MonoidK, SemigroupK, Semigroupal}
 import cats.arrow._
 import cats.data.{Cokleisli, NonEmptyList}
-import cats.instances.all._
 import cats.kernel.Eq
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/ComposeSuite.scala
+++ b/tests/src/test/scala/cats/tests/ComposeSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.Endo
 import cats.arrow.Compose
-import cats.instances.all._
 import cats.kernel.laws.discipline.SemigroupTests
 import cats.laws.discipline.{MiniInt, SemigroupKTests, SerializableTests}
 import cats.laws.discipline.eq.catsLawsEqForFn1Exhaustive

--- a/tests/src/test/scala/cats/tests/ConstSuite.scala
+++ b/tests/src/test/scala/cats/tests/ConstSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats._
 import cats.data.{Const, NonEmptyList}
-import cats.instances.all._
 import cats.kernel.Semigroup
 import cats.kernel.laws.discipline.{
   EqTests,

--- a/tests/src/test/scala/cats/tests/ContTSuite.scala
+++ b/tests/src/test/scala/cats/tests/ContTSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.Eval
 import cats.data.ContT
-import cats.instances.all._
 import cats.kernel.Eq
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/ContravariantSuite.scala
+++ b/tests/src/test/scala/cats/tests/ContravariantSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.{Contravariant, ContravariantMonoidal, ContravariantSemigroupal}
 import cats.data.Const
-import cats.instances.all._
 import cats.kernel.{Eq, Monoid, Semigroup}
 import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
 import cats.laws.discipline.{ContravariantMonoidalTests, ExhaustiveCheck, MiniInt}

--- a/tests/src/test/scala/cats/tests/DurationSuite.scala
+++ b/tests/src/test/scala/cats/tests/DurationSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.Show
-import cats.instances.all._
 import cats.laws.discipline.SerializableTests
 import scala.concurrent.duration.{Duration, DurationInt}
 

--- a/tests/src/test/scala/cats/tests/EitherKSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherKSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats._
 import cats.data.EitherK
-import cats.instances.all._
 import cats.kernel.laws.discipline.EqTests
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/EitherSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherSuite.scala
@@ -3,7 +3,6 @@ package cats.tests
 import cats._
 import cats.data.{EitherT, NonEmptyChain, NonEmptyList, NonEmptySet, Validated}
 import cats.kernel.laws.discipline.{EqTests, MonoidTests, OrderTests, PartialOrderTests, SemigroupTests}
-import cats.instances.all._
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
@@ -375,7 +374,6 @@ final class EitherInstancesSuite extends AnyFunSuiteLike {
 
   test("parallel instance in cats.instances.either") {
     import cats.instances.either._
-    import cats.instances.string._
     import cats.syntax.parallel._
 
     def either: Either[String, Int] = Left("Test")

--- a/tests/src/test/scala/cats/tests/EitherTSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherTSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats._
 import cats.data.{EitherT, State}
-import cats.instances.all._
 import cats.kernel.laws.discipline.{EqTests, MonoidTests, OrderTests, PartialOrderTests, SemigroupTests}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
@@ -90,7 +89,7 @@ class EitherTSuite extends CatsSuite {
     implicit val eq2: Eq[EitherT[EitherT[Option, String, *], Unit, String]] =
       EitherT.catsDataEqForEitherT[EitherT[Option, String, *], Unit, String](eq1)
     implicit val me: MonadError[EitherT[Option, String, *], Unit] =
-      EitherT.catsDataMonadErrorFForEitherT[Option, Unit, String](catsStdInstancesForOption)
+      EitherT.catsDataMonadErrorFForEitherT[Option, Unit, String](cats.instances.option.catsStdInstancesForOption)
 
     Functor[EitherT[Option, String, *]]
     Applicative[EitherT[Option, String, *]]

--- a/tests/src/test/scala/cats/tests/EqSuite.scala
+++ b/tests/src/test/scala/cats/tests/EqSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.{Contravariant, ContravariantMonoidal, ContravariantSemigroupal, Invariant, Semigroupal}
-import cats.instances.all._
 import cats.kernel.Eq
 import cats.kernel.laws.discipline.SerializableTests
 import cats.laws.discipline.{ContravariantMonoidalTests, MiniInt}

--- a/tests/src/test/scala/cats/tests/EquivSuite.scala
+++ b/tests/src/test/scala/cats/tests/EquivSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.{Contravariant, ContravariantMonoidal, ContravariantSemigroupal, Invariant, Semigroupal}
-import cats.instances.all._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/EvalSuite.scala
+++ b/tests/src/test/scala/cats/tests/EvalSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.{Bimonad, CommutativeMonad, Eval, Reducible}
-import cats.instances.all._
 import cats.laws.ComonadLaws
 import cats.laws.discipline.{
   BimonadTests,

--- a/tests/src/test/scala/cats/tests/ExtraRegressionSuite.scala
+++ b/tests/src/test/scala/cats/tests/ExtraRegressionSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.Show
-import cats.instances.all._
 import ExtraRegressionSuite._
 
 class ExtraRegressionSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/FiniteDurationSuite.scala
+++ b/tests/src/test/scala/cats/tests/FiniteDurationSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.Show
-import cats.instances.all._
 import cats.laws.discipline.SerializableTests
 import scala.concurrent.duration.{DurationInt, FiniteDuration}
 

--- a/tests/src/test/scala/cats/tests/FuncSuite.scala
+++ b/tests/src/test/scala/cats/tests/FuncSuite.scala
@@ -3,7 +3,6 @@ package cats.tests
 import cats.{Applicative, Apply, Contravariant, Functor, Semigroupal, Show}
 import cats.data.{AppFunc, Func}
 import cats.data.Func.appFunc
-import cats.instances.all._
 import cats.kernel.Eq
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/FunctionKSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctionKSuite.scala
@@ -4,7 +4,6 @@ import cats.Id
 import cats.arrow.FunctionK
 import cats.data.EitherK
 import cats.data.NonEmptyList
-import cats.instances.all._
 import cats.laws.discipline.arbitrary._
 
 class FunctionKSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/FunctionSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctionSuite.scala
@@ -14,7 +14,6 @@ import cats.{
   Semigroupal
 }
 import cats.arrow.{ArrowChoice, Choice, CommutativeArrow}
-import cats.instances.all._
 import cats.kernel._
 import cats.kernel.laws.HashLaws
 import cats.kernel.laws.discipline.{

--- a/tests/src/test/scala/cats/tests/FunctorSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctorSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.Functor
-import cats.instances.all._
 import cats.syntax.functor._
 
 class FunctorSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/GroupSuite.scala
+++ b/tests/src/test/scala/cats/tests/GroupSuite.scala
@@ -1,6 +1,5 @@
 package cats.tests
 
-import cats.instances.all._
 import cats.kernel.Group
 import cats.kernel.laws.discipline.GroupTests
 

--- a/tests/src/test/scala/cats/tests/HashSuite.scala
+++ b/tests/src/test/scala/cats/tests/HashSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.{Contravariant, Invariant}
-import cats.instances.all._
 import cats.kernel.Hash
 import cats.syntax.hash._
 

--- a/tests/src/test/scala/cats/tests/IdSuite.scala
+++ b/tests/src/test/scala/cats/tests/IdSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.{Bimonad, CommutativeMonad, Id, Reducible, Traverse}
-import cats.instances.all._
 import cats.laws.discipline._
 
 class IdSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/IdTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IdTSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats._
 import cats.data.{Const, IdT, NonEmptyList}
-import cats.instances.all._
 import cats.kernel.laws.discipline.{EqTests, OrderTests}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedReaderWriterStateTSuite.scala
@@ -3,7 +3,6 @@ package cats.tests
 import cats.{~>, Bifunctor, Contravariant, Eval, Functor, Id, Monad, MonadError, SemigroupK}
 import cats.arrow.{Profunctor, Strong}
 import cats.data.{EitherT, IRWST, IndexedReaderWriterStateT, ReaderWriterState, ReaderWriterStateT}
-import cats.instances.all._
 import cats.kernel.{Eq, Monoid}
 import cats.laws.discipline._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/InjectKSuite.scala
+++ b/tests/src/test/scala/cats/tests/InjectKSuite.scala
@@ -3,7 +3,6 @@ package cats.tests
 import cats.{:<:, Functor, InjectK}
 import cats.data.EitherK
 import cats.kernel.Eq
-import cats.instances.all._
 import cats.laws.discipline.InjectKTests
 import org.scalacheck._
 

--- a/tests/src/test/scala/cats/tests/InjectSuite.scala
+++ b/tests/src/test/scala/cats/tests/InjectSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.Inject
-import cats.instances.all._
 import cats.laws.discipline.InjectTests
 
 class InjectSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/IorSuite.scala
+++ b/tests/src/test/scala/cats/tests/IorSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.{Bitraverse, MonadError, Semigroupal, Show, Traverse}
 import cats.data.{EitherT, Ior, NonEmptyChain, NonEmptyList, NonEmptySet}
-import cats.instances.all._
 import cats.kernel.{Eq, Semigroup}
 import cats.kernel.laws.discipline.SemigroupTests
 import cats.laws.discipline.{

--- a/tests/src/test/scala/cats/tests/IorTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IorTSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.{~>, Bifunctor, Eval, Foldable, Functor, Id, Monad, MonadError, Traverse}
 import cats.data.{Ior, IorT}
-import cats.instances.all._
 import cats.kernel.{Eq, Monoid, Semigroup}
 import cats.kernel.laws.discipline.{EqTests, MonoidTests, SemigroupTests}
 import cats.laws.discipline._

--- a/tests/src/test/scala/cats/tests/KernelContravariantSuite.scala
+++ b/tests/src/test/scala/cats/tests/KernelContravariantSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.{Contravariant, ContravariantSemigroupal, Invariant, Semigroupal}
-import cats.instances.all._
 import cats.kernel.{Eq, Hash, Order, PartialOrder}
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline._

--- a/tests/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/KleisliSuite.scala
@@ -3,7 +3,6 @@ package cats.tests
 import cats._
 import cats.arrow._
 import cats.data.{Const, EitherT, Kleisli, Reader, ReaderT}
-import cats.instances.all._
 import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/ListSuite.scala
+++ b/tests/src/test/scala/cats/tests/ListSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.{Align, Alternative, CoflatMap, Monad, Semigroupal, Traverse, TraverseFilter}
 import cats.data.{NonEmptyList, ZipList}
-import cats.instances.all._
 import cats.laws.discipline.{
   AlignTests,
   AlternativeTests,

--- a/tests/src/test/scala/cats/tests/MapSuite.scala
+++ b/tests/src/test/scala/cats/tests/MapSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.{Align, FlatMap, FunctorFilter, MonoidK, Semigroupal, Show, UnorderedTraverse}
 import cats.arrow.Compose
-import cats.instances.all._
 import cats.kernel.instances.StaticMethods.wrapMutableMap
 import cats.laws.discipline.{
   AlignTests,

--- a/tests/src/test/scala/cats/tests/MiniIntSuite.scala
+++ b/tests/src/test/scala/cats/tests/MiniIntSuite.scala
@@ -1,6 +1,5 @@
 package cats.tests
 
-import cats.instances.all._
 import cats.kernel.{BoundedSemilattice, CommutativeGroup, CommutativeMonoid, Hash, Order}
 import cats.kernel.laws.discipline._
 import cats.laws.discipline.MiniInt

--- a/tests/src/test/scala/cats/tests/MonadErrorSuite.scala
+++ b/tests/src/test/scala/cats/tests/MonadErrorSuite.scala
@@ -1,6 +1,5 @@
 package cats.tests
 
-import cats.instances.all._
 import cats.kernel.Eq
 import cats.syntax.applicativeError._
 import cats.syntax.monadError._

--- a/tests/src/test/scala/cats/tests/MonadSuite.scala
+++ b/tests/src/test/scala/cats/tests/MonadSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.{Id, Monad}
 import cats.data.{IndexedStateT, StateT}
-import cats.instances.all._
 import cats.syntax.apply._
 import cats.syntax.monad._
 import org.scalacheck.Gen

--- a/tests/src/test/scala/cats/tests/MonoidSuite.scala
+++ b/tests/src/test/scala/cats/tests/MonoidSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.{Invariant, InvariantSemigroupal}
-import cats.instances.all._
 import cats.kernel.Monoid
 
 class MonoidSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/NestedSuite.scala
+++ b/tests/src/test/scala/cats/tests/NestedSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats._
 import cats.data._
-import cats.instances.all._
 import cats.laws.discipline._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms._
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/NonEmptyChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyChainSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.{Align, Bimonad, SemigroupK, Show, Traverse}
 import cats.data.{Chain, NonEmptyChain, NonEmptyChainOps}
-import cats.instances.all._
 import cats.kernel.{Eq, Order, PartialOrder, Semigroup}
 import cats.kernel.laws.discipline.{EqTests, OrderTests, PartialOrderTests, SemigroupTests}
 import cats.laws.discipline.{AlignTests, BimonadTests, NonEmptyTraverseTests, SemigroupKTests, SerializableTests}

--- a/tests/src/test/scala/cats/tests/NonEmptyCollectionSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyCollectionSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.data.NonEmptyCollection
-import cats.instances.all._
 import org.scalacheck.Arbitrary
 
 abstract class NonEmptyCollectionSuite[U[+_], NE[+_], NEC[x] <: NonEmptyCollection[x, U, NE]](

--- a/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
@@ -3,7 +3,6 @@ package cats.tests
 import cats.{Align, Bimonad, Eval, NonEmptyTraverse, Now, Reducible, SemigroupK, Show}
 import cats.data.{NonEmptyList, NonEmptyMap, NonEmptySet, NonEmptyVector}
 import cats.data.NonEmptyList.ZipNonEmptyList
-import cats.instances.all._
 import cats.kernel.{Eq, Order, PartialOrder, Semigroup}
 import cats.kernel.laws.discipline.{EqTests, OrderTests, PartialOrderTests, SemigroupTests}
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
@@ -3,7 +3,6 @@ package cats.tests
 import cats.{Align, Eval, Foldable, Now, SemigroupK, Show}
 import cats.data.{NonEmptyList, NonEmptyMap}
 import cats.kernel.laws.discipline.{SerializableTests => _, _}
-import cats.instances.all._
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.syntax.foldable._

--- a/tests/src/test/scala/cats/tests/NonEmptySetSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptySetSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.{Eval, Now, Reducible, SemigroupK, Show}
 import cats.data.NonEmptySet
-import cats.instances.all._
 import cats.kernel.{Eq, Order, PartialOrder, Semilattice}
 import cats.kernel.laws.discipline.{EqTests, HashTests, OrderTests, SemilatticeTests}
 import cats.laws.discipline._

--- a/tests/src/test/scala/cats/tests/OneAndSuite.scala
+++ b/tests/src/test/scala/cats/tests/OneAndSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.{Alternative, Applicative, Foldable, Functor, Monad, SemigroupK, Traverse}
 import cats.data.OneAnd
-import cats.instances.all._
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms

--- a/tests/src/test/scala/cats/tests/OpSuite.scala
+++ b/tests/src/test/scala/cats/tests/OpSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.arrow._
 import cats.data.{Kleisli, Op}
-import cats.instances.all._
 import cats.kernel.Eq
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/OptionSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionSuite.scala
@@ -1,6 +1,5 @@
 package cats.tests
 
-import cats.instances.all._
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.{ApplicativeLaws, CoflatMapLaws, FlatMapLaws, MonadLaws}

--- a/tests/src/test/scala/cats/tests/OptionTSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionTSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats._
 import cats.data.{Const, IdT, OptionT}
-import cats.instances.all._
 import cats.kernel.laws.discipline.{EqTests, MonoidTests, OrderTests, PartialOrderTests, SemigroupTests}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/OrderSuite.scala
+++ b/tests/src/test/scala/cats/tests/OrderSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.{Contravariant, ContravariantMonoidal, Invariant}
-import cats.instances.all._
 import cats.kernel.{Order, PartialOrder}
 import cats.kernel.laws.discipline.{OrderTests, SerializableTests}
 import cats.laws.discipline.{ContravariantMonoidalTests, MiniInt}

--- a/tests/src/test/scala/cats/tests/OrderingSuite.scala
+++ b/tests/src/test/scala/cats/tests/OrderingSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.{Contravariant, ContravariantMonoidal, ContravariantSemigroupal, Invariant, Semigroupal}
-import cats.instances.all._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/ParallelSuite.scala
+++ b/tests/src/test/scala/cats/tests/ParallelSuite.scala
@@ -3,7 +3,6 @@ package cats.tests
 import cats._
 import cats.data._
 import cats.data.NonEmptyList.ZipNonEmptyList
-import cats.instances.all._
 import cats.kernel.compat.scalaVersionSpecific._
 import cats.laws.discipline.{ApplicativeErrorTests, MiniInt, NonEmptyParallelTests, ParallelTests, SerializableTests}
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/PartialOrderSuite.scala
+++ b/tests/src/test/scala/cats/tests/PartialOrderSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.{Contravariant, ContravariantMonoidal, Invariant}
-import cats.instances.all._
 import cats.kernel.{Order, PartialOrder}
 import cats.kernel.laws.discipline.SerializableTests
 import cats.laws.discipline.{ContravariantMonoidalTests, MiniInt}

--- a/tests/src/test/scala/cats/tests/PartialOrderingSuite.scala
+++ b/tests/src/test/scala/cats/tests/PartialOrderingSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.{Contravariant, ContravariantMonoidal, ContravariantSemigroupal, Invariant, Semigroupal}
-import cats.instances.all._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline._
 import cats.laws.discipline.eq._

--- a/tests/src/test/scala/cats/tests/QueueSuite.scala
+++ b/tests/src/test/scala/cats/tests/QueueSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.{Alternative, CoflatMap, Monad, Semigroupal, Traverse, TraverseFilter}
-import cats.instances.all._
 import cats.laws.discipline.{
   AlternativeTests,
   CoflatMapTests,

--- a/tests/src/test/scala/cats/tests/ReducibleSuite.scala
+++ b/tests/src/test/scala/cats/tests/ReducibleSuite.scala
@@ -3,7 +3,6 @@ package cats.tests
 import cats.{Eval, NonEmptyReducible, Now, Reducible}
 import cats.data.NonEmptyList
 import cats.kernel.Eq
-import cats.instances.all._
 import cats.syntax.either._
 import cats.syntax.foldable._
 import cats.syntax.list._

--- a/tests/src/test/scala/cats/tests/RegressionSuite.scala
+++ b/tests/src/test/scala/cats/tests/RegressionSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.{Apply, Monad, MonadError, StackSafeMonad, Traverse}
 import cats.data.{Const, NonEmptyList, StateT}
-import cats.instances.all._
 import cats.kernel.Eq
 import cats.kernel.compat.scalaVersionSpecific._
 import cats.syntax.applicativeError._

--- a/tests/src/test/scala/cats/tests/RepresentableStoreSuite.scala
+++ b/tests/src/test/scala/cats/tests/RepresentableStoreSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.Comonad
 import cats.data.{RepresentableStore, Store}
-import cats.instances.all._
 import cats.kernel.Eq
 import cats.laws.discipline.{ComonadTests, SerializableTests}
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/RepresentableSuite.scala
+++ b/tests/src/test/scala/cats/tests/RepresentableSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.{Bimonad, Distributive, Eq, Eval, Id, Monad, Representable}
 import cats.data.Kleisli
-import cats.instances.all._
 import cats.kernel.Monoid
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/SemigroupKSuite.scala
+++ b/tests/src/test/scala/cats/tests/SemigroupKSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.{Align, Alternative, SemigroupK}
 import cats.data.{Chain, Validated}
-import cats.instances.all._
 import cats.laws.discipline.AlignTests
 import cats.laws.discipline.arbitrary._
 

--- a/tests/src/test/scala/cats/tests/SetSuite.scala
+++ b/tests/src/test/scala/cats/tests/SetSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.{MonoidK, Show, UnorderedTraverse}
 import cats.data.Validated
-import cats.instances.all._
 import cats.kernel.laws.discipline.MonoidTests
 import cats.laws.discipline.{MonoidKTests, SerializableTests, UnorderedTraverseTests}
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/ShowSuite.scala
+++ b/tests/src/test/scala/cats/tests/ShowSuite.scala
@@ -3,7 +3,6 @@ package cats.tests
 import cats.{Contravariant, Show}
 import cats.Show.ContravariantShow
 import cats.kernel.Order
-import cats.instances.all._
 import cats.syntax.show._
 import cats.laws.discipline.{ContravariantTests, MiniInt, SerializableTests}
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/SortedMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/SortedMapSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.{Align, FlatMap, MonoidK, Semigroupal, Show, Traverse, TraverseFilter}
-import cats.instances.all._
 import cats.kernel.{CommutativeMonoid, Monoid}
 import cats.kernel.laws.discipline.{CommutativeMonoidTests, HashTests, MonoidTests}
 import cats.laws.discipline.{

--- a/tests/src/test/scala/cats/tests/SortedSetSuite.scala
+++ b/tests/src/test/scala/cats/tests/SortedSetSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.{SemigroupK, Semigroupal, Show}
-import cats.instances.all._
 import cats.kernel.{Order, PartialOrder}
 import cats.kernel.laws.discipline.{BoundedSemilatticeTests, HashTests, OrderTests, PartialOrderTests}
 import cats.kernel.{BoundedSemilattice, Semilattice}

--- a/tests/src/test/scala/cats/tests/SplitSuite.scala
+++ b/tests/src/test/scala/cats/tests/SplitSuite.scala
@@ -1,6 +1,5 @@
 package cats.tests
 
-import cats.instances.all._
 import cats.syntax.arrow._
 
 class SplitSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/TailRecSuite.scala
+++ b/tests/src/test/scala/cats/tests/TailRecSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.{Defer, Monad}
-import cats.instances.all._
 import cats.kernel.Eq
 import cats.laws.discipline.{DeferTests, MonadTests, SerializableTests}
 import scala.util.control.TailCalls.{done, tailcall, TailRec}

--- a/tests/src/test/scala/cats/tests/TrySuite.scala
+++ b/tests/src/test/scala/cats/tests/TrySuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.{CoflatMap, Eval, Later, Monad, MonadError, Semigroupal, Traverse}
-import cats.instances.all._
 import cats.kernel.{Eq, Monoid, Semigroup}
 import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
 import cats.laws.{ApplicativeLaws, CoflatMapLaws, FlatMapLaws, MonadLaws}

--- a/tests/src/test/scala/cats/tests/Tuple2KSuite.scala
+++ b/tests/src/test/scala/cats/tests/Tuple2KSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats._
 import cats.data.{Const, Tuple2K, Validated}
-import cats.instances.all._
 import cats.kernel.laws.discipline.{EqTests, OrderTests, PartialOrderTests}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/TupleSuite.scala
+++ b/tests/src/test/scala/cats/tests/TupleSuite.scala
@@ -13,7 +13,6 @@ import cats.{
   Traverse
 }
 import cats.data.NonEmptyList
-import cats.instances.all._
 import cats.kernel.{Eq, Order}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._

--- a/tests/src/test/scala/cats/tests/UnorderedTraverseSuite.scala
+++ b/tests/src/test/scala/cats/tests/UnorderedTraverseSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.Id
-import cats.instances.all._
 import cats.syntax.unorderedTraverse._
 
 class UnorderedTraverseSuite extends CatsSuite {

--- a/tests/src/test/scala/cats/tests/ValidatedSuite.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedSuite.scala
@@ -13,7 +13,6 @@ import cats.{
 }
 import cats.data.{EitherT, Ior, NonEmptyChain, NonEmptyList, Validated, ValidatedNel}
 import cats.data.Validated.{Invalid, Valid}
-import cats.instances.all._
 import cats.kernel.{Eq, Order, PartialOrder, Semigroup}
 import cats.kernel.laws.discipline.{EqTests, MonoidTests, OrderTests, PartialOrderTests, SemigroupTests}
 import cats.laws.discipline._

--- a/tests/src/test/scala/cats/tests/VectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/VectorSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.{Align, Alternative, CoflatMap, Monad, Semigroupal, Traverse, TraverseFilter}
 import cats.data.{NonEmptyVector, ZipVector}
-import cats.instances.all._
 import cats.laws.discipline.{
   AlignTests,
   AlternativeTests,

--- a/tests/src/test/scala/cats/tests/WordCountSuite.scala
+++ b/tests/src/test/scala/cats/tests/WordCountSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.data.{AppFunc, Const}
 import cats.data.Func.appFunc
-import cats.instances.all._
 
 /*
  * This an example of applicative function composition.

--- a/tests/src/test/scala/cats/tests/WriterSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterSuite.scala
@@ -1,7 +1,6 @@
 package cats.tests
 
 import cats.data.Writer
-import cats.instances.all._
 import cats.syntax.applicative._
 import cats.syntax.writer._
 

--- a/tests/src/test/scala/cats/tests/WriterTSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterTSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats._
 import cats.data.{Const, EitherT, Validated, Writer, WriterT}
-import cats.instances.all._
 import cats.kernel.laws.discipline.{EqTests, MonoidTests, SemigroupTests}
 import cats.laws.discipline._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms


### PR DESCRIPTION
This is something I kind of messed up in #3043. I'd originally removed (almost) all use of `cats.instances` in the tests by getting rid of both imports and the instance traits, but then a few weeks ago we merged #3304, which replaced the instance traits with imports, and I didn't include the import removal in the final rebase. That's what I get for having PRs open for six months. :smile:

This isn't a big deal—it just means the tests need the change in this PR in order to actually exercise the implicit scope instances. There is one instance that's missing (`Align` for `Stream`), but I'll add that in a follow-up, to keep this PR tests-only.
