### PR TITLE
First two missing instances

### DIFF
--- a/core/src/main/scala-2.12/cats/ScalaVersionSpecificInstances.scala
+++ b/core/src/main/scala-2.12/cats/ScalaVersionSpecificInstances.scala
@@ -33,4 +33,7 @@ private[cats] trait ScalaVersionSpecificTraverseFilterInstances {
     cats.instances.stream.catsStdTraverseFilterForStream
 }
 
-private[cats] trait ScalaVersionSpecificAlignInstances
+private[cats] trait ScalaVersionSpecificAlignInstances {
+  implicit def catsAlignForStream: Align[Stream] =
+    cats.instances.stream.catsStdInstancesForStream
+}

--- a/kernel/src/main/scala/cats/kernel/Semigroup.scala
+++ b/kernel/src/main/scala/cats/kernel/Semigroup.scala
@@ -236,6 +236,8 @@ private[kernel] trait MonoidInstances extends BandInstances {
     cats.kernel.instances.function.catsKernelMonoidForFunction0[A]
   implicit def catsKernelMonoidForFunction1[A, B: Monoid]: Monoid[A => B] =
     cats.kernel.instances.function.catsKernelMonoidForFunction1[A, B]
+  implicit def catsKernelMonoidForMap[K, V: Semigroup]: Monoid[Map[K, V]] =
+    cats.kernel.instances.map.catsKernelStdMonoidForMap[K, V]
   implicit def catsKernelMonoidForSortedMap[K: Order, V: Semigroup]: Monoid[SortedMap[K, V]] =
     cats.kernel.instances.sortedMap.catsKernelStdMonoidForSortedMap[K, V]
   implicit def catsKernelMonoidForEither[A, B: Monoid]: Monoid[Either[A, B]] =

--- a/tests/src/test/scala/cats/tests/MapSuite.scala
+++ b/tests/src/test/scala/cats/tests/MapSuite.scala
@@ -2,8 +2,9 @@ package cats.tests
 
 import cats.{Align, FlatMap, FunctorFilter, MonoidK, Semigroupal, Show, UnorderedTraverse}
 import cats.arrow.Compose
-import cats.instances.all._
+import cats.kernel.{CommutativeMonoid, Monoid}
 import cats.kernel.instances.StaticMethods.wrapMutableMap
+import cats.kernel.laws.discipline.{CommutativeMonoidTests, HashTests, MonoidTests}
 import cats.laws.discipline.{
   AlignTests,
   ComposeTests,
@@ -40,6 +41,12 @@ class MapSuite extends CatsSuite {
 
   checkAll("Map[Int, Int]", AlignTests[Map[Int, *]].align[Int, Int, Int, Int])
   checkAll("Align[Map]", SerializableTests.serializable(Align[Map[Int, *]]))
+
+  checkAll("Hash[Map[Int, String]]", HashTests[Map[Int, String]].hash)
+  checkAll("CommutativeMonoid[Map[String, Int]]", CommutativeMonoidTests[Map[String, Int]].commutativeMonoid)
+  checkAll("CommutativeMonoid[Map[String, Int]]", SerializableTests.serializable(CommutativeMonoid[Map[String, Int]]))
+  checkAll("Monoid[Map[String, String]]", MonoidTests[Map[String, String]].monoid)
+  checkAll("Monoid[Map[String, String]]", SerializableTests.serializable(Monoid[Map[String, String]]))
 
   test("show isn't empty and is formatted as expected") {
     forAll { (map: Map[Int, String]) =>

--- a/tests/src/test/scala/cats/tests/StreamSuite.scala
+++ b/tests/src/test/scala/cats/tests/StreamSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.{Align, Alternative, CoflatMap, Monad, Semigroupal, Traverse, TraverseFilter}
 import cats.data.ZipStream
-import cats.instances.all._
 import cats.laws.discipline.{
   AlignTests,
   AlternativeTests,


### PR DESCRIPTION
Congrats to my colleague @CremboC on finding the first instance that didn't make it into implicit scope:

```scala
scala> cats.Semigroup[Map[String, List[Int]]]
                     ^
       error: could not find implicit value for parameter ev: cats.kernel.Semigroup[Map[String,List[Int]]]
```
This affects any map where the element type doesn't have a commutative semigroup. Pre-2.2.0-M1 usage continues to work fine in 2.2.0-M1, you just need at least the `cats.kernel.instances.map._` import.

I've also added a missing `Align[Stream]` on 2.12, which was turned up in #3378.

I'll give us a couple of days to find any more of these (and maybe fix #3377) and then publish a second milestone.
