### PR TITLE
Add syntax for FlatMap to nomenclature docs

### DIFF
--- a/docs/src/main/tut/nomenclature.md
+++ b/docs/src/main/tut/nomenclature.md
@@ -52,13 +52,13 @@ _WARNING_: this page is written manually, and not automatically generated, so ma
 
 ### FlatMap
 
-| Type          | Method Name |
-| ------------- |---------------|
-| `F[F[A]] => F[A]` | `flatten`  |
-| `F[A] => (A => F[B]) => F[B]` | `flatMap`
-| `F[A] => (A => F[B]) => F[(A,B)]` | `productM`
-| `F[Boolean] => F[A] => F[A] => F[A]` | `ifM`
-| `F[A] => (A => F[B]) => F[A]` | `flatTap`
+| Type          | Method Name | Symbol |
+| ------------- |---------------|---------------|
+| `F[F[A]] => F[A]` | `flatten`  | 
+| `F[A] => (A => F[B]) => F[B]` | `flatMap` | `>>`, `>>=`
+| `F[A] => (A => F[B]) => F[(A,B)]` | `productM` |
+| `F[Boolean] => F[A] => F[A] => F[A]` | `ifM` |
+| `F[A] => (A => F[B]) => F[A]` | `flatTap` |
 
 ### FunctorFilter
 


### PR DESCRIPTION
FlatMap syntax is missing from `nomenclature.md`