### PR TITLE
Syntax for function1 kleisli-composition [help for tests appreciated]

### DIFF
--- a/core/src/main/scala/cats/syntax/function1.scala
+++ b/core/src/main/scala/cats/syntax/function1.scala
@@ -1,10 +1,18 @@
 package cats
 package syntax
 
+import cats.arrow.Compose
+import cats.data.Kleisli
+
 trait Function1Syntax {
 
   implicit def catsSyntaxFunction1[F[_]: Functor, A, B](fab: F[Function1[A, B]]): Function1Ops[F, A, B] =
     new Function1Ops[F, A, B](fab)
+
+  implicit def catsSyntaxFunction1ComposeKleisli[F[_], A, B](
+    fab: Function1[A, F[B]]
+  )(implicit ev: Compose[Kleisli[F, *, *]]): Function1ComposeKleisliOps[F, A, B] =
+    new Function1ComposeKleisliOps[F, A, B](fab)
 
   final class Function1Ops[F[_]: Functor, A, B](fab: F[Function1[A, B]]) {
 
@@ -29,5 +37,18 @@ trait Function1Syntax {
      * }}}
      */
     def mapApply(a: A): F[B] = Functor[F].map(fab)(_(a))
+  }
+
+  final class Function1ComposeKleisliOps[F[_], A, B](f: A => F[B])(implicit CK: Compose[Kleisli[F, *, *]]) {
+
+    /**
+     * Alias for `(Kleisli(f) >>> Kleisli(g)).run` or `(Kleisli(f) andThen Kleisli(g)).run`
+     */
+    def >=>[C](g: B => F[C]): A => F[C] = CK.andThen(Kleisli(f), Kleisli(g)).run
+
+    /**
+     * Alias for `(Kleisli(f) <<< Kleisli(g)).run` or `(Kleisli(f) compose Kleisli(g)).run`
+     */
+    def <=<[C](g: C => F[A]): C => F[B] = CK.compose(Kleisli(f), Kleisli(g)).run
   }
 }

--- a/tests/src/test/scala/cats/tests/SyntaxSuite.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxSuite.scala
@@ -2,7 +2,7 @@ package cats.tests
 
 import cats._
 import cats.arrow.Compose
-import cats.data.{Binested, Nested, NonEmptyChain, NonEmptyList, NonEmptySet}
+import cats.data.{Binested, Kleisli, Nested, NonEmptyChain, NonEmptyList, NonEmptySet}
 import cats.syntax.all._
 import scala.collection.immutable.{SortedMap, SortedSet}
 
@@ -55,6 +55,15 @@ object SyntaxSuite {
     val a = x >>> y >>> z
     val b = z <<< y <<< x
 
+  }
+
+  def testComposeKleisli[F[_]: Lambda[X[_] => Compose[Kleisli[X, *, *]]], A, B, C, D]: Unit = {
+    val x = mock[Function[A, F[B]]]
+    val y = mock[Function[B, F[C]]]
+    val z = mock[Function[C, F[D]]]
+
+    val a = x >=> y >=> z
+    val b = z <=< y <=< x
   }
 
   def testEq[A: Eq]: Unit = {


### PR DESCRIPTION
This PR aims to add syntax for easily composing functions without wrapping them into `Kleisli` manually, based on a gitter conversation: https://gitter.im/typelevel/cats?at=5e971c478821056d3e124e4a

I looked into the tests, but I'm unsure what tests to write for the syntax methods that are added in this PR. Optimally I would like to write a property test / law in the style of `forAll{ f >=> g <-> Kleisli(f) >>> Kleisli(g) }`

TODO
- [ ] Add tests for the new syntax methods