### PR TITLE
Add NonEmptyReducible to type signatures

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -512,8 +512,11 @@ object NonEmptyList extends NonEmptyListInstances {
 
 sealed abstract private[data] class NonEmptyListInstances extends NonEmptyListInstances0 {
 
-  implicit val catsDataInstancesForNonEmptyList
-    : SemigroupK[NonEmptyList] with Bimonad[NonEmptyList] with NonEmptyTraverse[NonEmptyList] with Align[NonEmptyList] =
+  implicit val catsDataInstancesForNonEmptyList: NonEmptyReducible[NonEmptyList, List]
+    with SemigroupK[NonEmptyList]
+    with Bimonad[NonEmptyList]
+    with NonEmptyTraverse[NonEmptyList]
+    with Align[NonEmptyList] =
     new NonEmptyReducible[NonEmptyList, List]
       with SemigroupK[NonEmptyList]
       with Bimonad[NonEmptyList]

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -327,7 +327,8 @@ final class NonEmptyVector[+A] private (val toVector: Vector[A])
 @suppressUnusedImportWarningForScalaVersionSpecific
 sealed abstract private[data] class NonEmptyVectorInstances {
 
-  implicit val catsDataInstancesForNonEmptyVector: SemigroupK[NonEmptyVector]
+  implicit val catsDataInstancesForNonEmptyVector: NonEmptyReducible[NonEmptyVector, Vector]
+    with SemigroupK[NonEmptyVector]
     with Bimonad[NonEmptyVector]
     with NonEmptyTraverse[NonEmptyVector]
     with Align[NonEmptyVector] =

--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -241,7 +241,7 @@ sealed abstract private[data] class OneAndLowPriority1 extends OneAndLowPriority
 }
 
 sealed abstract private[data] class OneAndLowPriority0_5 extends OneAndLowPriority1 {
-  implicit def catsDataReducibleForOneAnd[F[_]](implicit F: Foldable[F]): Reducible[OneAnd[F, *]] =
+  implicit def catsDataReducibleForOneAnd[F[_]](implicit F: Foldable[F]): NonEmptyReducible[OneAnd[F, *], F] =
     new NonEmptyReducible[OneAnd[F, *], F] {
       override def split[A](fa: OneAnd[F, A]): (A, F[A]) = (fa.head, fa.tail)
 
@@ -253,8 +253,10 @@ sealed abstract private[data] class OneAndLowPriority0_5 extends OneAndLowPriori
 }
 
 sealed abstract private[data] class OneAndLowPriority0 extends OneAndLowPriority0_5 {
-  implicit def catsDataNonEmptyTraverseForOneAnd[F[_]](implicit F: Traverse[F],
-                                                       F2: Alternative[F]): NonEmptyTraverse[OneAnd[F, *]] =
+  implicit def catsDataNonEmptyTraverseForOneAnd[F[_]](
+    implicit F: Traverse[F],
+    F2: Alternative[F]
+  ): NonEmptyReducible[OneAnd[F, *], F] with NonEmptyTraverse[OneAnd[F, *]] =
     new NonEmptyReducible[OneAnd[F, *], F] with NonEmptyTraverse[OneAnd[F, *]] {
       def nonEmptyTraverse[G[_], A, B](fa: OneAnd[F, A])(f: (A) => G[B])(implicit G: Apply[G]): G[OneAnd[F, B]] =
         fa.map(a => Apply[G].map(f(a))(OneAnd(_, F2.empty[B])))(F)


### PR DESCRIPTION
This PR exposes the NonEmptyReducible typeclass instances.

Currently, the instances aren't exposed and can't be summoned.  The following code does not compile:
```scala
import cats.implicits._
import cats.data._

object Test {
  implicitly[NonEmptyReducible[NonEmptyVector, Vector]]
}
```
I assume this isn't the behaviour we want.

I noticed that there are no `NonEmptyReducibleTests`.  Let me know if you would like these added.