### PR TITLE
Configure codecov to simplify PR comments

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,4 @@
+comment:
+  layout: "diff"
+  require_changes: true
+


### PR DESCRIPTION
We currently use Codecov for test coverage reporting, which works nicely in general, but its default template for PR comments is much too verbose, especially since our use of property-based testing means there are often many files with small differences in coverage that show up in the report.

The result is that at the top of every PR thread there's an enormous comment that fills a screen or more and must be scrolled past to get to actual discussion.

I'm tempted to disable the PR comments entirely, and instead just have large changes in coverage fail the build. The reports would still be available on Codecov for anyone who needs them. Before we consider doing that, though, I thought we could try the smaller change here, which just removes the (often very long) `reach`, `flags`, and `file` sections from the PR comment. It also disables commenting when there are no changes to coverage, but I think that's unlikely to apply often because of property-based testing coverage noise.