### PR TITLE
Make new method final

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -450,7 +450,7 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
    * res0: Boolean = true
    *}}}
    */
-  def toNev[B >: A]: NonEmptyVector[B] =
+  final def toNev[B >: A]: NonEmptyVector[B] =
     NonEmptyVector.fromVectorUnsafe(toList.toVector)
 }
 


### PR DESCRIPTION
This is a minor thing to follow up on #3423, which introduces two new `toNev` methods but only makes one of them final. There are a lot of places where we missed the boat on making things final, and can't now because of bincompat, but for new methods like this I think we should try to do it consistently.
