### PR TITLE
Fix Simulacrum exclusion in POM

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -87,7 +87,7 @@ lazy val simulacrumSettings = Seq(
         case e: xml.Elem
             if e.label == "dependency" &&
               e.child.exists(child => child.label == "groupId" && child.text == "org.typelevel") &&
-              e.child.exists(child => child.label == "artifactId" && child.text.startsWith("simulacrum_")) =>
+              e.child.exists(child => child.label == "artifactId" && child.text.startsWith("simulacrum")) =>
           Nil
         case _ => Seq(node)
       }


### PR DESCRIPTION
Previously we'd filtered the Simulacrum dependency (which is only needed at compile-time) by matching the artifact name with `simulacrum_`. In #3424 this changed, though, from `simulacrum_2.x` to `simulacrum-scalafix-annotation_2.x`. This PR fixes the filter. I've published locally and verified that the dependency isn't included in the POM, and that everything works at runtime (by running Circe's tests using the local snapshot).