### PR TITLE
Use FullOptStage

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -109,7 +109,7 @@ lazy val commonJsSettings = Seq(
     val g = "https://raw.githubusercontent.com/typelevel/cats/" + tagOrHash
     s"-P:scalajs:mapSourceURI:$a->$g/"
   },
-  scalaJSStage in Global := FastOptStage,
+  scalaJSStage in Global := FullOptStage,
   parallelExecution := false,
   jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv(),
   // batch mode decreases the amount of memory needed to compile Scala.js code


### PR DESCRIPTION
This is a follow-up to #3357, where updating the default Scala.js version from 0.6 to 1.1 significantly increased test times. In a couple of quick experiments this change brings them back down part of the way.
