### PR TITLE
Change value-level kind-projector syntax

### DIFF
--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -759,7 +759,9 @@ object EitherT extends EitherTInstances {
    * }}}
    */
   final def liftAttemptK[F[_], E](implicit F: ApplicativeError[F, E]): F ~> EitherT[F, E, *] =
-    λ[F ~> EitherT[F, E, *]](fa => EitherT(F.attempt(fa)))
+    new (F ~> EitherT[F, E, *]) {
+      def apply[A](fa: F[A]): EitherT[F, E, A] = EitherT(F.attempt(fa))
+    }
 
   @deprecated("Use EitherT.liftF.", "1.0.0-RC1")
   final def liftT[F[_], A, B](fb: F[B])(implicit F: Functor[F]): EitherT[F, A, B] = right(fb)


### PR DESCRIPTION
This is a trivial syntax switch away from kind-projector lambdas that aren't supported in Dotty.

This got merged in #3374—I just started refreshing #3269 and noticed it again. It's the only one that's snuck in, and we might as well go ahead and change it.

