### PR TITLE
Make boilerplate syntax classes extend Serializable

### DIFF
--- a/core/src/main/scala/cats/syntax/semigroupal.scala
+++ b/core/src/main/scala/cats/syntax/semigroupal.scala
@@ -11,7 +11,7 @@ trait SemigroupalSyntax {
     }
 }
 
-abstract class SemigroupalOps[F[_], A] extends Semigroupal.Ops[F, A] {
+abstract class SemigroupalOps[F[_], A] extends Semigroupal.Ops[F, A] with Serializable {
 
   @deprecated("Replaced by an apply syntax, e.g. instead of (a |@| b).map(...) use (a, b).mapN(...)", "1.0.0-MF")
   final private[syntax] def |@|[B](fb: F[B]): SemigroupalBuilder[F]#SemigroupalBuilder2[A, B] =

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -149,10 +149,10 @@ object Boilerplate {
       |
       |
       |@deprecated("replaced by apply syntax", "1.0.0-MF")
-      |private[syntax] final class SemigroupalBuilder[F[_]] {
+      |private[syntax] final class SemigroupalBuilder[F[_]] extends Serializable {
       |  def |@|[A](a: F[A]) = new SemigroupalBuilder1(a)
       |
-        -  private[syntax] final class SemigroupalBuilder$arity[${`A..N`}]($params) {
+        -  private[syntax] final class SemigroupalBuilder$arity[${`A..N`}]($params) extends Serializable {
         -    $next
         -    def apWith[Z](f: F[(${`A..N`}) => Z])(implicit apply: Apply[F]): F[Z] = apply.ap$n(f)(${`a..n`})
         -    $map
@@ -417,7 +417,7 @@ object Boilerplate {
          -  implicit def catsSyntaxTuple${arity}Parallel[M[_], ${`A..N`}]($tupleTpe): Tuple${arity}ParallelOps[M, ${`A..N`}] = new Tuple${arity}ParallelOps(t$arity)
       |}
       |
-         -private[syntax] final class Tuple${arity}ParallelOps[M[_], ${`A..N`}](private val $tupleTpe) {
+         -private[syntax] final class Tuple${arity}ParallelOps[M[_], ${`A..N`}](private val $tupleTpe) extends Serializable {
          -  $parMap
          -  $parTupled
          -}
@@ -487,7 +487,7 @@ object Boilerplate {
         -  implicit def catsSyntaxTuple${arity}Semigroupal[F[_], ${`A..N`}]($tupleTpe): Tuple${arity}SemigroupalOps[F, ${`A..N`}] = new Tuple${arity}SemigroupalOps(t$arity)
       |}
       |
-        -private[syntax] final class Tuple${arity}SemigroupalOps[F[_], ${`A..N`}](private val $tupleTpe) {
+        -private[syntax] final class Tuple${arity}SemigroupalOps[F[_], ${`A..N`}](private val $tupleTpe) extends Serializable {
         -  $map
         -  $contramap
         -  $imap

--- a/tests/src/test/scala/cats/tests/SyntaxSerializationSuite.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxSerializationSuite.scala
@@ -1,0 +1,25 @@
+package cats.tests
+
+import cats.laws.discipline.SerializableTests
+
+/**
+ * Test that our syntax implicits are serializable.
+ */
+class SyntaxSerializationSuite extends CatsSuite {
+  checkAll(
+    "Tuple3SemigroupalOps[Option, Boolean, Int, Long]",
+    SerializableTests.serializable(
+      cats.syntax.all.catsSyntaxTuple3Semigroupal[Option, Boolean, Int, Long]((None, None, None))
+    )
+  )
+
+  checkAll("SemigroupalOps[Option, Int]",
+           SerializableTests.serializable(cats.syntax.all.catsSyntaxSemigroupal[Option, Int](None)))
+
+  checkAll(
+    "Tuple3ParallelOps[Either[String, ?], Boolean, Int, Long]",
+    SerializableTests.serializable(
+      cats.syntax.all.catsSyntaxTuple3Parallel[Either[String, ?], Boolean, Int, Long]((Left("a"), Left("b"), Left("c")))
+    )
+  )
+}


### PR DESCRIPTION
Today I ran into a serializability issue when using `mapN` in a Spark
environment 😬.