### PR TITLE
Mark Ops traits as Serializable

### DIFF
--- a/alleycats-core/src/main/scala/alleycats/ConsK.scala
+++ b/alleycats-core/src/main/scala/alleycats/ConsK.scala
@@ -18,18 +18,19 @@ object ConsK {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[ConsK]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: ConsK[F]): ConsK[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: ConsK[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
   }
   trait AllOps[F[_], A] extends Ops[F, A]
-  trait ToConsKOps {
+  trait ToConsKOps extends Serializable {
     implicit def toConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): Ops[F, A] {
       type TypeClassType = ConsK[F]
     } =

--- a/alleycats-core/src/main/scala/alleycats/Empty.scala
+++ b/alleycats-core/src/main/scala/alleycats/Empty.scala
@@ -26,12 +26,13 @@ object Empty extends EmptyInstances0 {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Empty]] for `A`.
    */
   @inline def apply[A](implicit instance: Empty[A]): Empty[A] = instance
 
-  trait Ops[A] {
+  trait Ops[A] extends Serializable {
     type TypeClassType <: Empty[A]
     def self: A
     val typeClassInstance: TypeClassType
@@ -39,7 +40,7 @@ object Empty extends EmptyInstances0 {
     def nonEmpty(implicit ev: Eq[A]): Boolean = typeClassInstance.nonEmpty(self)(ev)
   }
   trait AllOps[A] extends Ops[A]
-  trait ToEmptyOps {
+  trait ToEmptyOps extends Serializable {
     implicit def toEmptyOps[A](target: A)(implicit tc: Empty[A]): Ops[A] {
       type TypeClassType = Empty[A]
     } =

--- a/alleycats-core/src/main/scala/alleycats/EmptyK.scala
+++ b/alleycats-core/src/main/scala/alleycats/EmptyK.scala
@@ -18,18 +18,19 @@ object EmptyK {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[EmptyK]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: EmptyK[F]): EmptyK[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: EmptyK[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
   }
   trait AllOps[F[_], A] extends Ops[F, A]
-  trait ToEmptyKOps {
+  trait ToEmptyKOps extends Serializable {
     implicit def toEmptyKOps[F[_], A](target: F[A])(implicit tc: EmptyK[F]): Ops[F, A] {
       type TypeClassType = EmptyK[F]
     } =

--- a/alleycats-core/src/main/scala/alleycats/Extract.scala
+++ b/alleycats-core/src/main/scala/alleycats/Extract.scala
@@ -28,19 +28,20 @@ object Extract {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Extract]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: Extract[F]): Extract[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Extract[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
     def extract: A = typeClassInstance.extract[A](self)
   }
   trait AllOps[F[_], A] extends Ops[F, A]
-  trait ToExtractOps {
+  trait ToExtractOps extends Serializable {
     implicit def toExtractOps[F[_], A](target: F[A])(implicit tc: Extract[F]): Ops[F, A] {
       type TypeClassType = Extract[F]
     } =

--- a/alleycats-core/src/main/scala/alleycats/One.scala
+++ b/alleycats-core/src/main/scala/alleycats/One.scala
@@ -23,12 +23,13 @@ object One {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[One]] for `A`.
    */
   @inline def apply[A](implicit instance: One[A]): One[A] = instance
 
-  trait Ops[A] {
+  trait Ops[A] extends Serializable {
     type TypeClassType <: One[A]
     def self: A
     val typeClassInstance: TypeClassType
@@ -36,7 +37,7 @@ object One {
     def nonOne(implicit ev: Eq[A]): Boolean = typeClassInstance.nonOne(self)(ev)
   }
   trait AllOps[A] extends Ops[A]
-  trait ToOneOps {
+  trait ToOneOps extends Serializable {
     implicit def toOneOps[A](target: A)(implicit tc: One[A]): Ops[A] {
       type TypeClassType = One[A]
     } =

--- a/alleycats-core/src/main/scala/alleycats/Pure.scala
+++ b/alleycats-core/src/main/scala/alleycats/Pure.scala
@@ -28,18 +28,19 @@ object Pure {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Pure]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: Pure[F]): Pure[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Pure[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
   }
   trait AllOps[F[_], A] extends Ops[F, A]
-  trait ToPureOps {
+  trait ToPureOps extends Serializable {
     implicit def toPureOps[F[_], A](target: F[A])(implicit tc: Pure[F]): Ops[F, A] {
       type TypeClassType = Pure[F]
     } =

--- a/alleycats-core/src/main/scala/alleycats/Zero.scala
+++ b/alleycats-core/src/main/scala/alleycats/Zero.scala
@@ -24,12 +24,13 @@ object Zero {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Zero]] for `A`.
    */
   @inline def apply[A](implicit instance: Zero[A]): Zero[A] = instance
 
-  trait Ops[A] {
+  trait Ops[A] extends Serializable {
     type TypeClassType <: Zero[A]
     def self: A
     val typeClassInstance: TypeClassType
@@ -37,7 +38,7 @@ object Zero {
     def nonZero(implicit ev: Eq[A]): Boolean = typeClassInstance.nonZero(self)(ev)
   }
   trait AllOps[A] extends Ops[A]
-  trait ToZeroOps {
+  trait ToZeroOps extends Serializable {
     implicit def toZeroOps[A](target: A)(implicit tc: Zero[A]): Ops[A] {
       type TypeClassType = Zero[A]
     } =

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val scoverageSettings = Seq(
 )
 
 organization in ThisBuild := "org.typelevel"
-scalafixDependencies in ThisBuild += "org.typelevel" %% "simulacrum-scalafix" % "0.2.0"
+scalafixDependencies in ThisBuild += "org.typelevel" %% "simulacrum-scalafix" % "0.3.0"
 
 val isTravisBuild = settingKey[Boolean]("Flag indicating whether the current build is running under Travis")
 val crossScalaVersionsFromTravis = settingKey[Seq[String]]("Scala versions set in .travis.yml as scala_version_XXX")

--- a/core/src/main/scala/cats/Align.scala
+++ b/core/src/main/scala/cats/Align.scala
@@ -133,12 +133,13 @@ object Align extends ScalaVersionSpecificAlignInstances {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Align]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: Align[F]): Align[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Align[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -151,7 +152,7 @@ object Align extends ScalaVersionSpecificAlignInstances {
     def zipAll[B](fb: F[B], a: A, b: B): F[(A, B)] = typeClassInstance.zipAll[A, B](self, fb, a, b)
   }
   trait AllOps[F[_], A] extends Ops[F, A]
-  trait ToAlignOps {
+  trait ToAlignOps extends Serializable {
     implicit def toAlignOps[F[_], A](target: F[A])(implicit tc: Align[F]): Ops[F, A] {
       type TypeClassType = Align[F]
     } =

--- a/core/src/main/scala/cats/Alternative.scala
+++ b/core/src/main/scala/cats/Alternative.scala
@@ -95,12 +95,13 @@ object Alternative {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Alternative]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: Alternative[F]): Alternative[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Alternative[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -114,7 +115,7 @@ object Alternative {
   trait AllOps[F[_], A] extends Ops[F, A] with Applicative.AllOps[F, A] with MonoidK.AllOps[F, A] {
     type TypeClassType <: Alternative[F]
   }
-  trait ToAlternativeOps {
+  trait ToAlternativeOps extends Serializable {
     implicit def toAlternativeOps[F[_], A](target: F[A])(implicit tc: Alternative[F]): Ops[F, A] {
       type TypeClassType = Alternative[F]
     } =

--- a/core/src/main/scala/cats/Applicative.scala
+++ b/core/src/main/scala/cats/Applicative.scala
@@ -233,12 +233,13 @@ object Applicative {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Applicative]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: Applicative[F]): Applicative[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Applicative[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -246,7 +247,7 @@ object Applicative {
   trait AllOps[F[_], A] extends Ops[F, A] with Apply.AllOps[F, A] with InvariantMonoidal.AllOps[F, A] {
     type TypeClassType <: Applicative[F]
   }
-  trait ToApplicativeOps {
+  trait ToApplicativeOps extends Serializable {
     implicit def toApplicativeOps[F[_], A](target: F[A])(implicit tc: Applicative[F]): Ops[F, A] {
       type TypeClassType = Applicative[F]
     } =

--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -270,12 +270,13 @@ object Apply {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Apply]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: Apply[F]): Apply[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Apply[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -295,7 +296,7 @@ object Apply {
   trait AllOps[F[_], A] extends Ops[F, A] with Functor.AllOps[F, A] with InvariantSemigroupal.AllOps[F, A] {
     type TypeClassType <: Apply[F]
   }
-  trait ToApplyOps {
+  trait ToApplyOps extends Serializable {
     implicit def toApplyOps[F[_], A](target: F[A])(implicit tc: Apply[F]): Ops[F, A] {
       type TypeClassType = Apply[F]
     } =

--- a/core/src/main/scala/cats/Bifoldable.scala
+++ b/core/src/main/scala/cats/Bifoldable.scala
@@ -41,12 +41,13 @@ object Bifoldable {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Bifoldable]] for `F`.
    */
   @inline def apply[F[_, _]](implicit instance: Bifoldable[F]): Bifoldable[F] = instance
 
-  trait Ops[F[_, _], A, B] {
+  trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: Bifoldable[F]
     def self: F[A, B]
     val typeClassInstance: TypeClassType
@@ -58,7 +59,7 @@ object Bifoldable {
     def bifold(implicit A: Monoid[A], B: Monoid[B]): (A, B) = typeClassInstance.bifold[A, B](self)(A, B)
   }
   trait AllOps[F[_, _], A, B] extends Ops[F, A, B]
-  trait ToBifoldableOps {
+  trait ToBifoldableOps extends Serializable {
     implicit def toBifoldableOps[F[_, _], A, B](target: F[A, B])(implicit tc: Bifoldable[F]): Ops[F, A, B] {
       type TypeClassType = Bifoldable[F]
     } =

--- a/core/src/main/scala/cats/Bifunctor.scala
+++ b/core/src/main/scala/cats/Bifunctor.scala
@@ -64,12 +64,13 @@ object Bifunctor {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Bifunctor]] for `F`.
    */
   @inline def apply[F[_, _]](implicit instance: Bifunctor[F]): Bifunctor[F] = instance
 
-  trait Ops[F[_, _], A, B] {
+  trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: Bifunctor[F]
     def self: F[A, B]
     val typeClassInstance: TypeClassType
@@ -78,7 +79,7 @@ object Bifunctor {
     def leftWiden[C >: A]: F[C, B] = typeClassInstance.leftWiden[A, B, C](self)
   }
   trait AllOps[F[_, _], A, B] extends Ops[F, A, B]
-  trait ToBifunctorOps {
+  trait ToBifunctorOps extends Serializable {
     implicit def toBifunctorOps[F[_, _], A, B](target: F[A, B])(implicit tc: Bifunctor[F]): Ops[F, A, B] {
       type TypeClassType = Bifunctor[F]
     } =

--- a/core/src/main/scala/cats/Bimonad.scala
+++ b/core/src/main/scala/cats/Bimonad.scala
@@ -11,12 +11,13 @@ object Bimonad {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Bimonad]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: Bimonad[F]): Bimonad[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Bimonad[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -24,7 +25,7 @@ object Bimonad {
   trait AllOps[F[_], A] extends Ops[F, A] with Monad.AllOps[F, A] with Comonad.AllOps[F, A] {
     type TypeClassType <: Bimonad[F]
   }
-  trait ToBimonadOps {
+  trait ToBimonadOps extends Serializable {
     implicit def toBimonadOps[F[_], A](target: F[A])(implicit tc: Bimonad[F]): Ops[F, A] {
       type TypeClassType = Bimonad[F]
     } =

--- a/core/src/main/scala/cats/Bitraverse.scala
+++ b/core/src/main/scala/cats/Bitraverse.scala
@@ -116,12 +116,13 @@ object Bitraverse {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Bitraverse]] for `F`.
    */
   @inline def apply[F[_, _]](implicit instance: Bitraverse[F]): Bitraverse[F] = instance
 
-  trait Ops[F[_, _], A, B] {
+  trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: Bitraverse[F]
     def self: F[A, B]
     val typeClassInstance: TypeClassType
@@ -133,7 +134,7 @@ object Bitraverse {
   trait AllOps[F[_, _], A, B] extends Ops[F, A, B] with Bifoldable.AllOps[F, A, B] with Bifunctor.AllOps[F, A, B] {
     type TypeClassType <: Bitraverse[F]
   }
-  trait ToBitraverseOps {
+  trait ToBitraverseOps extends Serializable {
     implicit def toBitraverseOps[F[_, _], A, B](target: F[A, B])(implicit tc: Bitraverse[F]): Ops[F, A, B] {
       type TypeClassType = Bitraverse[F]
     } =

--- a/core/src/main/scala/cats/CoflatMap.scala
+++ b/core/src/main/scala/cats/CoflatMap.scala
@@ -53,12 +53,13 @@ object CoflatMap {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[CoflatMap]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: CoflatMap[F]): CoflatMap[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: CoflatMap[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -68,7 +69,7 @@ object CoflatMap {
   trait AllOps[F[_], A] extends Ops[F, A] with Functor.AllOps[F, A] {
     type TypeClassType <: CoflatMap[F]
   }
-  trait ToCoflatMapOps {
+  trait ToCoflatMapOps extends Serializable {
     implicit def toCoflatMapOps[F[_], A](target: F[A])(implicit tc: CoflatMap[F]): Ops[F, A] {
       type TypeClassType = CoflatMap[F]
     } =

--- a/core/src/main/scala/cats/CommutativeApplicative.scala
+++ b/core/src/main/scala/cats/CommutativeApplicative.scala
@@ -31,12 +31,13 @@ object CommutativeApplicative {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[CommutativeApplicative]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: CommutativeApplicative[F]): CommutativeApplicative[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: CommutativeApplicative[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -44,7 +45,7 @@ object CommutativeApplicative {
   trait AllOps[F[_], A] extends Ops[F, A] with Applicative.AllOps[F, A] with CommutativeApply.AllOps[F, A] {
     type TypeClassType <: CommutativeApplicative[F]
   }
-  trait ToCommutativeApplicativeOps {
+  trait ToCommutativeApplicativeOps extends Serializable {
     implicit def toCommutativeApplicativeOps[F[_], A](target: F[A])(implicit tc: CommutativeApplicative[F]): Ops[F, A] {
       type TypeClassType = CommutativeApplicative[F]
     } =

--- a/core/src/main/scala/cats/CommutativeApply.scala
+++ b/core/src/main/scala/cats/CommutativeApply.scala
@@ -27,12 +27,13 @@ object CommutativeApply {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[CommutativeApply]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: CommutativeApply[F]): CommutativeApply[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: CommutativeApply[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -40,7 +41,7 @@ object CommutativeApply {
   trait AllOps[F[_], A] extends Ops[F, A] with Apply.AllOps[F, A] {
     type TypeClassType <: CommutativeApply[F]
   }
-  trait ToCommutativeApplyOps {
+  trait ToCommutativeApplyOps extends Serializable {
     implicit def toCommutativeApplyOps[F[_], A](target: F[A])(implicit tc: CommutativeApply[F]): Ops[F, A] {
       type TypeClassType = CommutativeApply[F]
     } =

--- a/core/src/main/scala/cats/CommutativeFlatMap.scala
+++ b/core/src/main/scala/cats/CommutativeFlatMap.scala
@@ -20,12 +20,13 @@ object CommutativeFlatMap {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[CommutativeFlatMap]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: CommutativeFlatMap[F]): CommutativeFlatMap[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: CommutativeFlatMap[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -33,7 +34,7 @@ object CommutativeFlatMap {
   trait AllOps[F[_], A] extends Ops[F, A] with FlatMap.AllOps[F, A] with CommutativeApply.AllOps[F, A] {
     type TypeClassType <: CommutativeFlatMap[F]
   }
-  trait ToCommutativeFlatMapOps {
+  trait ToCommutativeFlatMapOps extends Serializable {
     implicit def toCommutativeFlatMapOps[F[_], A](target: F[A])(implicit tc: CommutativeFlatMap[F]): Ops[F, A] {
       type TypeClassType = CommutativeFlatMap[F]
     } =

--- a/core/src/main/scala/cats/CommutativeMonad.scala
+++ b/core/src/main/scala/cats/CommutativeMonad.scala
@@ -20,12 +20,13 @@ object CommutativeMonad {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[CommutativeMonad]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: CommutativeMonad[F]): CommutativeMonad[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: CommutativeMonad[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -37,7 +38,7 @@ object CommutativeMonad {
       with CommutativeApplicative.AllOps[F, A] {
     type TypeClassType <: CommutativeMonad[F]
   }
-  trait ToCommutativeMonadOps {
+  trait ToCommutativeMonadOps extends Serializable {
     implicit def toCommutativeMonadOps[F[_], A](target: F[A])(implicit tc: CommutativeMonad[F]): Ops[F, A] {
       type TypeClassType = CommutativeMonad[F]
     } =

--- a/core/src/main/scala/cats/Comonad.scala
+++ b/core/src/main/scala/cats/Comonad.scala
@@ -35,12 +35,13 @@ object Comonad {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Comonad]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: Comonad[F]): Comonad[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Comonad[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -49,7 +50,7 @@ object Comonad {
   trait AllOps[F[_], A] extends Ops[F, A] with CoflatMap.AllOps[F, A] {
     type TypeClassType <: Comonad[F]
   }
-  trait ToComonadOps {
+  trait ToComonadOps extends Serializable {
     implicit def toComonadOps[F[_], A](target: F[A])(implicit tc: Comonad[F]): Ops[F, A] {
       type TypeClassType = Comonad[F]
     } =

--- a/core/src/main/scala/cats/Contravariant.scala
+++ b/core/src/main/scala/cats/Contravariant.scala
@@ -36,12 +36,13 @@ object Contravariant {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Contravariant]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: Contravariant[F]): Contravariant[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Contravariant[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -51,7 +52,7 @@ object Contravariant {
   trait AllOps[F[_], A] extends Ops[F, A] with Invariant.AllOps[F, A] {
     type TypeClassType <: Contravariant[F]
   }
-  trait ToContravariantOps {
+  trait ToContravariantOps extends Serializable {
     implicit def toContravariantOps[F[_], A](target: F[A])(implicit tc: Contravariant[F]): Ops[F, A] {
       type TypeClassType = Contravariant[F]
     } =

--- a/core/src/main/scala/cats/ContravariantMonoidal.scala
+++ b/core/src/main/scala/cats/ContravariantMonoidal.scala
@@ -30,12 +30,13 @@ object ContravariantMonoidal extends SemigroupalArityFunctions {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[ContravariantMonoidal]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: ContravariantMonoidal[F]): ContravariantMonoidal[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: ContravariantMonoidal[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -46,7 +47,7 @@ object ContravariantMonoidal extends SemigroupalArityFunctions {
       with InvariantMonoidal.AllOps[F, A] {
     type TypeClassType <: ContravariantMonoidal[F]
   }
-  trait ToContravariantMonoidalOps {
+  trait ToContravariantMonoidalOps extends Serializable {
     implicit def toContravariantMonoidalOps[F[_], A](target: F[A])(implicit tc: ContravariantMonoidal[F]): Ops[F, A] {
       type TypeClassType = ContravariantMonoidal[F]
     } =

--- a/core/src/main/scala/cats/ContravariantSemigroupal.scala
+++ b/core/src/main/scala/cats/ContravariantSemigroupal.scala
@@ -24,12 +24,13 @@ object ContravariantSemigroupal extends SemigroupalArityFunctions {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[ContravariantSemigroupal]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: ContravariantSemigroupal[F]): ContravariantSemigroupal[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: ContravariantSemigroupal[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -37,7 +38,7 @@ object ContravariantSemigroupal extends SemigroupalArityFunctions {
   trait AllOps[F[_], A] extends Ops[F, A] with InvariantSemigroupal.AllOps[F, A] with Contravariant.AllOps[F, A] {
     type TypeClassType <: ContravariantSemigroupal[F]
   }
-  trait ToContravariantSemigroupalOps {
+  trait ToContravariantSemigroupalOps extends Serializable {
     implicit def toContravariantSemigroupalOps[F[_], A](
       target: F[A]
     )(implicit tc: ContravariantSemigroupal[F]): Ops[F, A] {

--- a/core/src/main/scala/cats/Distributive.scala
+++ b/core/src/main/scala/cats/Distributive.scala
@@ -28,12 +28,13 @@ object Distributive {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Distributive]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: Distributive[F]): Distributive[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Distributive[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -41,7 +42,7 @@ object Distributive {
   trait AllOps[F[_], A] extends Ops[F, A] with Functor.AllOps[F, A] {
     type TypeClassType <: Distributive[F]
   }
-  trait ToDistributiveOps {
+  trait ToDistributiveOps extends Serializable {
     implicit def toDistributiveOps[F[_], A](target: F[A])(implicit tc: Distributive[F]): Ops[F, A] {
       type TypeClassType = Distributive[F]
     } =

--- a/core/src/main/scala/cats/FlatMap.scala
+++ b/core/src/main/scala/cats/FlatMap.scala
@@ -205,12 +205,13 @@ object FlatMap {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[FlatMap]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: FlatMap[F]): FlatMap[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: FlatMap[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -224,7 +225,7 @@ object FlatMap {
   trait AllOps[F[_], A] extends Ops[F, A] with Apply.AllOps[F, A] {
     type TypeClassType <: FlatMap[F]
   }
-  trait ToFlatMapOps {
+  trait ToFlatMapOps extends Serializable {
     implicit def toFlatMapOps[F[_], A](target: F[A])(implicit tc: FlatMap[F]): Ops[F, A] {
       type TypeClassType = FlatMap[F]
     } =

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -913,12 +913,13 @@ object Foldable {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Foldable]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: Foldable[F]): Foldable[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Foldable[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -978,7 +979,7 @@ object Foldable {
   trait AllOps[F[_], A] extends Ops[F, A] with UnorderedFoldable.AllOps[F, A] {
     type TypeClassType <: Foldable[F]
   }
-  trait ToFoldableOps {
+  trait ToFoldableOps extends Serializable {
     implicit def toFoldableOps[F[_], A](target: F[A])(implicit tc: Foldable[F]): Ops[F, A] {
       type TypeClassType = Foldable[F]
     } =

--- a/core/src/main/scala/cats/Functor.scala
+++ b/core/src/main/scala/cats/Functor.scala
@@ -210,12 +210,13 @@ object Functor {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Functor]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: Functor[F]): Functor[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Functor[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -232,7 +233,7 @@ object Functor {
   trait AllOps[F[_], A] extends Ops[F, A] with Invariant.AllOps[F, A] {
     type TypeClassType <: Functor[F]
   }
-  trait ToFunctorOps {
+  trait ToFunctorOps extends Serializable {
     implicit def toFunctorOps[F[_], A](target: F[A])(implicit tc: Functor[F]): Ops[F, A] {
       type TypeClassType = Functor[F]
     } =

--- a/core/src/main/scala/cats/FunctorFilter.scala
+++ b/core/src/main/scala/cats/FunctorFilter.scala
@@ -94,12 +94,13 @@ object FunctorFilter extends ScalaVersionSpecificTraverseFilterInstances {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[FunctorFilter]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: FunctorFilter[F]): FunctorFilter[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: FunctorFilter[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -111,7 +112,7 @@ object FunctorFilter extends ScalaVersionSpecificTraverseFilterInstances {
     def filterNot(f: A => Boolean): F[A] = typeClassInstance.filterNot[A](self)(f)
   }
   trait AllOps[F[_], A] extends Ops[F, A]
-  trait ToFunctorFilterOps {
+  trait ToFunctorFilterOps extends Serializable {
     implicit def toFunctorFilterOps[F[_], A](target: F[A])(implicit tc: FunctorFilter[F]): Ops[F, A] {
       type TypeClassType = FunctorFilter[F]
     } =

--- a/core/src/main/scala/cats/Invariant.scala
+++ b/core/src/main/scala/cats/Invariant.scala
@@ -186,19 +186,20 @@ object Invariant extends ScalaVersionSpecificInvariantInstances with InvariantIn
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Invariant]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: Invariant[F]): Invariant[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Invariant[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
     def imap[B](f: A => B)(g: B => A): F[B] = typeClassInstance.imap[A, B](self)(f)(g)
   }
   trait AllOps[F[_], A] extends Ops[F, A]
-  trait ToInvariantOps {
+  trait ToInvariantOps extends Serializable {
     implicit def toInvariantOps[F[_], A](target: F[A])(implicit tc: Invariant[F]): Ops[F, A] {
       type TypeClassType = Invariant[F]
     } =

--- a/core/src/main/scala/cats/InvariantMonoidal.scala
+++ b/core/src/main/scala/cats/InvariantMonoidal.scala
@@ -39,12 +39,13 @@ object InvariantMonoidal {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[InvariantMonoidal]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: InvariantMonoidal[F]): InvariantMonoidal[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: InvariantMonoidal[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -52,7 +53,7 @@ object InvariantMonoidal {
   trait AllOps[F[_], A] extends Ops[F, A] with InvariantSemigroupal.AllOps[F, A] {
     type TypeClassType <: InvariantMonoidal[F]
   }
-  trait ToInvariantMonoidalOps {
+  trait ToInvariantMonoidalOps extends Serializable {
     implicit def toInvariantMonoidalOps[F[_], A](target: F[A])(implicit tc: InvariantMonoidal[F]): Ops[F, A] {
       type TypeClassType = InvariantMonoidal[F]
     } =

--- a/core/src/main/scala/cats/InvariantSemigroupal.scala
+++ b/core/src/main/scala/cats/InvariantSemigroupal.scala
@@ -29,12 +29,13 @@ object InvariantSemigroupal extends SemigroupalArityFunctions {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[InvariantSemigroupal]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: InvariantSemigroupal[F]): InvariantSemigroupal[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: InvariantSemigroupal[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -42,7 +43,7 @@ object InvariantSemigroupal extends SemigroupalArityFunctions {
   trait AllOps[F[_], A] extends Ops[F, A] with Semigroupal.AllOps[F, A] with Invariant.AllOps[F, A] {
     type TypeClassType <: InvariantSemigroupal[F]
   }
-  trait ToInvariantSemigroupalOps {
+  trait ToInvariantSemigroupalOps extends Serializable {
     implicit def toInvariantSemigroupalOps[F[_], A](target: F[A])(implicit tc: InvariantSemigroupal[F]): Ops[F, A] {
       type TypeClassType = InvariantSemigroupal[F]
     } =

--- a/core/src/main/scala/cats/Monad.scala
+++ b/core/src/main/scala/cats/Monad.scala
@@ -124,12 +124,13 @@ object Monad {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Monad]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: Monad[F]): Monad[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Monad[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -142,7 +143,7 @@ object Monad {
   trait AllOps[F[_], A] extends Ops[F, A] with FlatMap.AllOps[F, A] with Applicative.AllOps[F, A] {
     type TypeClassType <: Monad[F]
   }
-  trait ToMonadOps {
+  trait ToMonadOps extends Serializable {
     implicit def toMonadOps[F[_], A](target: F[A])(implicit tc: Monad[F]): Ops[F, A] {
       type TypeClassType = Monad[F]
     } =

--- a/core/src/main/scala/cats/MonoidK.scala
+++ b/core/src/main/scala/cats/MonoidK.scala
@@ -58,12 +58,13 @@ object MonoidK {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[MonoidK]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: MonoidK[F]): MonoidK[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: MonoidK[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -71,7 +72,7 @@ object MonoidK {
   trait AllOps[F[_], A] extends Ops[F, A] with SemigroupK.AllOps[F, A] {
     type TypeClassType <: MonoidK[F]
   }
-  trait ToMonoidKOps {
+  trait ToMonoidKOps extends Serializable {
     implicit def toMonoidKOps[F[_], A](target: F[A])(implicit tc: MonoidK[F]): Ops[F, A] {
       type TypeClassType = MonoidK[F]
     } =

--- a/core/src/main/scala/cats/NonEmptyTraverse.scala
+++ b/core/src/main/scala/cats/NonEmptyTraverse.scala
@@ -101,12 +101,13 @@ object NonEmptyTraverse {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[NonEmptyTraverse]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: NonEmptyTraverse[F]): NonEmptyTraverse[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: NonEmptyTraverse[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -122,7 +123,7 @@ object NonEmptyTraverse {
   trait AllOps[F[_], A] extends Ops[F, A] with Traverse.AllOps[F, A] with Reducible.AllOps[F, A] {
     type TypeClassType <: NonEmptyTraverse[F]
   }
-  trait ToNonEmptyTraverseOps {
+  trait ToNonEmptyTraverseOps extends Serializable {
     implicit def toNonEmptyTraverseOps[F[_], A](target: F[A])(implicit tc: NonEmptyTraverse[F]): Ops[F, A] {
       type TypeClassType = NonEmptyTraverse[F]
     } =

--- a/core/src/main/scala/cats/Reducible.scala
+++ b/core/src/main/scala/cats/Reducible.scala
@@ -289,12 +289,13 @@ object Reducible {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Reducible]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: Reducible[F]): Reducible[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Reducible[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -329,7 +330,7 @@ object Reducible {
   trait AllOps[F[_], A] extends Ops[F, A] with Foldable.AllOps[F, A] {
     type TypeClassType <: Reducible[F]
   }
-  trait ToReducibleOps {
+  trait ToReducibleOps extends Serializable {
     implicit def toReducibleOps[F[_], A](target: F[A])(implicit tc: Reducible[F]): Ops[F, A] {
       type TypeClassType = Reducible[F]
     } =

--- a/core/src/main/scala/cats/SemigroupK.scala
+++ b/core/src/main/scala/cats/SemigroupK.scala
@@ -110,12 +110,13 @@ object SemigroupK extends ScalaVersionSpecificMonoidKInstances {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[SemigroupK]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: SemigroupK[F]): SemigroupK[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: SemigroupK[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -124,7 +125,7 @@ object SemigroupK extends ScalaVersionSpecificMonoidKInstances {
     def sum[B](fb: F[B])(implicit F: Functor[F]): F[Either[A, B]] = typeClassInstance.sum[A, B](self, fb)(F)
   }
   trait AllOps[F[_], A] extends Ops[F, A]
-  trait ToSemigroupKOps {
+  trait ToSemigroupKOps extends Serializable {
     implicit def toSemigroupKOps[F[_], A](target: F[A])(implicit tc: SemigroupK[F]): Ops[F, A] {
       type TypeClassType = SemigroupK[F]
     } =

--- a/core/src/main/scala/cats/Semigroupal.scala
+++ b/core/src/main/scala/cats/Semigroupal.scala
@@ -87,19 +87,20 @@ object Semigroupal extends ScalaVersionSpecificSemigroupalInstances with Semigro
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Semigroupal]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: Semigroupal[F]): Semigroupal[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Semigroupal[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
     def product[B](fb: F[B]): F[(A, B)] = typeClassInstance.product[A, B](self, fb)
   }
   trait AllOps[F[_], A] extends Ops[F, A]
-  trait ToSemigroupalOps {
+  trait ToSemigroupalOps extends Serializable {
     implicit def toSemigroupalOps[F[_], A](target: F[A])(implicit tc: Semigroupal[F]): Ops[F, A] {
       type TypeClassType = Semigroupal[F]
     } =

--- a/core/src/main/scala/cats/Traverse.scala
+++ b/core/src/main/scala/cats/Traverse.scala
@@ -138,12 +138,13 @@ object Traverse {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Traverse]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: Traverse[F]): Traverse[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Traverse[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -167,7 +168,7 @@ object Traverse {
       with UnorderedTraverse.AllOps[F, A] {
     type TypeClassType <: Traverse[F]
   }
-  trait ToTraverseOps {
+  trait ToTraverseOps extends Serializable {
     implicit def toTraverseOps[F[_], A](target: F[A])(implicit tc: Traverse[F]): Ops[F, A] {
       type TypeClassType = Traverse[F]
     } =

--- a/core/src/main/scala/cats/TraverseFilter.scala
+++ b/core/src/main/scala/cats/TraverseFilter.scala
@@ -93,12 +93,13 @@ object TraverseFilter {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[TraverseFilter]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: TraverseFilter[F]): TraverseFilter[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: TraverseFilter[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -112,7 +113,7 @@ object TraverseFilter {
   trait AllOps[F[_], A] extends Ops[F, A] with FunctorFilter.AllOps[F, A] {
     type TypeClassType <: TraverseFilter[F]
   }
-  trait ToTraverseFilterOps {
+  trait ToTraverseFilterOps extends Serializable {
     implicit def toTraverseFilterOps[F[_], A](target: F[A])(implicit tc: TraverseFilter[F]): Ops[F, A] {
       type TypeClassType = TraverseFilter[F]
     } =

--- a/core/src/main/scala/cats/UnorderedFoldable.scala
+++ b/core/src/main/scala/cats/UnorderedFoldable.scala
@@ -117,12 +117,13 @@ object UnorderedFoldable extends ScalaVersionSpecificTraverseInstances {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[UnorderedFoldable]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: UnorderedFoldable[F]): UnorderedFoldable[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: UnorderedFoldable[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -136,7 +137,7 @@ object UnorderedFoldable extends ScalaVersionSpecificTraverseInstances {
     def size: Long = typeClassInstance.size[A](self)
   }
   trait AllOps[F[_], A] extends Ops[F, A]
-  trait ToUnorderedFoldableOps {
+  trait ToUnorderedFoldableOps extends Serializable {
     implicit def toUnorderedFoldableOps[F[_], A](target: F[A])(implicit tc: UnorderedFoldable[F]): Ops[F, A] {
       type TypeClassType = UnorderedFoldable[F]
     } =

--- a/core/src/main/scala/cats/UnorderedTraverse.scala
+++ b/core/src/main/scala/cats/UnorderedTraverse.scala
@@ -19,12 +19,13 @@ object UnorderedTraverse {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[UnorderedTraverse]] for `F`.
    */
   @inline def apply[F[_]](implicit instance: UnorderedTraverse[F]): UnorderedTraverse[F] = instance
 
-  trait Ops[F[_], A] {
+  trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: UnorderedTraverse[F]
     def self: F[A]
     val typeClassInstance: TypeClassType
@@ -36,7 +37,7 @@ object UnorderedTraverse {
   trait AllOps[F[_], A] extends Ops[F, A] with UnorderedFoldable.AllOps[F, A] {
     type TypeClassType <: UnorderedTraverse[F]
   }
-  trait ToUnorderedTraverseOps {
+  trait ToUnorderedTraverseOps extends Serializable {
     implicit def toUnorderedTraverseOps[F[_], A](target: F[A])(implicit tc: UnorderedTraverse[F]): Ops[F, A] {
       type TypeClassType = UnorderedTraverse[F]
     } =

--- a/core/src/main/scala/cats/arrow/Arrow.scala
+++ b/core/src/main/scala/cats/arrow/Arrow.scala
@@ -77,12 +77,13 @@ object Arrow {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Arrow]] for `F`.
    */
   @inline def apply[F[_, _]](implicit instance: Arrow[F]): Arrow[F] = instance
 
-  trait Ops[F[_, _], A, B] {
+  trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: Arrow[F]
     def self: F[A, B]
     val typeClassInstance: TypeClassType
@@ -94,7 +95,7 @@ object Arrow {
   trait AllOps[F[_, _], A, B] extends Ops[F, A, B] with Category.AllOps[F, A, B] with Strong.AllOps[F, A, B] {
     type TypeClassType <: Arrow[F]
   }
-  trait ToArrowOps {
+  trait ToArrowOps extends Serializable {
     implicit def toArrowOps[F[_, _], A, B](target: F[A, B])(implicit tc: Arrow[F]): Ops[F, A, B] {
       type TypeClassType = Arrow[F]
     } =

--- a/core/src/main/scala/cats/arrow/ArrowChoice.scala
+++ b/core/src/main/scala/cats/arrow/ArrowChoice.scala
@@ -49,12 +49,13 @@ object ArrowChoice {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[ArrowChoice]] for `F`.
    */
   @inline def apply[F[_, _]](implicit instance: ArrowChoice[F]): ArrowChoice[F] = instance
 
-  trait Ops[F[_, _], A, B] {
+  trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: ArrowChoice[F]
     def self: F[A, B]
     val typeClassInstance: TypeClassType
@@ -66,7 +67,7 @@ object ArrowChoice {
   trait AllOps[F[_, _], A, B] extends Ops[F, A, B] with Arrow.AllOps[F, A, B] with Choice.AllOps[F, A, B] {
     type TypeClassType <: ArrowChoice[F]
   }
-  trait ToArrowChoiceOps {
+  trait ToArrowChoiceOps extends Serializable {
     implicit def toArrowChoiceOps[F[_, _], A, B](target: F[A, B])(implicit tc: ArrowChoice[F]): Ops[F, A, B] {
       type TypeClassType = ArrowChoice[F]
     } =

--- a/core/src/main/scala/cats/arrow/Category.scala
+++ b/core/src/main/scala/cats/arrow/Category.scala
@@ -30,12 +30,13 @@ object Category {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Category]] for `F`.
    */
   @inline def apply[F[_, _]](implicit instance: Category[F]): Category[F] = instance
 
-  trait Ops[F[_, _], A, B] {
+  trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: Category[F]
     def self: F[A, B]
     val typeClassInstance: TypeClassType
@@ -43,7 +44,7 @@ object Category {
   trait AllOps[F[_, _], A, B] extends Ops[F, A, B] with Compose.AllOps[F, A, B] {
     type TypeClassType <: Category[F]
   }
-  trait ToCategoryOps {
+  trait ToCategoryOps extends Serializable {
     implicit def toCategoryOps[F[_, _], A, B](target: F[A, B])(implicit tc: Category[F]): Ops[F, A, B] {
       type TypeClassType = Category[F]
     } =

--- a/core/src/main/scala/cats/arrow/Choice.scala
+++ b/core/src/main/scala/cats/arrow/Choice.scala
@@ -53,12 +53,13 @@ object Choice {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Choice]] for `F`.
    */
   @inline def apply[F[_, _]](implicit instance: Choice[F]): Choice[F] = instance
 
-  trait Ops[F[_, _], A, B] {
+  trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: Choice[F]
     def self: F[A, B]
     val typeClassInstance: TypeClassType
@@ -68,7 +69,7 @@ object Choice {
   trait AllOps[F[_, _], A, B] extends Ops[F, A, B] with Category.AllOps[F, A, B] {
     type TypeClassType <: Choice[F]
   }
-  trait ToChoiceOps {
+  trait ToChoiceOps extends Serializable {
     implicit def toChoiceOps[F[_, _], A, B](target: F[A, B])(implicit tc: Choice[F]): Ops[F, A, B] {
       type TypeClassType = Choice[F]
     } =

--- a/core/src/main/scala/cats/arrow/CommutativeArrow.scala
+++ b/core/src/main/scala/cats/arrow/CommutativeArrow.scala
@@ -18,12 +18,13 @@ object CommutativeArrow {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[CommutativeArrow]] for `F`.
    */
   @inline def apply[F[_, _]](implicit instance: CommutativeArrow[F]): CommutativeArrow[F] = instance
 
-  trait Ops[F[_, _], A, B] {
+  trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: CommutativeArrow[F]
     def self: F[A, B]
     val typeClassInstance: TypeClassType
@@ -31,7 +32,7 @@ object CommutativeArrow {
   trait AllOps[F[_, _], A, B] extends Ops[F, A, B] with Arrow.AllOps[F, A, B] {
     type TypeClassType <: CommutativeArrow[F]
   }
-  trait ToCommutativeArrowOps {
+  trait ToCommutativeArrowOps extends Serializable {
     implicit def toCommutativeArrowOps[F[_, _], A, B](target: F[A, B])(implicit tc: CommutativeArrow[F]): Ops[F, A, B] {
       type TypeClassType = CommutativeArrow[F]
     } =

--- a/core/src/main/scala/cats/arrow/Compose.scala
+++ b/core/src/main/scala/cats/arrow/Compose.scala
@@ -48,12 +48,13 @@ object Compose {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Compose]] for `F`.
    */
   @inline def apply[F[_, _]](implicit instance: Compose[F]): Compose[F] = instance
 
-  trait Ops[F[_, _], A, B] {
+  trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: Compose[F]
     def self: F[A, B]
     val typeClassInstance: TypeClassType
@@ -63,7 +64,7 @@ object Compose {
     def >>>[C](g: F[B, C]): F[A, C] = typeClassInstance.andThen[A, B, C](self, g)
   }
   trait AllOps[F[_, _], A, B] extends Ops[F, A, B]
-  trait ToComposeOps {
+  trait ToComposeOps extends Serializable {
     implicit def toComposeOps[F[_, _], A, B](target: F[A, B])(implicit tc: Compose[F]): Ops[F, A, B] {
       type TypeClassType = Compose[F]
     } =

--- a/core/src/main/scala/cats/arrow/Profunctor.scala
+++ b/core/src/main/scala/cats/arrow/Profunctor.scala
@@ -50,12 +50,13 @@ object Profunctor {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Profunctor]] for `F`.
    */
   @inline def apply[F[_, _]](implicit instance: Profunctor[F]): Profunctor[F] = instance
 
-  trait Ops[F[_, _], A, B] {
+  trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: Profunctor[F]
     def self: F[A, B]
     val typeClassInstance: TypeClassType
@@ -64,7 +65,7 @@ object Profunctor {
     def rmap[C](f: B => C): F[A, C] = typeClassInstance.rmap[A, B, C](self)(f)
   }
   trait AllOps[F[_, _], A, B] extends Ops[F, A, B]
-  trait ToProfunctorOps {
+  trait ToProfunctorOps extends Serializable {
     implicit def toProfunctorOps[F[_, _], A, B](target: F[A, B])(implicit tc: Profunctor[F]): Ops[F, A, B] {
       type TypeClassType = Profunctor[F]
     } =

--- a/core/src/main/scala/cats/arrow/Strong.scala
+++ b/core/src/main/scala/cats/arrow/Strong.scala
@@ -46,12 +46,13 @@ object Strong {
   /****************************************************************************/
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
   /****************************************************************************/
+
   /**
    * Summon an instance of [[Strong]] for `F`.
    */
   @inline def apply[F[_, _]](implicit instance: Strong[F]): Strong[F] = instance
 
-  trait Ops[F[_, _], A, B] {
+  trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: Strong[F]
     def self: F[A, B]
     val typeClassInstance: TypeClassType
@@ -61,7 +62,7 @@ object Strong {
   trait AllOps[F[_, _], A, B] extends Ops[F, A, B] with Profunctor.AllOps[F, A, B] {
     type TypeClassType <: Strong[F]
   }
-  trait ToStrongOps {
+  trait ToStrongOps extends Serializable {
     implicit def toStrongOps[F[_, _], A, B](target: F[A, B])(implicit tc: Strong[F]): Ops[F, A, B] {
       type TypeClassType = Strong[F]
     } =

--- a/core/src/main/scala/cats/syntax/semigroupal.scala
+++ b/core/src/main/scala/cats/syntax/semigroupal.scala
@@ -11,7 +11,7 @@ trait SemigroupalSyntax {
     }
 }
 
-abstract class SemigroupalOps[F[_], A] extends Semigroupal.Ops[F, A] with Serializable {
+abstract class SemigroupalOps[F[_], A] extends Semigroupal.Ops[F, A] {
 
   @deprecated("Replaced by an apply syntax, e.g. instead of (a |@| b).map(...) use (a, b).mapN(...)", "1.0.0-MF")
   final private[syntax] def |@|[B](fb: F[B]): SemigroupalBuilder[F]#SemigroupalBuilder2[A, B] =


### PR DESCRIPTION
Addresses part of the issue noted by @ceedubs in #3439 more generally. This is a draft PR only because I used a locally-published version of Scalafix Simulacrum to make it. It's ready for review, and can be merged if [this PR](https://github.com/typelevel/simulacrum-scalafix/pull/29) is merged and released as 0.3.0.
