### PR TITLE
Some travis ci updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,8 @@ jdk:
   - openjdk8
 
 
-scala_version_212: &scala_version_212 2.12.10
-scala_version_213: &scala_version_213 2.13.1
+scala_version_212: &scala_version_212 2.12.11
+scala_version_213: &scala_version_213 2.13.2
 
 before_install:
  - export PATH=${PATH}:./vendor/bundle
@@ -56,10 +56,11 @@ jobs:
 
 
     - stage: test
-      name: Make Microsite
+      name: Make Microsite 2.12
       env: TEST="docs"
       install: gem install jekyll -v 4.0.0
-      script: sbt docs/makeMicrosite
+      script: sbt ++$TRAVIS_SCALA_VERSION! docs/makeMicrosite
+      scala: *scala_version_212
 
     - stage: test
       name: Scalafix tests
@@ -115,7 +116,7 @@ cache:
     - $HOME/.m2
     - $HOME/.ivy2/cache
     - $HOME/.sbt
-    - $HOME/.coursier
+    - $HOME/.cache/coursier
     # Pants cache
     - $HOME/.cache
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,10 +56,10 @@ jobs:
 
 
     - stage: test
-      name: Make Microsite
+      name: Make Microsite on 2.12.10
       env: TEST="docs"
       install: gem install jekyll -v 4.0.0
-      script: sbt docs/makeMicrosite
+      script: sbt ++2.12.10! docs/makeMicrosite
 
     - stage: test
       name: Scalafix tests

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,11 +56,10 @@ jobs:
 
 
     - stage: test
-      name: Make Microsite 2.12
+      name: Make Microsite
       env: TEST="docs"
       install: gem install jekyll -v 4.0.0
-      script: sbt ++$TRAVIS_SCALA_VERSION! docs/makeMicrosite
-      scala: *scala_version_212
+      script: sbt docs/makeMicrosite
 
     - stage: test
       name: Scalafix tests


### PR DESCRIPTION
This PR addresses the Coursier warning in Travis CI
```
Warning: a legacy coursier cache was found at /home/travis/.coursier/cache/v1 and is currently being used.

Support for that cache location will be removed in coursier 2.0.0 final, whose release is imminent.

Follow the instructions at

  https://github.com/coursier/cache-migration#cache-migration

in order to migrate your cache to the newer location.
```
(an example [here](https://travis-ci.org/github/typelevel/cats/jobs/697278210#L243)) just changing the cache location without migrating the existing.
Also it updates the Scala Version and runs explicitly the Microsite build on 2.12.

**UPDATE**: I have to force Microsite make to 2.12.10. I hope it's ok while waiting for the docs port to alternatives (paradox + mdoc ?).