### PR TITLE
Remove Order constraints from SortedMap and NonEmptyMap instances

### DIFF
--- a/core/src/main/scala/cats/Align.scala
+++ b/core/src/main/scala/cats/Align.scala
@@ -113,7 +113,7 @@ object Align extends ScalaVersionSpecificAlignInstances {
   implicit def catsAlignForOption: Align[Option] = cats.instances.option.catsStdInstancesForOption
   implicit def catsAlignForVector: Align[Vector] = cats.instances.vector.catsStdInstancesForVector
   implicit def catsAlignForMap[K]: Align[Map[K, *]] = cats.instances.map.catsStdInstancesForMap[K]
-  implicit def catsAlignForSortedMap[K: Order]: Align[SortedMap[K, *]] =
+  implicit def catsAlignForSortedMap[K]: Align[SortedMap[K, *]] =
     cats.instances.sortedMap.catsStdInstancesForSortedMap[K]
   implicit def catsAlignForEither[A]: Align[Either[A, *]] = cats.instances.either.catsStdInstancesForEither[A]
 

--- a/core/src/main/scala/cats/FunctorFilter.scala
+++ b/core/src/main/scala/cats/FunctorFilter.scala
@@ -84,9 +84,9 @@ object FunctorFilter extends ScalaVersionSpecificTraverseFilterInstances {
   implicit def catsTraverseFilterForList: TraverseFilter[List] = cats.instances.list.catsStdTraverseFilterForList
   implicit def catsTraverseFilterForVector: TraverseFilter[Vector] =
     cats.instances.vector.catsStdTraverseFilterForVector
-  implicit def catsFunctorFilterForMap[K: Order]: FunctorFilter[Map[K, *]] =
+  implicit def catsFunctorFilterForMap[K]: FunctorFilter[Map[K, *]] =
     cats.instances.map.catsStdFunctorFilterForMap[K]
-  implicit def catsTraverseFilterForSortedMap[K: Order]: TraverseFilter[SortedMap[K, *]] =
+  implicit def catsTraverseFilterForSortedMap[K]: TraverseFilter[SortedMap[K, *]] =
     cats.instances.sortedMap.catsStdTraverseFilterForSortedMap[K]
   implicit def catsTraverseFilterForQueue: TraverseFilter[Queue] =
     cats.instances.queue.catsStdTraverseFilterForQueue

--- a/core/src/main/scala/cats/Invariant.scala
+++ b/core/src/main/scala/cats/Invariant.scala
@@ -68,7 +68,7 @@ object Invariant extends ScalaVersionSpecificInvariantInstances with InvariantIn
   implicit def catsMonadForTailRec: Monad[TailRec] = cats.instances.tailRec.catsInstancesForTailRec
 
   implicit def catsFlatMapForMap[K]: FlatMap[Map[K, *]] = cats.instances.map.catsStdInstancesForMap[K]
-  implicit def catsFlatMapForSortedMap[K: Order]: FlatMap[SortedMap[K, *]] =
+  implicit def catsFlatMapForSortedMap[K]: FlatMap[SortedMap[K, *]] =
     cats.instances.sortedMap.catsStdInstancesForSortedMap[K]
   implicit def catsBimonadForFunction0[I]: Bimonad[Function0] = cats.instances.function.catsStdBimonadForFunction0
   implicit def catsMonadForFunction1[I]: Monad[I => *] = cats.instances.function.catsStdMonadForFunction1[I]

--- a/core/src/main/scala/cats/SemigroupK.scala
+++ b/core/src/main/scala/cats/SemigroupK.scala
@@ -128,6 +128,8 @@ object SemigroupK extends ScalaVersionSpecificMonoidKInstances {
   implicit def catsSemigroupKForEither[A]: SemigroupK[Either[A, *]] =
     cats.instances.either.catsStdSemigroupKForEither[A]
   implicit def catsSemigroupKForSortedSet: SemigroupK[SortedSet] = cats.instances.sortedSet.catsStdInstancesForSortedSet
+  implicit def catsSemigroupKForSortedMap[K]: SemigroupK[SortedMap[K, *]] =
+    cats.instances.sortedMap.catsStdSemigroupKForSortedMap[K]
   implicit def catsMonoidKForSortedMap[K: Order]: MonoidK[SortedMap[K, *]] =
     cats.instances.sortedMap.catsStdMonoidKForSortedMap[K]
   implicit def catsMonoidKForEndo: MonoidK[Endo] = cats.instances.function.catsStdMonoidKForFunction1

--- a/core/src/main/scala/cats/Semigroupal.scala
+++ b/core/src/main/scala/cats/Semigroupal.scala
@@ -58,7 +58,7 @@ object Semigroupal extends ScalaVersionSpecificSemigroupalInstances with Semigro
     cats.instances.either.catsStdInstancesForEither[A]
   implicit def catsSemigroupalForSortedSet: Semigroupal[SortedSet] =
     cats.instances.sortedSet.catsStdSemigroupalForSortedSet
-  implicit def catsSemigroupalForSortedMap[K: Order]: Semigroupal[SortedMap[K, *]] =
+  implicit def catsSemigroupalForSortedMap[K]: Semigroupal[SortedMap[K, *]] =
     cats.instances.sortedMap.catsStdInstancesForSortedMap[K]
   implicit def catsSemigroupalForFunction1[A]: Semigroupal[A => *] =
     cats.instances.function.catsStdMonadForFunction1[A]

--- a/core/src/main/scala/cats/Show.scala
+++ b/core/src/main/scala/cats/Show.scala
@@ -93,7 +93,7 @@ object Show extends ScalaVersionSpecificShowInstances with ShowInstances {
   implicit def catsShowForSet[A: Show]: Show[Set[A]] = cats.instances.set.catsStdShowForSet[A]
   implicit def catsShowForMap[K: Show, V: Show]: Show[Map[K, V]] = cats.instances.map.catsStdShowForMap[K, V]
   implicit def catsShowForSortedSet[A: Show]: Show[SortedSet[A]] = cats.instances.sortedSet.catsStdShowForSortedSet[A]
-  implicit def catsShowForSortedMap[K: Order: Show, V: Show]: Show[SortedMap[K, V]] =
+  implicit def catsShowForSortedMap[K: Show, V: Show]: Show[SortedMap[K, V]] =
     cats.instances.sortedMap.catsStdShowForSortedMap[K, V]
 }
 

--- a/core/src/main/scala/cats/UnorderedFoldable.scala
+++ b/core/src/main/scala/cats/UnorderedFoldable.scala
@@ -102,7 +102,7 @@ object UnorderedFoldable extends ScalaVersionSpecificTraverseInstances {
   implicit def catsTraverseForQueue: Traverse[Queue] = cats.instances.queue.catsStdInstancesForQueue
   implicit def catsUnorderedTraverseForSet: UnorderedTraverse[Set] = cats.instances.set.catsStdInstancesForSet
   implicit def catsFoldableForSortedSet: Foldable[SortedSet] = cats.instances.sortedSet.catsStdInstancesForSortedSet
-  implicit def catsTraverseForSortedMap[K: Order]: Traverse[SortedMap[K, *]] =
+  implicit def catsTraverseForSortedMap[K]: Traverse[SortedMap[K, *]] =
     cats.instances.sortedMap.catsStdInstancesForSortedMap[K]
 
   implicit def catsUnorderedTraverseForMap[K]: UnorderedTraverse[Map[K, *]] =

--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -2,7 +2,6 @@ package cats
 package data
 
 import cats.kernel._
-import cats.{Always, Apply, Eval, Foldable, Functor, Later, NonEmptyTraverse, Now, SemigroupK, Show}
 
 import scala.collection.immutable._
 
@@ -14,12 +13,20 @@ private[data] object NonEmptyMapImpl extends NonEmptyMapInstances with Newtype2 
   private[data] def unwrap[K, A](m: Type[K, A]): SortedMap[K, A] =
     m.asInstanceOf[SortedMap[K, A]]
 
-  def fromMap[K: Order, A](as: SortedMap[K, A]): Option[NonEmptyMap[K, A]] =
+  def fromMap[K, A](as: SortedMap[K, A]): Option[NonEmptyMap[K, A]] =
     if (as.nonEmpty) Option(create(as)) else None
 
-  def fromMapUnsafe[K: Order, A](m: SortedMap[K, A]): NonEmptyMap[K, A] =
+  @deprecated("Use fromMap override without Order", "2.2.0-M2")
+  def fromMap[K, A](as: SortedMap[K, A], orderK: Order[K]): Option[NonEmptyMap[K, A]] =
+    fromMap(as)
+
+  def fromMapUnsafe[K, A](m: SortedMap[K, A]): NonEmptyMap[K, A] =
     if (m.nonEmpty) create(m)
     else throw new IllegalArgumentException("Cannot create NonEmptyMap from empty map")
+
+  @deprecated("Use fromMapUnsafe override without Order", "2.2.0-M2")
+  def fromMapUnsafe[K, A](m: SortedMap[K, A], orderK: Order[K]): NonEmptyMap[K, A] =
+    fromMapUnsafe(m)
 
   def apply[K, A](head: (K, A), tail: SortedMap[K, A])(implicit K: Order[K]): NonEmptyMap[K, A] =
     create(SortedMap(head)(K.toOrdering) ++ tail)
@@ -249,7 +256,7 @@ sealed class NonEmptyMapOps[K, A](val value: NonEmptyMap[K, A]) {
 
 sealed abstract private[data] class NonEmptyMapInstances extends NonEmptyMapInstances0 {
 
-  implicit def catsDataInstancesForNonEmptyMap[K: Order]
+  implicit def catsDataInstancesForNonEmptyMap[K]
     : SemigroupK[NonEmptyMap[K, *]] with NonEmptyTraverse[NonEmptyMap[K, *]] with Align[NonEmptyMap[K, *]] =
     new SemigroupK[NonEmptyMap[K, *]] with NonEmptyTraverse[NonEmptyMap[K, *]] with Align[NonEmptyMap[K, *]] {
 
@@ -305,8 +312,18 @@ sealed abstract private[data] class NonEmptyMapInstances extends NonEmptyMapInst
         NonEmptyMap.fromMapUnsafe(Align[SortedMap[K, *]].align(fa.toSortedMap, fb.toSortedMap))
     }
 
-  implicit def catsDataHashForNonEmptyMap[K: Hash: Order, A: Hash]: Hash[NonEmptyMap[K, A]] =
+  @deprecated("Use catsDataInstancesForNonEmptyMap override without Order", "2.2.0-M2")
+  implicit def catsDataInstancesForNonEmptyMap[K](
+    orderK: Order[K]
+  ): SemigroupK[NonEmptyMap[K, *]] with NonEmptyTraverse[NonEmptyMap[K, *]] with Align[NonEmptyMap[K, *]] =
+    catsDataInstancesForNonEmptyMap[K]
+
+  implicit def catsDataHashForNonEmptyMap[K: Hash, A: Hash]: Hash[NonEmptyMap[K, A]] =
     Hash[SortedMap[K, A]].asInstanceOf[Hash[NonEmptyMap[K, A]]]
+
+  @deprecated("Use catsDataHashForNonEmptyMap override without Order", "2.2.0-M2")
+  def catsDataHashForNonEmptyMap[K, A](hashK: Hash[K], orderK: Order[K], hashA: Hash[A]): Hash[NonEmptyMap[K, A]] =
+    catsDataHashForNonEmptyMap(hashK, hashA)
 
   implicit def catsDataShowForNonEmptyMap[K: Show, A: Show]: Show[NonEmptyMap[K, A]] =
     Show.show[NonEmptyMap[K, A]](_.show)
@@ -318,8 +335,9 @@ sealed abstract private[data] class NonEmptyMapInstances extends NonEmptyMapInst
 }
 
 sealed abstract private[data] class NonEmptyMapInstances0 {
-  implicit def catsDataEqForNonEmptyMap[K: Order, A: Eq]: Eq[NonEmptyMap[K, A]] =
-    new Eq[NonEmptyMap[K, A]] {
-      def eqv(x: NonEmptyMap[K, A], y: NonEmptyMap[K, A]): Boolean = x === y
-    }
+  implicit def catsDataEqForNonEmptyMap[K, A: Eq]: Eq[NonEmptyMap[K, A]] = _ === _
+
+  @deprecated("Use catsDataEqForNonEmptyMap override without Order", "2.2.0-M2")
+  def catsDataEqForNonEmptyMap[K, A](orderK: Order[K], eqA: Eq[A]): Eq[NonEmptyMap[K, A]] =
+    catsDataEqForNonEmptyMap(eqA)
 }

--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -16,7 +16,7 @@ private[data] object NonEmptyMapImpl extends NonEmptyMapInstances with Newtype2 
   def fromMap[K, A](as: SortedMap[K, A]): Option[NonEmptyMap[K, A]] =
     if (as.nonEmpty) Option(create(as)) else None
 
-  @deprecated("Use fromMap override without Order", "2.2.0-M2")
+  @deprecated("Use fromMap override without Order", "2.2.0-M3")
   def fromMap[K, A](as: SortedMap[K, A], orderK: Order[K]): Option[NonEmptyMap[K, A]] =
     fromMap(as)
 
@@ -24,7 +24,7 @@ private[data] object NonEmptyMapImpl extends NonEmptyMapInstances with Newtype2 
     if (m.nonEmpty) create(m)
     else throw new IllegalArgumentException("Cannot create NonEmptyMap from empty map")
 
-  @deprecated("Use fromMapUnsafe override without Order", "2.2.0-M2")
+  @deprecated("Use fromMapUnsafe override without Order", "2.2.0-M3")
   def fromMapUnsafe[K, A](m: SortedMap[K, A], orderK: Order[K]): NonEmptyMap[K, A] =
     fromMapUnsafe(m)
 
@@ -312,7 +312,7 @@ sealed abstract private[data] class NonEmptyMapInstances extends NonEmptyMapInst
         NonEmptyMap.fromMapUnsafe(Align[SortedMap[K, *]].align(fa.toSortedMap, fb.toSortedMap))
     }
 
-  @deprecated("Use catsDataInstancesForNonEmptyMap override without Order", "2.2.0-M2")
+  @deprecated("Use catsDataInstancesForNonEmptyMap override without Order", "2.2.0-M3")
   implicit def catsDataInstancesForNonEmptyMap[K](
     orderK: Order[K]
   ): SemigroupK[NonEmptyMap[K, *]] with NonEmptyTraverse[NonEmptyMap[K, *]] with Align[NonEmptyMap[K, *]] =
@@ -321,7 +321,7 @@ sealed abstract private[data] class NonEmptyMapInstances extends NonEmptyMapInst
   implicit def catsDataHashForNonEmptyMap[K: Hash, A: Hash]: Hash[NonEmptyMap[K, A]] =
     Hash[SortedMap[K, A]].asInstanceOf[Hash[NonEmptyMap[K, A]]]
 
-  @deprecated("Use catsDataHashForNonEmptyMap override without Order", "2.2.0-M2")
+  @deprecated("Use catsDataHashForNonEmptyMap override without Order", "2.2.0-M3")
   def catsDataHashForNonEmptyMap[K, A](hashK: Hash[K], orderK: Order[K], hashA: Hash[A]): Hash[NonEmptyMap[K, A]] =
     catsDataHashForNonEmptyMap(hashK, hashA)
 
@@ -337,7 +337,7 @@ sealed abstract private[data] class NonEmptyMapInstances extends NonEmptyMapInst
 sealed abstract private[data] class NonEmptyMapInstances0 {
   implicit def catsDataEqForNonEmptyMap[K, A: Eq]: Eq[NonEmptyMap[K, A]] = _ === _
 
-  @deprecated("Use catsDataEqForNonEmptyMap override without Order", "2.2.0-M2")
+  @deprecated("Use catsDataEqForNonEmptyMap override without Order", "2.2.0-M3")
   def catsDataEqForNonEmptyMap[K, A](orderK: Order[K], eqA: Eq[A]): Eq[NonEmptyMap[K, A]] =
     catsDataEqForNonEmptyMap(eqA)
 }

--- a/core/src/main/scala/cats/instances/sortedMap.scala
+++ b/core/src/main/scala/cats/instances/sortedMap.scala
@@ -22,7 +22,7 @@ trait SortedMapInstances extends SortedMapInstances2 {
       .map { case (a, b) => showA.show(a) + " -> " + showB.show(b) }
       .mkString("SortedMap(", ", ", ")")
 
-  @deprecated("Use catsStdShowForSortedMap override without Order", "2.2.0-M2")
+  @deprecated("Use catsStdShowForSortedMap override without Order", "2.2.0-M3")
   implicit def catsStdShowForSortedMap[A, B](orderA: Order[A], showA: Show[A], showB: Show[B]): Show[SortedMap[A, B]] =
     catsStdShowForSortedMap(showA, showB)
 
@@ -144,7 +144,7 @@ trait SortedMapInstances extends SortedMapInstances2 {
       }
     }
 
-  @deprecated("Use catsStdInstancesForSortedMap override without Order", "2.2.0-M2")
+  @deprecated("Use catsStdInstancesForSortedMap override without Order", "2.2.0-M3")
   def catsStdInstancesForSortedMap[K](
     orderK: Order[K]
   ): Traverse[SortedMap[K, *]] with FlatMap[SortedMap[K, *]] with Align[SortedMap[K, *]] =
@@ -230,7 +230,7 @@ private[instances] trait SortedMapInstancesBinCompat0 {
         traverseFilter(fa)(a => G.map(f(a))(if (_) Some(a) else None))
     }
 
-  @deprecated("Use catsStdTraverseFilterForSortedMap override without Order", "2.2.0-M2")
+  @deprecated("Use catsStdTraverseFilterForSortedMap override without Order", "2.2.0-M3")
   def catsStdTraverseFilterForSortedMap[K](orderK: Order[K]): TraverseFilter[SortedMap[K, *]] =
     catsStdTraverseFilterForSortedMap[K]
 }

--- a/kernel/src/main/scala/cats/kernel/Eq.scala
+++ b/kernel/src/main/scala/cats/kernel/Eq.scala
@@ -247,7 +247,7 @@ private[kernel] trait HashInstances extends EqInstances {
     cats.kernel.instances.function.catsKernelHashForFunction0[A]
   implicit def catsKernelHashForMap[K: Hash, V: Hash]: Hash[Map[K, V]] =
     cats.kernel.instances.map.catsKernelStdHashForMap[K, V]
-  implicit def catsKernelHashForSortedMap[K: Order: Hash, V: Hash]: Hash[SortedMap[K, V]] =
+  implicit def catsKernelHashForSortedMap[K: Hash, V: Hash]: Hash[SortedMap[K, V]] =
     cats.kernel.instances.sortedMap.catsKernelStdHashForSortedMap[K, V]
   implicit def catsKernelHashForEither[A: Hash, B: Hash]: Hash[Either[A, B]] =
     cats.kernel.instances.either.catsStdHashForEither[A, B]
@@ -260,7 +260,7 @@ private[kernel] trait EqInstances {
   implicit def catsKernelEqForQueue[A: Eq]: Eq[Queue[A]] = cats.kernel.instances.queue.catsKernelStdEqForQueue[A]
   implicit def catsKernelEqForFunction0[A: Eq]: Eq[() => A] = cats.kernel.instances.function.catsKernelEqForFunction0[A]
   implicit def catsKernelEqForMap[K, V: Eq]: Eq[Map[K, V]] = cats.kernel.instances.map.catsKernelStdEqForMap[K, V]
-  implicit def catsKernelEqForSortedMap[K: Order, V: Eq]: Eq[SortedMap[K, V]] =
+  implicit def catsKernelEqForSortedMap[K, V: Eq]: Eq[SortedMap[K, V]] =
     cats.kernel.instances.sortedMap.catsKernelStdEqForSortedMap[K, V]
   implicit def catsKernelEqForEither[A: Eq, B: Eq]: Eq[Either[A, B]] =
     cats.kernel.instances.either.catsStdEqForEither[A, B]

--- a/kernel/src/main/scala/cats/kernel/Semigroup.scala
+++ b/kernel/src/main/scala/cats/kernel/Semigroup.scala
@@ -197,6 +197,9 @@ object Semigroup
 
   implicit def catsKernelCommutativeMonoidForMap[K, V: CommutativeSemigroup]: CommutativeMonoid[Map[K, V]] =
     cats.kernel.instances.map.catsKernelStdCommutativeMonoidForMap[K, V]
+  implicit def catsKernelCommutativeSemigroupForSortedMap[K, V: CommutativeSemigroup]
+    : CommutativeSemigroup[SortedMap[K, V]] =
+    cats.kernel.instances.sortedMap.catsKernelStdCommutativeSemigroupForSortedMap[K, V]
   implicit def catsKernelCommutativeMonoidForSortedMap[K: Order, V: CommutativeSemigroup]
     : CommutativeMonoid[SortedMap[K, V]] =
     cats.kernel.instances.sortedMap.catsKernelStdCommutativeMonoidForSortedMap[K, V]
@@ -239,6 +242,8 @@ private[kernel] trait MonoidInstances extends BandInstances {
     cats.kernel.instances.function.catsKernelMonoidForFunction1[A, B]
   implicit def catsKernelMonoidForMap[K, V: Semigroup]: Monoid[Map[K, V]] =
     cats.kernel.instances.map.catsKernelStdMonoidForMap[K, V]
+  implicit def catsKernelSemigroupForSortedMap[K, V: Semigroup]: Semigroup[SortedMap[K, V]] =
+    cats.kernel.instances.sortedMap.catsKernelStdSemigroupForSortedMap[K, V]
   implicit def catsKernelMonoidForSortedMap[K: Order, V: Semigroup]: Monoid[SortedMap[K, V]] =
     cats.kernel.instances.sortedMap.catsKernelStdMonoidForSortedMap[K, V]
   implicit def catsKernelMonoidForEither[A, B: Monoid]: Monoid[Either[A, B]] =

--- a/kernel/src/main/scala/cats/kernel/instances/SortedMapInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/SortedMapInstances.scala
@@ -7,7 +7,7 @@ trait SortedMapInstances extends SortedMapInstances2 {
   implicit def catsKernelStdHashForSortedMap[K: Hash, V: Hash]: Hash[SortedMap[K, V]] =
     new SortedMapHash[K, V]
 
-  @deprecated("Use catsKernelStdHashForSortedMap override without Order", "2.2.0-M2")
+  @deprecated("Use catsKernelStdHashForSortedMap override without Order", "2.2.0-M3")
   def catsKernelStdHashForSortedMap[K, V](hashK: Hash[K], orderK: Order[K], hashV: Hash[V]): Hash[SortedMap[K, V]] =
     new SortedMapHash[K, V]()(hashV, hashK)
 
@@ -24,7 +24,7 @@ private[instances] trait SortedMapInstances1 {
   implicit def catsKernelStdEqForSortedMap[K, V: Eq]: Eq[SortedMap[K, V]] =
     new SortedMapEq[K, V]
 
-  @deprecated("Use catsKernelStdEqForSortedMap override without Order", "2.2.0-M2")
+  @deprecated("Use catsKernelStdEqForSortedMap override without Order", "2.2.0-M3")
   def catsKernelStdEqForSortedMap[K, V](orderK: Order[K], eqV: Eq[V]): Eq[SortedMap[K, V]] =
     new SortedMapEq[K, V]()(eqV)
 }
@@ -39,7 +39,7 @@ private[instances] trait SortedMapInstances2 extends SortedMapInstances1 {
 
 class SortedMapHash[K, V](implicit V: Hash[V], K: Hash[K]) extends SortedMapEq[K, V]()(V) with Hash[SortedMap[K, V]] {
 
-  @deprecated("Use the constructor _without_ Order instead, since Order is not required", "2.2.0-M2")
+  @deprecated("Use the constructor _without_ Order instead, since Order is not required", "2.2.0-M3")
   private[instances] def this(V: Hash[V], O: Order[K], K: Hash[K]) = this()(V, K)
 
   // adapted from [[scala.util.hashing.MurmurHash3]],

--- a/kernel/src/main/scala/cats/kernel/instances/SortedMapInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/SortedMapInstances.scala
@@ -4,8 +4,16 @@ package instances
 import scala.collection.immutable.SortedMap
 
 trait SortedMapInstances extends SortedMapInstances2 {
-  implicit def catsKernelStdHashForSortedMap[K: Hash: Order, V: Hash]: Hash[SortedMap[K, V]] =
+  implicit def catsKernelStdHashForSortedMap[K: Hash, V: Hash]: Hash[SortedMap[K, V]] =
     new SortedMapHash[K, V]
+
+  @deprecated("Use catsKernelStdHashForSortedMap override without Order", "2.2.0-M2")
+  def catsKernelStdHashForSortedMap[K, V](hashK: Hash[K], orderK: Order[K], hashV: Hash[V]): Hash[SortedMap[K, V]] =
+    new SortedMapHash[K, V]()(hashV, hashK)
+
+  implicit def catsKernelStdCommutativeSemigroupForSortedMap[K, V: CommutativeSemigroup]
+    : CommutativeSemigroup[SortedMap[K, V]] =
+    new SortedMapCommutativeSemigroup[K, V]
 
   implicit def catsKernelStdCommutativeMonoidForSortedMap[K: Order, V: CommutativeSemigroup]
     : CommutativeMonoid[SortedMap[K, V]] =
@@ -13,18 +21,27 @@ trait SortedMapInstances extends SortedMapInstances2 {
 }
 
 private[instances] trait SortedMapInstances1 {
-  implicit def catsKernelStdEqForSortedMap[K: Order, V: Eq]: Eq[SortedMap[K, V]] =
+  implicit def catsKernelStdEqForSortedMap[K, V: Eq]: Eq[SortedMap[K, V]] =
     new SortedMapEq[K, V]
+
+  @deprecated("Use catsKernelStdEqForSortedMap override without Order", "2.2.0-M2")
+  def catsKernelStdEqForSortedMap[K, V](orderK: Order[K], eqV: Eq[V]): Eq[SortedMap[K, V]] =
+    new SortedMapEq[K, V]()(eqV)
 }
 
 private[instances] trait SortedMapInstances2 extends SortedMapInstances1 {
+  implicit def catsKernelStdSemigroupForSortedMap[K, V: Semigroup]: Semigroup[SortedMap[K, V]] =
+    new SortedMapSemigroup[K, V]
+
   implicit def catsKernelStdMonoidForSortedMap[K: Order, V: Semigroup]: Monoid[SortedMap[K, V]] =
     new SortedMapMonoid[K, V]
 }
 
-class SortedMapHash[K, V](implicit V: Hash[V], O: Order[K], K: Hash[K])
-    extends SortedMapEq[K, V]()(V, O)
-    with Hash[SortedMap[K, V]] {
+class SortedMapHash[K, V](implicit V: Hash[V], K: Hash[K]) extends SortedMapEq[K, V]()(V) with Hash[SortedMap[K, V]] {
+
+  @deprecated("Use the constructor _without_ Order instead, since Order is not required", "2.2.0-M2")
+  private[instances] def this(V: Hash[V], O: Order[K], K: Hash[K]) = this()(V, K)
+
   // adapted from [[scala.util.hashing.MurmurHash3]],
   // but modified standard `Any#hashCode` to `ev.hash`.
   import scala.util.hashing.MurmurHash3._
@@ -47,7 +64,11 @@ class SortedMapHash[K, V](implicit V: Hash[V], O: Order[K], K: Hash[K])
   }
 }
 
-class SortedMapEq[K, V](implicit V: Eq[V], O: Order[K]) extends Eq[SortedMap[K, V]] {
+class SortedMapEq[K, V](implicit V: Eq[V]) extends Eq[SortedMap[K, V]] {
+
+  @deprecated("Use the constructor _without_ Order instead, since Order is not required", "2.2.0")
+  private[instances] def this(V: Eq[V], O: Order[K]) = this()(V)
+
   def eqv(x: SortedMap[K, V], y: SortedMap[K, V]): Boolean =
     if (x eq y) true
     else
@@ -60,13 +81,15 @@ class SortedMapEq[K, V](implicit V: Eq[V], O: Order[K]) extends Eq[SortedMap[K, 
       }
 }
 
+class SortedMapCommutativeSemigroup[K, V](implicit V: CommutativeSemigroup[V])
+    extends SortedMapSemigroup[K, V]
+    with CommutativeSemigroup[SortedMap[K, V]]
+
 class SortedMapCommutativeMonoid[K, V](implicit V: CommutativeSemigroup[V], O: Order[K])
     extends SortedMapMonoid[K, V]
     with CommutativeMonoid[SortedMap[K, V]]
 
-class SortedMapMonoid[K, V](implicit V: Semigroup[V], O: Order[K]) extends Monoid[SortedMap[K, V]] {
-
-  def empty: SortedMap[K, V] = SortedMap.empty(O.toOrdering)
+class SortedMapSemigroup[K, V](implicit V: Semigroup[V]) extends Semigroup[SortedMap[K, V]] {
 
   def combine(xs: SortedMap[K, V], ys: SortedMap[K, V]): SortedMap[K, V] =
     if (xs.size <= ys.size) {
@@ -80,5 +103,11 @@ class SortedMapMonoid[K, V](implicit V: Semigroup[V], O: Order[K]) extends Monoi
           mx.updated(k, Semigroup.maybeCombine(mx.get(k), y))
       }
     }
+}
 
+class SortedMapMonoid[K, V](implicit V: Semigroup[V], O: Order[K])
+    extends SortedMapSemigroup[K, V]
+    with Monoid[SortedMap[K, V]] {
+
+  def empty: SortedMap[K, V] = SortedMap.empty(O.toOrdering)
 }


### PR DESCRIPTION
These are @joroKr21's commits from #3397, but rebased to resolve a conflict. (I'm opening this as a new PR since I messed up the conflict resolution in #3397, but the commits / PR credit will go to @joroKr21.)