### PR TITLE
Rename master to main

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -185,7 +185,7 @@ As a side note, the latter command uses [sbt-mima](https://github.com/lightbend/
 ## Contributing documentation
 
 ### source for the documentation
-The documentation for this website is stored alongside the source, in the [docs subproject](https://github.com/typelevel/cats/tree/master/docs).
+The documentation for this website is stored alongside the source, in the [docs subproject](https://github.com/typelevel/cats/tree/main/docs).
 
 * The source for the tut compiled pages is in `docs/src/main/tut`
 * The menu structure for these pages is in `docs/src/main/resources/microsite/data/menu.yml`
@@ -223,7 +223,7 @@ staying up-to-date.
 
 ### Write examples
 
-One of the best ways to provide examples is doctest, here is [an example](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/Functor.scala#L19-L33). Doctest is a [sbt plugin](https://github.com/tkawachi/sbt-doctest) which generates tests based on the syntax mentioned above and runs when sbt's `test` task is invoked. You can find more information in the plugin documentation.
+One of the best ways to provide examples is doctest, here is [an example](https://github.com/typelevel/cats/blob/main/core/src/main/scala/cats/Functor.scala#L19-L33). Doctest is a [sbt plugin](https://github.com/tkawachi/sbt-doctest) which generates tests based on the syntax mentioned above and runs when sbt's `test` task is invoked. You can find more information in the plugin documentation.
 
 ### Submit a pull request
 

--- a/PROCESS.md
+++ b/PROCESS.md
@@ -18,17 +18,17 @@ When fixing typos, improving documentation or minor build fix only
 one sign-off is required (although for major edits waiting for two
  may be preferable).
 
-In some cases pull requests that don't target the master branch may be
+In some cases pull requests that don't target the main branch may be
 merged with a single sign-off from a maintainer (as long as they
 aren't also the author of the pull request). For example, backporting
-changes from master to the `scala_2.11` branch generally shouldn't
+changes from main to the `scala_2.11` branch generally shouldn't
 require multiple reviews. If either the pull request author or a Cats
 maintainer thinks that a specific change should receive multiple
-approvals even though it doesn't target the master branch, their
+approvals even though it doesn't target the main branch, their
 request should be respected.
 
 For serious emergencies or work on the build which can't easily be
-reviewed or tested, pushing directly to master may be OK (but is
+reviewed or tested, pushing directly to main may be OK (but is
 definitely not encouraged). In these cases it's best to comment in
 Gitter or elsewhere about what happened and what was done.
 
@@ -67,7 +67,7 @@ replace `2019-05-29` with the last release date.
 
 For non-milestone releases (e.g. 2.0.0-M1), we shall release from a release branch. For each *MINOR* version, we shall have a corresponding branch, e.g. `2.1.x`. There are 2 main benefits for this: 
 1. Since we need to go through at least 1 release candidate release, having a release branch makes it easier to incorporate potential fixes and release the official release later. 
-2. The master branch of Cats is protected. This means sbt-release cannot push post release commits and more importantly tags directly to master. It can with a release branch, and a PR can be submitted to merge the release branch back into master. 
+2. The main branch of Cats is protected. This means sbt-release cannot push post release commits and more importantly tags directly to main. It can with a release branch, and a PR can be submitted to merge the release branch back into main.
 
   
 ### Releasing
@@ -90,7 +90,7 @@ including releasing the artifacts on Sonatype.
 
 If the Sonatype publishing fails, but the artifacts were uploaded, you
 can finish the release manually using the Sonatype web site. In that
-case you will also need to do `git push --tags origin master` to push
+case you will also need to do `git push --tags origin main` to push
 the new version's tags.
 
 (In the future we may want to create branches for major versions,
@@ -114,7 +114,7 @@ to be updated:
 (Other changes may be necessary, especially for large releases.)
 
 If the [Pre-release](#pre-release) step is properly done, meaning all released PRs are properly assigned with label and milestone, you can use a [script](
-https://github.com/typelevel/cats/blob/master/scripts/releaseNotes.scala) to generate the release note. Follow the doc in the script for instructions.  
+https://github.com/typelevel/cats/blob/main/scripts/releaseNotes.scala) to generate the release note. Follow the doc in the script for instructions.
 
 Alternatively, you can get a list of changes between release tags `v0.1.2` and
 `v0.2.0` via `git log v0.1.2..v0.2.0`. Scanning this list of commit

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 * **May 25 2019** [Cats 2.0.0-M2 is released](https://github.com/typelevel/cats/releases/tag/v2.0.0-M2) with support for Scala 2.13.0-RC2
 * **Apr 26 2019** [We launched a sustainability program](https://typelevel.org/blog/2019/04/24/typelevel-sustainability-program-announcement.html). Please consider supporting us.
 * **Apr 25 2019** [Cats 2.0.0-M1 is released](https://github.com/typelevel/cats/releases/tag/v2.0.0-M1) with binary compatibility with 1.x on `cats-kernel`, `cats-core` and `cats-free`
-* **Feb 15 2019** [Cats 2019 roadmap](https://github.com/typelevel/cats/blob/master/ROADMAP_2019.md) is published.
+* **Feb 15 2019** [Cats 2019 roadmap](https://github.com/typelevel/cats/blob/main/ROADMAP_2019.md) is published.
 
 ## Cats
 
@@ -25,7 +25,7 @@
 
 [![Build Status](https://api.travis-ci.org/typelevel/cats.svg)](https://travis-ci.org/typelevel/cats)
 [![Financial Contributors on Open Collective](https://opencollective.com/typelevel/all/badge.svg?label=financial+contributors)](https://opencollective.com/typelevel) [![Chat](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/typelevel/cats)
-[![codecov.io](http://codecov.io/github/typelevel/cats/coverage.svg?branch=master)](http://codecov.io/github/typelevel/cats?branch=master)
+[![codecov.io](http://codecov.io/github/typelevel/cats/coverage.svg?branch=main)](http://codecov.io/github/typelevel/cats?branch=main)
 [![Latest version](https://index.scala-lang.org/typelevel/cats/cats-core/latest.svg?color=orange&v=1)](https://index.scala-lang.org/typelevel/cats/cats-core)
 [![Scala.js](http://scala-js.org/assets/badges/scalajs-0.6.14.svg)](http://scala-js.org)
 
@@ -142,8 +142,8 @@ functionality, you can pick-and-choose from amongst these modules
  * [`cats-collections`](https://github.com/typelevel/cats-collections): Data structures which facilitate pure functional programming
  * [`cats-testkit-scalatest`](https://github.com/typelevel/cats-testkit-scalatest): Cats testkit integration with Scalatest
 
-Past release notes for Cats are available in [CHANGES.md](https://github.com/typelevel/cats/blob/master/CHANGES.md).
-See [Cats 2019 roadmap](https://github.com/typelevel/cats/blob/master/ROADMAP_2019.md) for our plan for 2019.
+Past release notes for Cats are available in [CHANGES.md](https://github.com/typelevel/cats/blob/main/CHANGES.md).
+See [Cats 2019 roadmap](https://github.com/typelevel/cats/blob/main/ROADMAP_2019.md) for our plan for 2019.
 
 ### Documentation
 
@@ -219,7 +219,7 @@ By sharing the same set of type classes, instances and data types provided by Ca
  * [sup](https://github.com/kubukoz/sup): Composable, purely functional healthchecks in Scala
  * [tsec](https://github.com/jmcardon/tsec/): Typesafe, functional, general purpose cryptography and security library
 
-Your project talks Cats too? [Submit a PR to add it here!](https://github.com/typelevel/cats/edit/master/README.md)
+Your project talks Cats too? [Submit a PR to add it here!](https://github.com/typelevel/cats/edit/main/README.md)
 
 *The full-size [Cats logo](https://typelevel.org/cats/img/cats-logo.png) is available for use for Cats related projects, contents, souvenirs, etc.*
 
@@ -292,7 +292,7 @@ versioning in the future. But that decision is yet to be made.
 
 ### Adopters
 
-Here's a (non-exhaustive) list of companies that use Cats in production. Don't see yours? [You can add it in a PR!](https://github.com/typelevel/cats/edit/master/README.md). And if you can, consider [supporting us](https://donorbox.org/typelevel-sustainability-program-2019?default_interval=m). 
+Here's a (non-exhaustive) list of companies that use Cats in production. Don't see yours? [You can add it in a PR!](https://github.com/typelevel/cats/edit/main/README.md). And if you can, consider [supporting us](https://donorbox.org/typelevel-sustainability-program-2019?default_interval=m).
 
 - [Abacus Protocol](https://abacusprotocol.com)
 - [Anduin Transactions](https://anduintransact.com)
@@ -388,7 +388,7 @@ The current maintainers (people who can merge pull requests) are:
 We are currently following a practice of requiring at least two
 sign-offs to merge code PRs (and for large or contentious issues we may
 wait for more). For typos, documentation improvements or minor build fix we
-relax this to a single sign-off. More detail in the [process document](https://github.com/typelevel/cats/blob/master/PROCESS.md).
+relax this to a single sign-off. More detail in the [process document](https://github.com/typelevel/cats/blob/main/PROCESS.md).
 
 
 

--- a/build.sbt
+++ b/build.sbt
@@ -206,7 +206,7 @@ lazy val docSettings = Seq(
     "-Xfatal-warnings",
     "-groups",
     "-doc-source-url",
-    scmInfo.value.get.browseUrl + "/tree/master€{FILE_PATH}.scala",
+    scmInfo.value.get.browseUrl + "/tree/main€{FILE_PATH}.scala",
     "-sourcepath",
     baseDirectory.in(LocalRootProject).value.getAbsolutePath,
     "-diagrams"

--- a/docs/src/main/tut/datatypes/validated.md
+++ b/docs/src/main/tut/datatypes/validated.md
@@ -248,7 +248,7 @@ object FormValidatorNec extends FormValidatorNec
 
 Let's see what changed here:
 
-1. In this new implementation, we're using a [NonEmptyChain](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/data/NonEmptyChain.scala), a data structure that guarantees that at least one element will be present. In case that multiple errors arise, you'll get a chain of `DomainValidation`.
+1. In this new implementation, we're using a [NonEmptyChain](https://github.com/typelevel/cats/blob/main/core/src/main/scala/cats/data/NonEmptyChain.scala), a data structure that guarantees that at least one element will be present. In case that multiple errors arise, you'll get a chain of `DomainValidation`.
 2. `ValidatedNec[DomainValidation, A]` is an alias for `Validated[NonEmptyChain[DomainValidation], A]`. When you use `ValidatedNec` you're stating that your accumulative structure will be a `NonEmptyChain`. With `Validated`, you have the choice about which data structure you want for reporting the errors (more on that soon).
 3. We've declared the type alias `ValidationResult` that conveniently expresses the return type of our validation.
 4. `.validNec` and `.invalidNec` combinators lets you _lift_ the success or failure in their respective container (either a `Valid` or `Invalid[NonEmptyChain[A]]`).

--- a/docs/src/main/tut/faq.md
+++ b/docs/src/main/tut/faq.md
@@ -57,7 +57,7 @@ a bunch of useful combinators around it. In Scala 2.12.x `Either`
 [became right-biased](https://github.com/scala/scala/pull/5135) so we revisited the use of `Xor` and
 [decided](https://github.com/typelevel/cats/issues/1192) that in the interest of interoperability, we would remove `Xor` in the Cats 0.8.0 release and
 fill in the gaps in the `scala.util.Either` API via
-[syntax enrichment](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/syntax/either.scala).
+[syntax enrichment](https://github.com/typelevel/cats/blob/main/core/src/main/scala/cats/syntax/either.scala).
 
 This syntax and the type class instances for `Either` can be imported using `cats.implicits._`, which will also bring in syntactic enrichment and instances for other standard library types, or you can import them individually with `cats.syntax.either._` and `cats.instances.either._`.
 
@@ -97,7 +97,7 @@ l.map(_.map(_ + 1))
 l.exists(_.exists(isEven))
 ```
 
-A naive implementation of `ListT` suffers from associativity issues; see [this gist](https://gist.github.com/tpolecat/1227e22e3161b5816e014c00650f3b57) for an example. It's possible to create a `ListT` that doesn't have these issues, but it tends to be pretty inefficient. For many use-cases, [Nested](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/data/Nested.scala) can be used to achieve the desired results.
+A naive implementation of `ListT` suffers from associativity issues; see [this gist](https://gist.github.com/tpolecat/1227e22e3161b5816e014c00650f3b57) for an example. It's possible to create a `ListT` that doesn't have these issues, but it tends to be pretty inefficient. For many use-cases, [Nested](https://github.com/typelevel/cats/blob/main/core/src/main/scala/cats/data/Nested.scala) can be used to achieve the desired results.
 
 Here is how we could achieve the effect of the previous example using `Nested`:
 
@@ -254,8 +254,8 @@ You can find more information [here](typeclasses/lawtesting.html).
 
 The Сats community welcomes and encourages contributions, even if you are completely new to Сats and functional programming. Here are a few ways to help out:
 
-- Find an undocumented method and write a ScalaDoc entry for it. See [Arrow.scala](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/arrow/Arrow.scala) for some examples of ScalaDoc entries that use [sbt-doctest](https://github.com/tkawachi/sbt-doctest).
-- Look at the [code coverage report](https://codecov.io/github/typelevel/cats?branch=master), find some untested code, and write a test for it. Even simple helper methods and syntax enrichment should be tested.
+- Find an undocumented method and write a ScalaDoc entry for it. See [Arrow.scala](https://github.com/typelevel/cats/blob/main/core/src/main/scala/cats/arrow/Arrow.scala) for some examples of ScalaDoc entries that use [sbt-doctest](https://github.com/tkawachi/sbt-doctest).
+- Look at the [code coverage report](https://codecov.io/github/typelevel/cats?branch=main), find some untested code, and write a test for it. Even simple helper methods and syntax enrichment should be tested.
 - Find an [open issue](https://github.com/typelevel/cats/issues?q=is%3Aopen+is%3Aissue+label%3Aready), leave a comment on it to let people know you are working on it, and submit a pull request. If you are new to Сats, you may want to look for items with the [low-hanging-fruit](https://github.com/typelevel/cats/issues?q=is%3Aopen+is%3Aissue+label%3A%22low-hanging+fruit%22) label.
 
 See the [contributing guide]({{ site.baseurl }}/contributing.html) for more information.

--- a/docs/src/main/tut/typeclasses/invariantmonoidal.md
+++ b/docs/src/main/tut/typeclasses/invariantmonoidal.md
@@ -2,7 +2,7 @@
 layout: docs
 title:  "InvariantMonoidal"
 section: "typeclasses"
-source: "https://github.com/non/cats/blob/master/core/src/main/scala/cats/InvariantMonoidal.scala"
+source: "https://github.com/non/cats/blob/main/core/src/main/scala/cats/InvariantMonoidal.scala"
 scaladoc: "#cats.InvariantMonoidal"
 ---
 # Invariant Monoidal

--- a/docs/src/main/tut/typeclasses/monoid.md
+++ b/docs/src/main/tut/typeclasses/monoid.md
@@ -140,5 +140,5 @@ This lifting and combining of `Semigroup`s into `Option` is provided by Cats as 
 
 N.B.
 Cats defines  the `Monoid` type class in cats-kernel. The
-[`cats` package object](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/package.scala)
+[`cats` package object](https://github.com/typelevel/cats/blob/main/core/src/main/scala/cats/package.scala)
 defines type aliases to the `Monoid` from cats-kernel, so that you can simply import `cats.Monoid`.

--- a/docs/src/main/tut/typeclasses/semigroup.md
+++ b/docs/src/main/tut/typeclasses/semigroup.md
@@ -181,5 +181,5 @@ or fallback value if the list is empty. We need a power expressive abstraction, 
 
 N.B.
 Cats defines the `Semigroup` type class in cats-kernel. The
-[`cats` package object](https://github.com/typelevel/cats/blob/master/core/src/main/scala/cats/package.scala)
+[`cats` package object](https://github.com/typelevel/cats/blob/main/core/src/main/scala/cats/package.scala)
 defines type aliases to the `Semigroup` from cats-kernel, so that you can simply import `cats.Semigroup`.

--- a/scripts/travis-publish.sh
+++ b/scripts/travis-publish.sh
@@ -15,14 +15,14 @@
 #    metrics when the tests are executing. This causes the full JVM build to be run a second time.
 
 # Example setting to use at command line for testing:
-# export TRAVIS_SCALA_VERSION=2.10.5;export TRAVIS_PULL_REQUEST="false";export TRAVIS_BRANCH="master"
+# export TRAVIS_SCALA_VERSION=2.10.5;export TRAVIS_PULL_REQUEST="false";export TRAVIS_BRANCH="main"
 
 
 sbt_cmd="sbt ++$TRAVIS_SCALA_VERSION"
 
 export publish_cmd="publishLocal"
 
-if [[ $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "master" && $(cat version.sbt) =~ "-SNAPSHOT" ]]; then
+if [[ $TRAVIS_PULL_REQUEST == "false" && $TRAVIS_BRANCH == "main" && $(cat version.sbt) =~ "-SNAPSHOT" ]]; then
   export publish_cmd="publish gitSnapshots publish"
   # temporarily disable to stabilize travis
   #if [[ $TRAVIS_SCALA_VERSION =~ ^2\.11\. ]]; then

--- a/tests/src/test/scala/cats/tests/EvalSuite.scala
+++ b/tests/src/test/scala/cats/tests/EvalSuite.scala
@@ -219,7 +219,7 @@ class EvalSuite extends CatsSuite {
       DeepEval(step(0, leaf, Nil))
     }
 
-    // we keep this low in master to keep travis happy.
+    // we keep this low in main to keep travis happy.
     // for an actual stress test increase to 200K or so.
     val MaxDepth = 100
 


### PR DESCRIPTION
This is a minor thing, but it's easy and will likely [soon be the default](https://twitter.com/natfriedman/status/1271253144442253312) on GitHub.

I've only changed links and references to the `master` branch in current instructions or documentation, not references in historical contexts like the changelog. I've chosen `main` since there seems to be consensus that that's the best replacement, but I'm happy to change it to one of the other alternatives.

There will be a few other steps that are necessary (see [here](https://twitter.com/mpilquist/status/1272694351181856769) or [here](https://www.hanselman.com/blog/EasilyRenameYourGitDefaultBranchFromMasterToMain.aspx)) in conjunction with this PR, which just ensures that we don't break links or CI.