### PR TITLE
Improve documentation for typeclasses

### DIFF
--- a/docs/src/main/tut/typeclasses/typeclasses.md
+++ b/docs/src/main/tut/typeclasses/typeclasses.md
@@ -38,7 +38,7 @@ The name `Monoid` is taken from abstract algebra which specifies precisely this 
 We can now write the functions above against this interface.
 
 ```tut:book:silent
-def combineAll[A](list: List[A], A: Monoid[A]): A = list.foldRight(A.empty)(A.combine)
+def combineAll[A](list: List[A], m: Monoid[A]): A = list.foldRight(m.empty)(m.combine)
 ```
 
 ## Type classes vs. subtyping


### PR DESCRIPTION
Small (opinionated) improvement. 

I've just read the documentation for typeclasses on the microsite and I was very confused by the use of duplicate name `A`. Although it compiles either way, I think this change will cause less confusion to future readers. Feel free to dismiss this PR if you feel different.

