### PR TITLE
Rerun Simulacrum after rearrangement for Scala.js

### DIFF
--- a/alleycats-core/src/main/scala/alleycats/ConsK.scala
+++ b/alleycats-core/src/main/scala/alleycats/ConsK.scala
@@ -24,6 +24,17 @@ object ConsK {
    */
   @inline def apply[F[_]](implicit instance: ConsK[F]): ConsK[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
+      type TypeClassType = ConsK[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = ConsK[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: ConsK[F]
     def self: F[A]
@@ -42,17 +53,6 @@ object ConsK {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToConsKOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllConsKOps[F[_], A](target: F[A])(implicit tc: ConsK[F]): AllOps[F, A] {
-      type TypeClassType = ConsK[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = ConsK[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/alleycats-core/src/main/scala/alleycats/Empty.scala
+++ b/alleycats-core/src/main/scala/alleycats/Empty.scala
@@ -32,6 +32,17 @@ object Empty extends EmptyInstances0 {
    */
   @inline def apply[A](implicit instance: Empty[A]): Empty[A] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllEmptyOps[A](target: A)(implicit tc: Empty[A]): AllOps[A] {
+      type TypeClassType = Empty[A]
+    } =
+      new AllOps[A] {
+        type TypeClassType = Empty[A]
+        val self: A = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[A] extends Serializable {
     type TypeClassType <: Empty[A]
     def self: A
@@ -52,17 +63,6 @@ object Empty extends EmptyInstances0 {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToEmptyOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllEmptyOps[A](target: A)(implicit tc: Empty[A]): AllOps[A] {
-      type TypeClassType = Empty[A]
-    } =
-      new AllOps[A] {
-        type TypeClassType = Empty[A]
-        val self: A = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/alleycats-core/src/main/scala/alleycats/EmptyK.scala
+++ b/alleycats-core/src/main/scala/alleycats/EmptyK.scala
@@ -24,6 +24,17 @@ object EmptyK {
    */
   @inline def apply[F[_]](implicit instance: EmptyK[F]): EmptyK[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllEmptyKOps[F[_], A](target: F[A])(implicit tc: EmptyK[F]): AllOps[F, A] {
+      type TypeClassType = EmptyK[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = EmptyK[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: EmptyK[F]
     def self: F[A]
@@ -42,17 +53,6 @@ object EmptyK {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToEmptyKOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllEmptyKOps[F[_], A](target: F[A])(implicit tc: EmptyK[F]): AllOps[F, A] {
-      type TypeClassType = EmptyK[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = EmptyK[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/alleycats-core/src/main/scala/alleycats/Extract.scala
+++ b/alleycats-core/src/main/scala/alleycats/Extract.scala
@@ -34,6 +34,17 @@ object Extract {
    */
   @inline def apply[F[_]](implicit instance: Extract[F]): Extract[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllExtractOps[F[_], A](target: F[A])(implicit tc: Extract[F]): AllOps[F, A] {
+      type TypeClassType = Extract[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = Extract[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Extract[F]
     def self: F[A]
@@ -53,17 +64,6 @@ object Extract {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToExtractOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllExtractOps[F[_], A](target: F[A])(implicit tc: Extract[F]): AllOps[F, A] {
-      type TypeClassType = Extract[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = Extract[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/alleycats-core/src/main/scala/alleycats/One.scala
+++ b/alleycats-core/src/main/scala/alleycats/One.scala
@@ -29,6 +29,17 @@ object One {
    */
   @inline def apply[A](implicit instance: One[A]): One[A] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllOneOps[A](target: A)(implicit tc: One[A]): AllOps[A] {
+      type TypeClassType = One[A]
+    } =
+      new AllOps[A] {
+        type TypeClassType = One[A]
+        val self: A = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[A] extends Serializable {
     type TypeClassType <: One[A]
     def self: A
@@ -49,17 +60,6 @@ object One {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToOneOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllOneOps[A](target: A)(implicit tc: One[A]): AllOps[A] {
-      type TypeClassType = One[A]
-    } =
-      new AllOps[A] {
-        type TypeClassType = One[A]
-        val self: A = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/alleycats-core/src/main/scala/alleycats/Pure.scala
+++ b/alleycats-core/src/main/scala/alleycats/Pure.scala
@@ -34,6 +34,17 @@ object Pure {
    */
   @inline def apply[F[_]](implicit instance: Pure[F]): Pure[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllPureOps[F[_], A](target: F[A])(implicit tc: Pure[F]): AllOps[F, A] {
+      type TypeClassType = Pure[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = Pure[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Pure[F]
     def self: F[A]
@@ -52,17 +63,6 @@ object Pure {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToPureOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllPureOps[F[_], A](target: F[A])(implicit tc: Pure[F]): AllOps[F, A] {
-      type TypeClassType = Pure[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = Pure[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/alleycats-core/src/main/scala/alleycats/Zero.scala
+++ b/alleycats-core/src/main/scala/alleycats/Zero.scala
@@ -30,6 +30,17 @@ object Zero {
    */
   @inline def apply[A](implicit instance: Zero[A]): Zero[A] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllZeroOps[A](target: A)(implicit tc: Zero[A]): AllOps[A] {
+      type TypeClassType = Zero[A]
+    } =
+      new AllOps[A] {
+        type TypeClassType = Zero[A]
+        val self: A = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[A] extends Serializable {
     type TypeClassType <: Zero[A]
     def self: A
@@ -50,17 +61,6 @@ object Zero {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToZeroOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllZeroOps[A](target: A)(implicit tc: Zero[A]): AllOps[A] {
-      type TypeClassType = Zero[A]
-    } =
-      new AllOps[A] {
-        type TypeClassType = Zero[A]
-        val self: A = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/build.sbt
+++ b/build.sbt
@@ -12,7 +12,7 @@ lazy val scoverageSettings = Seq(
 )
 
 organization in ThisBuild := "org.typelevel"
-scalafixDependencies in ThisBuild += "org.typelevel" %% "simulacrum-scalafix" % "0.4.0"
+scalafixDependencies in ThisBuild += "org.typelevel" %% "simulacrum-scalafix" % "0.5.0"
 
 val isTravisBuild = settingKey[Boolean]("Flag indicating whether the current build is running under Travis")
 val crossScalaVersionsFromTravis = settingKey[Seq[String]]("Scala versions set in .travis.yml as scala_version_XXX")
@@ -80,7 +80,7 @@ lazy val catsSettings = Seq(
 lazy val simulacrumSettings = Seq(
   addCompilerPlugin(scalafixSemanticdb),
   scalacOptions ++= Seq(s"-P:semanticdb:targetroot:${baseDirectory.value}/target/.semanticdb", "-Yrangepos"),
-  libraryDependencies += "org.typelevel" %% "simulacrum-scalafix-annotations" % "0.4.0",
+  libraryDependencies += "org.typelevel" %% "simulacrum-scalafix-annotations" % "0.5.0",
   pomPostProcess := { (node: xml.Node) =>
     new RuleTransformer(new RewriteRule {
       override def transform(node: xml.Node): Seq[xml.Node] =

--- a/core/src/main/scala/cats/Align.scala
+++ b/core/src/main/scala/cats/Align.scala
@@ -139,6 +139,17 @@ object Align extends ScalaVersionSpecificAlignInstances {
    */
   @inline def apply[F[_]](implicit instance: Align[F]): Align[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllAlignOps[F[_], A](target: F[A])(implicit tc: Align[F]): AllOps[F, A] {
+      type TypeClassType = Align[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = Align[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Align[F]
     def self: F[A]
@@ -164,17 +175,6 @@ object Align extends ScalaVersionSpecificAlignInstances {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToAlignOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllAlignOps[F[_], A](target: F[A])(implicit tc: Align[F]): AllOps[F, A] {
-      type TypeClassType = Align[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = Align[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/Alternative.scala
+++ b/core/src/main/scala/cats/Alternative.scala
@@ -101,6 +101,17 @@ object Alternative {
    */
   @inline def apply[F[_]](implicit instance: Alternative[F]): Alternative[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllAlternativeOps[F[_], A](target: F[A])(implicit tc: Alternative[F]): AllOps[F, A] {
+      type TypeClassType = Alternative[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = Alternative[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Alternative[F]
     def self: F[A]
@@ -127,17 +138,6 @@ object Alternative {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToAlternativeOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllAlternativeOps[F[_], A](target: F[A])(implicit tc: Alternative[F]): AllOps[F, A] {
-      type TypeClassType = Alternative[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = Alternative[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/Applicative.scala
+++ b/core/src/main/scala/cats/Applicative.scala
@@ -239,6 +239,17 @@ object Applicative {
    */
   @inline def apply[F[_]](implicit instance: Applicative[F]): Applicative[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllApplicativeOps[F[_], A](target: F[A])(implicit tc: Applicative[F]): AllOps[F, A] {
+      type TypeClassType = Applicative[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = Applicative[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Applicative[F]
     def self: F[A]
@@ -259,17 +270,6 @@ object Applicative {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToApplicativeOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllApplicativeOps[F[_], A](target: F[A])(implicit tc: Applicative[F]): AllOps[F, A] {
-      type TypeClassType = Applicative[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = Applicative[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -285,6 +285,17 @@ object Apply {
    */
   @inline def apply[F[_]](implicit instance: Apply[F]): Apply[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllApplyOps[F[_], A](target: F[A])(implicit tc: Apply[F]): AllOps[F, A] {
+      type TypeClassType = Apply[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = Apply[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Apply[F]
     def self: F[A]
@@ -317,17 +328,6 @@ object Apply {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToApplyOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllApplyOps[F[_], A](target: F[A])(implicit tc: Apply[F]): AllOps[F, A] {
-      type TypeClassType = Apply[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = Apply[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/Bifoldable.scala
+++ b/core/src/main/scala/cats/Bifoldable.scala
@@ -53,6 +53,17 @@ object Bifoldable {
    */
   @inline def apply[F[_, _]](implicit instance: Bifoldable[F]): Bifoldable[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllBifoldableOps[F[_, _], A, B](target: F[A, B])(implicit tc: Bifoldable[F]): AllOps[F, A, B] {
+      type TypeClassType = Bifoldable[F]
+    } =
+      new AllOps[F, A, B] {
+        type TypeClassType = Bifoldable[F]
+        val self: F[A, B] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: Bifoldable[F]
     def self: F[A, B]
@@ -77,17 +88,6 @@ object Bifoldable {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToBifoldableOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllBifoldableOps[F[_, _], A, B](target: F[A, B])(implicit tc: Bifoldable[F]): AllOps[F, A, B] {
-      type TypeClassType = Bifoldable[F]
-    } =
-      new AllOps[F, A, B] {
-        type TypeClassType = Bifoldable[F]
-        val self: F[A, B] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/Bifunctor.scala
+++ b/core/src/main/scala/cats/Bifunctor.scala
@@ -72,6 +72,17 @@ object Bifunctor {
    */
   @inline def apply[F[_, _]](implicit instance: Bifunctor[F]): Bifunctor[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllBifunctorOps[F[_, _], A, B](target: F[A, B])(implicit tc: Bifunctor[F]): AllOps[F, A, B] {
+      type TypeClassType = Bifunctor[F]
+    } =
+      new AllOps[F, A, B] {
+        type TypeClassType = Bifunctor[F]
+        val self: F[A, B] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: Bifunctor[F]
     def self: F[A, B]
@@ -93,17 +104,6 @@ object Bifunctor {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToBifunctorOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllBifunctorOps[F[_, _], A, B](target: F[A, B])(implicit tc: Bifunctor[F]): AllOps[F, A, B] {
-      type TypeClassType = Bifunctor[F]
-    } =
-      new AllOps[F, A, B] {
-        type TypeClassType = Bifunctor[F]
-        val self: F[A, B] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/Bimonad.scala
+++ b/core/src/main/scala/cats/Bimonad.scala
@@ -17,6 +17,17 @@ object Bimonad {
    */
   @inline def apply[F[_]](implicit instance: Bimonad[F]): Bimonad[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllBimonadOps[F[_], A](target: F[A])(implicit tc: Bimonad[F]): AllOps[F, A] {
+      type TypeClassType = Bimonad[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = Bimonad[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Bimonad[F]
     def self: F[A]
@@ -37,17 +48,6 @@ object Bimonad {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToBimonadOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllBimonadOps[F[_], A](target: F[A])(implicit tc: Bimonad[F]): AllOps[F, A] {
-      type TypeClassType = Bimonad[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = Bimonad[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/Bitraverse.scala
+++ b/core/src/main/scala/cats/Bitraverse.scala
@@ -124,6 +124,17 @@ object Bitraverse {
    */
   @inline def apply[F[_, _]](implicit instance: Bitraverse[F]): Bitraverse[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllBitraverseOps[F[_, _], A, B](target: F[A, B])(implicit tc: Bitraverse[F]): AllOps[F, A, B] {
+      type TypeClassType = Bitraverse[F]
+    } =
+      new AllOps[F, A, B] {
+        type TypeClassType = Bitraverse[F]
+        val self: F[A, B] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: Bitraverse[F]
     def self: F[A, B]
@@ -148,17 +159,6 @@ object Bitraverse {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToBitraverseOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllBitraverseOps[F[_, _], A, B](target: F[A, B])(implicit tc: Bitraverse[F]): AllOps[F, A, B] {
-      type TypeClassType = Bitraverse[F]
-    } =
-      new AllOps[F, A, B] {
-        type TypeClassType = Bitraverse[F]
-        val self: F[A, B] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/CoflatMap.scala
+++ b/core/src/main/scala/cats/CoflatMap.scala
@@ -59,6 +59,17 @@ object CoflatMap {
    */
   @inline def apply[F[_]](implicit instance: CoflatMap[F]): CoflatMap[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllCoflatMapOps[F[_], A](target: F[A])(implicit tc: CoflatMap[F]): AllOps[F, A] {
+      type TypeClassType = CoflatMap[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = CoflatMap[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: CoflatMap[F]
     def self: F[A]
@@ -81,17 +92,6 @@ object CoflatMap {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToCoflatMapOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllCoflatMapOps[F[_], A](target: F[A])(implicit tc: CoflatMap[F]): AllOps[F, A] {
-      type TypeClassType = CoflatMap[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = CoflatMap[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/CommutativeApplicative.scala
+++ b/core/src/main/scala/cats/CommutativeApplicative.scala
@@ -37,6 +37,19 @@ object CommutativeApplicative {
    */
   @inline def apply[F[_]](implicit instance: CommutativeApplicative[F]): CommutativeApplicative[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllCommutativeApplicativeOps[F[_], A](
+      target: F[A]
+    )(implicit tc: CommutativeApplicative[F]): AllOps[F, A] {
+      type TypeClassType = CommutativeApplicative[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = CommutativeApplicative[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: CommutativeApplicative[F]
     def self: F[A]
@@ -57,19 +70,6 @@ object CommutativeApplicative {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToCommutativeApplicativeOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllCommutativeApplicativeOps[F[_], A](
-      target: F[A]
-    )(implicit tc: CommutativeApplicative[F]): AllOps[F, A] {
-      type TypeClassType = CommutativeApplicative[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = CommutativeApplicative[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/CommutativeApply.scala
+++ b/core/src/main/scala/cats/CommutativeApply.scala
@@ -33,6 +33,17 @@ object CommutativeApply {
    */
   @inline def apply[F[_]](implicit instance: CommutativeApply[F]): CommutativeApply[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllCommutativeApplyOps[F[_], A](target: F[A])(implicit tc: CommutativeApply[F]): AllOps[F, A] {
+      type TypeClassType = CommutativeApply[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = CommutativeApply[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: CommutativeApply[F]
     def self: F[A]
@@ -53,17 +64,6 @@ object CommutativeApply {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToCommutativeApplyOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllCommutativeApplyOps[F[_], A](target: F[A])(implicit tc: CommutativeApply[F]): AllOps[F, A] {
-      type TypeClassType = CommutativeApply[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = CommutativeApply[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/CommutativeFlatMap.scala
+++ b/core/src/main/scala/cats/CommutativeFlatMap.scala
@@ -26,6 +26,17 @@ object CommutativeFlatMap {
    */
   @inline def apply[F[_]](implicit instance: CommutativeFlatMap[F]): CommutativeFlatMap[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllCommutativeFlatMapOps[F[_], A](target: F[A])(implicit tc: CommutativeFlatMap[F]): AllOps[F, A] {
+      type TypeClassType = CommutativeFlatMap[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = CommutativeFlatMap[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: CommutativeFlatMap[F]
     def self: F[A]
@@ -46,17 +57,6 @@ object CommutativeFlatMap {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToCommutativeFlatMapOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllCommutativeFlatMapOps[F[_], A](target: F[A])(implicit tc: CommutativeFlatMap[F]): AllOps[F, A] {
-      type TypeClassType = CommutativeFlatMap[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = CommutativeFlatMap[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/CommutativeMonad.scala
+++ b/core/src/main/scala/cats/CommutativeMonad.scala
@@ -26,6 +26,17 @@ object CommutativeMonad {
    */
   @inline def apply[F[_]](implicit instance: CommutativeMonad[F]): CommutativeMonad[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllCommutativeMonadOps[F[_], A](target: F[A])(implicit tc: CommutativeMonad[F]): AllOps[F, A] {
+      type TypeClassType = CommutativeMonad[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = CommutativeMonad[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: CommutativeMonad[F]
     def self: F[A]
@@ -50,17 +61,6 @@ object CommutativeMonad {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToCommutativeMonadOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllCommutativeMonadOps[F[_], A](target: F[A])(implicit tc: CommutativeMonad[F]): AllOps[F, A] {
-      type TypeClassType = CommutativeMonad[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = CommutativeMonad[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/Comonad.scala
+++ b/core/src/main/scala/cats/Comonad.scala
@@ -41,6 +41,17 @@ object Comonad {
    */
   @inline def apply[F[_]](implicit instance: Comonad[F]): Comonad[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllComonadOps[F[_], A](target: F[A])(implicit tc: Comonad[F]): AllOps[F, A] {
+      type TypeClassType = Comonad[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = Comonad[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Comonad[F]
     def self: F[A]
@@ -62,17 +73,6 @@ object Comonad {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToComonadOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllComonadOps[F[_], A](target: F[A])(implicit tc: Comonad[F]): AllOps[F, A] {
-      type TypeClassType = Comonad[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = Comonad[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/Contravariant.scala
+++ b/core/src/main/scala/cats/Contravariant.scala
@@ -42,6 +42,17 @@ object Contravariant {
    */
   @inline def apply[F[_]](implicit instance: Contravariant[F]): Contravariant[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllContravariantOps[F[_], A](target: F[A])(implicit tc: Contravariant[F]): AllOps[F, A] {
+      type TypeClassType = Contravariant[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = Contravariant[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Contravariant[F]
     def self: F[A]
@@ -64,17 +75,6 @@ object Contravariant {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToContravariantOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllContravariantOps[F[_], A](target: F[A])(implicit tc: Contravariant[F]): AllOps[F, A] {
-      type TypeClassType = Contravariant[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = Contravariant[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/ContravariantMonoidal.scala
+++ b/core/src/main/scala/cats/ContravariantMonoidal.scala
@@ -36,6 +36,19 @@ object ContravariantMonoidal extends SemigroupalArityFunctions {
    */
   @inline def apply[F[_]](implicit instance: ContravariantMonoidal[F]): ContravariantMonoidal[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllContravariantMonoidalOps[F[_], A](
+      target: F[A]
+    )(implicit tc: ContravariantMonoidal[F]): AllOps[F, A] {
+      type TypeClassType = ContravariantMonoidal[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = ContravariantMonoidal[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: ContravariantMonoidal[F]
     def self: F[A]
@@ -59,19 +72,6 @@ object ContravariantMonoidal extends SemigroupalArityFunctions {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToContravariantMonoidalOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllContravariantMonoidalOps[F[_], A](
-      target: F[A]
-    )(implicit tc: ContravariantMonoidal[F]): AllOps[F, A] {
-      type TypeClassType = ContravariantMonoidal[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = ContravariantMonoidal[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/ContravariantSemigroupal.scala
+++ b/core/src/main/scala/cats/ContravariantSemigroupal.scala
@@ -30,6 +30,19 @@ object ContravariantSemigroupal extends SemigroupalArityFunctions {
    */
   @inline def apply[F[_]](implicit instance: ContravariantSemigroupal[F]): ContravariantSemigroupal[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllContravariantSemigroupalOps[F[_], A](
+      target: F[A]
+    )(implicit tc: ContravariantSemigroupal[F]): AllOps[F, A] {
+      type TypeClassType = ContravariantSemigroupal[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = ContravariantSemigroupal[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: ContravariantSemigroupal[F]
     def self: F[A]
@@ -52,19 +65,6 @@ object ContravariantSemigroupal extends SemigroupalArityFunctions {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToContravariantSemigroupalOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllContravariantSemigroupalOps[F[_], A](
-      target: F[A]
-    )(implicit tc: ContravariantSemigroupal[F]): AllOps[F, A] {
-      type TypeClassType = ContravariantSemigroupal[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = ContravariantSemigroupal[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/Distributive.scala
+++ b/core/src/main/scala/cats/Distributive.scala
@@ -34,6 +34,17 @@ object Distributive {
    */
   @inline def apply[F[_]](implicit instance: Distributive[F]): Distributive[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllDistributiveOps[F[_], A](target: F[A])(implicit tc: Distributive[F]): AllOps[F, A] {
+      type TypeClassType = Distributive[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = Distributive[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Distributive[F]
     def self: F[A]
@@ -54,17 +65,6 @@ object Distributive {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToDistributiveOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllDistributiveOps[F[_], A](target: F[A])(implicit tc: Distributive[F]): AllOps[F, A] {
-      type TypeClassType = Distributive[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = Distributive[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/FlatMap.scala
+++ b/core/src/main/scala/cats/FlatMap.scala
@@ -211,6 +211,17 @@ object FlatMap {
    */
   @inline def apply[F[_]](implicit instance: FlatMap[F]): FlatMap[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllFlatMapOps[F[_], A](target: F[A])(implicit tc: FlatMap[F]): AllOps[F, A] {
+      type TypeClassType = FlatMap[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = FlatMap[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: FlatMap[F]
     def self: F[A]
@@ -237,17 +248,6 @@ object FlatMap {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToFlatMapOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllFlatMapOps[F[_], A](target: F[A])(implicit tc: FlatMap[F]): AllOps[F, A] {
-      type TypeClassType = FlatMap[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = FlatMap[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -921,6 +921,17 @@ object Foldable {
    */
   @inline def apply[F[_]](implicit instance: Foldable[F]): Foldable[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllFoldableOps[F[_], A](target: F[A])(implicit tc: Foldable[F]): AllOps[F, A] {
+      type TypeClassType = Foldable[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = Foldable[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Foldable[F]
     def self: F[A]
@@ -993,17 +1004,6 @@ object Foldable {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToFoldableOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllFoldableOps[F[_], A](target: F[A])(implicit tc: Foldable[F]): AllOps[F, A] {
-      type TypeClassType = Foldable[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = Foldable[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/Functor.scala
+++ b/core/src/main/scala/cats/Functor.scala
@@ -215,6 +215,17 @@ object Functor {
    */
   @inline def apply[F[_]](implicit instance: Functor[F]): Functor[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllFunctorOps[F[_], A](target: F[A])(implicit tc: Functor[F]): AllOps[F, A] {
+      type TypeClassType = Functor[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = Functor[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Functor[F]
     def self: F[A]
@@ -244,17 +255,6 @@ object Functor {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToFunctorOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllFunctorOps[F[_], A](target: F[A])(implicit tc: Functor[F]): AllOps[F, A] {
-      type TypeClassType = Functor[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = Functor[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/FunctorFilter.scala
+++ b/core/src/main/scala/cats/FunctorFilter.scala
@@ -100,6 +100,17 @@ object FunctorFilter extends ScalaVersionSpecificTraverseFilterInstances {
    */
   @inline def apply[F[_]](implicit instance: FunctorFilter[F]): FunctorFilter[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllFunctorFilterOps[F[_], A](target: F[A])(implicit tc: FunctorFilter[F]): AllOps[F, A] {
+      type TypeClassType = FunctorFilter[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = FunctorFilter[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: FunctorFilter[F]
     def self: F[A]
@@ -124,17 +135,6 @@ object FunctorFilter extends ScalaVersionSpecificTraverseFilterInstances {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToFunctorFilterOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllFunctorFilterOps[F[_], A](target: F[A])(implicit tc: FunctorFilter[F]): AllOps[F, A] {
-      type TypeClassType = FunctorFilter[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = FunctorFilter[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/Invariant.scala
+++ b/core/src/main/scala/cats/Invariant.scala
@@ -192,6 +192,17 @@ object Invariant extends ScalaVersionSpecificInvariantInstances with InvariantIn
    */
   @inline def apply[F[_]](implicit instance: Invariant[F]): Invariant[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllInvariantOps[F[_], A](target: F[A])(implicit tc: Invariant[F]): AllOps[F, A] {
+      type TypeClassType = Invariant[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = Invariant[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Invariant[F]
     def self: F[A]
@@ -211,17 +222,6 @@ object Invariant extends ScalaVersionSpecificInvariantInstances with InvariantIn
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToInvariantOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllInvariantOps[F[_], A](target: F[A])(implicit tc: Invariant[F]): AllOps[F, A] {
-      type TypeClassType = Invariant[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = Invariant[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/InvariantMonoidal.scala
+++ b/core/src/main/scala/cats/InvariantMonoidal.scala
@@ -45,6 +45,17 @@ object InvariantMonoidal {
    */
   @inline def apply[F[_]](implicit instance: InvariantMonoidal[F]): InvariantMonoidal[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllInvariantMonoidalOps[F[_], A](target: F[A])(implicit tc: InvariantMonoidal[F]): AllOps[F, A] {
+      type TypeClassType = InvariantMonoidal[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = InvariantMonoidal[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: InvariantMonoidal[F]
     def self: F[A]
@@ -65,17 +76,6 @@ object InvariantMonoidal {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToInvariantMonoidalOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllInvariantMonoidalOps[F[_], A](target: F[A])(implicit tc: InvariantMonoidal[F]): AllOps[F, A] {
-      type TypeClassType = InvariantMonoidal[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = InvariantMonoidal[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/InvariantSemigroupal.scala
+++ b/core/src/main/scala/cats/InvariantSemigroupal.scala
@@ -35,6 +35,19 @@ object InvariantSemigroupal extends SemigroupalArityFunctions {
    */
   @inline def apply[F[_]](implicit instance: InvariantSemigroupal[F]): InvariantSemigroupal[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllInvariantSemigroupalOps[F[_], A](
+      target: F[A]
+    )(implicit tc: InvariantSemigroupal[F]): AllOps[F, A] {
+      type TypeClassType = InvariantSemigroupal[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = InvariantSemigroupal[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: InvariantSemigroupal[F]
     def self: F[A]
@@ -55,19 +68,6 @@ object InvariantSemigroupal extends SemigroupalArityFunctions {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToInvariantSemigroupalOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllInvariantSemigroupalOps[F[_], A](
-      target: F[A]
-    )(implicit tc: InvariantSemigroupal[F]): AllOps[F, A] {
-      type TypeClassType = InvariantSemigroupal[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = InvariantSemigroupal[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/Monad.scala
+++ b/core/src/main/scala/cats/Monad.scala
@@ -130,6 +130,17 @@ object Monad {
    */
   @inline def apply[F[_]](implicit instance: Monad[F]): Monad[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllMonadOps[F[_], A](target: F[A])(implicit tc: Monad[F]): AllOps[F, A] {
+      type TypeClassType = Monad[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = Monad[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Monad[F]
     def self: F[A]
@@ -155,17 +166,6 @@ object Monad {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToMonadOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllMonadOps[F[_], A](target: F[A])(implicit tc: Monad[F]): AllOps[F, A] {
-      type TypeClassType = Monad[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = Monad[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/MonoidK.scala
+++ b/core/src/main/scala/cats/MonoidK.scala
@@ -64,6 +64,17 @@ object MonoidK {
    */
   @inline def apply[F[_]](implicit instance: MonoidK[F]): MonoidK[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllMonoidKOps[F[_], A](target: F[A])(implicit tc: MonoidK[F]): AllOps[F, A] {
+      type TypeClassType = MonoidK[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = MonoidK[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: MonoidK[F]
     def self: F[A]
@@ -84,17 +95,6 @@ object MonoidK {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToMonoidKOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllMonoidKOps[F[_], A](target: F[A])(implicit tc: MonoidK[F]): AllOps[F, A] {
-      type TypeClassType = MonoidK[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = MonoidK[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/NonEmptyTraverse.scala
+++ b/core/src/main/scala/cats/NonEmptyTraverse.scala
@@ -107,6 +107,17 @@ object NonEmptyTraverse {
    */
   @inline def apply[F[_]](implicit instance: NonEmptyTraverse[F]): NonEmptyTraverse[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllNonEmptyTraverseOps[F[_], A](target: F[A])(implicit tc: NonEmptyTraverse[F]): AllOps[F, A] {
+      type TypeClassType = NonEmptyTraverse[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = NonEmptyTraverse[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: NonEmptyTraverse[F]
     def self: F[A]
@@ -135,17 +146,6 @@ object NonEmptyTraverse {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToNonEmptyTraverseOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllNonEmptyTraverseOps[F[_], A](target: F[A])(implicit tc: NonEmptyTraverse[F]): AllOps[F, A] {
-      type TypeClassType = NonEmptyTraverse[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = NonEmptyTraverse[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/Reducible.scala
+++ b/core/src/main/scala/cats/Reducible.scala
@@ -295,6 +295,17 @@ object Reducible {
    */
   @inline def apply[F[_]](implicit instance: Reducible[F]): Reducible[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllReducibleOps[F[_], A](target: F[A])(implicit tc: Reducible[F]): AllOps[F, A] {
+      type TypeClassType = Reducible[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = Reducible[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Reducible[F]
     def self: F[A]
@@ -342,17 +353,6 @@ object Reducible {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToReducibleOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllReducibleOps[F[_], A](target: F[A])(implicit tc: Reducible[F]): AllOps[F, A] {
-      type TypeClassType = Reducible[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = Reducible[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/SemigroupK.scala
+++ b/core/src/main/scala/cats/SemigroupK.scala
@@ -143,6 +143,17 @@ object SemigroupK extends ScalaVersionSpecificMonoidKInstances {
    */
   @inline def apply[F[_]](implicit instance: SemigroupK[F]): SemigroupK[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllSemigroupKOps[F[_], A](target: F[A])(implicit tc: SemigroupK[F]): AllOps[F, A] {
+      type TypeClassType = SemigroupK[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = SemigroupK[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: SemigroupK[F]
     def self: F[A]
@@ -165,17 +176,6 @@ object SemigroupK extends ScalaVersionSpecificMonoidKInstances {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToSemigroupKOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllSemigroupKOps[F[_], A](target: F[A])(implicit tc: SemigroupK[F]): AllOps[F, A] {
-      type TypeClassType = SemigroupK[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = SemigroupK[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/Semigroupal.scala
+++ b/core/src/main/scala/cats/Semigroupal.scala
@@ -93,6 +93,17 @@ object Semigroupal extends ScalaVersionSpecificSemigroupalInstances with Semigro
    */
   @inline def apply[F[_]](implicit instance: Semigroupal[F]): Semigroupal[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllSemigroupalOps[F[_], A](target: F[A])(implicit tc: Semigroupal[F]): AllOps[F, A] {
+      type TypeClassType = Semigroupal[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = Semigroupal[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Semigroupal[F]
     def self: F[A]
@@ -112,17 +123,6 @@ object Semigroupal extends ScalaVersionSpecificSemigroupalInstances with Semigro
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToSemigroupalOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllSemigroupalOps[F[_], A](target: F[A])(implicit tc: Semigroupal[F]): AllOps[F, A] {
-      type TypeClassType = Semigroupal[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = Semigroupal[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/Traverse.scala
+++ b/core/src/main/scala/cats/Traverse.scala
@@ -144,6 +144,17 @@ object Traverse {
    */
   @inline def apply[F[_]](implicit instance: Traverse[F]): Traverse[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllTraverseOps[F[_], A](target: F[A])(implicit tc: Traverse[F]): AllOps[F, A] {
+      type TypeClassType = Traverse[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = Traverse[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: Traverse[F]
     def self: F[A]
@@ -180,17 +191,6 @@ object Traverse {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToTraverseOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllTraverseOps[F[_], A](target: F[A])(implicit tc: Traverse[F]): AllOps[F, A] {
-      type TypeClassType = Traverse[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = Traverse[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/TraverseFilter.scala
+++ b/core/src/main/scala/cats/TraverseFilter.scala
@@ -98,6 +98,17 @@ object TraverseFilter {
    */
   @inline def apply[F[_]](implicit instance: TraverseFilter[F]): TraverseFilter[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllTraverseFilterOps[F[_], A](target: F[A])(implicit tc: TraverseFilter[F]): AllOps[F, A] {
+      type TypeClassType = TraverseFilter[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = TraverseFilter[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: TraverseFilter[F]
     def self: F[A]
@@ -124,17 +135,6 @@ object TraverseFilter {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToTraverseFilterOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllTraverseFilterOps[F[_], A](target: F[A])(implicit tc: TraverseFilter[F]): AllOps[F, A] {
-      type TypeClassType = TraverseFilter[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = TraverseFilter[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/UnorderedFoldable.scala
+++ b/core/src/main/scala/cats/UnorderedFoldable.scala
@@ -123,6 +123,17 @@ object UnorderedFoldable extends ScalaVersionSpecificTraverseInstances {
    */
   @inline def apply[F[_]](implicit instance: UnorderedFoldable[F]): UnorderedFoldable[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllUnorderedFoldableOps[F[_], A](target: F[A])(implicit tc: UnorderedFoldable[F]): AllOps[F, A] {
+      type TypeClassType = UnorderedFoldable[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = UnorderedFoldable[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: UnorderedFoldable[F]
     def self: F[A]
@@ -149,17 +160,6 @@ object UnorderedFoldable extends ScalaVersionSpecificTraverseInstances {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToUnorderedFoldableOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllUnorderedFoldableOps[F[_], A](target: F[A])(implicit tc: UnorderedFoldable[F]): AllOps[F, A] {
-      type TypeClassType = UnorderedFoldable[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = UnorderedFoldable[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/UnorderedTraverse.scala
+++ b/core/src/main/scala/cats/UnorderedTraverse.scala
@@ -25,6 +25,17 @@ object UnorderedTraverse {
    */
   @inline def apply[F[_]](implicit instance: UnorderedTraverse[F]): UnorderedTraverse[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllUnorderedTraverseOps[F[_], A](target: F[A])(implicit tc: UnorderedTraverse[F]): AllOps[F, A] {
+      type TypeClassType = UnorderedTraverse[F]
+    } =
+      new AllOps[F, A] {
+        type TypeClassType = UnorderedTraverse[F]
+        val self: F[A] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_], A] extends Serializable {
     type TypeClassType <: UnorderedTraverse[F]
     def self: F[A]
@@ -49,17 +60,6 @@ object UnorderedTraverse {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToUnorderedTraverseOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllUnorderedTraverseOps[F[_], A](target: F[A])(implicit tc: UnorderedTraverse[F]): AllOps[F, A] {
-      type TypeClassType = UnorderedTraverse[F]
-    } =
-      new AllOps[F, A] {
-        type TypeClassType = UnorderedTraverse[F]
-        val self: F[A] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/arrow/Arrow.scala
+++ b/core/src/main/scala/cats/arrow/Arrow.scala
@@ -83,6 +83,17 @@ object Arrow {
    */
   @inline def apply[F[_, _]](implicit instance: Arrow[F]): Arrow[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllArrowOps[F[_, _], A, B](target: F[A, B])(implicit tc: Arrow[F]): AllOps[F, A, B] {
+      type TypeClassType = Arrow[F]
+    } =
+      new AllOps[F, A, B] {
+        type TypeClassType = Arrow[F]
+        val self: F[A, B] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: Arrow[F]
     def self: F[A, B]
@@ -107,17 +118,6 @@ object Arrow {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToArrowOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllArrowOps[F[_, _], A, B](target: F[A, B])(implicit tc: Arrow[F]): AllOps[F, A, B] {
-      type TypeClassType = Arrow[F]
-    } =
-      new AllOps[F, A, B] {
-        type TypeClassType = Arrow[F]
-        val self: F[A, B] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/arrow/ArrowChoice.scala
+++ b/core/src/main/scala/cats/arrow/ArrowChoice.scala
@@ -55,6 +55,17 @@ object ArrowChoice {
    */
   @inline def apply[F[_, _]](implicit instance: ArrowChoice[F]): ArrowChoice[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllArrowChoiceOps[F[_, _], A, B](target: F[A, B])(implicit tc: ArrowChoice[F]): AllOps[F, A, B] {
+      type TypeClassType = ArrowChoice[F]
+    } =
+      new AllOps[F, A, B] {
+        type TypeClassType = ArrowChoice[F]
+        val self: F[A, B] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: ArrowChoice[F]
     def self: F[A, B]
@@ -79,17 +90,6 @@ object ArrowChoice {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToArrowChoiceOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllArrowChoiceOps[F[_, _], A, B](target: F[A, B])(implicit tc: ArrowChoice[F]): AllOps[F, A, B] {
-      type TypeClassType = ArrowChoice[F]
-    } =
-      new AllOps[F, A, B] {
-        type TypeClassType = ArrowChoice[F]
-        val self: F[A, B] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/arrow/Category.scala
+++ b/core/src/main/scala/cats/arrow/Category.scala
@@ -36,6 +36,17 @@ object Category {
    */
   @inline def apply[F[_, _]](implicit instance: Category[F]): Category[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllCategoryOps[F[_, _], A, B](target: F[A, B])(implicit tc: Category[F]): AllOps[F, A, B] {
+      type TypeClassType = Category[F]
+    } =
+      new AllOps[F, A, B] {
+        type TypeClassType = Category[F]
+        val self: F[A, B] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: Category[F]
     def self: F[A, B]
@@ -56,17 +67,6 @@ object Category {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToCategoryOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllCategoryOps[F[_, _], A, B](target: F[A, B])(implicit tc: Category[F]): AllOps[F, A, B] {
-      type TypeClassType = Category[F]
-    } =
-      new AllOps[F, A, B] {
-        type TypeClassType = Category[F]
-        val self: F[A, B] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/arrow/Choice.scala
+++ b/core/src/main/scala/cats/arrow/Choice.scala
@@ -59,6 +59,17 @@ object Choice {
    */
   @inline def apply[F[_, _]](implicit instance: Choice[F]): Choice[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllChoiceOps[F[_, _], A, B](target: F[A, B])(implicit tc: Choice[F]): AllOps[F, A, B] {
+      type TypeClassType = Choice[F]
+    } =
+      new AllOps[F, A, B] {
+        type TypeClassType = Choice[F]
+        val self: F[A, B] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: Choice[F]
     def self: F[A, B]
@@ -81,17 +92,6 @@ object Choice {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToChoiceOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllChoiceOps[F[_, _], A, B](target: F[A, B])(implicit tc: Choice[F]): AllOps[F, A, B] {
-      type TypeClassType = Choice[F]
-    } =
-      new AllOps[F, A, B] {
-        type TypeClassType = Choice[F]
-        val self: F[A, B] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/arrow/CommutativeArrow.scala
+++ b/core/src/main/scala/cats/arrow/CommutativeArrow.scala
@@ -24,6 +24,19 @@ object CommutativeArrow {
    */
   @inline def apply[F[_, _]](implicit instance: CommutativeArrow[F]): CommutativeArrow[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllCommutativeArrowOps[F[_, _], A, B](
+      target: F[A, B]
+    )(implicit tc: CommutativeArrow[F]): AllOps[F, A, B] {
+      type TypeClassType = CommutativeArrow[F]
+    } =
+      new AllOps[F, A, B] {
+        type TypeClassType = CommutativeArrow[F]
+        val self: F[A, B] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: CommutativeArrow[F]
     def self: F[A, B]
@@ -44,19 +57,6 @@ object CommutativeArrow {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToCommutativeArrowOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllCommutativeArrowOps[F[_, _], A, B](
-      target: F[A, B]
-    )(implicit tc: CommutativeArrow[F]): AllOps[F, A, B] {
-      type TypeClassType = CommutativeArrow[F]
-    } =
-      new AllOps[F, A, B] {
-        type TypeClassType = CommutativeArrow[F]
-        val self: F[A, B] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/arrow/Compose.scala
+++ b/core/src/main/scala/cats/arrow/Compose.scala
@@ -57,6 +57,17 @@ object Compose {
    */
   @inline def apply[F[_, _]](implicit instance: Compose[F]): Compose[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllComposeOps[F[_, _], A, B](target: F[A, B])(implicit tc: Compose[F]): AllOps[F, A, B] {
+      type TypeClassType = Compose[F]
+    } =
+      new AllOps[F, A, B] {
+        type TypeClassType = Compose[F]
+        val self: F[A, B] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: Compose[F]
     def self: F[A, B]
@@ -79,17 +90,6 @@ object Compose {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToComposeOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllComposeOps[F[_, _], A, B](target: F[A, B])(implicit tc: Compose[F]): AllOps[F, A, B] {
-      type TypeClassType = Compose[F]
-    } =
-      new AllOps[F, A, B] {
-        type TypeClassType = Compose[F]
-        val self: F[A, B] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/arrow/Profunctor.scala
+++ b/core/src/main/scala/cats/arrow/Profunctor.scala
@@ -59,6 +59,17 @@ object Profunctor {
    */
   @inline def apply[F[_, _]](implicit instance: Profunctor[F]): Profunctor[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllProfunctorOps[F[_, _], A, B](target: F[A, B])(implicit tc: Profunctor[F]): AllOps[F, A, B] {
+      type TypeClassType = Profunctor[F]
+    } =
+      new AllOps[F, A, B] {
+        type TypeClassType = Profunctor[F]
+        val self: F[A, B] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: Profunctor[F]
     def self: F[A, B]
@@ -80,17 +91,6 @@ object Profunctor {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToProfunctorOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllProfunctorOps[F[_, _], A, B](target: F[A, B])(implicit tc: Profunctor[F]): AllOps[F, A, B] {
-      type TypeClassType = Profunctor[F]
-    } =
-      new AllOps[F, A, B] {
-        type TypeClassType = Profunctor[F]
-        val self: F[A, B] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */

--- a/core/src/main/scala/cats/arrow/Strong.scala
+++ b/core/src/main/scala/cats/arrow/Strong.scala
@@ -52,6 +52,17 @@ object Strong {
    */
   @inline def apply[F[_, _]](implicit instance: Strong[F]): Strong[F] = instance
 
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllStrongOps[F[_, _], A, B](target: F[A, B])(implicit tc: Strong[F]): AllOps[F, A, B] {
+      type TypeClassType = Strong[F]
+    } =
+      new AllOps[F, A, B] {
+        type TypeClassType = Strong[F]
+        val self: F[A, B] = target
+        val typeClassInstance: TypeClassType = tc
+      }
+  }
   trait Ops[F[_, _], A, B] extends Serializable {
     type TypeClassType <: Strong[F]
     def self: F[A, B]
@@ -74,17 +85,6 @@ object Strong {
   }
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToStrongOps
-  @deprecated("Use cats.syntax object imports", "2.2.0")
-  object ops {
-    implicit def toAllStrongOps[F[_, _], A, B](target: F[A, B])(implicit tc: Strong[F]): AllOps[F, A, B] {
-      type TypeClassType = Strong[F]
-    } =
-      new AllOps[F, A, B] {
-        type TypeClassType = Strong[F]
-        val self: F[A, B] = target
-        val typeClassInstance: TypeClassType = tc
-      }
-  }
 
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */


### PR DESCRIPTION
See [this bug](https://github.com/scala/bug/issues/11997) and the Simulacrum Scalafix workaround by @joroKr21 [here](https://github.com/typelevel/simulacrum-scalafix/pull/38). In short the problem is that defining a lowercase `ops` after the capitalized `Ops` trait causes problems on Scala.js 1.x on some platforms. (This bug also affects the macro annotation implementation of Simulacrum.)

This change uses the new 0.5.0 release of Simulacrum Scalafix I just published with that and one other fix (which doesn't affect Cats's usage).
