### PR TITLE
Add ScalaTest 3.2.0 dependencies

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,8 @@ isTravisBuild in Global := sys.env.get("TRAVIS").isDefined
 
 val scalaCheckVersion = "1.14.3"
 
-val scalatestplusScalaCheckVersion = "3.1.2.0"
+val scalatestVersion = "3.2.0"
+val scalatestplusScalaCheckVersion = "3.2.0.0"
 
 val disciplineVersion = "1.0.2"
 
@@ -148,6 +149,8 @@ lazy val disciplineDependencies = Seq(
 lazy val testingDependencies = Seq(
   libraryDependencies ++= Seq(
     "org.typelevel" %%% "discipline-scalatest" % disciplineScalatestVersion % Test,
+    "org.scalatest" %%% "scalatest-shouldmatchers" % scalatestVersion % Test,
+    "org.scalatest" %%% "scalatest-funsuite" % scalatestVersion % Test,
     "org.scalatestplus" %%% "scalacheck-1-14" % scalatestplusScalaCheckVersion % Test
   )
 )

--- a/tests/src/test/scala/cats/tests/SemigroupSuite.scala
+++ b/tests/src/test/scala/cats/tests/SemigroupSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.{Invariant, InvariantMonoidal, Semigroupal}
 import cats.kernel.Semigroup
-import org.scalatest._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.funsuite._
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks


### PR DESCRIPTION
The update in #3483 fails because it transitively bumps ScalaTest to 3.2.0, which splits some packages into their own modules, which have to be added to the build, which I've done here.