### PR TITLE
Another attempt at Dotty cross-building

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ jdk:
 
 scala_version_212: &scala_version_212 2.12.11
 scala_version_213: &scala_version_213 2.13.2
+dotty_version: &dotty_version 0.24.0
 
 before_install:
  - export PATH=${PATH}:./vendor/bundle
@@ -75,6 +76,14 @@ jobs:
     - <<: *bincompat
       name: Binary compatibility 2.13
       scala: *scala_version_213
+
+    # Note that we're currently only building some modules on Dotty, not running tests.
+    - &dotty_tests
+      stage: test
+      name: Dotty tests
+      env: TEST="Dotty tests"
+      script: sbt ++$TRAVIS_SCALA_VERSION! alleycatsLawsJVM/compile
+      scala: *dotty_version
 
     - stage: styling
       name: Linting

--- a/build.sbt
+++ b/build.sbt
@@ -782,7 +782,8 @@ addCommandAlias("validateJVM", ";fmtCheck;buildJVM;bench/test;validateBC;makeMic
 addCommandAlias("validateJS", ";catsJS/compile;testsJS/test;js/test")
 addCommandAlias("validateKernelJS", "kernelLawsJS/test")
 addCommandAlias("validateFreeJS", "freeJS/test") //separated due to memory constraint on travis
-addCommandAlias("validate", ";clean;validateJS;validateKernelJS;validateFreeJS;validateJVM")
+addCommandAlias("validateDotty", ";++0.24.0!;alleycatsLawsJVM/compile")
+addCommandAlias("validate", ";clean;validateJS;validateKernelJS;validateFreeJS;validateJVM;validateDotty")
 
 addCommandAlias("prePR", "fmt")
 

--- a/build.sbt
+++ b/build.sbt
@@ -44,9 +44,9 @@ def scalaVersionSpecificFolders(srcName: String, srcBaseDir: java.io.File, scala
     List(CrossType.Pure, CrossType.Full)
       .flatMap(_.sharedSrcDir(srcBaseDir, srcName).toList.map(f => file(f.getPath + suffix)))
   CrossVersion.partialVersion(scalaVersion) match {
-    case Some((2, y)) if y >= 13 =>
-      extraDirs("-2.13+")
-    case _ => Nil
+    case Some((2, y)) => extraDirs("-2.x") ++ (if (y >= 13) extraDirs("-2.13+") else Nil)
+    case Some((0, _)) => extraDirs("-2.13+") ++ extraDirs("-3.x")
+    case _            => Nil
   }
 }
 
@@ -59,8 +59,11 @@ commonScalaVersionSettings
 
 ThisBuild / mimaFailOnNoPrevious := false
 
+def doctestGenTestsDottyCompat(isDotty: Boolean, genTests: Seq[File]): Seq[File] =
+  if (isDotty) Nil else genTests
+
 lazy val commonSettings = commonScalaVersionSettings ++ Seq(
-  scalacOptions ++= commonScalacOptions(scalaVersion.value),
+  scalacOptions ++= commonScalacOptions(scalaVersion.value, isDotty.value),
   Compile / unmanagedSourceDirectories ++= scalaVersionSpecificFolders("main", baseDirectory.value, scalaVersion.value),
   Test / unmanagedSourceDirectories ++= scalaVersionSpecificFolders("test", baseDirectory.value, scalaVersion.value),
   resolvers ++= Seq(Resolver.sonatypeRepo("releases"), Resolver.sonatypeRepo("snapshots")),
@@ -69,19 +72,24 @@ lazy val commonSettings = commonScalaVersionSettings ++ Seq(
 ) ++ warnUnusedImport
 
 def macroDependencies(scalaVersion: String) =
-  Seq("org.scala-lang" % "scala-reflect" % scalaVersion % Provided)
+  if (scalaVersion.startsWith("2")) Seq("org.scala-lang" % "scala-reflect" % scalaVersion % Provided) else Nil
 
 lazy val catsSettings = Seq(
   incOptions := incOptions.value.withLogRecompileOnMacro(false),
-  libraryDependencies ++= Seq(
-    compilerPlugin(("org.typelevel" %% "kind-projector" % kindProjectorVersion).cross(CrossVersion.full))
+  libraryDependencies ++= (
+    if (isDotty.value) Nil else Seq(
+      compilerPlugin(("org.typelevel" %% "kind-projector" % kindProjectorVersion).cross(CrossVersion.full))
+    )
   ) ++ macroDependencies(scalaVersion.value)
 ) ++ commonSettings ++ publishSettings ++ scoverageSettings ++ simulacrumSettings
 
 lazy val simulacrumSettings = Seq(
-  addCompilerPlugin(scalafixSemanticdb),
-  scalacOptions ++= Seq(s"-P:semanticdb:targetroot:${baseDirectory.value}/target/.semanticdb", "-Yrangepos"),
-  libraryDependencies += "org.typelevel" %% "simulacrum-scalafix-annotations" % "0.5.0",
+  libraryDependencies ++= (if (isDotty.value) Nil else Seq(compilerPlugin(scalafixSemanticdb))),
+  scalacOptions ++= (
+    if (isDotty.value) Nil else Seq(s"-P:semanticdb:targetroot:${baseDirectory.value}/target/.semanticdb", "-Yrangepos")
+  ),
+  libraryDependencies +=
+    ("org.typelevel" %% "simulacrum-scalafix-annotations" % "0.5.0").withDottyCompat(scalaVersion.value),
   pomPostProcess := { (node: xml.Node) =>
     new RuleTransformer(new RewriteRule {
       override def transform(node: xml.Node): Seq[xml.Node] =
@@ -141,17 +149,25 @@ lazy val includeGeneratedSrc: Setting[_] = {
 }
 
 lazy val disciplineDependencies = Seq(
-  libraryDependencies ++= Seq("org.scalacheck" %%% "scalacheck" % scalaCheckVersion,
-                              "org.typelevel" %%% "discipline-core" % disciplineVersion
-  )
+  libraryDependencies ++= Seq(
+    "org.scalacheck" %%% "scalacheck" % scalaCheckVersion,
+    "org.typelevel" %%% "discipline-core" % disciplineVersion
+  ).map(_.withDottyCompat(scalaVersion.value))
 )
 
 lazy val testingDependencies = Seq(
   libraryDependencies ++= Seq(
-    "org.typelevel" %%% "discipline-scalatest" % disciplineScalatestVersion % Test,
     "org.scalatest" %%% "scalatest-shouldmatchers" % scalatestVersion % Test,
     "org.scalatest" %%% "scalatest-funsuite" % scalatestVersion % Test,
     "org.scalatestplus" %%% "scalacheck-1-14" % scalatestplusScalaCheckVersion % Test
+  ),
+  libraryDependencies ++= Seq(
+    ("org.typelevel" %%% "discipline-scalatest" % disciplineScalatestVersion % Test)
+  ).map(
+    _.exclude("org.scalatestplus", "scalacheck-1-14_2.13")
+      .exclude("org.scalactic", "scalactic_2.13")
+      .exclude("org.scalatest", "scalatest_2.13")
+      .withDottyCompat(scalaVersion.value)
   )
 )
 
@@ -397,6 +413,7 @@ lazy val docs = project
   .settings(docSettings)
   .settings(commonJvmSettings)
   .settings(
+    crossScalaVersions := crossScalaVersions.value.init,
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "discipline-scalatest" % disciplineScalatestVersion
     ),
@@ -489,7 +506,10 @@ lazy val kernel = crossProject(JSPlatform, JVMPlatform)
   .settings(includeGeneratedSrc)
   .jsSettings(commonJsSettings)
   .jvmSettings(commonJvmSettings ++ mimaSettings("cats-kernel"))
-  .settings(libraryDependencies += "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % Test)
+  .settings(
+    libraryDependencies += ("org.scalacheck" %%% "scalacheck" % scalaCheckVersion % Test)
+      .withDottyCompat(scalaVersion.value)
+  )
 
 lazy val kernelLaws = crossProject(JSPlatform, JVMPlatform)
   .in(file("kernel-laws"))
@@ -512,7 +532,11 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
   .settings(catsSettings)
   .settings(sourceGenerators in Compile += (sourceManaged in Compile).map(Boilerplate.gen).taskValue)
   .settings(includeGeneratedSrc)
-  .settings(libraryDependencies += "org.scalacheck" %%% "scalacheck" % scalaCheckVersion % Test)
+  .settings(
+    libraryDependencies += ("org.scalacheck" %%% "scalacheck" % scalaCheckVersion % Test)
+      .withDottyCompat(scalaVersion.value),
+    doctestGenTests := doctestGenTestsDottyCompat(isDotty.value, doctestGenTests.value)
+  )
   .jsSettings(commonJsSettings)
   .jvmSettings(commonJvmSettings ++ mimaSettings("cats-core"))
 
@@ -776,21 +800,14 @@ lazy val crossVersionSharedSources: Seq[Setting[_]] =
     }
   }
 
-def commonScalacOptions(scalaVersion: String) =
+def commonScalacOptions(scalaVersion: String, isDotty: Boolean) =
   Seq(
     "-encoding",
     "UTF-8",
     "-feature",
-    "-language:existentials",
-    "-language:higherKinds",
-    "-language:implicitConversions",
     "-unchecked",
-    "-Ywarn-dead-code",
-    "-Ywarn-numeric-widen",
-    "-Ywarn-value-discard",
     "-Xfatal-warnings",
-    "-deprecation",
-    "-Xlint:-unused,_"
+    "-deprecation"
   ) ++ (if (priorTo2_13(scalaVersion))
           Seq(
             "-Yno-adapted-args",
@@ -798,7 +815,18 @@ def commonScalacOptions(scalaVersion: String) =
             "-Xfuture"
           )
         else
-          Nil)
+          Nil) ++ (if (isDotty)
+                     Seq("-language:implicitConversions", "-Ykind-projector", "-Xignore-scala2-macros")
+                   else
+                     Seq(
+                       "-language:existentials",
+                       "-language:higherKinds",
+                       "-language:implicitConversions",
+                       "-Ywarn-dead-code",
+                       "-Ywarn-numeric-widen",
+                       "-Ywarn-value-discard",
+                       "-Xlint:-unused,_"
+                     ))
 
 def priorTo2_13(scalaVersion: String): Boolean =
   CrossVersion.partialVersion(scalaVersion) match {
@@ -839,7 +867,7 @@ lazy val sharedReleaseProcess = Seq(
 )
 
 lazy val warnUnusedImport = Seq(
-  scalacOptions ++= Seq("-Ywarn-unused:imports"),
+  scalacOptions ++= (if (isDotty.value) Nil else Seq("-Ywarn-unused:imports")),
   scalacOptions in (Compile, console) ~= { _.filterNot(Set("-Ywarn-unused-import", "-Ywarn-unused:imports")) },
   scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value
 )

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,8 @@ isTravisBuild in Global := sys.env.get("TRAVIS").isDefined
 
 val scalaCheckVersion = "1.14.3"
 
-val scalatestplusScalaCheckVersion = "3.1.2.0"
+val scalatestVersion = "3.2.0"
+val scalatestplusScalaCheckVersion = "3.2.0.0"
 
 val disciplineVersion = "1.0.2"
 
@@ -148,6 +149,8 @@ lazy val disciplineDependencies = Seq(
 lazy val testingDependencies = Seq(
   libraryDependencies ++= Seq(
     "org.typelevel" %%% "discipline-scalatest" % disciplineScalatestVersion % Test,
+    "org.scalatest" %%% "scalatest-shouldmatchers" % scalatestVersion % Test,
+    "org.scalatest" %%% "scalatest-funsuite" % scalatestVersion % Test,
     "org.scalatestplus" %%% "scalacheck-1-14" % scalatestplusScalaCheckVersion % Test
   )
 )

--- a/build.sbt
+++ b/build.sbt
@@ -77,9 +77,11 @@ def macroDependencies(scalaVersion: String) =
 lazy val catsSettings = Seq(
   incOptions := incOptions.value.withLogRecompileOnMacro(false),
   libraryDependencies ++= (
-    if (isDotty.value) Nil else Seq(
-      compilerPlugin(("org.typelevel" %% "kind-projector" % kindProjectorVersion).cross(CrossVersion.full))
-    )
+    if (isDotty.value) Nil
+    else
+      Seq(
+        compilerPlugin(("org.typelevel" %% "kind-projector" % kindProjectorVersion).cross(CrossVersion.full))
+      )
   ) ++ macroDependencies(scalaVersion.value)
 ) ++ commonSettings ++ publishSettings ++ scoverageSettings ++ simulacrumSettings
 
@@ -536,6 +538,13 @@ lazy val core = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies += ("org.scalacheck" %%% "scalacheck" % scalaCheckVersion % Test)
       .withDottyCompat(scalaVersion.value),
     doctestGenTests := doctestGenTestsDottyCompat(isDotty.value, doctestGenTests.value)
+  )
+  .settings(
+    scalacOptions in Compile :=
+      (scalacOptions in Compile).value.filter {
+        case "-Xfatal-warnings" if isDotty.value => false
+        case _                                   => true
+      }
   )
   .jsSettings(commonJsSettings)
   .jvmSettings(commonJvmSettings ++ mimaSettings("cats-core"))

--- a/core/src/main/scala-2.x/src/main/scala/cats/arrow/FunctionKMacros.scala
+++ b/core/src/main/scala-2.x/src/main/scala/cats/arrow/FunctionKMacros.scala
@@ -1,0 +1,102 @@
+package cats
+package arrow
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox.Context
+
+private[arrow] class FunctionKMacroMethods {
+
+  /**
+   * Lifts function `f` of `F[A] => G[A]` into a `FunctionK[F, G]`.
+   *
+   * {{{
+   *   def headOption[A](list: List[A]): Option[A] = list.headOption
+   *   val lifted: FunctionK[List, Option] = FunctionK.lift(headOption)
+   * }}}
+   *
+   * Note: This method has a macro implementation that returns a new
+   * `FunctionK` instance as follows:
+   *
+   * {{{
+   *   new FunctionK[F, G] {
+   *     def apply[A](fa: F[A]): G[A] = f(fa)
+   *   }
+   * }}}
+   *
+   * Additionally, the type parameters on `f` must not be specified.
+   */
+  def lift[F[_], G[_]](f: (F[α] => G[α]) forSome { type α }): FunctionK[F, G] =
+    macro FunctionKMacros.lift[F, G]
+}
+
+private[arrow] object FunctionKMacros {
+
+  def lift[F[_], G[_]](c: Context)(
+    f: c.Expr[(F[α] => G[α]) forSome { type α }]
+  )(implicit
+    evF: c.WeakTypeTag[F[_]],
+    evG: c.WeakTypeTag[G[_]]
+  ): c.Expr[FunctionK[F, G]] =
+    c.Expr[FunctionK[F, G]](new Lifter[c.type](c).lift[F, G](f.tree))
+  // ^^note: extra space after c.type to appease scalastyle
+
+  private[this] class Lifter[C <: Context](val c: C) {
+    import c.universe._
+
+    def lift[F[_], G[_]](tree: Tree)(implicit
+      evF: c.WeakTypeTag[F[_]],
+      evG: c.WeakTypeTag[G[_]]
+    ): Tree =
+      unblock(tree) match {
+        case q"($param) => $trans[..$typeArgs](${arg: Ident})" if param.name == arg.name =>
+          typeArgs
+            .collect { case tt: TypeTree => tt }
+            .find(tt => Option(tt.original).isDefined)
+            .foreach { param =>
+              c.abort(param.pos,
+                      s"type parameter $param must not be supplied when lifting function $trans to FunctionK"
+              )
+            }
+
+          val F = punchHole(evF.tpe)
+          val G = punchHole(evG.tpe)
+
+          q"""
+        new _root_.cats.arrow.FunctionK[$F, $G] {
+          def apply[A](fa: $F[A]): $G[A] = $trans(fa)
+        }
+       """
+        case other =>
+          c.abort(other.pos, s"Unexpected tree $other when lifting to FunctionK")
+      }
+
+    private[this] def unblock(tree: Tree): Tree =
+      tree match {
+        case Block(Nil, expr) => expr
+        case _                => tree
+      }
+
+    private[this] def punchHole(tpe: Type): Tree =
+      tpe match {
+        case PolyType(undet :: Nil, underlying: TypeRef) =>
+          val α = TypeName("α")
+          def rebind(typeRef: TypeRef): Tree =
+            if (typeRef.sym == undet) tq"$α"
+            else {
+              val args = typeRef.args.map {
+                case ref: TypeRef => rebind(ref)
+                case arg          => tq"$arg"
+              }
+              tq"${typeRef.sym}[..$args]"
+            }
+          val rebound = rebind(underlying)
+          tq"""({type λ[$α] = $rebound})#λ"""
+        case TypeRef(pre, sym, Nil) =>
+          tq"$sym"
+        case _ =>
+          c.abort(c.enclosingPosition, s"Unexpected type $tpe when lifting to FunctionK")
+      }
+
+  }
+
+}

--- a/core/src/main/scala-3.x/src/main/scala/cats/arrow/FunctionKMacros.scala
+++ b/core/src/main/scala-3.x/src/main/scala/cats/arrow/FunctionKMacros.scala
@@ -1,0 +1,4 @@
+package cats
+package arrow
+
+private[arrow] class FunctionKMacroMethods

--- a/core/src/main/scala/cats/arrow/FunctionK.scala
+++ b/core/src/main/scala/cats/arrow/FunctionK.scala
@@ -1,9 +1,6 @@
 package cats
 package arrow
 
-import scala.language.experimental.macros
-import scala.reflect.macros.blackbox.Context
-
 import cats.data.{EitherK, Tuple2K}
 
 /**
@@ -64,105 +61,11 @@ trait FunctionK[F[_], G[_]] extends Serializable { self =>
     new FunctionK[F, Tuple2K[G, H, *]] { def apply[A](fa: F[A]): Tuple2K[G, H, A] = Tuple2K(self(fa), h(fa)) }
 }
 
-object FunctionK {
+object FunctionK extends FunctionKMacroMethods {
 
   /**
    * The identity transformation of `F` to `F`
    */
   def id[F[_]]: FunctionK[F, F] = new FunctionK[F, F] { def apply[A](fa: F[A]): F[A] = fa }
-
-  /**
-   * Lifts function `f` of `F[A] => G[A]` into a `FunctionK[F, G]`.
-   *
-   * {{{
-   *   def headOption[A](list: List[A]): Option[A] = list.headOption
-   *   val lifted: FunctionK[List, Option] = FunctionK.lift(headOption)
-   * }}}
-   *
-   * Note: This method has a macro implementation that returns a new
-   * `FunctionK` instance as follows:
-   *
-   * {{{
-   *   new FunctionK[F, G] {
-   *     def apply[A](fa: F[A]): G[A] = f(fa)
-   *   }
-   * }}}
-   *
-   * Additionally, the type parameters on `f` must not be specified.
-   */
-  def lift[F[_], G[_]](f: (F[α] => G[α]) forSome { type α }): FunctionK[F, G] =
-    macro FunctionKMacros.lift[F, G]
-
-}
-
-private[arrow] object FunctionKMacros {
-
-  def lift[F[_], G[_]](c: Context)(
-    f: c.Expr[(F[α] => G[α]) forSome { type α }]
-  )(implicit
-    evF: c.WeakTypeTag[F[_]],
-    evG: c.WeakTypeTag[G[_]]
-  ): c.Expr[FunctionK[F, G]] =
-    c.Expr[FunctionK[F, G]](new Lifter[c.type](c).lift[F, G](f.tree))
-  // ^^note: extra space after c.type to appease scalastyle
-
-  private[this] class Lifter[C <: Context](val c: C) {
-    import c.universe._
-
-    def lift[F[_], G[_]](tree: Tree)(implicit
-      evF: c.WeakTypeTag[F[_]],
-      evG: c.WeakTypeTag[G[_]]
-    ): Tree =
-      unblock(tree) match {
-        case q"($param) => $trans[..$typeArgs](${arg: Ident})" if param.name == arg.name =>
-          typeArgs
-            .collect { case tt: TypeTree => tt }
-            .find(tt => Option(tt.original).isDefined)
-            .foreach { param =>
-              c.abort(param.pos,
-                      s"type parameter $param must not be supplied when lifting function $trans to FunctionK"
-              )
-            }
-
-          val F = punchHole(evF.tpe)
-          val G = punchHole(evG.tpe)
-
-          q"""
-        new _root_.cats.arrow.FunctionK[$F, $G] {
-          def apply[A](fa: $F[A]): $G[A] = $trans(fa)
-        }
-       """
-        case other =>
-          c.abort(other.pos, s"Unexpected tree $other when lifting to FunctionK")
-      }
-
-    private[this] def unblock(tree: Tree): Tree =
-      tree match {
-        case Block(Nil, expr) => expr
-        case _                => tree
-      }
-
-    private[this] def punchHole(tpe: Type): Tree =
-      tpe match {
-        case PolyType(undet :: Nil, underlying: TypeRef) =>
-          val α = TypeName("α")
-          def rebind(typeRef: TypeRef): Tree =
-            if (typeRef.sym == undet) tq"$α"
-            else {
-              val args = typeRef.args.map {
-                case ref: TypeRef => rebind(ref)
-                case arg          => tq"$arg"
-              }
-              tq"${typeRef.sym}[..$args]"
-            }
-          val rebound = rebind(underlying)
-          tq"""({type λ[$α] = $rebound})#λ"""
-        case TypeRef(pre, sym, Nil) =>
-          tq"$sym"
-        case _ =>
-          c.abort(c.enclosingPosition, s"Unexpected type $tpe when lifting to FunctionK")
-      }
-
-  }
 
 }

--- a/laws/src/main/scala/cats/laws/ApplicativeErrorLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplicativeErrorLaws.scala
@@ -32,7 +32,7 @@ trait ApplicativeErrorLaws[F[_], E] extends ApplicativeLaws[F] {
     F.handleError(fa)(f) <-> F.recover(fa) { case x => f(x) }
 
   def recoverConsistentWithRecoverWith[A](fa: F[A], pf: PartialFunction[E, A]): IsEq[F[A]] =
-    F.recover(fa)(pf) <-> F.recoverWith(fa)(pf.andThen(F.pure _))
+    F.recover(fa)(pf) <-> F.recoverWith(fa)(pf.andThen(F.pure(_)))
 
   def attemptConsistentWithAttemptT[A](fa: F[A]): IsEq[EitherT[F, E, A]] =
     EitherT(F.attempt(fa)) <-> F.attemptT(fa)

--- a/laws/src/main/scala/cats/laws/NonEmptyTraverseLaws.scala
+++ b/laws/src/main/scala/cats/laws/NonEmptyTraverseLaws.scala
@@ -1,6 +1,8 @@
 package cats.laws
 
-import cats.{Apply, Id, NonEmptyTraverse, Semigroup}
+// The `catsInstancesForId` import is necessary to work around a Dotty
+// issue related to https://github.com/lampepfl/dotty/issues/9067.
+import cats.{catsInstancesForId, Apply, Id, NonEmptyTraverse, Semigroup}
 import cats.data.{Const, Nested}
 import cats.syntax.nonEmptyTraverse._
 import cats.syntax.reducible._

--- a/laws/src/main/scala/cats/laws/discipline/Eq.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Eq.scala
@@ -154,7 +154,7 @@ object eq {
    * and comparing the application of the two functions.
    */
   implicit def catsLawsEqForFn2[A, B, C](implicit A: Arbitrary[A], B: Arbitrary[B], C: Eq[C]): Eq[(A, B) => C] =
-    Eq.by((_: (A, B) => C).tupled)(catsLawsEqForFn1)
+    Eq.by((_: (A, B) => C).tupled)(catsLawsEqForFn1[(A, B), C])
 
   /**
    * `Eq[AndThen]` instance, built by piggybacking on [[catsLawsEqForFn1]].

--- a/laws/src/main/scala/cats/laws/discipline/NonEmptyParallelTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/NonEmptyParallelTests.scala
@@ -35,6 +35,6 @@ object NonEmptyParallelTests {
   def apply[M[_]](implicit ev: NonEmptyParallel[M]): NonEmptyParallelTests.Aux[M, ev.F] =
     apply[M, ev.F](ev, implicitly)
 
-  def apply[M[_], F[_]](implicit ev: NonEmptyParallel.Aux[M, F], D: DummyImplicit): NonEmptyParallelTests.Aux[M, F] =
-    new NonEmptyParallelTests[M] { val laws = NonEmptyParallelLaws[M] }
+  def apply[M[_], F0[_]](implicit ev: NonEmptyParallel.Aux[M, F0], D: DummyImplicit): NonEmptyParallelTests.Aux[M, F0] =
+    new NonEmptyParallelTests[M] { val laws: NonEmptyParallelLaws.Aux[M, F0] = NonEmptyParallelLaws[M](ev) }
 }

--- a/laws/src/main/scala/cats/laws/discipline/ParallelTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ParallelTests.scala
@@ -31,6 +31,6 @@ object ParallelTests {
   def apply[M[_]](implicit ev: Parallel[M]): ParallelTests.Aux[M, ev.F] =
     apply[M, ev.F](ev, implicitly)
 
-  def apply[M[_], F[_]](implicit ev: Parallel.Aux[M, F], D: DummyImplicit): ParallelTests.Aux[M, F] =
-    new ParallelTests[M] { val laws = ParallelLaws[M] }
+  def apply[M[_], F0[_]](implicit ev: Parallel.Aux[M, F0], D: DummyImplicit): ParallelTests.Aux[M, F0] =
+    new ParallelTests[M] { val laws: ParallelLaws.Aux[M, F0] = ParallelLaws[M](ev) }
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,3 +1,4 @@
+addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.1")
 addSbtPlugin("ch.epfl.scala" % "sbt-scalafix" % "0.9.17")
 addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.3")
 addSbtPlugin("com.github.gseitz" %% "sbt-release" % "1.0.13")

--- a/tests/src/test/scala/cats/tests/SemigroupSuite.scala
+++ b/tests/src/test/scala/cats/tests/SemigroupSuite.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.{Invariant, InvariantMonoidal, Semigroupal}
 import cats.kernel.Semigroup
-import org.scalatest._
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.funsuite._
 import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks


### PR DESCRIPTION
This PR partially includes and supersedes #3269. It also depends on #3484, which is ~trivial and should be merged soon.

There are a lot of issues with building and running our tests on Dotty, and I don't have the interest or will to deal with them right now, but I don't think that should block getting the core modules cross-building now. This PR enables Dotty cross-building (on the JVM only) for kernel, kernel-laws, core, laws, alleycats, and alleycats-laws, but does not run any tests.

Merging this now gets us a couple of things:

* We catch changes that break on Dotty sooner, at least for most of the code.
* It's easier for people other than me to work on the issues that are turning up in the tests.

None of the changes here should have any impact on the Scala 2 build, except for the introduction of a package-private `FunctionKMacroMethods` trait.

----

Note that I've disabled fatal warnings (for Dotty only) because of two issues:

* A [false positive from an exhaustivity check](https://github.com/lampepfl/dotty/issues/9067), which should be fixed in 0.25.
* Some weird type test error in `ContT` that I think I investigated once and maybe even reported, but can't find now.