### PR TITLE
Scalafmt core 2.6.1

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version=2.6.0
+version=2.6.1
 align.openParenCallSite = true
 align.openParenDefnSite = true
 maxColumn = 120

--- a/core/src/main/scala/cats/syntax/either.scala
+++ b/core/src/main/scala/cats/syntax/either.scala
@@ -131,7 +131,8 @@ final class EitherOps[A, B](private val eab: Either[A, B]) extends AnyVal {
 
   /**
    * Returns a [[cats.data.ValidatedNel]] representation of this disjunction with the `Left` value
-   * as a single element on the `Invalid` side of the [[cats.data.NonEmptyList]]. */
+   * as a single element on the `Invalid` side of the [[cats.data.NonEmptyList]].
+   */
   def toValidatedNel[AA >: A]: ValidatedNel[AA, B] =
     eab match {
       case Left(a)  => Validated.invalidNel(a)
@@ -489,7 +490,8 @@ final private[syntax] class EitherOpsBinCompat0[A, B](private val value: Either[
 
   /**
    * Returns a [[cats.data.ValidatedNec]] representation of this disjunction with the `Left` value
-   * as a single element on the `Invalid` side of the [[cats.data.NonEmptyList]]. */
+   * as a single element on the `Invalid` side of the [[cats.data.NonEmptyList]].
+   */
   def toValidatedNec: ValidatedNec[A, B] =
     value match {
       case Left(a)  => Validated.invalidNec(a)


### PR DESCRIPTION
A little formatting is required by this https://github.com/typelevel/cats/pull/3487 . It's actually not bad as those 2 examples were kind of unique in the style.
