### PR TITLE
Don't skip PartialOrder antisymmetry and transitivity

### DIFF
--- a/kernel-laws/shared/src/main/scala/cats/kernel/laws/discipline/EqTests.scala
+++ b/kernel-laws/shared/src/main/scala/cats/kernel/laws/discipline/EqTests.scala
@@ -17,10 +17,10 @@ trait EqTests[A] extends Laws {
     new DefaultRuleSet(
       "eq",
       None,
-      "reflexivity" -> forAll(laws.reflexivityEq _),
-      "symmetry" -> forAll(laws.symmetryEq _),
-      "antisymmetry" -> forAll(laws.antiSymmetryEq _),
-      "transitivity" -> forAll(laws.transitivityEq _)
+      "reflexivity eq" -> forAll(laws.reflexivityEq _),
+      "symmetry eq" -> forAll(laws.symmetryEq _),
+      "antisymmetry eq" -> forAll(laws.antiSymmetryEq _),
+      "transitivity eq" -> forAll(laws.transitivityEq _)
     )
   }
 }


### PR DESCRIPTION
PartialOrderTests' transitivity and antisymmetry properties are shadowed by EqTests'.  When discipline finds duplicate laws in parent rulesets, the child's properties are silently dropped.  This counterintuitive behavior and sent us on a wild chase on http4s/http4s#3518.

We work around this by changing the EqTests' names to match the law names.