### PR TITLE
Review Simulacrum Scalafix annotation practices

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -91,7 +91,7 @@ lazy val simulacrumSettings = Seq(
     if (isDotty.value) Nil else Seq(s"-P:semanticdb:targetroot:${baseDirectory.value}/target/.semanticdb", "-Yrangepos")
   ),
   libraryDependencies +=
-    ("org.typelevel" %% "simulacrum-scalafix-annotations" % "0.5.0").withDottyCompat(scalaVersion.value),
+    ("org.typelevel" %% "simulacrum-scalafix-annotations" % "0.5.0" % Provided).withDottyCompat(scalaVersion.value),
   pomPostProcess := { (node: xml.Node) =>
     new RuleTransformer(new RewriteRule {
       override def transform(node: xml.Node): Seq[xml.Node] =


### PR DESCRIPTION
This is a follow-up to @djspiewak's question [here](https://github.com/typelevel/cats/pull/3486#discussion_r442866335) about whether the Simulacrum Scalafix annotations dependency needs to be in the runtime classpath.

With Simulacrum 1 we used the following approach:

* Simulacrum's annotations extended `StaticAnnotation`.
* The annotations were themselves annotated with `@compileTimeOnly`.
* The Simulacrum macro removed the annotations.
* Cats's Simulacrum dependency had `Provided` scope.
* Cats used [POM postprocessing](https://github.com/typelevel/cats/blob/v2.1.1/build.sbt#L90-L101) to remove the dependency entirely from the published artifact configuration.

With Simulacrum Scalafix we currently do the following:

* The annotations only extend `scala.annotation.Annotation`.
* Cats uses the same POM postprocessing to remove the dependency entirely.

This PR changes that to reinstate the `Provided` scope configuration. I'm not sure this actually does anything given the POM postprocessing already in our build, but I also don't think it hurts anything.

### Some additional details

In the new model I made the annotations only extend `Annotation` because there's no step where we could remove them, and extending `Annotation` directly seems to be the recommended way to define non-macro annotations that shouldn't exist at runtime. From the [Scaladoc](https://www.scala-lang.org/api/current/scala/annotation/Annotation.html):

> Annotations extending this class directly are not preserved in the classfile. To enable storing annotations in the classfile's Scala signature and make it available to Scala reflection and other tools, the annotation needs to inherit from `scala.annotation.StaticAnnotation`.

I hadn't used `@compileTimeOnly` in Simulacrum Scalafix because it didn't seem necessary, since unlike `StaticAnnotation`, the `Annotation`-extending annotations are _never_ preserved in the classfile. ~I don't think it would hurt to add the annotation, though, and will propose that in a Simulacrum Scalafix PR~ [update: adding the annotation fails for some reason—I guess it's only intended for use with `StaticAnnotation`?].

We can confirm that the Simulacrum Scalafix annotations aren't available to either Scala or Java reflection:

```scala
scala> cats.Monad.getClass.getAnnotations
res0: Array[java.lang.annotation.Annotation] = Array()

scala> reflect.runtime.universe.weakTypeOf[cats.Monad[Option]].typeSymbol.annotations
res1: List[reflect.runtime.universe.Annotation] = List(scala.annotation.implicitNotFound("Could not find an instance of Monad for ${F}"))
```

(This is the same both with and without `Provided`.)