### PR TITLE
Enable breakout in functions reduceRightToOption and reduceRightTo.

### DIFF
--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -3,7 +3,8 @@ package cats
 import scala.collection.mutable
 import cats.kernel.CommutativeMonoid
 import simulacrum.{noop, typeclass}
-import Foldable.sentinel
+import Foldable.{sentinel, Source}
+
 import scala.annotation.implicitNotFound
 
 /**
@@ -98,7 +99,7 @@ import scala.annotation.implicitNotFound
 
   def foldRightDefer[G[_]: Defer, A, B](fa: F[A], gb: G[B])(fn: (A, G[B]) => G[B]): G[B] =
     Defer[G].defer(
-      this.foldLeft(fa, (z: G[B]) => z) { (acc, elem) => z =>
+      foldLeft(fa, (z: G[B]) => z) { (acc, elem) => z =>
         Defer[G].defer(acc(fn(elem, z)))
       }(gb)
     )
@@ -109,13 +110,19 @@ import scala.annotation.implicitNotFound
       case (None, a)    => Some(f(a))
     }
 
-  def reduceRightToOption[A, B](fa: F[A])(f: A => B)(g: (A, Eval[B]) => Eval[B]): Eval[Option[B]] =
-    foldRight(fa, Now(Option.empty[B])) { (a, lb) =>
-      lb.flatMap {
-        case Some(b) => g(a, Now(b)).map(Some(_))
-        case None    => Later(Some(f(a)))
-      }
+  def reduceRightToOption[A, B](fa: F[A])(f: A => B)(g: (A, Eval[B]) => Eval[B]): Eval[Option[B]] = {
+    Source.fromFoldable(fa)(self).uncons match {
+      case Some((first, s)) =>
+        def loop(now: A, source: Source[A]): Eval[B] =
+          source.uncons match {
+            case Some((next, s)) => g(now, Eval.defer(loop(next, s.value)))
+            case None            => Eval.later(f(now))
+          }
+
+        Eval.defer(loop(first, s.value).map(Some(_)))
+      case None => Eval.now(None)
     }
+  }
 
   /**
    * Reduce the elements of this structure down to a single value by applying

--- a/core/src/main/scala/cats/data/NonEmptyChain.scala
+++ b/core/src/main/scala/cats/data/NonEmptyChain.scala
@@ -2,7 +2,6 @@ package cats
 package data
 
 import NonEmptyChainImpl.create
-import cats.{Order, Semigroup}
 import cats.kernel._
 import scala.collection.immutable.SortedMap
 

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -606,7 +606,7 @@ sealed abstract private[data] class NonEmptyListInstances extends NonEmptyListIn
 
       override def nonEmptyPartition[A, B, C](
         fa: NonEmptyList[A]
-      )(f: (A) => Either[B, C]): Ior[NonEmptyList[B], NonEmptyList[C]] = {
+      )(f: A => Either[B, C]): Ior[NonEmptyList[B], NonEmptyList[C]] = {
         val reversed = fa.reverse
         val lastIor = f(reversed.head) match {
           case Right(c) => Ior.right(NonEmptyList.one(c))

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -116,7 +116,7 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
 
       override def partitionEither[A, B, C](
         fa: List[A]
-      )(f: (A) => Either[B, C])(implicit A: Alternative[List]): (List[B], List[C]) =
+      )(f: A => Either[B, C])(implicit A: Alternative[List]): (List[B], List[C]) =
         fa.foldRight((List.empty[B], List.empty[C]))((a, acc) =>
           f(a) match {
             case Left(b)  => (b :: acc._1, acc._2)


### PR DESCRIPTION
now
```scala
import cats.data.NonEmptyList
import cats.implicits._

val notAllEven = NonEmptyList.of(2, 4, 6, 9, 10, 12, 14)
notAllEven.reduceMapA { a => println(a); if (a % 2 == 0) Some(a) else None }

14
12
10
9
6
4
2
res: Option[Int] = None
```

After applying this PR

```scala
import cats.data.NonEmptyList
import cats.implicits._

val notAllEven = NonEmptyList.of(2, 4, 6, 9, 10, 12, 14)
notAllEven.reduceMapA { a => println(a); if (a % 2 == 0) Some(a) else None }

2
4
6
9
res: Option[Int] = None
```
