### PR TITLE
Foldable Source value class

### DIFF
--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -890,23 +890,14 @@ object Foldable {
    *     type Source[+A] = () => Option[(A, Source[A])]
    *
    * (except that recursive type aliases are not allowed).
-   *
-   * It could be made a value class after
-   * https://github.com/scala/bug/issues/9600 is resolved.
    */
-  sealed abstract private[cats] class Source[+A] {
-    def uncons: Option[(A, Eval[Source[A]])]
-  }
+  final private[cats] class Source[+A](val uncons: Option[(A, Eval[Source[A]])]) extends AnyVal
 
   private[cats] object Source {
-    val Empty: Source[Nothing] = new Source[Nothing] {
-      def uncons = None
-    }
+    val Empty: Source[Nothing] = new Source[Nothing](uncons = None)
 
     def cons[A](a: A, src: Eval[Source[A]]): Source[A] =
-      new Source[A] {
-        def uncons = Some((a, src))
-      }
+      new Source[A](uncons = Some((a, src)))
 
     def fromFoldable[F[_], A](fa: F[A])(implicit F: Foldable[F]): Source[A] =
       F.foldRight[A, Source[A]](fa, Now(Empty))((a, evalSrc) => Later(cons(a, evalSrc))).value


### PR DESCRIPTION
It seems that the problem here https://github.com/scala/bug/issues/9600 is resolved.
Also for ref https://github.com/scala/bug/issues/7449, https://github.com/scala/bug/issues/11870 and https://github.com/scala/scala/pull/9069.

This change breaks bin-compatibility though, so how about we add it to milestone 3 https://github.com/typelevel/cats/milestone/8 ?

Happy to close it if it's too early.

