### PR TITLE
Put implicit support for evidence from predef types

### DIFF
--- a/core/src/main/scala-2.12/cats/evidence/AsSupport.scala
+++ b/core/src/main/scala-2.12/cats/evidence/AsSupport.scala
@@ -1,6 +1,7 @@
 package cats.evidence
 
 private[evidence] trait AsSupport {
+
   /**
    * In 2.13 there is a method on ev that makes this safe.
    * But lack of this method does not make the cast unsafe

--- a/core/src/main/scala-2.12/cats/evidence/AsSupport.scala
+++ b/core/src/main/scala-2.12/cats/evidence/AsSupport.scala
@@ -8,5 +8,5 @@ private[evidence] trait AsSupport {
    * it just makes it not provable without the cast.
    */
   @inline implicit def asFromPredef[A, B](implicit ev: A <:< B): A As B =
-    As.fromPredef(ev)
+    As.refl[A].asInstanceOf[A As B]
 }

--- a/core/src/main/scala-2.12/cats/evidence/AsSupport.scala
+++ b/core/src/main/scala-2.12/cats/evidence/AsSupport.scala
@@ -1,0 +1,11 @@
+package cats.evidence
+
+private[evidence] trait AsSupport {
+  /**
+   * In 2.13 there is a method on ev that makes this safe.
+   * But lack of this method does not make the cast unsafe
+   * it just makes it not provable without the cast.
+   */
+  @inline implicit def asFromPredef[A, B](implicit ev: A <:< B): A As B =
+    As.fromPredef(ev)
+}

--- a/core/src/main/scala-2.12/cats/evidence/IsSupport.scala
+++ b/core/src/main/scala-2.12/cats/evidence/IsSupport.scala
@@ -1,0 +1,11 @@
+package cats.evidence
+
+private[evidence] trait IsSupport {
+  /**
+   * In 2.13 there is a method on ev that makes this safe.
+   * But lack of this method does not make the cast unsafe
+   * it just makes it not provable without the cast.
+   */
+  @inline implicit def isFromPredef[A, B](implicit ev: A =:= B): A Is B =
+    Is.refl[A].asInstanceOf[A Is B]
+}

--- a/core/src/main/scala-2.12/cats/evidence/IsSupport.scala
+++ b/core/src/main/scala-2.12/cats/evidence/IsSupport.scala
@@ -1,6 +1,7 @@
 package cats.evidence
 
 private[evidence] trait IsSupport {
+
   /**
    * In 2.13 there is a method on ev that makes this safe.
    * But lack of this method does not make the cast unsafe

--- a/core/src/main/scala-2.13+/cats/evidence/AsSupport.scala
+++ b/core/src/main/scala-2.13+/cats/evidence/AsSupport.scala
@@ -1,0 +1,10 @@
+package cats.evidence
+
+private[evidence] trait AsSupport {
+  @inline implicit def asFromPredef[A, B](implicit ev: A <:< B): A As B = {
+    // we need F to be covariant, and the type lambda loses that
+    // if we write As[A, ?]
+    type F[+Z] = As[A, Z]
+    ev.substituteCo[F](As.refl[A])
+  }
+}

--- a/core/src/main/scala-2.13+/cats/evidence/IsSupport.scala
+++ b/core/src/main/scala-2.13+/cats/evidence/IsSupport.scala
@@ -1,0 +1,6 @@
+package cats.evidence
+
+private[evidence] trait IsSupport {
+  @inline implicit def isFromPredef[A, B](implicit ev: A =:= B): A Is B =
+    ev.substituteCo[Is[A, *]](Is.refl[A])
+}

--- a/core/src/main/scala/cats/evidence/As.scala
+++ b/core/src/main/scala/cats/evidence/As.scala
@@ -39,8 +39,10 @@ sealed abstract class As[-A, +B] extends Serializable {
    * A value `A As B` is always sufficient to produce a similar `Predef.<:<`
    * value.
    */
-  @inline final def toPredef: A <:< B =
-    substitute[<:<[*, B]](implicitly[B <:< B])
+  @inline final def toPredef: A <:< B = {
+    type F[-Z] = <:<[Z, B]
+    substitute[F](implicitly[B <:< B])
+  }
 }
 
 sealed abstract class AsInstances {

--- a/core/src/main/scala/cats/evidence/As.scala
+++ b/core/src/main/scala/cats/evidence/As.scala
@@ -34,6 +34,13 @@ sealed abstract class As[-A, +B] extends Serializable {
   @inline final def compose[C](that: (C As A)): (C As B) = As.compose(this, that)
 
   @inline final def coerce(a: A): B = As.witness(this)(a)
+
+  /**
+   * A value `A As B` is always sufficient to produce a similar `Predef.<:<`
+   * value.
+   */
+  @inline final def toPredef: A <:< B =
+    substitute[<:<[*, B]](implicitly[B <:< B])
 }
 
 sealed abstract class AsInstances {
@@ -49,7 +56,7 @@ sealed abstract class AsInstances {
   }
 }
 
-object As extends AsInstances {
+object As extends AsInstances with AsSupport {
 
   /**
    * In truth, "all values of `A Is B` are `refl`". `reflAny` is that
@@ -88,12 +95,11 @@ object As extends AsInstances {
 
   /**
    * It can be convenient to convert a <:< value into a `<~<` value.
-   * This is not strictly valid as while it is almost certainly true that
-   * `A <:< B` implies `A <~< B` it is not the case that you can create
-   * evidence of `A <~< B` except via a coercion. Use responsibly.
+   * This is not actually unsafe, but was previously labeled as such out
+   * of an abundance of caution
    */
   def fromPredef[A, B](eq: A <:< B): A As B =
-    reflAny.asInstanceOf[A As B]
+    asFromPredef(eq)
 
   /**
    * We can lift subtyping into any covariant type constructor

--- a/core/src/main/scala/cats/evidence/Is.scala
+++ b/core/src/main/scala/cats/evidence/Is.scala
@@ -62,7 +62,15 @@ abstract class Is[A, B] extends Serializable {
    * A value `A Is B` is always sufficient to produce a similar `Predef.=:=`
    * value.
    */
+  @deprecated("Use toPredef for consistency with As", "2.2.0")
   @inline final def predefEq: A =:= B =
+    substitute[=:=[A, *]](implicitly[A =:= A])
+
+  /**
+   * A value `A Is B` is always sufficient to produce a similar `Predef.=:=`
+   * value.
+   */
+  @inline final def toPredef: A =:= B =
     substitute[=:=[A, *]](implicitly[A =:= A])
 }
 
@@ -78,7 +86,7 @@ sealed abstract class IsInstances {
   }
 }
 
-object Is extends IsInstances {
+object Is extends IsInstances with IsSupport {
 
   /**
    * In truth, "all values of `A Is B` are `refl`". `reflAny` is that
@@ -102,11 +110,10 @@ object Is extends IsInstances {
 
   /**
    * It can be convenient to convert a `Predef.=:=` value into an `Is` value.
-   * This is not strictly valid as while it is almost certainly true that
-   * `A =:= B` implies `A Is B` it is not the case that you can create
-   * evidence of `A Is B` except via a coercion. Use responsibly.
+   * This is not actually unsafe, but was previously labeled as such out
+   * of an abundance of caution
    */
+  @deprecated("use Is.isFromPredef", "2.2.0")
   @inline def unsafeFromPredef[A, B](eq: A =:= B): A Is B =
-    reflAny.asInstanceOf[A Is B]
-
+    Is.isFromPredef(eq)
 }

--- a/tests/src/test/scala/cats/tests/AsSuite.scala
+++ b/tests/src/test/scala/cats/tests/AsSuite.scala
@@ -45,7 +45,7 @@ class AsSuite extends CatsSuite {
     {
       trait Foo
       trait Bar
-      implicit def subFooBar: Foo <:< Bar = null
+      implicit def subFooBar: Foo <:< Bar = implicitly[Foo <:< Foo].asInstanceOf[Foo <:< Bar]
       // make sure the above is found
       implicitly[As[Foo, Bar]]
       val res: Foo <:< Bar = implicitly[As[Foo, Bar]].toPredef

--- a/tests/src/test/scala/cats/tests/AsSuite.scala
+++ b/tests/src/test/scala/cats/tests/AsSuite.scala
@@ -41,6 +41,15 @@ class AsSuite extends CatsSuite {
     implicitly[String <~< AnyRef]
     implicitly[(String, Int) <~< (AnyRef, Any)]
     implicitly[scala.collection.immutable.List[String] <~< scala.collection.Seq[Any]]
+
+    {
+      trait Foo
+      trait Bar
+      implicit def subFooBar: Foo <:< Bar = null
+      // make sure the above is found
+      implicitly[As[Foo, Bar]]
+      val res: Foo <:< Bar = implicitly[As[Foo, Bar]].toPredef
+    }
   }
 
   trait Top {

--- a/tests/src/test/scala/cats/tests/IsSuite.scala
+++ b/tests/src/test/scala/cats/tests/IsSuite.scala
@@ -28,11 +28,11 @@ class IsSuite extends CatsSuite {
     val flip: Leibniz[Bar, Bar] = lifted.flip
     val lift: Leibniz[List[Bar], List[Bar]] = lifted.lift[List]
     val coerce: Bar = lifted.coerce(new Bar {})
-    val predefEq: =:=[Bar, Bar] = lifted.predefEq
+    val predefEq: =:=[Bar, Bar] = lifted.toPredef
 
     {
       trait Foo
-      implicit def eqFooBar: Foo =:= Bar = null
+      implicit def eqFooBar: Foo =:= Bar = implicitly[Foo =:= Foo].asInstanceOf[Foo =:= Bar]
       // make sure the above is found
       implicitly[Is[Foo, Bar]]
 

--- a/tests/src/test/scala/cats/tests/IsSuite.scala
+++ b/tests/src/test/scala/cats/tests/IsSuite.scala
@@ -29,6 +29,15 @@ class IsSuite extends CatsSuite {
     val lift: Leibniz[List[Bar], List[Bar]] = lifted.lift[List]
     val coerce: Bar = lifted.coerce(new Bar {})
     val predefEq: =:=[Bar, Bar] = lifted.predefEq
+
+    {
+      trait Foo
+      implicit def eqFooBar: Foo =:= Bar = null
+      // make sure the above is found
+      implicitly[Is[Foo, Bar]]
+
+      val res: Foo =:= Bar = implicitly[Is[Foo, Bar]].toPredef
+    }
   }
 
 }


### PR DESCRIPTION
close #2569

There is no reason not to create Is and As instances from the predef ones. The changes in 2.13 make this perfectly safe, but nothing in 2.12 (or before) made it unsafe, the types just lacked a substitute method.

This PR improves matters a bit.

I did notice that `Is` is not sealed, but `As` is. In general these two types have a pretty different API considering how similar they are conceptually.

I only did a bit, I added `toPredef` to both of them to convert back to predef types.