### PR TITLE
Fix cross-versioning for docs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -415,7 +415,6 @@ lazy val docs = project
   .settings(docSettings)
   .settings(commonJvmSettings)
   .settings(
-    crossScalaVersions := crossScalaVersions.value.init,
     libraryDependencies ++= Seq(
       "org.typelevel" %%% "discipline-scalatest" % disciplineScalatestVersion
     ),


### PR DESCRIPTION
This change is something I introduced when first setting up the Dotty build, and it's causing `sbt +package` to fail. It should be unnecessary now, I think, since Dotty isn't in `crossScalaVersions`.