### PR TITLE
remove casts from Eval, fix stack overflow in Eval

### DIFF
--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -30,8 +30,10 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
         if (fb.isEmpty) Nil // do O(1) work if fb is empty
         else fa.flatMap(a => fb.map(b => f(a, b))) // already O(1) if fa is empty
 
+      private[this] val evalNil: Eval[List[Nothing]] = Eval.now(Nil)
+
       override def map2Eval[A, B, Z](fa: List[A], fb: Eval[List[B]])(f: (A, B) => Z): Eval[List[Z]] =
-        if (fa.isEmpty) Eval.now(Nil) // no need to evaluate fb
+        if (fa.isEmpty) evalNil // no need to evaluate fb
         else fb.map(fb => map2(fa, fb)(f))
 
       def tailRecM[A, B](a: A)(f: A => List[Either[A, B]]): List[B] = {

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -30,8 +30,10 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
         if (fb.isEmpty) Vector.empty // do O(1) work if either is empty
         else fa.flatMap(a => fb.map(b => f(a, b))) // already O(1) if fa is empty
 
+      private[this] val evalEmpty: Eval[Vector[Nothing]] = Eval.now(Vector.empty)
+
       override def map2Eval[A, B, Z](fa: Vector[A], fb: Eval[Vector[B]])(f: (A, B) => Z): Eval[Vector[Z]] =
-        if (fa.isEmpty) Eval.now(Vector.empty) // no need to evaluate fb
+        if (fa.isEmpty) evalEmpty // no need to evaluate fb
         else fb.map(fb => map2(fa, fb)(f))
 
       def coflatMap[A, B](fa: Vector[A])(f: Vector[A] => B): Vector[B] = {

--- a/docs/src/main/tut/datatypes/eval.md
+++ b/docs/src/main/tut/datatypes/eval.md
@@ -93,13 +93,13 @@ Another great example are mutual tail-recursive calls:
 object MutualRecursion {
   def even(n: Int): Eval[Boolean] =
     Eval.always(n == 0).flatMap {
-      case true => Eval.now(true)
+      case true => Eval.True
       case false => odd(n - 1)
     }
 
   def odd(n: Int): Eval[Boolean] =
     Eval.always(n == 0).flatMap {
-      case true => Eval.now(false)
+      case true => Eval.False
       case false => even(n - 1)
     }
 }

--- a/docs/src/main/tut/typeclasses/foldable.md
+++ b/docs/src/main/tut/typeclasses/foldable.md
@@ -133,5 +133,5 @@ With the lazy `foldRight` on `Foldable`, the calculation terminates
 after looking at only one value:
 
 ```tut:book
-Foldable[Stream].foldRight(allFalse, Eval.True)((a,b) => if (a) b else Eval.now(false)).value
+Foldable[Stream].foldRight(allFalse, Eval.True)((a,b) => if (a) b else Eval.False).value
 ```

--- a/tests/src/test/scala/cats/tests/EvalSuite.scala
+++ b/tests/src/test/scala/cats/tests/EvalSuite.scala
@@ -96,6 +96,14 @@ class EvalSuite extends CatsSuite {
     spooky.counter should ===(2)
   }
 
+  test("Defer and FlatMap compose without blowing the stack") {
+    def inc(a: Eval[Int], count: Int): Eval[Int] =
+      if (count <= 0) a
+      else Eval.defer(Eval.defer(inc(a, count - 1))).flatMap { i => Eval.now(i + 1) }
+
+    assert(inc(Eval.now(0), 1000000).value == 1000000)
+  }
+
   {
     implicit val iso: SemigroupalTests.Isomorphisms[Eval] =
       SemigroupalTests.Isomorphisms.invariant[Eval]


### PR DESCRIPTION
similar to #3518 we use the 2.12 ability to do tailrec when the generic parameter changes to remove the casts.

Instead of using `List[Any => Eval[Any]]` we have to introduce a new type-aligned stack of functions, but I make this private.

This simplification leads to one optimization: if we have a finished `Memoize` in FlatMap we don't need to `loop(Now...` we can directly apply the flatMap function.

Also, I noticed perhaps the source of stack overflows I've seen in the past: #2587