### PR TITLE
make collection traversals stack safe

### DIFF
--- a/alleycats-tests/shared/src/test/scala/alleycats/tests/MapSuite.scala
+++ b/alleycats-tests/shared/src/test/scala/alleycats/tests/MapSuite.scala
@@ -11,4 +11,15 @@ class MapSuite extends AlleycatsSuite {
   checkAll("TraverseFilter[Map[Int, *]]", TraverseFilterTests[Map[Int, *]].traverseFilter[Int, Int, Int])
 
   checkAll("Map[Int, *]", ShortCircuitingTests[Map[Int, *]].traverseFilter[Int])
+
+  test("traverse is stack-safe") {
+    val items = Map((0 until 100000).map { i => (i.toString, i) }: _*)
+    val sumAll = Traverse[Map[String, *]]
+      .traverse(items) { i => () => i }
+      .apply
+      .values
+      .sum
+
+    assert(sumAll == items.values.sum)
+  }
 }

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -1,7 +1,7 @@
 package cats
 package instances
 
-import cats.data.ZipVector
+import cats.data.{Chain, ZipVector}
 import cats.syntax.show._
 
 import scala.annotation.tailrec
@@ -90,11 +90,53 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
         loop(0).value
       }
 
-      final override def traverse[G[_], A, B](fa: Vector[A])(f: A => G[B])(implicit G: Applicative[G]): G[Vector[B]] = {
-        def loop(i: Int): Eval[G[List[B]]] =
-          if (i < fa.length) G.map2Eval(f(fa(i)), Eval.defer(loop(i + 1)))(_ :: _) else Eval.now(G.pure(Nil))
-        G.map(loop(0).value)(_.toVector)
-      }
+      final override def traverse[G[_], A, B](fa: Vector[A])(f: A => G[B])(implicit G: Applicative[G]): G[Vector[B]] =
+        if (fa.isEmpty) G.pure(empty)
+        else {
+          // this is a specialized version of Chain.traverseViaChain since
+          // we don't need to materialize the Vector first
+
+          // we branch out by this factor
+          val width = 128
+          // By making a tree here we don't blow the stack
+          // even if the List is very long
+          // by construction, this is never called with start == end
+          def loop(start: Int, end: Int): Eval[G[Chain[B]]] =
+            if (end - start <= width) {
+              // Here we are at the leafs of the trees
+              // we don't use map2Eval since it is always
+              // at most width in size.
+              val aend = fa(end - 1)
+              var flist = Eval.later(G.map(f(aend))(_ :: Nil))
+              var idx = end - 2
+              while (start <= idx) {
+                val a = fa(idx)
+                // don't capture a var in the defer
+                val right = flist
+                flist = Eval.defer(G.map2Eval(f(a), right)(_ :: _))
+                idx = idx - 1
+              }
+              flist.map { glist => G.map(glist)(Chain.fromSeq(_)) }
+            } else {
+              // we have width + 1 or more nodes left
+              val step = (end - start) / width
+
+              var fchain = Eval.defer(loop(start, start + step))
+              var start0 = start + step
+              var end0 = start0 + step
+
+              while (start0 < end) {
+                val end1 = math.min(end, end0)
+                val right = loop(start0, end1)
+                fchain = fchain.flatMap(G.map2Eval(_, right)(_.concat(_)))
+                start0 = start0 + step
+                end0 = end0 + step
+              }
+              fchain
+            }
+
+          G.map(loop(0, fa.size).value)(_.toVector)
+        }
 
       override def mapWithIndex[A, B](fa: Vector[A])(f: (A, Int) => B): Vector[B] =
         fa.iterator.zipWithIndex.map(ai => f(ai._1, ai._2)).toVector
@@ -181,11 +223,55 @@ private[instances] trait VectorInstancesBinCompat0 {
     override def flattenOption[A](fa: Vector[Option[A]]): Vector[A] = fa.flatten
 
     def traverseFilter[G[_], A, B](fa: Vector[A])(f: (A) => G[Option[B]])(implicit G: Applicative[G]): G[Vector[B]] =
-      traverse
-        .foldRight(fa, Eval.now(G.pure(Vector.empty[B])))((x, xse) =>
-          G.map2Eval(f(x), xse)((i, o) => i.fold(o)(_ +: o))
-        )
-        .value
+      if (fa.isEmpty) G.pure(Vector.empty[B])
+      else {
+        // we branch out by this factor
+        val width = 128
+        // By making a tree here we don't blow the stack
+        // even if the List is very long
+        // by construction, this is never called with start == end
+        def loop(start: Int, end: Int): Eval[G[Chain[B]]] =
+          if (end - start <= width) {
+            // Here we are at the leafs of the trees
+            // we don't use map2Eval since it is always
+            // at most width in size.
+            val aend = fa(end - 1)
+            var flist = Eval.later(G.map(f(aend)) { optB =>
+              if (optB.isDefined) optB.get :: Nil
+              else Nil
+            })
+            var idx = end - 2
+            while (start <= idx) {
+              val a = fa(idx)
+              // don't capture a var in the defer
+              val right = flist
+              flist = Eval.defer(G.map2Eval(f(a), right) { (optB, tail) =>
+                if (optB.isDefined) optB.get :: tail
+                else tail
+              })
+              idx = idx - 1
+            }
+            flist.map { glist => G.map(glist)(Chain.fromSeq(_)) }
+          } else {
+            // we have width + 1 or more nodes left
+            val step = (end - start) / width
+
+            var fchain = Eval.defer(loop(start, start + step))
+            var start0 = start + step
+            var end0 = start0 + step
+
+            while (start0 < end) {
+              val end1 = math.min(end, end0)
+              val right = loop(start0, end1)
+              fchain = fchain.flatMap(G.map2Eval(_, right)(_.concat(_)))
+              start0 = start0 + step
+              end0 = end0 + step
+            }
+            fchain
+          }
+
+        G.map(loop(0, fa.size).value)(_.toVector)
+      }
 
     override def filterA[G[_], A](fa: Vector[A])(f: (A) => G[Boolean])(implicit G: Applicative[G]): G[Vector[A]] =
       traverse

--- a/tests/src/test/scala/cats/tests/ChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/ChainSuite.scala
@@ -290,4 +290,14 @@ class ChainSuite extends CatsSuite {
     }
   }
 
+  test("traverse is stack-safe") {
+    val chain = (0 until 100000).map(Chain.one).reduce(_.concat(_))
+    val sumAll = Traverse[Chain]
+      .traverse(chain) { i => () => i }
+      .apply
+      .iterator
+      .sum
+
+    assert(sumAll == chain.iterator.sum)
+  }
 }

--- a/tests/src/test/scala/cats/tests/ListSuite.scala
+++ b/tests/src/test/scala/cats/tests/ListSuite.scala
@@ -76,6 +76,16 @@ class ListSuite extends CatsSuite {
       l.show should ===(l.toString)
     }
   }
+
+  test("traverse is stack-safe") {
+    val lst = (0 until 100000).toList
+    val sumAll = Traverse[List]
+      .traverse(lst) { i => () => i }
+      .apply
+      .sum
+
+    assert(sumAll == lst.sum)
+  }
 }
 
 final class ListInstancesSuite extends AnyFunSuiteLike {

--- a/tests/src/test/scala/cats/tests/QueueSuite.scala
+++ b/tests/src/test/scala/cats/tests/QueueSuite.scala
@@ -40,4 +40,15 @@ class QueueSuite extends CatsSuite {
     Queue(1, 2, 3).show should ===("Queue(1, 2, 3)")
     Queue.empty[Int].show should ===("Queue()")
   }
+
+  test("traverse is stack-safe") {
+    val queue = (0 until 100000).foldLeft(Queue.empty[Int])(_ :+ _)
+    val sumAll = Traverse[Queue]
+      .traverse(queue) { i => () => i }
+      .apply
+      .iterator
+      .sum
+
+    assert(sumAll == queue.sum)
+  }
 }

--- a/tests/src/test/scala/cats/tests/SortedMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/SortedMapSuite.scala
@@ -62,4 +62,15 @@ class SortedMapSuite extends CatsSuite {
 
   checkAll("SortedMap[String, String]", MonoidKTests[SortedMap[String, *]].monoidK[String])
   checkAll("MonoidK[SortedMap[String, *]]", SerializableTests.serializable(MonoidK[SortedMap[String, *]]))
+
+  test("traverse is stack-safe") {
+    val items = SortedMap((0 until 100000).map { i => (i.toString, i) }: _*)
+    val sumAll = Traverse[SortedMap[String, *]]
+      .traverse(items) { i => () => i }
+      .apply
+      .values
+      .sum
+
+    assert(sumAll == items.values.sum)
+  }
 }

--- a/tests/src/test/scala/cats/tests/VectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/VectorSuite.scala
@@ -65,6 +65,16 @@ class VectorSuite extends CatsSuite {
   test("toNev on empty vector returns None") {
     assert(Vector.empty[Int].toNev == None)
   }
+
+  test("traverse is stack-safe") {
+    val vec = (0 until 100000).toVector
+    val sumAll = Traverse[Vector]
+      .traverse(vec) { i => () => i }
+      .apply
+      .sum
+
+    assert(sumAll == vec.sum)
+  }
 }
 
 final class VectorInstancesSuite extends AnyFunSuiteLike {


### PR DESCRIPTION
close #3517 

This makes all the traversals of all collections stack safe.

It follows the approach of: https://github.com/functional-streams-for-scala/fs2/pull/1957 but it is lazier (and maybe a bit slower because of that).

Cats has some tests that traversals on Applicatives that have lazy map2Eval instances that it won't trigger the function in those cases, so these laws require the traverse not only to have a certain result, but also invoke a function a known number of times.

I added tests before making each change and showed that the collection would fail a certain traversal (using Function0 as an example monad with poor stack safety).
