### PR TITLE
Improve traverseViaChain API

### DIFF
--- a/alleycats-core/src/main/scala/alleycats/std/map.scala
+++ b/alleycats-core/src/main/scala/alleycats/std/map.scala
@@ -3,6 +3,7 @@ package std
 
 import cats._
 import cats.data.Chain
+import cats.kernel.instances.StaticMethods.wrapMutableIndexedSeq
 
 object map extends MapInstances
 
@@ -18,7 +19,7 @@ trait MapInstances {
           G.map(Chain.traverseViaChain {
             val as = collection.mutable.ArrayBuffer[(K, A)]()
             as ++= fa
-            as
+            wrapMutableIndexedSeq(as)
           } {
             case (k, a) => G.map(f(a))((k, _))
           }) { chain => chain.foldLeft(Map.empty[K, B]) { case (m, (k, b)) => m.updated(k, b) } }
@@ -69,7 +70,7 @@ trait MapInstances {
           G.map(Chain.traverseFilterViaChain {
             val as = collection.mutable.ArrayBuffer[(K, A)]()
             as ++= fa
-            as
+            wrapMutableIndexedSeq(as)
           } {
             case (k, a) =>
               G.map(f(a)) { optB =>

--- a/alleycats-core/src/main/scala/alleycats/std/map.scala
+++ b/alleycats-core/src/main/scala/alleycats/std/map.scala
@@ -15,7 +15,11 @@ trait MapInstances {
       def traverse[G[_], A, B](fa: Map[K, A])(f: A => G[B])(implicit G: Applicative[G]): G[Map[K, B]] =
         if (fa.isEmpty) G.pure(Map.empty[K, B])
         else
-          G.map(Chain.traverseViaChain(fa.iterator) {
+          G.map(Chain.traverseViaChain {
+            val as = collection.mutable.ArrayBuffer[(K, A)]()
+            as ++= fa
+            as
+          } {
             case (k, a) => G.map(f(a))((k, _))
           }) { chain => chain.foldLeft(Map.empty[K, B]) { case (m, (k, b)) => m.updated(k, b) } }
 
@@ -62,7 +66,11 @@ trait MapInstances {
       def traverseFilter[G[_], A, B](fa: Map[K, A])(f: A => G[Option[B]])(implicit G: Applicative[G]): G[Map[K, B]] =
         if (fa.isEmpty) G.pure(Map.empty[K, B])
         else
-          G.map(Chain.traverseFilterViaChain(fa.iterator) {
+          G.map(Chain.traverseFilterViaChain {
+            val as = collection.mutable.ArrayBuffer[(K, A)]()
+            as ++= fa
+            as
+          } {
             case (k, a) =>
               G.map(f(a)) { optB =>
                 if (optB.isDefined) Some((k, optB.get))

--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -621,7 +621,9 @@ object Chain extends ChainInstances {
   def apply[A](as: A*): Chain[A] =
     fromSeq(as)
 
-  def traverseViaChain[G[_], A, B](as: IndexedSeq[A])(f: A => G[B])(implicit G: Applicative[G]): G[Chain[B]] =
+  def traverseViaChain[G[_], A, B](
+    as: collection.IndexedSeq[A]
+  )(f: A => G[B])(implicit G: Applicative[G]): G[Chain[B]] =
     if (as.isEmpty) G.pure(Chain.nil)
     else {
       // we branch out by this factor
@@ -666,7 +668,7 @@ object Chain extends ChainInstances {
     }
 
   def traverseFilterViaChain[G[_], A, B](
-    as: IndexedSeq[A]
+    as: collection.IndexedSeq[A]
   )(f: A => G[Option[B]])(implicit G: Applicative[G]): G[Chain[B]] =
     if (as.isEmpty) G.pure(Chain.nil)
     else {

--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -383,14 +383,6 @@ sealed abstract class Chain[+A] {
   }
 
   /**
-   * Applies the supplied function to each element, left to right.
-   */
-  final private def foreach(f: A => Unit): Unit =
-    foreachUntil { a =>
-      f(a); false
-    }
-
-  /**
    * Applies the supplied function to each element, left to right, but stops when true is returned
    */
   // scalastyle:off null return cyclomatic.complexity
@@ -508,11 +500,11 @@ sealed abstract class Chain[+A] {
     val builder = new StringBuilder("Chain(")
     var first = true
 
-    foreach { a =>
+    foreachUntil { a =>
       if (first) {
         builder ++= AA.show(a); first = false
       } else builder ++= ", " + AA.show(a)
-      ()
+      false
     }
     builder += ')'
     builder.result

--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -5,7 +5,7 @@ import Chain._
 import cats.kernel.instances.StaticMethods
 
 import scala.annotation.tailrec
-import scala.collection.immutable.{SortedMap, TreeSet}
+import scala.collection.immutable.{SortedMap, TreeSet, IndexedSeq => ImIndexedSeq}
 import scala.collection.mutable.ListBuffer
 
 /**
@@ -622,7 +622,7 @@ object Chain extends ChainInstances {
     fromSeq(as)
 
   def traverseViaChain[G[_], A, B](
-    as: collection.IndexedSeq[A]
+    as: ImIndexedSeq[A]
   )(f: A => G[B])(implicit G: Applicative[G]): G[Chain[B]] =
     if (as.isEmpty) G.pure(Chain.nil)
     else {
@@ -668,7 +668,7 @@ object Chain extends ChainInstances {
     }
 
   def traverseFilterViaChain[G[_], A, B](
-    as: collection.IndexedSeq[A]
+    as: ImIndexedSeq[A]
   )(f: A => G[Option[B]])(implicit G: Applicative[G]): G[Chain[B]] =
     if (as.isEmpty) G.pure(Chain.nil)
     else {
@@ -856,7 +856,7 @@ sealed abstract private[data] class ChainInstances extends ChainInstances1 {
           traverseViaChain {
             val as = collection.mutable.ArrayBuffer[A]()
             as ++= fa.iterator
-            as
+            StaticMethods.wrapMutableIndexedSeq(as)
           }(f)
 
       def empty[A]: Chain[A] = Chain.nil
@@ -962,7 +962,7 @@ sealed abstract private[data] class ChainInstances extends ChainInstances1 {
         traverseFilterViaChain {
           val as = collection.mutable.ArrayBuffer[A]()
           as ++= fa.iterator
-          as
+          StaticMethods.wrapMutableIndexedSeq(as)
         }(f)
 
     override def filterA[G[_], A](fa: Chain[A])(f: A => G[Boolean])(implicit G: Applicative[G]): G[Chain[A]] =

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -2,6 +2,7 @@ package cats
 package instances
 
 import cats.data.{Chain, ZipList}
+import cats.kernel.instances.StaticMethods.wrapMutableIndexedSeq
 import cats.syntax.show._
 
 import scala.annotation.tailrec
@@ -91,7 +92,7 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
           G.map(Chain.traverseViaChain {
             val as = collection.mutable.ArrayBuffer[A]()
             as ++= fa
-            as
+            wrapMutableIndexedSeq(as)
           }(f))(_.toList)
 
       def functor: Functor[List] = this
@@ -221,7 +222,7 @@ private[instances] trait ListInstancesBinCompat0 {
         G.map(Chain.traverseFilterViaChain {
           val as = collection.mutable.ArrayBuffer[A]()
           as ++= fa
-          as
+          wrapMutableIndexedSeq(as)
         }(f))(_.toList)
 
     override def filterA[G[_], A](fa: List[A])(f: (A) => G[Boolean])(implicit G: Applicative[G]): G[List[A]] =

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -87,7 +87,12 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
 
       def traverse[G[_], A, B](fa: List[A])(f: A => G[B])(implicit G: Applicative[G]): G[List[B]] =
         if (fa.isEmpty) G.pure(Nil)
-        else G.map(Chain.traverseViaChain(fa.iterator)(f))(_.toList)
+        else
+          G.map(Chain.traverseViaChain {
+            val as = collection.mutable.ArrayBuffer[A]()
+            as ++= fa
+            as
+          }(f))(_.toList)
 
       def functor: Functor[List] = this
 
@@ -212,7 +217,12 @@ private[instances] trait ListInstancesBinCompat0 {
 
     def traverseFilter[G[_], A, B](fa: List[A])(f: (A) => G[Option[B]])(implicit G: Applicative[G]): G[List[B]] =
       if (fa.isEmpty) G.pure(Nil)
-      else G.map(Chain.traverseFilterViaChain(fa.iterator)(f))(_.toList)
+      else
+        G.map(Chain.traverseFilterViaChain {
+          val as = collection.mutable.ArrayBuffer[A]()
+          as ++= fa
+          as
+        }(f))(_.toList)
 
     override def filterA[G[_], A](fa: List[A])(f: (A) => G[Boolean])(implicit G: Applicative[G]): G[List[A]] =
       traverse

--- a/core/src/main/scala/cats/instances/queue.scala
+++ b/core/src/main/scala/cats/instances/queue.scala
@@ -82,7 +82,11 @@ trait QueueInstances extends cats.kernel.instances.QueueInstances {
       def traverse[G[_], A, B](fa: Queue[A])(f: A => G[B])(implicit G: Applicative[G]): G[Queue[B]] =
         if (fa.isEmpty) G.pure(Queue.empty[B])
         else
-          G.map(Chain.traverseViaChain(fa.iterator)(f)) { chain =>
+          G.map(Chain.traverseViaChain {
+            val as = collection.mutable.ArrayBuffer[A]()
+            as ++= fa
+            as
+          }(f)) { chain =>
             chain.foldLeft(Queue.empty[B])(_ :+ _)
           }
 
@@ -177,7 +181,11 @@ private object QueueInstances {
     def traverseFilter[G[_], A, B](fa: Queue[A])(f: (A) => G[Option[B]])(implicit G: Applicative[G]): G[Queue[B]] =
       if (fa.isEmpty) G.pure(Queue.empty[B])
       else
-        G.map(Chain.traverseFilterViaChain(fa.iterator)(f)) { chain =>
+        G.map(Chain.traverseFilterViaChain {
+          val as = collection.mutable.ArrayBuffer[A]()
+          as ++= fa
+          as
+        }(f)) { chain =>
           chain.foldLeft(Queue.empty[B])(_ :+ _)
         }
 

--- a/core/src/main/scala/cats/instances/queue.scala
+++ b/core/src/main/scala/cats/instances/queue.scala
@@ -2,6 +2,7 @@ package cats
 package instances
 
 import cats.data.Chain
+import cats.kernel.instances.StaticMethods.wrapMutableIndexedSeq
 import cats.syntax.show._
 import scala.annotation.tailrec
 import scala.collection.immutable.Queue
@@ -85,7 +86,7 @@ trait QueueInstances extends cats.kernel.instances.QueueInstances {
           G.map(Chain.traverseViaChain {
             val as = collection.mutable.ArrayBuffer[A]()
             as ++= fa
-            as
+            wrapMutableIndexedSeq(as)
           }(f)) { chain =>
             chain.foldLeft(Queue.empty[B])(_ :+ _)
           }
@@ -184,7 +185,7 @@ private object QueueInstances {
         G.map(Chain.traverseFilterViaChain {
           val as = collection.mutable.ArrayBuffer[A]()
           as ++= fa
-          as
+          wrapMutableIndexedSeq(as)
         }(f)) { chain =>
           chain.foldLeft(Queue.empty[B])(_ :+ _)
         }

--- a/core/src/main/scala/cats/instances/sortedMap.scala
+++ b/core/src/main/scala/cats/instances/sortedMap.scala
@@ -35,7 +35,11 @@ trait SortedMapInstances extends SortedMapInstances2 {
         implicit val ordering: Ordering[K] = fa.ordering
         if (fa.isEmpty) G.pure(SortedMap.empty[K, B])
         else
-          G.map(Chain.traverseViaChain(fa.iterator) {
+          G.map(Chain.traverseViaChain {
+            val as = collection.mutable.ArrayBuffer[(K, A)]()
+            as ++= fa
+            as
+          } {
             case (k, a) => G.map(f(a))((k, _))
           }) { chain => chain.foldLeft(SortedMap.empty[K, B]) { case (m, (k, b)) => m.updated(k, b) } }
       }
@@ -194,7 +198,11 @@ private[instances] trait SortedMapInstancesBinCompat0 {
         implicit val ordering: Ordering[K] = fa.ordering
         if (fa.isEmpty) G.pure(SortedMap.empty[K, B])
         else
-          G.map(Chain.traverseFilterViaChain(fa.iterator) {
+          G.map(Chain.traverseFilterViaChain {
+            val as = collection.mutable.ArrayBuffer[(K, A)]()
+            as ++= fa
+            as
+          } {
             case (k, a) =>
               G.map(f(a)) { optB =>
                 if (optB.isDefined) Some((k, optB.get))

--- a/core/src/main/scala/cats/instances/sortedMap.scala
+++ b/core/src/main/scala/cats/instances/sortedMap.scala
@@ -3,6 +3,7 @@ package cats.instances
 import cats._
 import cats.data.{Chain, Ior}
 import cats.kernel.{CommutativeMonoid, CommutativeSemigroup}
+import cats.kernel.instances.StaticMethods.wrapMutableIndexedSeq
 
 import scala.annotation.tailrec
 import scala.collection.immutable.SortedMap
@@ -38,7 +39,7 @@ trait SortedMapInstances extends SortedMapInstances2 {
           G.map(Chain.traverseViaChain {
             val as = collection.mutable.ArrayBuffer[(K, A)]()
             as ++= fa
-            as
+            wrapMutableIndexedSeq(as)
           } {
             case (k, a) => G.map(f(a))((k, _))
           }) { chain => chain.foldLeft(SortedMap.empty[K, B]) { case (m, (k, b)) => m.updated(k, b) } }
@@ -201,7 +202,7 @@ private[instances] trait SortedMapInstancesBinCompat0 {
           G.map(Chain.traverseFilterViaChain {
             val as = collection.mutable.ArrayBuffer[(K, A)]()
             as ++= fa
-            as
+            wrapMutableIndexedSeq(as)
           } {
             case (k, a) =>
               G.map(f(a)) { optB =>

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -93,52 +93,7 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
       }
 
       final override def traverse[G[_], A, B](fa: Vector[A])(f: A => G[B])(implicit G: Applicative[G]): G[Vector[B]] =
-        if (fa.isEmpty) G.pure(empty)
-        else {
-          // this is a specialized version of Chain.traverseViaChain since
-          // we don't need to materialize the Vector first
-
-          // we branch out by this factor
-          val width = 128
-          // By making a tree here we don't blow the stack
-          // even if the List is very long
-          // by construction, this is never called with start == end
-          def loop(start: Int, end: Int): Eval[G[Chain[B]]] =
-            if (end - start <= width) {
-              // Here we are at the leafs of the trees
-              // we don't use map2Eval since it is always
-              // at most width in size.
-              val aend = fa(end - 1)
-              var flist = Eval.later(G.map(f(aend))(_ :: Nil))
-              var idx = end - 2
-              while (start <= idx) {
-                val a = fa(idx)
-                // don't capture a var in the defer
-                val right = flist
-                flist = Eval.defer(G.map2Eval(f(a), right)(_ :: _))
-                idx = idx - 1
-              }
-              flist.map { glist => G.map(glist)(Chain.fromSeq(_)) }
-            } else {
-              // we have width + 1 or more nodes left
-              val step = (end - start) / width
-
-              var fchain = Eval.defer(loop(start, start + step))
-              var start0 = start + step
-              var end0 = start0 + step
-
-              while (start0 < end) {
-                val end1 = math.min(end, end0)
-                val right = loop(start0, end1)
-                fchain = fchain.flatMap(G.map2Eval(_, right)(_.concat(_)))
-                start0 = start0 + step
-                end0 = end0 + step
-              }
-              fchain
-            }
-
-          G.map(loop(0, fa.size).value)(_.toVector)
-        }
+        G.map(Chain.traverseViaChain(fa)(f))(_.toVector)
 
       override def mapWithIndex[A, B](fa: Vector[A])(f: (A, Int) => B): Vector[B] =
         fa.iterator.zipWithIndex.map(ai => f(ai._1, ai._2)).toVector
@@ -225,55 +180,7 @@ private[instances] trait VectorInstancesBinCompat0 {
     override def flattenOption[A](fa: Vector[Option[A]]): Vector[A] = fa.flatten
 
     def traverseFilter[G[_], A, B](fa: Vector[A])(f: (A) => G[Option[B]])(implicit G: Applicative[G]): G[Vector[B]] =
-      if (fa.isEmpty) G.pure(Vector.empty[B])
-      else {
-        // we branch out by this factor
-        val width = 128
-        // By making a tree here we don't blow the stack
-        // even if the List is very long
-        // by construction, this is never called with start == end
-        def loop(start: Int, end: Int): Eval[G[Chain[B]]] =
-          if (end - start <= width) {
-            // Here we are at the leafs of the trees
-            // we don't use map2Eval since it is always
-            // at most width in size.
-            val aend = fa(end - 1)
-            var flist = Eval.later(G.map(f(aend)) { optB =>
-              if (optB.isDefined) optB.get :: Nil
-              else Nil
-            })
-            var idx = end - 2
-            while (start <= idx) {
-              val a = fa(idx)
-              // don't capture a var in the defer
-              val right = flist
-              flist = Eval.defer(G.map2Eval(f(a), right) { (optB, tail) =>
-                if (optB.isDefined) optB.get :: tail
-                else tail
-              })
-              idx = idx - 1
-            }
-            flist.map { glist => G.map(glist)(Chain.fromSeq(_)) }
-          } else {
-            // we have width + 1 or more nodes left
-            val step = (end - start) / width
-
-            var fchain = Eval.defer(loop(start, start + step))
-            var start0 = start + step
-            var end0 = start0 + step
-
-            while (start0 < end) {
-              val end1 = math.min(end, end0)
-              val right = loop(start0, end1)
-              fchain = fchain.flatMap(G.map2Eval(_, right)(_.concat(_)))
-              start0 = start0 + step
-              end0 = end0 + step
-            }
-            fchain
-          }
-
-        G.map(loop(0, fa.size).value)(_.toVector)
-      }
+      G.map(Chain.traverseFilterViaChain(fa)(f))(_.toVector)
 
     override def filterA[G[_], A](fa: Vector[A])(f: (A) => G[Boolean])(implicit G: Applicative[G]): G[Vector[A]] =
       traverse

--- a/kernel/src/main/scala/cats/kernel/instances/StaticMethods.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/StaticMethods.scala
@@ -2,8 +2,10 @@ package cats
 package kernel
 package instances
 
+import scala.collection.immutable.{IndexedSeq => ImIndexedSeq}
 import scala.collection.mutable
 import compat.scalaVersionSpecific._
+
 @suppressUnusedImportWarningForScalaVersionSpecific
 object StaticMethods extends cats.kernel.compat.HashCompat {
 
@@ -15,6 +17,22 @@ object StaticMethods extends cats.kernel.compat.HashCompat {
     override def size: Int = m.size
     def get(k: K): Option[V] = m.get(k)
     def iterator: Iterator[(K, V)] = m.iterator
+  }
+
+  /**
+   * When you "own" this m, and will not mutate it again, this
+   * is safe to call. It is unsafe to call this, then mutate
+   * the original collection.
+   *
+   * You are giving up ownership when calling this method
+   */
+  def wrapMutableIndexedSeq[A](m: mutable.IndexedSeq[A]): ImIndexedSeq[A] =
+    new WrappedIndexedSeq(m)
+
+  private[kernel] class WrappedIndexedSeq[A](m: mutable.IndexedSeq[A]) extends ImIndexedSeq[A] {
+    override def length: Int = m.length
+    override def apply(i: Int): A = m(i)
+    override def iterator: Iterator[A] = m.iterator
   }
 
   // scalastyle:off return


### PR DESCRIPTION
follow up to #3521 

In that PR, I added an API that consumes an Iterator. That is a bummer to have an API with a mutable arg, even if most people know that iterators must be considered with ownership semantics.

In fact, the first thing we do is materialize an IndexedSeq, so, why not just take an IndexedSeq and have callers materialize one if needed. This also removes duplication since Vector can share the same implementation now.

As an added bonus, you can use `Chain.traverseViaChain(0 until 100000)(f)` since Range is an IndexedSeq as well, which is nice.

It would be nice to get this in before 2.2.0 so we aren't stuck with the mutable API.
