### PR TITLE
Remove traverseForEither in Traverse companion object

### DIFF
--- a/core/src/main/scala/cats/Traverse.scala
+++ b/core/src/main/scala/cats/Traverse.scala
@@ -133,7 +133,6 @@ import scala.annotation.implicitNotFound
 }
 
 object Traverse {
-  implicit def catsTraverseForEither[A]: Traverse[Either[A, *]] = cats.instances.either.catsStdInstancesForEither[A]
 
   /* ======================================================================== */
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */


### PR DESCRIPTION
I'm not quite sure how this got here, but it's messing up things in dotty 0.25 so we should get rid of it asap.