### PR TITLE
Merge 2.2.x after 2.2.0-RC2 release

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -275,6 +275,7 @@ possible:
  * Trond Bjerkestrand
  * Tya
  * Valentin Willscher
+ * Valeriy Avanesov
  * Valy Diarrassouba
  * Vasileios Lampridis
  * Vasilis Nicolaou

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,25 @@
+## Version 2.2.0-RC2
+
+_2020 July 21
+
+### 7 API / feature enhancements
+
+* [#3524](https://github.com/typelevel/cats/pull/3524) A method `StateT.fromState` turning `State[A, F[B]]` into `StateT[F,A, B]` is added.  by @akopich
+* [#3498](https://github.com/typelevel/cats/pull/3498) Enable breakout in functions reduceRightToOption and reduceRightTo.  by @takayahilton
+* [#3519](https://github.com/typelevel/cats/pull/3519) remove casts from Eval, fix stack overflow in Eval  by @johnynek
+* [#3521](https://github.com/typelevel/cats/pull/3521) make collection traversals stack safe  by @johnynek
+* [#3516](https://github.com/typelevel/cats/pull/3516) Override some Option Apply/Applicative methods  by @johnynek
+* [#3518](https://github.com/typelevel/cats/pull/3518) remove some casts in AndThen  by @johnynek
+* [#3515](https://github.com/typelevel/cats/pull/3515) Add some more implementations to Function0 and Function1 Monads  by @johnynek
+
+
+### 3 build improvements
+
+* [#3525](https://github.com/typelevel/cats/pull/3525) Update scalafmt-core to 2.6.4  by @scala-steward
+* [#3520](https://github.com/typelevel/cats/pull/3520) Update sbt-scalafix to 0.9.19  by @scala-steward
+* [#3514](https://github.com/typelevel/cats/pull/3514) Scalafmt-core 2.6.3  by @barambani
+
+
 ## Version 2.2.0-RC1
 
 _2020 July 6_

--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
 
 ### ![#f03c15](https://placehold.it/15/f03c15/000000?text=+) Community Announcements ![#f03c15](https://placehold.it/15/f03c15/000000?text=+)
+* **Jul 21 2020** [Cats 2.2.0-RC2 is released](https://github.com/typelevel/cats/releases/tag/v2.2.0-RC2)
 * **Jul 6 2020** [Cats 2.2.0-RC1 is released](https://github.com/typelevel/cats/releases/tag/v2.2.0-RC1)
-* **Jun 17 2020** [Cats 2.2.0-M3 is released](https://github.com/typelevel/cats/releases/tag/v2.2.0-M3)
-* **May 25 2020** [Cats 2.2.0-M2 is released](https://github.com/typelevel/cats/releases/tag/v2.2.0-M2)
-* **Mar 31 2020** [Cats 2.2.0-M1 is released](https://github.com/typelevel/cats/releases/tag/v2.2.0-M1)
 * **Dec 18 2019** [Cats 2.1.0 is released](https://github.com/typelevel/cats/releases/tag/v2.1.0)
 * **Sep 9 2019** [Cats 2.0.0 is released](https://github.com/typelevel/cats/releases/tag/v2.0.0)
 * **Jun 3 2019** [Cats 1.6.1 is released](https://github.com/typelevel/cats/releases/tag/v1.6.1) with backported bug fixes

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.2.0-RC2"
+version in ThisBuild := "2.2.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.2.0-SNAPSHOT"
+version in ThisBuild := "2.2.0-RC2"


### PR DESCRIPTION
I meant to open this after publishing [2.2.0-RC2](https://github.com/typelevel/cats/releases/tag/v2.2.0-RC2) but forgot. It'll need to be merged before the next release (which should probably be another RC).

Please note that this PR should be merged with a merge commit, since if it is squashed or rebased the `v2.2.0-RC2` tag won't point to a commit on the main branch.
