### PR TITLE
Comments on NonEmptyReducible not being a typeclass

### DIFF
--- a/core/src/main/scala/cats/Reducible.scala
+++ b/core/src/main/scala/cats/Reducible.scala
@@ -369,6 +369,9 @@ object Reducible {
  *
  * This class can be used on any type where the first value (`A`) and
  * the "rest" of the values (`G[A]`) can be easily found.
+ *
+ * This class is only a helper, does not define a typeclass and should not be used outside of Cats.
+ * Also see the discussion: PR #3541 and issue #3069.
  */
 abstract class NonEmptyReducible[F[_], G[_]](implicit G: Foldable[G]) extends Reducible[F] {
   def split[A](fa: F[A]): (A, G[A])

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -528,6 +528,12 @@ object NonEmptyList extends NonEmptyListInstances {
 
 sealed abstract private[data] class NonEmptyListInstances extends NonEmptyListInstances0 {
 
+  /**
+   * This is not a bug. The declared type of `catsDataInstancesForNonEmptyList` intentionally ignores
+   * `NonEmptyReducible` trait for it not being a typeclass.
+   *
+   * Also see the discussion: PR #3541 and issue #3069.
+   */
   implicit val catsDataInstancesForNonEmptyList
     : SemigroupK[NonEmptyList] with Bimonad[NonEmptyList] with NonEmptyTraverse[NonEmptyList] with Align[NonEmptyList] =
     new NonEmptyReducible[NonEmptyList, List]

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -332,6 +332,12 @@ final class NonEmptyVector[+A] private (val toVector: Vector[A])
 @suppressUnusedImportWarningForScalaVersionSpecific
 sealed abstract private[data] class NonEmptyVectorInstances {
 
+  /**
+   * This is not a bug. The declared type of `catsDataInstancesForNonEmptyVector` intentionally ignores
+   * `NonEmptyReducible` trait for it not being a typeclass.
+   *
+   * Also see the discussion: PR #3541 and issue #3069.
+   */
   implicit val catsDataInstancesForNonEmptyVector: SemigroupK[NonEmptyVector]
     with Bimonad[NonEmptyVector]
     with NonEmptyTraverse[NonEmptyVector]


### PR DESCRIPTION
`NonEmptyReducible` is not a typeclass and should not be used outside of Cats. Thus, the corresponding comments are added to the `NonEmptyReducible` along with `catsDataInstancesForNonEmptyVector` and `catsDataInstancesForNonEmptyList` implementing it.


