### PR TITLE
Fix ReducibleLaws causing stack overflow by calling `Eval.now` early

### DIFF
--- a/laws/src/main/scala/cats/laws/ReducibleLaws.scala
+++ b/laws/src/main/scala/cats/laws/ReducibleLaws.scala
@@ -26,8 +26,8 @@ trait ReducibleLaws[F[_]] extends FoldableLaws[F] {
       fa.reduceRightTo(f)((a, eb) => eb.map(f(a) |+| _)).map(Option(_)).value
 
   def reduceRightConsistentWithReduceRightOption[A](fa: F[A], f: (A, A) => A): IsEq[Option[A]] =
-    fa.reduceRight((a1, e2) => Now(f(a1, e2.value))).map(Option(_)).value <->
-      fa.reduceRightOption((a1, e2) => Now(f(a1, e2.value))).value
+    fa.reduceRight((a1, e2) => e2.map(f(a1, _))).map(Option(_)).value <->
+      fa.reduceRightOption((a1, e2) => e2.map(f(a1, _))).value
 
   def reduceReduceLeftConsistent[B](fa: F[B])(implicit B: Semigroup[B]): IsEq[B] =
     fa.reduce <-> fa.reduceLeft(B.combine)


### PR DESCRIPTION
The test `reduceRightConsistentWithReduceRightOption` currently calls
`value` on an `Eval` before the end of the computation, i.e. it calls `value`
inside the functions passed to `reduceRight` and `reduceRightOption`.
This can cause a stack overflow in otherwise lawful `Reducible` instances.

The test has been changed to instead use `map` on the `Eval` which is
the intended way of using `Eval` in methods like `reduceRight`.