### PR TITLE
Change AndThen to directly check isRightAssociated

### DIFF
--- a/tests/src/test/scala/cats/tests/AndThenSuite.scala
+++ b/tests/src/test/scala/cats/tests/AndThenSuite.scala
@@ -154,11 +154,13 @@ class AndThenSuite extends CatsSuite with ScalaCheckSuite {
 
     // Right associated should be identity
     forAll(genRight[Int]) { at =>
-      AndThen.toRightAssociated(at) == at
+      AndThen.isRightAssociated(AndThen.toRightAssociated(at))
     } &&
     // Left associated is never right associated
     forAll(genLeft[Int]) { at =>
-      AndThen.toRightAssociated(at) != at
+      val notInit = AndThen.isRightAssociated(at)
+      val done = AndThen.isRightAssociated(AndThen.toRightAssociated(at))
+      (!notInit && done)
     } &&
     // check that right associating doesn't change the function value
     forAll(genAndThen[Int], Gen.choose(Int.MinValue, Int.MaxValue)) { (at, i) =>


### PR DESCRIPTION
fix #3568 

The change to address the above is to avoid `equal` which on a very deep structure can blow the stack. Instead, directly check the property we want: isRightAssociated.

I removed a microoptimization (using != instead of <) since I would be *SHOCKED* if that changed the perf of this code which has to do quite a bit of pattern matching already. The != is not very safe since if a refactor gets it wrong, it can easily blow past the limit.

Lastly, I couldn't resist a bit of refactoring to share more of the code and improve associations (still at O(1) cost per andThen/compose).

cc @travisbrown 
