### PR TITLE
Merge 2.2.x after 2.2.0-RC3

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -46,6 +46,7 @@ possible:
  * Ben Hutchison
  * Ben Kirwin
  * Ben Plommer
+ * Ben Stewart
  * Benjamin Thuillier
  * Binh Nguyen
  * Bjørn Madsen
@@ -91,6 +92,7 @@ possible:
  * enzief
  * Eric Torreborre
  * ericaovo
+ * Erik Erlandson
  * Erik LaBianca
  * Erik Osheim
  * Eugene Burmako
@@ -267,6 +269,7 @@ possible:
  * Takayuki Sakai
  * Tanaka Takaya
  * Taylor Brown
+ * Tim Spence
  * Tom Switzer
  * Tomas Mikula
  * Tongfei Chen

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,54 @@
+## Version 2.2.0-RC3
+
+_2020 August 15_
+
+### 1 bug fix
+
+* [#3565](https://github.com/typelevel/cats/pull/3565) Fix ReducibleLaws causing stack overflow by calling `Eval.now` early  by @bastewart
+
+
+### 15 API / feature enhancements
+
+* [#3569](https://github.com/typelevel/cats/pull/3569) Change AndThen to directly check isRightAssociated  by @johnynek
+* [#3567](https://github.com/typelevel/cats/pull/3567) Avoid all evaluation of LazyList#foldRightDefer  by @takayahilton
+* [#3560](https://github.com/typelevel/cats/pull/3560) Improve AndThen use of Single  by @johnynek
+* [#3553](https://github.com/typelevel/cats/pull/3553) add ifElseM  by @mtomko
+* [#3556](https://github.com/typelevel/cats/pull/3556) Order for writert  by @TimWSpence
+* [#3527](https://github.com/typelevel/cats/pull/3527) Add toRightAssociated to AndThen  by @johnynek
+* [#3555](https://github.com/typelevel/cats/pull/3555) Order for IorT  by @TimWSpence
+* [#3554](https://github.com/typelevel/cats/pull/3554) Order for Ior  by @TimWSpence
+* [#3540](https://github.com/typelevel/cats/pull/3540) Remove traverseForEither in Traverse companion object  by @LukaJCB
+* [#3549](https://github.com/typelevel/cats/pull/3549) Enable breakout in Reducible[NonEmptyVector].reduceMapA  by @takayahilton
+* [#3545](https://github.com/typelevel/cats/pull/3545) Enable breakout in functions nonEmptyTraverse_ and nonEmptySequence_  by @takayahilton
+* [#3533](https://github.com/typelevel/cats/pull/3533) Improve invariants and performance in Chain  by @johnynek
+* [#3535](https://github.com/typelevel/cats/pull/3535) Improve traverseViaChain API  by @johnynek
+* [#3538](https://github.com/typelevel/cats/pull/3538) Preliminary Munit port  by @LukaJCB
+* [#3528](https://github.com/typelevel/cats/pull/3528) Optimize toNonEmptyList of Reducible[NonEmptyChain]  by @takayahilton
+
+
+### 4 documentation improvements
+
+* [#3562](https://github.com/typelevel/cats/pull/3562) Comments on NonEmptyReducible not being a typeclass  by @akopich
+* [#3537](https://github.com/typelevel/cats/pull/3537) add coulomb-cats to ecosystem list  by @erikerlandson
+* [#3531](https://github.com/typelevel/cats/pull/3531) adding Hootsuite Inc. to the list of Adopters  by @jyoo980
+* [#3526](https://github.com/typelevel/cats/pull/3526) Update README.md  by @Immozentral
+
+
+### 11 build improvements
+
+* [#3564](https://github.com/typelevel/cats/pull/3564) Remove redundant parentheses  by @barambani
+* [#3561](https://github.com/typelevel/cats/pull/3561) Update munit-scalacheck to 0.7.11  by @scala-steward
+* [#3558](https://github.com/typelevel/cats/pull/3558) Update sbt-doctest to 0.9.7  by @scala-steward
+* [#3557](https://github.com/typelevel/cats/pull/3557) Update sbt-buildinfo to 0.10.0  by @scala-steward
+* [#3546](https://github.com/typelevel/cats/pull/3546) Fix alleycats-tests on Scala.js  by @joroKr21
+* [#3548](https://github.com/typelevel/cats/pull/3548) Test freeJS with FastOptStage to save some CO2  by @joroKr21
+* [#3544](https://github.com/typelevel/cats/pull/3544) Scala 2.12.3 and 2.12.12  by @barambani
+* [#3543](https://github.com/typelevel/cats/pull/3543) Update discipline-munit to 0.2.3  by @scala-steward
+* [#3542](https://github.com/typelevel/cats/pull/3542) Update sbt-scalafmt to 2.4.2  by @scala-steward
+* [#3539](https://github.com/typelevel/cats/pull/3539) Update discipline-core to 1.0.3  by @scala-steward
+* [#3530](https://github.com/typelevel/cats/pull/3530) Update discipline-scalatest to 2.0.0  by @scala-steward
+
+
 ## Version 2.2.0-RC2
 
 _2020 July 21

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 
 ### ![#f03c15](https://placehold.it/15/f03c15/000000?text=+) Community Announcements ![#f03c15](https://placehold.it/15/f03c15/000000?text=+)
+* **Aug 15 2020** [Cats 2.2.0-RC3 is released](https://github.com/typelevel/cats/releases/tag/v2.2.0-RC3)
 * **Jul 21 2020** [Cats 2.2.0-RC2 is released](https://github.com/typelevel/cats/releases/tag/v2.2.0-RC2)
 * **Jul 6 2020** [Cats 2.2.0-RC1 is released](https://github.com/typelevel/cats/releases/tag/v2.2.0-RC1)
 * **Dec 18 2019** [Cats 2.1.0 is released](https://github.com/typelevel/cats/releases/tag/v2.1.0)

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.2.0-RC3"
+version in ThisBuild := "2.2.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.2.0-SNAPSHOT"
+version in ThisBuild := "2.2.0-RC3"


### PR DESCRIPTION
Pretty routine. One thing to note is that I put the adopter list PRs into the release notes this time, because I think it makes sense to give them more visibility, but didn't add the authors to the contributors list (which has always been the policy for changes like that).

Needs to be a merge commit to get the release tag on master.
