### PR TITLE
Merge 2.2.x after 2.2.0-RC4

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -89,6 +89,7 @@ possible:
  * Earl St Sauver
  * Edd Steel
  * Endre Galaczi
+ * Enrico Benini
  * enzief
  * Eric Torreborre
  * ericaovo

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,18 @@
+## Version 2.2.0-RC4
+
+_2020 August 22_
+
+### 2 API / feature enhancements
+
+* [#3572](https://github.com/typelevel/cats/pull/3572) Add Future instances to implicit scope  by @travisbrown
+* [#3573](https://github.com/typelevel/cats/pull/3573) Avoid all evaluation of NonEmptyLazyList#reduceRightTo  by @takayahilton
+
+### 2 documentation improvements
+
+* [#3575](https://github.com/typelevel/cats/pull/3575) Missing a "]" in CONTRIBUTING.md  by @benkio
+* [#3574](https://github.com/typelevel/cats/pull/3574) Update README.md  by @diesalbla
+
+
 ## Version 2.2.0-RC3
 
 _2020 August 15_

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 
 ### ![#f03c15](https://placehold.it/15/f03c15/000000?text=+) Community Announcements ![#f03c15](https://placehold.it/15/f03c15/000000?text=+)
+* **Aug 21 2020** [Cats 2.2.0-RC4 is released](https://github.com/typelevel/cats/releases/tag/v2.2.0-RC4)
 * **Aug 15 2020** [Cats 2.2.0-RC3 is released](https://github.com/typelevel/cats/releases/tag/v2.2.0-RC3)
-* **Jul 21 2020** [Cats 2.2.0-RC2 is released](https://github.com/typelevel/cats/releases/tag/v2.2.0-RC2)
-* **Jul 6 2020** [Cats 2.2.0-RC1 is released](https://github.com/typelevel/cats/releases/tag/v2.2.0-RC1)
 * **Dec 18 2019** [Cats 2.1.0 is released](https://github.com/typelevel/cats/releases/tag/v2.1.0)
 * **Sep 9 2019** [Cats 2.0.0 is released](https://github.com/typelevel/cats/releases/tag/v2.0.0)
 * **Jun 3 2019** [Cats 1.6.1 is released](https://github.com/typelevel/cats/releases/tag/v1.6.1) with backported bug fixes

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.2.0-SNAPSHOT"
+version in ThisBuild := "2.2.0-RC4"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "2.2.0-RC4"
+version in ThisBuild := "2.2.0-SNAPSHOT"


### PR DESCRIPTION
The usual for [2.2.0-RC4](https://github.com/typelevel/cats/releases/tag/v2.2.0-RC4). Needs to be a merge commit for the release tag.