### PR TITLE
Add `flatTapOnError` To `MonadError`

### DIFF
--- a/core/src/main/scala/cats/syntax/monadError.scala
+++ b/core/src/main/scala/cats/syntax/monadError.scala
@@ -35,6 +35,9 @@ final class MonadErrorOps[F[_], E, A](private val fa: F[A]) extends AnyVal {
 
   def attemptTap[B](f: Either[E, A] => F[B])(implicit F: MonadError[F, E]): F[A] =
     F.attemptTap(fa)(f)
+
+  def flatTapOnError[B](f: E => F[B])(implicit F: MonadError[F, E]): F[A] =
+    F.flatTapOnError(fa)(f)
 }
 
 final class MonadErrorRethrowOps[F[_], E, A](private val fea: F[Either[E, A]]) extends AnyVal {


### PR DESCRIPTION
This is similar to `attemptTap`, but it only applies to the error branch.

This is based off of [another PR to cats-tagless](https://github.com/typelevel/cats-tagless/pull/162). @kailuowang thought that the functions in that PR didn't really belong directly in the `FunctorK` class and recommended I PR them to cats directly.

I was going to add the `FunctionK` similar to the one defined in that PR, something like this,

```scala
  def flatTapOnErrorK[F[_], A, E](f: E => F[A])(implicit F: MonadError[F, E]): FunctionK[F, F] =
    new FunctionK[F, F]{
      override def apply[B](fa: F[B]): F[B] =
        F.flatTapOnError(fa)(f)
    }
```

but honestly I can't really see a time when anyone would want to use this outside of `FunctorK.mapK`, when applying some side effect to all methods on a F-Algebra.

That being said, I think that, while simple, `flatTapOnError` has a general enough use case to stand on its own. I find it very useful for adding logging to effect types.



