### PR TITLE
Fix typo in FoldableTests (constistency -> consistency)

### DIFF
--- a/laws/src/main/scala/cats/laws/discipline/FoldableTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/FoldableTests.scala
@@ -29,7 +29,7 @@ trait FoldableTests[F[_]] extends UnorderedFoldableTests[F] {
       "foldLeft consistent with foldMap" -> forAll(laws.leftFoldConsistentWithFoldMap[A, B] _),
       "foldRight consistent with foldMap" -> forAll(laws.rightFoldConsistentWithFoldMap[A, B] _),
       "foldRight is lazy" -> forAll(laws.foldRightLazy[A] _),
-      "ordered constistency" -> forAll(laws.orderedConsistency[A] _),
+      "ordered consistency" -> forAll(laws.orderedConsistency[A] _),
       "exists consistent with find" -> forAll(laws.existsConsistentWithFind[A] _),
       "foldM identity" -> forAll(laws.foldMIdentity[A, B] _),
       "reduceLeftOption consistent with reduceLeftToOption" ->


### PR DESCRIPTION
Fixes test name `ordered constistency` to `ordered consistency`.