### PR TITLE
scalafix: document scalafixAll to migrate test code as well

### DIFF
--- a/scalafix/README.md
+++ b/scalafix/README.md
@@ -17,7 +17,7 @@ ThisBuild / scalacOptions += "-P:semanticdb:synthetics:on"
 Then run Scalafix:
 
 ```sh
-sbt scalafix github:typelevel/cats/Cats_v2_2_0
+sbt scalafixAll github:typelevel/cats/Cats_v2_2_0
 ```
 
 ### Available rules
@@ -28,7 +28,7 @@ sbt scalafix github:typelevel/cats/Cats_v2_2_0
 ## Migration to Cats v1.0.0
 
 ```sh
-sbt scalafix github:typelevel/cats/Cats_v1_0_0
+sbt scalafixAll github:typelevel/cats/Cats_v1_0_0
 ```
 
 ### Available rules


### PR DESCRIPTION
The `scalafixAll` task is available as of [sbt-scalafix 0.9.18](https://github.com/scalacenter/sbt-scalafix/releases/tag/v0.9.18). See https://scalacenter.github.io/scalafix/docs/users/installation.html#settings-and-tasks.

For the record, that's what scala-steward uses as of https://github.com/scala-steward-org/scala-steward/pull/1523.