### PR TITLE
Add Group instance for Map to alleycats

### DIFF
--- a/alleycats-core/src/main/scala/alleycats/std/map.scala
+++ b/alleycats-core/src/main/scala/alleycats/std/map.scala
@@ -80,7 +80,7 @@ trait MapInstances {
           }) { chain => chain.foldLeft(Map.empty[K, B]) { case (m, (k, b)) => m.updated(k, b) } }
     }
 
-  implicit def alleycatsStdMapGroup[K, V : Group]: Group[Map[K, V]] = new MapMonoid[K, V] with Group[Map[K, V]] {
+  implicit def alleycatsStdMapGroup[K, V: Group]: Group[Map[K, V]] = new MapMonoid[K, V] with Group[Map[K, V]] {
     override def inverse(a: Map[K, V]): Map[K, V] = a.map { case (k, v) => (k, Group[V].inverse(v)) }
   }
 

--- a/alleycats-core/src/main/scala/alleycats/std/map.scala
+++ b/alleycats-core/src/main/scala/alleycats/std/map.scala
@@ -3,6 +3,7 @@ package std
 
 import cats._
 import cats.data.Chain
+import cats.kernel.instances.MapMonoid
 import cats.kernel.instances.StaticMethods.wrapMutableIndexedSeq
 
 object map extends MapInstances
@@ -78,4 +79,9 @@ trait MapInstances {
             }
           }) { chain => chain.foldLeft(Map.empty[K, B]) { case (m, (k, b)) => m.updated(k, b) } }
     }
+
+  implicit def alleycatsStdMapGroup[K, V : Group]: Group[Map[K, V]] = new MapMonoid[K, V] with Group[Map[K, V]] {
+    override def inverse(a: Map[K, V]): Map[K, V] = a.map { case (k, v) => (k, Group[V].inverse(v)) }
+  }
+
 }

--- a/alleycats-tests/shared/src/test/scala/alleycats/tests/MapSuite.scala
+++ b/alleycats-tests/shared/src/test/scala/alleycats/tests/MapSuite.scala
@@ -4,7 +4,7 @@ import cats.Traverse
 import cats.instances.all._
 import cats.kernel.laws.GroupLaws
 import cats.laws.discipline.arbitrary._
-import cats.laws.discipline.{SerializableTests, ShortCircuitingTests, TraverseFilterTests, catsLawsIsEqToProp}
+import cats.laws.discipline.{catsLawsIsEqToProp, SerializableTests, ShortCircuitingTests, TraverseFilterTests}
 import org.scalacheck.Prop
 
 class MapSuite extends AlleycatsSuite {

--- a/alleycats-tests/shared/src/test/scala/alleycats/tests/MapSuite.scala
+++ b/alleycats-tests/shared/src/test/scala/alleycats/tests/MapSuite.scala
@@ -2,8 +2,10 @@ package alleycats.tests
 
 import cats.Traverse
 import cats.instances.all._
+import cats.kernel.laws.GroupLaws
 import cats.laws.discipline.arbitrary._
-import cats.laws.discipline.{SerializableTests, ShortCircuitingTests, TraverseFilterTests}
+import cats.laws.discipline.{SerializableTests, ShortCircuitingTests, TraverseFilterTests, catsLawsIsEqToProp}
+import org.scalacheck.Prop
 
 class MapSuite extends AlleycatsSuite {
   checkAll("Traverse[Map[Int, *]]", SerializableTests.serializable(Traverse[Map[Int, *]]))
@@ -22,4 +24,7 @@ class MapSuite extends AlleycatsSuite {
 
     assert(sumAll == items.values.sum)
   }
+
+  property("group has consistent inverse")(Prop.forAll(GroupLaws[Map[String, Int]].consistentInverse _))
+
 }


### PR DESCRIPTION
This PR adds a `Group` for `Map` to alleycats. It can be constructed where the value type has a `Group` instance.

```scala
import cats.syntax.group._

val x = Map("a" -> 2, "b" -> 1)
val y = Map("a" -> 3)

assert((x |-| y) === Map("a" -> -1, "b" -> 1))
```

The resulting instance violates the left- and right-inverse laws, since an empty `Map` is not equal to one with a key bound to an empty value:

```scala
import cats.syntax.group._

val x = Map("a" -> 1)

assert((x |-| x) === Map.empty) // Fails, since x |-| x is Map("a" -> 0)
```

Despite this, I've found this `Group` instance useful in contexts where there is no semantic difference between the lack of a binding and a binding to an empty value.

I believe you can construct a `CommutativeGroup` in the same way, which I would be happy to add as a higher-priority implicit.

I realise I've raised this PR without first discussing the change in an issue or on Gitter. Please feel free to provide any feedback or reject this PR as appropriate. 