### PR TITLE
Add typeclasses for immutable.Seq

### DIFF
--- a/core/src/main/scala-2.12/cats/compat/Seq.scala
+++ b/core/src/main/scala-2.12/cats/compat/Seq.scala
@@ -1,0 +1,8 @@
+package cats.compat
+
+import scala.collection.immutable.{Seq => ISeq}
+
+private[cats] object Seq {
+  def zipWith[A, B, C](fa: ISeq[A], fb: ISeq[B])(f: (A, B) => C): ISeq[C] =
+    (fa, fb).zipped.map(f)
+}

--- a/core/src/main/scala-2.12/cats/instances/all.scala
+++ b/core/src/main/scala-2.12/cats/instances/all.scala
@@ -10,6 +10,7 @@ abstract class AllInstancesBinCompat
     with AllInstancesBinCompat4
     with AllInstancesBinCompat5
     with AllInstancesBinCompat6
+    with AllInstancesBinCompat7
 
 trait AllInstances
     extends AnyValInstances
@@ -64,3 +65,5 @@ trait AllInstancesBinCompat4 extends SortedMapInstancesBinCompat1 with MapInstan
 trait AllInstancesBinCompat5 extends SortedSetInstancesBinCompat0
 
 trait AllInstancesBinCompat6 extends SortedSetInstancesBinCompat1 with SortedMapInstancesBinCompat2
+
+trait AllInstancesBinCompat7 extends SeqInstances

--- a/core/src/main/scala-2.12/cats/instances/package.scala
+++ b/core/src/main/scala-2.12/cats/instances/package.scala
@@ -31,6 +31,7 @@ package object instances {
   object partialOrdering extends PartialOrderingInstances
   object queue extends QueueInstances
   object set extends SetInstances
+  object seq extends SeqInstances
   object short extends ShortInstances
   object sortedMap
       extends SortedMapInstances

--- a/core/src/main/scala-2.13+/cats/compat/Seq.scala
+++ b/core/src/main/scala-2.13+/cats/compat/Seq.scala
@@ -1,0 +1,8 @@
+package cats.compat
+
+import scala.collection.immutable.{Seq => ISeq}
+
+private[cats] object Seq {
+  def zipWith[A, B, C](fa: ISeq[A], fb: ISeq[B])(f: (A, B) => C): ISeq[C] =
+    fa.lazyZip(fb).map(f)
+}

--- a/core/src/main/scala-2.13+/cats/instances/all.scala
+++ b/core/src/main/scala-2.13+/cats/instances/all.scala
@@ -10,6 +10,7 @@ abstract class AllInstancesBinCompat
     with AllInstancesBinCompat4
     with AllInstancesBinCompat5
     with AllInstancesBinCompat6
+    with AllInstancesBinCompat7
 
 trait AllInstances
     extends AnyValInstances
@@ -66,3 +67,5 @@ trait AllInstancesBinCompat4 extends SortedMapInstancesBinCompat1 with MapInstan
 trait AllInstancesBinCompat5 extends SortedSetInstancesBinCompat0
 
 trait AllInstancesBinCompat6 extends SortedSetInstancesBinCompat1 with SortedMapInstancesBinCompat2
+
+trait AllInstancesBinCompat7 extends SeqInstances

--- a/core/src/main/scala-2.13+/cats/instances/package.scala
+++ b/core/src/main/scala-2.13+/cats/instances/package.scala
@@ -32,6 +32,7 @@ package object instances {
   object partialOrdering extends PartialOrderingInstances
   object queue extends QueueInstances
   object set extends SetInstances
+  object seq extends SeqInstances
   object short extends ShortInstances
   object sortedMap
       extends SortedMapInstances

--- a/core/src/main/scala/cats/Align.scala
+++ b/core/src/main/scala/cats/Align.scala
@@ -3,7 +3,7 @@ package cats
 import simulacrum.typeclass
 
 import cats.data.Ior
-import scala.collection.immutable.SortedMap
+import scala.collection.immutable.{Seq, SortedMap}
 import scala.annotation.implicitNotFound
 
 /**
@@ -111,6 +111,7 @@ object Align extends ScalaVersionSpecificAlignInstances {
 
   implicit def catsAlignForList: Align[List] = cats.instances.list.catsStdInstancesForList
   implicit def catsAlignForOption: Align[Option] = cats.instances.option.catsStdInstancesForOption
+  implicit def catsAlignForSeq: Align[Seq] = cats.instances.seq.catsStdInstancesForSeq
   implicit def catsAlignForVector: Align[Vector] = cats.instances.vector.catsStdInstancesForVector
   implicit def catsAlignForMap[K]: Align[Map[K, *]] = cats.instances.map.catsStdInstancesForMap[K]
   implicit def catsAlignForSortedMap[K]: Align[SortedMap[K, *]] =

--- a/core/src/main/scala/cats/FunctorFilter.scala
+++ b/core/src/main/scala/cats/FunctorFilter.scala
@@ -1,6 +1,6 @@
 package cats
 
-import scala.collection.immutable.{Queue, SortedMap}
+import scala.collection.immutable.{Queue, Seq, SortedMap}
 import simulacrum.typeclass
 import scala.annotation.implicitNotFound
 
@@ -82,6 +82,7 @@ object FunctorFilter extends ScalaVersionSpecificTraverseFilterInstances {
   implicit def catsTraverseFilterForOption: TraverseFilter[Option] =
     cats.instances.option.catsStdTraverseFilterForOption
   implicit def catsTraverseFilterForList: TraverseFilter[List] = cats.instances.list.catsStdTraverseFilterForList
+  implicit def catsTraverseFilterForSeq: TraverseFilter[Seq] = cats.instances.seq.catsStdTraverseFilterForSeq
   implicit def catsTraverseFilterForVector: TraverseFilter[Vector] =
     cats.instances.vector.catsStdTraverseFilterForVector
   implicit def catsFunctorFilterForMap[K]: FunctorFilter[Map[K, *]] =

--- a/core/src/main/scala/cats/FunctorFilter.scala
+++ b/core/src/main/scala/cats/FunctorFilter.scala
@@ -78,11 +78,10 @@ trait FunctorFilter[F[_]] extends Serializable {
     mapFilter(fa)(Some(_).filterNot(f))
 }
 
-object FunctorFilter extends ScalaVersionSpecificTraverseFilterInstances {
+object FunctorFilter extends ScalaVersionSpecificTraverseFilterInstances with FunctorFilterInstances0 {
   implicit def catsTraverseFilterForOption: TraverseFilter[Option] =
     cats.instances.option.catsStdTraverseFilterForOption
   implicit def catsTraverseFilterForList: TraverseFilter[List] = cats.instances.list.catsStdTraverseFilterForList
-  implicit def catsTraverseFilterForSeq: TraverseFilter[Seq] = cats.instances.seq.catsStdTraverseFilterForSeq
   implicit def catsTraverseFilterForVector: TraverseFilter[Vector] =
     cats.instances.vector.catsStdTraverseFilterForVector
   implicit def catsFunctorFilterForMap[K]: FunctorFilter[Map[K, *]] =
@@ -140,5 +139,11 @@ object FunctorFilter extends ScalaVersionSpecificTraverseFilterInstances {
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */
   /* ======================================================================== */
+
+}
+
+trait FunctorFilterInstances0 {
+
+  implicit def catsTraverseFilterForSeq: TraverseFilter[Seq] = cats.instances.seq.catsStdTraverseFilterForSeq
 
 }

--- a/core/src/main/scala/cats/Invariant.scala
+++ b/core/src/main/scala/cats/Invariant.scala
@@ -113,8 +113,6 @@ object Invariant extends ScalaVersionSpecificInvariantInstances with InvariantIn
     cats.instances.option.catsStdInstancesForOption
   implicit def catsInstancesForList: Monad[List] with Alternative[List] with CoflatMap[List] =
     cats.instances.list.catsStdInstancesForList
-  implicit def catsInstancesForSeq: Monad[Seq] with Alternative[Seq] with CoflatMap[Seq] =
-    cats.instances.seq.catsStdInstancesForSeq
   implicit def catsInstancesForVector: Monad[Vector] with Alternative[Vector] with CoflatMap[Vector] =
     cats.instances.vector.catsStdInstancesForVector
   implicit def catsInstancesForQueue: Monad[Queue] with Alternative[Queue] with CoflatMap[Queue] =
@@ -297,6 +295,8 @@ private[cats] trait InvariantInstances0 extends TupleInstances0 {
     cats.instances.function.catsStdDistributiveForFunction1[I]
   implicit def catsApplicativeForArrow[F[_, _], A](implicit F: Arrow[F]): Applicative[F[A, *]] =
     new ArrowApplicative[F, A](F)
+  implicit def catsInstancesForSeq: Monad[Seq] with Alternative[Seq] with CoflatMap[Seq] =
+    cats.instances.seq.catsStdInstancesForSeq
 }
 
 private trait TupleInstances0 extends TupleInstances1 {

--- a/core/src/main/scala/cats/Invariant.scala
+++ b/core/src/main/scala/cats/Invariant.scala
@@ -5,7 +5,7 @@ import cats.kernel._
 import simulacrum.typeclass
 import cats.kernel.compat.scalaVersionSpecific._
 import scala.annotation.implicitNotFound
-import scala.collection.immutable.{Queue, SortedMap}
+import scala.collection.immutable.{Queue, Seq, SortedMap}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 import scala.util.control.TailCalls.TailRec
@@ -113,6 +113,8 @@ object Invariant extends ScalaVersionSpecificInvariantInstances with InvariantIn
     cats.instances.option.catsStdInstancesForOption
   implicit def catsInstancesForList: Monad[List] with Alternative[List] with CoflatMap[List] =
     cats.instances.list.catsStdInstancesForList
+  implicit def catsInstancesForSeq: Monad[Seq] with Alternative[Seq] with CoflatMap[Seq] =
+    cats.instances.seq.catsStdInstancesForSeq
   implicit def catsInstancesForVector: Monad[Vector] with Alternative[Vector] with CoflatMap[Vector] =
     cats.instances.vector.catsStdInstancesForVector
   implicit def catsInstancesForQueue: Monad[Queue] with Alternative[Queue] with CoflatMap[Queue] =

--- a/core/src/main/scala/cats/SemigroupK.scala
+++ b/core/src/main/scala/cats/SemigroupK.scala
@@ -112,7 +112,7 @@ import scala.annotation.implicitNotFound
     combineK(F.map(fa)(Left(_)), F.map(fb)(Right(_)))
 }
 
-object SemigroupK extends ScalaVersionSpecificMonoidKInstances {
+object SemigroupK extends ScalaVersionSpecificMonoidKInstances with SemigroupKInstances0 {
   def align[F[_]: SemigroupK: Functor]: Align[F] =
     new Align[F] {
       def align[A, B](fa: F[A], fb: F[B]): F[Ior[A, B]] =
@@ -122,7 +122,6 @@ object SemigroupK extends ScalaVersionSpecificMonoidKInstances {
 
   implicit def catsMonoidKForOption: MonoidK[Option] = cats.instances.option.catsStdInstancesForOption
   implicit def catsMonoidKForList: MonoidK[List] = cats.instances.list.catsStdInstancesForList
-  implicit def catsMonoidKForSeq: MonoidK[Seq] = cats.instances.seq.catsStdInstancesForSeq
   implicit def catsMonoidKForVector: MonoidK[Vector] = cats.instances.vector.catsStdInstancesForVector
   implicit def catsMonoidKForSet: MonoidK[Set] = cats.instances.set.catsStdInstancesForSet
   implicit def catsMonoidKForMap[K]: MonoidK[Map[K, *]] = cats.instances.map.catsStdMonoidKForMap[K]
@@ -181,5 +180,11 @@ object SemigroupK extends ScalaVersionSpecificMonoidKInstances {
   /* ======================================================================== */
   /* END OF SIMULACRUM-MANAGED CODE                                           */
   /* ======================================================================== */
+
+}
+
+trait SemigroupKInstances0 {
+
+  implicit def catsMonoidKForSeq: MonoidK[Seq] = cats.instances.seq.catsStdInstancesForSeq
 
 }

--- a/core/src/main/scala/cats/SemigroupK.scala
+++ b/core/src/main/scala/cats/SemigroupK.scala
@@ -1,6 +1,6 @@
 package cats
 
-import scala.collection.immutable.{SortedMap, SortedSet}
+import scala.collection.immutable.{Seq, SortedMap, SortedSet}
 import simulacrum.typeclass
 import cats.data.Ior
 import scala.annotation.implicitNotFound
@@ -122,6 +122,7 @@ object SemigroupK extends ScalaVersionSpecificMonoidKInstances {
 
   implicit def catsMonoidKForOption: MonoidK[Option] = cats.instances.option.catsStdInstancesForOption
   implicit def catsMonoidKForList: MonoidK[List] = cats.instances.list.catsStdInstancesForList
+  implicit def catsMonoidKForSeq: MonoidK[Seq] = cats.instances.seq.catsStdInstancesForSeq
   implicit def catsMonoidKForVector: MonoidK[Vector] = cats.instances.vector.catsStdInstancesForVector
   implicit def catsMonoidKForSet: MonoidK[Set] = cats.instances.set.catsStdInstancesForSet
   implicit def catsMonoidKForMap[K]: MonoidK[Map[K, *]] = cats.instances.map.catsStdMonoidKForMap[K]

--- a/core/src/main/scala/cats/Semigroupal.scala
+++ b/core/src/main/scala/cats/Semigroupal.scala
@@ -1,7 +1,7 @@
 package cats
 
 import cats.kernel.CommutativeSemigroup
-import scala.collection.immutable.{Queue, SortedMap, SortedSet}
+import scala.collection.immutable.{Queue, Seq, SortedMap, SortedSet}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.Try
 import simulacrum.typeclass
@@ -54,6 +54,7 @@ object Semigroupal extends ScalaVersionSpecificSemigroupalInstances with Semigro
   implicit def catsSemigroupalForFuture(implicit ec: ExecutionContext): Semigroupal[Future] =
     cats.instances.future.catsStdInstancesForFuture(ec)
   implicit def catsSemigroupalForList: Semigroupal[List] = cats.instances.list.catsStdInstancesForList
+  implicit def catsSemigroupalForSeq: Semigroupal[Seq] = cats.instances.seq.catsStdInstancesForSeq
   implicit def catsSemigroupalForVector: Semigroupal[Vector] = cats.instances.vector.catsStdInstancesForVector
   implicit def catsSemigroupalForQueue: Semigroupal[Queue] = cats.instances.queue.catsStdInstancesForQueue
   implicit def catsSemigroupalForMap[K]: Semigroupal[Map[K, *]] = cats.instances.map.catsStdInstancesForMap[K]

--- a/core/src/main/scala/cats/Show.scala
+++ b/core/src/main/scala/cats/Show.scala
@@ -1,7 +1,7 @@
 package cats
 
 import java.util.UUID
-import scala.collection.immutable.{BitSet, Queue, SortedMap, SortedSet}
+import scala.collection.immutable.{BitSet, Queue, Seq, SortedMap, SortedSet}
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.util.Try
 
@@ -89,6 +89,7 @@ object Show extends ScalaVersionSpecificShowInstances with ShowInstances {
   implicit def catsShowForOption[A: Show]: Show[Option[A]] = cats.instances.option.catsStdShowForOption[A]
   implicit def catsShowForTry[A: Show]: Show[Try[A]] = cats.instances.try_.catsStdShowForTry[A]
   implicit def catsShowForList[A: Show]: Show[List[A]] = cats.instances.list.catsStdShowForList[A]
+  implicit def catsShowForSeq[A: Show]: Show[Seq[A]] = cats.instances.seq.catsStdShowForSeq[A]
   implicit def catsShowForVector[A: Show]: Show[Vector[A]] = cats.instances.vector.catsStdShowForVector[A]
   implicit def catsShowForQueue[A: Show]: Show[Queue[A]] = cats.instances.queue.catsStdShowForQueue[A]
   implicit def catsShowForEither[A: Show, B: Show]: Show[Either[A, B]] =

--- a/core/src/main/scala/cats/UnorderedFoldable.scala
+++ b/core/src/main/scala/cats/UnorderedFoldable.scala
@@ -1,7 +1,7 @@
 package cats
 
 import cats.kernel.CommutativeMonoid
-import scala.collection.immutable.{Queue, SortedMap, SortedSet}
+import scala.collection.immutable.{Queue, Seq, SortedMap, SortedSet}
 import scala.util.Try
 import simulacrum.{noop, typeclass}
 import scala.annotation.implicitNotFound
@@ -98,6 +98,7 @@ object UnorderedFoldable extends ScalaVersionSpecificTraverseInstances {
   implicit def catsNonEmptyTraverseForId: NonEmptyTraverse[Id] = catsInstancesForId
   implicit def catsTraverseForOption: Traverse[Option] = cats.instances.option.catsStdInstancesForOption
   implicit def catsTraverseForList: Traverse[List] = cats.instances.list.catsStdInstancesForList
+  implicit def catsTraverseForSeq: Traverse[Seq] = cats.instances.seq.catsStdInstancesForSeq
   implicit def catsTraverseForVector: Traverse[Vector] = cats.instances.vector.catsStdInstancesForVector
   implicit def catsTraverseForQueue: Traverse[Queue] = cats.instances.queue.catsStdInstancesForQueue
   implicit def catsUnorderedTraverseForSet: UnorderedTraverse[Set] = cats.instances.set.catsStdInstancesForSet

--- a/core/src/main/scala/cats/data/NonEmptySeq.scala
+++ b/core/src/main/scala/cats/data/NonEmptySeq.scala
@@ -1,0 +1,552 @@
+package cats
+package data
+
+import cats.data.NonEmptySeq.ZipNonEmptySeq
+
+import scala.annotation.tailrec
+import scala.collection.mutable
+import scala.collection.immutable.{Seq, SortedMap, TreeMap, TreeSet}
+import kernel.compat.scalaVersionSpecific._
+
+/**
+ * A data type which represents a `Seq` guaranteed to contain at least one element.
+ * <br/>
+ * Note that the constructor is `private` to prevent accidental construction of an empty
+ * `NonEmptySeq`. However, due to https://issues.scala-lang.org/browse/SI-6601, on
+ * Scala 2.10, this may be bypassed due to a compiler bug.
+ */
+final class NonEmptySeq[+A] private (val toSeq: Seq[A]) extends AnyVal with NonEmptyCollection[A, Seq, NonEmptySeq] {
+
+  /**
+   * Gets the element at the index, if it exists
+   */
+  def get(i: Int): Option[A] =
+    toSeq.lift(i)
+
+  /**
+   * Gets the element at the index, or throws an exception if none exists
+   */
+  def getUnsafe(i: Int): A = toSeq(i)
+
+  /**
+   * Updates the element at the index, if it exists
+   */
+  def updated[AA >: A](i: Int, a: AA): Option[NonEmptySeq[AA]] =
+    if (toSeq.isDefinedAt(i)) Some(new NonEmptySeq(toSeq.updated(i, a))) else None
+
+  /**
+   * Updates the element at the index, or throws an `IndexOutOfBoundsException`
+   * if none exists (if `i` does not satisfy `0 <= i < length`).
+   */
+  def updatedUnsafe[AA >: A](i: Int, a: AA): NonEmptySeq[AA] = new NonEmptySeq(toSeq.updated(i, a))
+
+  def head: A = toSeq.head
+
+  def tail: Seq[A] = toSeq.tail
+
+  def last: A = toSeq.last
+
+  def init: Seq[A] = toSeq.init
+
+  final def iterator: Iterator[A] = toSeq.iterator
+
+  /**
+   * Remove elements not matching the predicate
+   *
+   * {{{
+   * scala> import cats.data.NonEmptySeq
+   * scala> val neSeq = NonEmptySeq.of(1, 2, 3, 4, 5)
+   * scala> neSeq.filter(_ < 3)
+   * res0: scala.collection.immutable.Seq[Int] = List(1, 2)
+   * }}}
+   */
+  def filter(f: A => Boolean): Seq[A] = toSeq.filter(f)
+
+  /**
+   * Remove elements matching the predicate
+   *
+   * {{{
+   * scala> import cats.data.NonEmptySeq
+   * scala> val neSeq = NonEmptySeq.of(1, 2, 3, 4, 5)
+   * scala> neSeq.filterNot(_ < 3)
+   * res0: scala.collection.immutable.Seq[Int] = List(3, 4, 5)
+   * }}}
+   */
+  def filterNot(f: A => Boolean): Seq[A] = toSeq.filterNot(f)
+
+  def collect[B](pf: PartialFunction[A, B]): Seq[B] = toSeq.collect(pf)
+
+  /**
+   * Alias for [[concat]]
+   */
+  def ++[AA >: A](other: Seq[AA]): NonEmptySeq[AA] = concat(other)
+
+  /**
+   * Append this NESeq to another NESeq, producing a new `NonEmptySeq`.
+   *
+   * {{{
+   * scala> import cats.data.NonEmptySeq
+   * scala> val neSeq = NonEmptySeq.of(1, 2, 3)
+   * scala> neSeq ++: NonEmptySeq.of(4, 5)
+   * res0: cats.data.NonEmptySeq[Int] = NonEmptySeq(1, 2, 3, 4, 5)
+   * }}}
+   */
+  def ++:[AA >: A](other: NonEmptySeq[AA]): NonEmptySeq[AA] = other.concatNeSeq(this)
+
+  /**
+   * Append another `Seq` to this, producing a new `NonEmptySeq`.
+   */
+  def concat[AA >: A](other: Seq[AA]): NonEmptySeq[AA] = new NonEmptySeq(toSeq ++ other)
+
+  /**
+   * Append another `NonEmptySeq` to this, producing a new `NonEmptySeq`.
+   */
+  def concatNeSeq[AA >: A](other: NonEmptySeq[AA]): NonEmptySeq[AA] = new NonEmptySeq(toSeq ++ other.toSeq)
+
+  /**
+   * Append an item to this, producing a new `NonEmptySeq`.
+   */
+  def append[AA >: A](a: AA): NonEmptySeq[AA] = new NonEmptySeq(toSeq :+ a)
+
+  /**
+   * Alias for [[append]]
+   */
+  def :+[AA >: A](a: AA): NonEmptySeq[AA] = append(a)
+
+  /**
+   * Prepend an item to this, producing a new `NonEmptySeq`.
+   */
+  def prepend[AA >: A](a: AA): NonEmptySeq[AA] = new NonEmptySeq(a +: toSeq)
+
+  /**
+   * Prepend a `Seq` to this, producing a new `NonEmptySeq`.
+   */
+  def prependSeq[AA >: A](Seq: Seq[AA]): NonEmptySeq[AA] =
+    new NonEmptySeq(Seq ++ this.toSeq)
+
+  /**
+   * Alias for [[prepend]]
+   */
+  def +:[AA >: A](a: AA): NonEmptySeq[AA] = prepend(a)
+
+  /**
+   * Find the first element matching the predicate, if one exists
+   */
+  def find(f: A => Boolean): Option[A] = toSeq.find(f)
+
+  /**
+   * Check whether at least one element satisfies the predicate.
+   */
+  def exists(f: A => Boolean): Boolean = toSeq.exists(f)
+
+  /**
+   * Check whether all elements satisfy the predicate.
+   */
+  def forall(f: A => Boolean): Boolean = toSeq.forall(f)
+
+  /**
+   * Left-associative fold using f.
+   */
+  def foldLeft[B](b: B)(f: (B, A) => B): B =
+    toSeq.foldLeft(b)(f)
+
+  /**
+   * Right-associative fold using f.
+   */
+  def foldRight[B](lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
+    Foldable[Seq].foldRight(toSeq, lb)(f)
+
+  /**
+   * Applies f to all the elements
+   */
+  def map[B](f: A => B): NonEmptySeq[B] =
+    new NonEmptySeq(toSeq.map(f))
+
+  /**
+   * Applies f to all elements and combines the result
+   */
+  def flatMap[B](f: A => NonEmptySeq[B]): NonEmptySeq[B] =
+    new NonEmptySeq(toSeq.flatMap(a => f(a).toSeq))
+
+  /**
+   * Left-associative reduce using f.
+   */
+  def reduceLeft[AA >: A](f: (AA, AA) => AA): AA =
+    tail.foldLeft(head: AA)(f)
+
+  /**
+   * Reduce using the Semigroup of A
+   */
+  def reduce[AA >: A](implicit S: Semigroup[AA]): AA =
+    S.combineAllOption(toSeq).get
+
+  /**
+   * Typesafe equality operator.
+   *
+   * This method is similar to == except that it only allows two
+   * NonEmptySeq[A] values to be compared to each other, and uses
+   * equality provided by Eq[_] instances, rather than using the
+   * universal equality provided by .equals.
+   */
+  def ===[AA >: A](that: NonEmptySeq[AA])(implicit A: Eq[AA]): Boolean =
+    Eq[Seq[AA]].eqv(toSeq, that.toSeq)
+
+  /**
+   * Typesafe stringification method.
+   *
+   * This method is similar to .toString except that it stringifies
+   * values according to Show[_] instances, rather than using the
+   * universal .toString method.
+   */
+  def show[AA >: A](implicit AA: Show[AA]): String =
+    s"NonEmptySeq(${toSeq.map(Show[AA].show).mkString(", ")})"
+
+  def length: Int = toSeq.length
+
+  override def toString: String = s"NonEmptySeq(${toSeq.map(_.toString).mkString(", ")})"
+
+  /**
+   * Remove duplicates. Duplicates are checked using `Order[_]` instance.
+   */
+  def distinct[AA >: A](implicit O: Order[AA]): NonEmptySeq[AA] = {
+    implicit val ord: Ordering[AA] = O.toOrdering
+
+    val buf = Seq.newBuilder[AA]
+    tail.foldLeft(TreeSet(head: AA)) { (elementsSoFar, a) =>
+      if (elementsSoFar(a)) elementsSoFar
+      else {
+        buf += a; elementsSoFar + a
+      }
+    }
+
+    NonEmptySeq(head, buf.result())
+  }
+
+  /**
+   * Zips this `NonEmptySeq` with another `NonEmptySeq` and applies a function for each pair of elements.
+   *
+   * {{{
+   * scala> import cats.data.NonEmptySeq
+   * scala> val as = NonEmptySeq.of(1, 2, 3)
+   * scala> val bs = NonEmptySeq.of("A", "B", "C")
+   * scala> as.zipWith(bs)(_.toString + _)
+   * res0: cats.data.NonEmptySeq[String] = NonEmptySeq(1A, 2B, 3C)
+   * }}}
+   */
+  def zipWith[B, C](b: NonEmptySeq[B])(f: (A, B) => C): NonEmptySeq[C] =
+    NonEmptySeq.fromSeqUnsafe(toSeq.lazyZip(b.toSeq).map(f))
+
+  def reverse: NonEmptySeq[A] =
+    new NonEmptySeq(toSeq.reverse)
+
+  def zipWithIndex: NonEmptySeq[(A, Int)] =
+    new NonEmptySeq(toSeq.zipWithIndex)
+
+  def sortBy[B](f: A => B)(implicit B: Order[B]): NonEmptySeq[A] =
+    new NonEmptySeq(toSeq.sortBy(f)(B.toOrdering))
+
+  def sorted[AA >: A](implicit AA: Order[AA]): NonEmptySeq[AA] =
+    new NonEmptySeq(toSeq.sorted(AA.toOrdering))
+
+  /**
+   * Groups elements inside this `NonEmptySeq` according to the `Order`
+   * of the keys produced by the given mapping function.
+   *
+   * {{{
+   * scala> import scala.collection.immutable.SortedMap
+   * scala> import cats.data.NonEmptySeq
+   * scala> import cats.implicits._
+   * scala> val neSeq = NonEmptySeq.of(12, -2, 3, -5)
+   * scala> val expectedResult = SortedMap(false -> NonEmptySeq.of(-2, -5), true -> NonEmptySeq.of(12, 3))
+   * scala> val result = neSeq.groupBy(_ >= 0)
+   * scala> result === expectedResult
+   * res0: Boolean = true
+   * }}}
+   */
+  final def groupBy[B](f: A => B)(implicit B: Order[B]): SortedMap[B, NonEmptySeq[A]] = {
+    implicit val ordering: Ordering[B] = B.toOrdering
+    var m = TreeMap.empty[B, mutable.Builder[A, Seq[A]]]
+
+    for { elem <- toSeq } {
+      val k = f(elem)
+
+      m.get(k) match {
+        case None          => m += ((k, Seq.newBuilder[A] += elem))
+        case Some(builder) => builder += elem
+      }
+    }
+
+    m.map { case (k, v) =>
+      (k, NonEmptySeq.fromSeqUnsafe(v.result()))
+    }: TreeMap[B, NonEmptySeq[A]]
+  }
+
+  /**
+   * Groups elements inside this `NonEmptySeq` according to the `Order`
+   * of the keys produced by the given mapping function.
+   *
+   * {{{
+   * scala> import cats.data.{NonEmptyMap, NonEmptySeq}
+   * scala> import cats.implicits._
+   * scala> val nel = NonEmptySeq.of(12, -2, 3, -5)
+   * scala> val expectedResult = NonEmptyMap.of(false -> NonEmptySeq.of(-2, -5), true -> NonEmptySeq.of(12, 3))
+   * scala> val result = nel.groupByNem(_ >= 0)
+   * scala> result === expectedResult
+   * res0: Boolean = true
+   * }}}
+   */
+  final def groupByNem[B](f: A => B)(implicit B: Order[B]): NonEmptyMap[B, NonEmptySeq[A]] =
+    NonEmptyMap.fromMapUnsafe(groupBy(f))
+
+  /**
+   * Creates new `NonEmptyMap`, similarly to List#toMap from scala standard library.
+   * {{{
+   * scala> import cats.data.{NonEmptyMap, NonEmptySeq}
+   * scala> import cats.implicits._
+   * scala> import scala.collection.immutable.Seq
+   * scala> val neSeq = NonEmptySeq((0, "a"), Seq((1, "b"),(0, "c"), (2, "d")))
+   * scala> val expectedResult = NonEmptyMap.of(0 -> "c", 1 -> "b", 2 -> "d")
+   * scala> val result = neSeq.toNem
+   * scala> result === expectedResult
+   * res0: Boolean = true
+   * }}}
+   */
+  final def toNem[T, U](implicit ev: A <:< (T, U), order: Order[T]): NonEmptyMap[T, U] =
+    NonEmptyMap.fromMapUnsafe(SortedMap(toSeq.map(ev): _*)(order.toOrdering))
+
+  /**
+   * Creates new `NonEmptySet`, similarly to List#toSet from scala standard library.
+   * {{{
+   * scala> import cats.data._
+   * scala> import cats.instances.int._
+   * scala> import scala.collection.immutable.Seq
+   * scala> val neSeq = NonEmptySeq(1, Seq(2,2,3,4))
+   * scala> neSeq.toNes
+   * res0: cats.data.NonEmptySet[Int] = TreeSet(1, 2, 3, 4)
+   * }}}
+   */
+  final def toNes[B >: A](implicit order: Order[B]): NonEmptySet[B] =
+    NonEmptySet.of(head, tail: _*)
+}
+
+@suppressUnusedImportWarningForScalaVersionSpecific
+sealed abstract private[data] class NonEmptySeqInstances {
+
+  /**
+   * This is not a bug. The declared type of `catsDataInstancesForNonEmptySeq` intentionally ignores
+   * `NonEmptyReducible` trait for it not being a typeclass.
+   *
+   * Also see the discussion: PR #3541 and issue #3069.
+   */
+  implicit val catsDataInstancesForNonEmptySeq
+    : SemigroupK[NonEmptySeq] with Bimonad[NonEmptySeq] with NonEmptyTraverse[NonEmptySeq] with Align[NonEmptySeq] =
+    new NonEmptyReducible[NonEmptySeq, Seq]
+      with SemigroupK[NonEmptySeq]
+      with Bimonad[NonEmptySeq]
+      with NonEmptyTraverse[NonEmptySeq]
+      with Align[NonEmptySeq] {
+
+      def combineK[A](a: NonEmptySeq[A], b: NonEmptySeq[A]): NonEmptySeq[A] =
+        a.concatNeSeq(b)
+
+      override def split[A](fa: NonEmptySeq[A]): (A, Seq[A]) = (fa.head, fa.tail)
+
+      override def size[A](fa: NonEmptySeq[A]): Long = fa.length.toLong
+
+      override def reduceLeft[A](fa: NonEmptySeq[A])(f: (A, A) => A): A =
+        fa.reduceLeft(f)
+
+      override def reduce[A](fa: NonEmptySeq[A])(implicit A: Semigroup[A]): A =
+        fa.reduce
+
+      override def map[A, B](fa: NonEmptySeq[A])(f: A => B): NonEmptySeq[B] =
+        fa.map(f)
+
+      def pure[A](x: A): NonEmptySeq[A] =
+        NonEmptySeq.one(x)
+
+      def flatMap[A, B](fa: NonEmptySeq[A])(f: A => NonEmptySeq[B]): NonEmptySeq[B] =
+        fa.flatMap(f)
+
+      def coflatMap[A, B](fa: NonEmptySeq[A])(f: NonEmptySeq[A] => B): NonEmptySeq[B] = {
+        @tailrec def consume(as: Seq[A], buf: mutable.Builder[B, Seq[B]]): Seq[B] =
+          as match {
+            case a +: as => consume(as, buf += f(NonEmptySeq(a, as)))
+            case _       => buf.result()
+          }
+        NonEmptySeq(f(fa), consume(fa.tail, Seq.newBuilder[B]))
+      }
+
+      def extract[A](fa: NonEmptySeq[A]): A = fa.head
+
+      def nonEmptyTraverse[G[_], A, B](
+        nev: NonEmptySeq[A]
+      )(f: A => G[B])(implicit G: Apply[G]): G[NonEmptySeq[B]] = {
+        def loop(head: A, tail: Seq[A]): Eval[G[NonEmptySeq[B]]] =
+          tail.headOption.fold(Eval.now(G.map(f(head))(NonEmptySeq(_, Seq.empty[B]))))(h =>
+            G.map2Eval(f(head), Eval.defer(loop(h, tail.tail)))((b, acc) => b +: acc)
+          )
+
+        loop(nev.head, nev.tail).value
+      }
+
+      override def traverse[G[_], A, B](
+        fa: NonEmptySeq[A]
+      )(f: (A) => G[B])(implicit G: Applicative[G]): G[NonEmptySeq[B]] =
+        G.map2Eval(f(fa.head), Always(Traverse[Seq].traverse(fa.tail)(f)))(NonEmptySeq(_, _)).value
+
+      override def zipWithIndex[A](fa: NonEmptySeq[A]): NonEmptySeq[(A, Int)] =
+        fa.zipWithIndex
+
+      override def foldLeft[A, B](fa: NonEmptySeq[A], b: B)(f: (B, A) => B): B =
+        fa.foldLeft(b)(f)
+
+      override def foldRight[A, B](fa: NonEmptySeq[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
+        fa.foldRight(lb)(f)
+
+      override def foldMap[A, B](fa: NonEmptySeq[A])(f: A => B)(implicit B: Monoid[B]): B =
+        B.combineAll(fa.toSeq.iterator.map(f))
+
+      override def nonEmptyPartition[A, B, C](
+        fa: NonEmptySeq[A]
+      )(f: (A) => Either[B, C]): Ior[NonEmptyList[B], NonEmptyList[C]] = {
+        val reversed = fa.reverse
+        val lastIor = f(reversed.head) match {
+          case Right(c) => Ior.right(NonEmptyList.one(c))
+          case Left(b)  => Ior.left(NonEmptyList.one(b))
+        }
+
+        reversed.tail.foldLeft(lastIor)((ior, a) =>
+          (f(a), ior) match {
+            case (Right(c), Ior.Left(_)) => ior.putRight(NonEmptyList.one(c))
+            case (Right(c), _)           => ior.map(c :: _)
+            case (Left(b), Ior.Right(r)) => Ior.bothNel(b, r)
+            case (Left(b), _)            => ior.leftMap(b :: _)
+          }
+        )
+      }
+
+      override def get[A](fa: NonEmptySeq[A])(idx: Long): Option[A] =
+        if (0 <= idx && idx < Int.MaxValue) fa.get(idx.toInt) else None
+
+      def tailRecM[A, B](a: A)(f: A => NonEmptySeq[Either[A, B]]): NonEmptySeq[B] = {
+        val buf = Seq.newBuilder[B]
+        @tailrec def go(v: NonEmptySeq[Either[A, B]]): Unit =
+          v.head match {
+            case Right(b) =>
+              buf += b
+              NonEmptySeq.fromSeq(v.tail) match {
+                case Some(t) => go(t)
+                case None    => ()
+              }
+            case Left(a) => go(f(a).concat(v.tail))
+          }
+        go(f(a))
+        NonEmptySeq.fromSeqUnsafe(buf.result())
+      }
+
+      override def fold[A](fa: NonEmptySeq[A])(implicit A: Monoid[A]): A =
+        fa.reduce
+
+      override def find[A](fa: NonEmptySeq[A])(f: A => Boolean): Option[A] =
+        fa.find(f)
+
+      override def forall[A](fa: NonEmptySeq[A])(p: A => Boolean): Boolean =
+        fa.forall(p)
+
+      override def exists[A](fa: NonEmptySeq[A])(p: A => Boolean): Boolean =
+        fa.exists(p)
+
+      override def toList[A](fa: NonEmptySeq[A]): List[A] = fa.toSeq.toList
+
+      override def toNonEmptyList[A](fa: NonEmptySeq[A]): NonEmptyList[A] =
+        NonEmptyList(fa.head, fa.tail.toList)
+
+      def functor: Functor[NonEmptySeq] = this
+
+      def align[A, B](fa: NonEmptySeq[A], fb: NonEmptySeq[B]): NonEmptySeq[Ior[A, B]] =
+        NonEmptySeq.fromSeqUnsafe(Align[Seq].align(fa.toSeq, fb.toSeq))
+
+      override def alignWith[A, B, C](fa: NonEmptySeq[A], fb: NonEmptySeq[B])(
+        f: Ior[A, B] => C
+      ): NonEmptySeq[C] =
+        NonEmptySeq.fromSeqUnsafe(Align[Seq].alignWith(fa.toSeq, fb.toSeq)(f))
+    }
+
+  implicit def catsDataEqForNonEmptySeq[A](implicit A: Eq[A]): Eq[NonEmptySeq[A]] =
+    new Eq[NonEmptySeq[A]] {
+      def eqv(x: NonEmptySeq[A], y: NonEmptySeq[A]): Boolean = x === y
+    }
+
+  implicit def catsDataShowForNonEmptySeq[A](implicit A: Show[A]): Show[NonEmptySeq[A]] =
+    Show.show[NonEmptySeq[A]](_.show)
+
+  implicit def catsDataSemigroupForNonEmptySeq[A]: Semigroup[NonEmptySeq[A]] =
+    catsDataInstancesForNonEmptySeq.algebra
+
+  implicit def catsDataParallelForNonEmptySeq: NonEmptyParallel.Aux[NonEmptySeq, ZipNonEmptySeq] =
+    new NonEmptyParallel[NonEmptySeq] {
+      type F[x] = ZipNonEmptySeq[x]
+
+      def apply: Apply[ZipNonEmptySeq] = ZipNonEmptySeq.catsDataCommutativeApplyForZipNonEmptySeq
+      def flatMap: FlatMap[NonEmptySeq] = NonEmptySeq.catsDataInstancesForNonEmptySeq
+
+      def sequential: ZipNonEmptySeq ~> NonEmptySeq =
+        new (ZipNonEmptySeq ~> NonEmptySeq) { def apply[A](a: ZipNonEmptySeq[A]): NonEmptySeq[A] = a.value }
+
+      def parallel: NonEmptySeq ~> ZipNonEmptySeq =
+        new (NonEmptySeq ~> ZipNonEmptySeq) {
+          def apply[A](nev: NonEmptySeq[A]): ZipNonEmptySeq[A] = new ZipNonEmptySeq(nev)
+        }
+    }
+
+}
+
+object NonEmptySeq extends NonEmptySeqInstances with Serializable {
+
+  def apply[A](head: A, tail: Seq[A]): NonEmptySeq[A] =
+    new NonEmptySeq(head +: tail)
+
+  def of[A](head: A, tail: A*): NonEmptySeq[A] = {
+    val buf = Seq.newBuilder[A]
+    buf += head
+    tail.foreach(buf += _)
+    new NonEmptySeq(buf.result())
+  }
+
+  def one[A](head: A): NonEmptySeq[A] = apply(head, Seq.empty[A])
+
+  def unapply[A](nev: NonEmptySeq[A]): Some[(A, Seq[A])] = Some((nev.head, nev.tail))
+
+  def fromSeq[A](Seq: Seq[A]): Option[NonEmptySeq[A]] =
+    if (Seq.isEmpty) None else Some(new NonEmptySeq(Seq))
+
+  def fromSeqUnsafe[A](Seq: Seq[A]): NonEmptySeq[A] =
+    if (Seq.nonEmpty) new NonEmptySeq(Seq)
+    else throw new IllegalArgumentException("Cannot create NonEmptySeq from empty Seq")
+
+  class ZipNonEmptySeq[A](val value: NonEmptySeq[A]) extends Serializable
+
+  object ZipNonEmptySeq {
+
+    def apply[A](nev: NonEmptySeq[A]): ZipNonEmptySeq[A] =
+      new ZipNonEmptySeq(nev)
+
+    implicit val catsDataCommutativeApplyForZipNonEmptySeq: CommutativeApply[ZipNonEmptySeq] =
+      new CommutativeApply[ZipNonEmptySeq] {
+        def ap[A, B](ff: ZipNonEmptySeq[A => B])(fa: ZipNonEmptySeq[A]): ZipNonEmptySeq[B] =
+          ZipNonEmptySeq(ff.value.zipWith(fa.value)(_.apply(_)))
+
+        override def map[A, B](fa: ZipNonEmptySeq[A])(f: (A) => B): ZipNonEmptySeq[B] =
+          ZipNonEmptySeq(fa.value.map(f))
+
+        override def product[A, B](fa: ZipNonEmptySeq[A], fb: ZipNonEmptySeq[B]): ZipNonEmptySeq[(A, B)] =
+          ZipNonEmptySeq(fa.value.zipWith(fb.value) { case (a, b) => (a, b) })
+      }
+
+    @deprecated("Use catsDataEqForZipNonEmptySeq", "2.0.0-RC2")
+    private[data] def zipNevEq[A: Eq]: Eq[ZipNonEmptySeq[A]] = catsDataEqForZipNonEmptySeq[A]
+
+    implicit def catsDataEqForZipNonEmptySeq[A: Eq]: Eq[ZipNonEmptySeq[A]] = Eq.by(_.value)
+  }
+}

--- a/core/src/main/scala/cats/data/ZipSeq.scala
+++ b/core/src/main/scala/cats/data/ZipSeq.scala
@@ -1,0 +1,24 @@
+package cats
+package data
+
+import scala.collection.immutable.Seq
+import kernel.compat.scalaVersionSpecific._
+
+class ZipSeq[A](val value: Seq[A]) extends AnyVal
+
+@suppressUnusedImportWarningForScalaVersionSpecific
+object ZipSeq {
+
+  def apply[A](value: Seq[A]): ZipSeq[A] = new ZipSeq(value)
+
+  implicit val catsDataCommutativeApplyForZipSeq: CommutativeApply[ZipSeq] = new CommutativeApply[ZipSeq] {
+
+    override def map[A, B](fa: ZipSeq[A])(f: (A) => B): ZipSeq[B] =
+      ZipSeq(fa.value.map(f))
+    def ap[A, B](ff: ZipSeq[A => B])(fa: ZipSeq[A]): ZipSeq[B] =
+      ZipSeq(ff.value.lazyZip(fa.value).map(_.apply(_)))
+
+  }
+
+  implicit def catsDataEqForZipSeq[A: Eq]: Eq[ZipSeq[A]] = Eq.by(_.value)
+}

--- a/core/src/main/scala/cats/instances/seq.scala
+++ b/core/src/main/scala/cats/instances/seq.scala
@@ -2,7 +2,6 @@ package cats
 package instances
 
 import cats.data.{Chain, ZipSeq}
-import cats.syntax.show._
 
 import scala.annotation.tailrec
 import scala.collection.{+:, mutable}
@@ -170,7 +169,7 @@ trait SeqInstances extends cats.kernel.instances.SeqInstances {
   implicit def catsStdShowForSeq[A: Show]: Show[Seq[A]] =
     new Show[Seq[A]] {
       def show(fa: Seq[A]): String =
-        fa.iterator.map(_.show).mkString("Seq(", ", ", ")")
+        fa.toString()
     }
 
   implicit def catsStdNonEmptyParallelForSeqZipSeq: NonEmptyParallel.Aux[Seq, ZipSeq] =

--- a/core/src/main/scala/cats/instances/seq.scala
+++ b/core/src/main/scala/cats/instances/seq.scala
@@ -1,0 +1,189 @@
+package cats
+package instances
+
+import cats.data.{Chain, ZipSeq}
+import cats.syntax.show._
+
+import scala.annotation.tailrec
+import scala.collection.{+:, mutable}
+import scala.collection.immutable.Seq
+import cats.data.Ior
+
+trait SeqInstances extends cats.kernel.instances.SeqInstances {
+  implicit val catsStdInstancesForSeq
+    : Traverse[Seq] with Monad[Seq] with Alternative[Seq] with CoflatMap[Seq] with Align[Seq] =
+    new Traverse[Seq] with Monad[Seq] with Alternative[Seq] with CoflatMap[Seq] with Align[Seq] {
+
+      def empty[A]: Seq[A] = Seq.empty[A]
+
+      def combineK[A](x: Seq[A], y: Seq[A]): Seq[A] = x ++ y
+
+      def pure[A](x: A): Seq[A] = Seq(x)
+
+      override def map[A, B](fa: Seq[A])(f: A => B): Seq[B] =
+        fa.map(f)
+
+      def flatMap[A, B](fa: Seq[A])(f: A => Seq[B]): Seq[B] =
+        fa.flatMap(f)
+
+      override def map2[A, B, Z](fa: Seq[A], fb: Seq[B])(f: (A, B) => Z): Seq[Z] =
+        if (fb.isEmpty) Seq.empty // do O(1) work if either is empty
+        else fa.flatMap(a => fb.map(b => f(a, b))) // already O(1) if fa is empty
+
+      private[this] val evalEmpty: Eval[Seq[Nothing]] = Eval.now(Seq.empty)
+
+      override def map2Eval[A, B, Z](fa: Seq[A], fb: Eval[Seq[B]])(f: (A, B) => Z): Eval[Seq[Z]] =
+        if (fa.isEmpty) evalEmpty // no need to evaluate fb
+        else fb.map(fb => map2(fa, fb)(f))
+
+      def coflatMap[A, B](fa: Seq[A])(f: Seq[A] => B): Seq[B] = {
+        @tailrec def loop(builder: mutable.Builder[B, Seq[B]], as: Seq[A]): Seq[B] =
+          as match {
+            case _ +: rest => loop(builder += f(as), rest)
+            case _         => builder.result()
+          }
+        loop(Seq.newBuilder[B], fa)
+      }
+
+      def foldLeft[A, B](fa: Seq[A], b: B)(f: (B, A) => B): B =
+        fa.foldLeft(b)(f)
+
+      def foldRight[A, B](fa: Seq[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] = {
+        def loop(i: Int): Eval[B] =
+          if (i < fa.length) f(fa(i), Eval.defer(loop(i + 1))) else lb
+        Eval.defer(loop(0))
+      }
+
+      override def foldMap[A, B](fa: Seq[A])(f: A => B)(implicit B: Monoid[B]): B =
+        B.combineAll(fa.iterator.map(f))
+
+      def tailRecM[A, B](a: A)(fn: A => Seq[Either[A, B]]): Seq[B] = {
+        val buf = Seq.newBuilder[B]
+        var state = List(fn(a).iterator)
+        @tailrec
+        def loop(): Unit =
+          state match {
+            case Nil => ()
+            case h :: tail if h.isEmpty =>
+              state = tail
+              loop()
+            case h :: tail =>
+              h.next() match {
+                case Right(b) =>
+                  buf += b
+                  loop()
+                case Left(a) =>
+                  state = (fn(a).iterator) :: h :: tail
+                  loop()
+              }
+          }
+        loop()
+        buf.result()
+      }
+
+      override def size[A](fa: Seq[A]): Long = fa.size.toLong
+
+      override def get[A](fa: Seq[A])(idx: Long): Option[A] =
+        if (idx < Int.MaxValue && fa.size > idx && idx >= 0) Some(fa(idx.toInt)) else None
+
+      override def foldMapK[G[_], A, B](fa: Seq[A])(f: A => G[B])(implicit G: MonoidK[G]): G[B] = {
+        def loop(i: Int): Eval[G[B]] =
+          if (i < fa.length) G.combineKEval(f(fa(i)), Eval.defer(loop(i + 1))) else Eval.now(G.empty)
+        loop(0).value
+      }
+
+      final override def traverse[G[_], A, B](fa: Seq[A])(f: A => G[B])(implicit G: Applicative[G]): G[Seq[B]] =
+        G.map(Chain.traverseViaChain(fa.toIndexedSeq)(f))(_.toVector)
+
+      override def mapWithIndex[A, B](fa: Seq[A])(f: (A, Int) => B): Seq[B] =
+        fa.iterator.zipWithIndex.map(ai => f(ai._1, ai._2)).toIndexedSeq
+
+      override def zipWithIndex[A](fa: Seq[A]): Seq[(A, Int)] =
+        fa.zipWithIndex
+
+      override def exists[A](fa: Seq[A])(p: A => Boolean): Boolean =
+        fa.exists(p)
+
+      override def isEmpty[A](fa: Seq[A]): Boolean = fa.isEmpty
+
+      override def foldM[G[_], A, B](fa: Seq[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] = {
+        val length = fa.length
+        G.tailRecM((z, 0)) { case (b, i) =>
+          if (i < length) G.map(f(b, fa(i)))(b => Left((b, i + 1)))
+          else G.pure(Right(b))
+        }
+      }
+
+      override def fold[A](fa: Seq[A])(implicit A: Monoid[A]): A = A.combineAll(fa)
+
+      override def toList[A](fa: Seq[A]): List[A] = fa.toList
+
+      override def reduceLeftOption[A](fa: Seq[A])(f: (A, A) => A): Option[A] =
+        fa.reduceLeftOption(f)
+
+      override def find[A](fa: Seq[A])(f: A => Boolean): Option[A] = fa.find(f)
+
+      override def algebra[A]: Monoid[Seq[A]] = new kernel.instances.SeqMonoid[A]
+
+      def functor: Functor[Seq] = this
+
+      def align[A, B](fa: Seq[A], fb: Seq[B]): Seq[A Ior B] = {
+        val aLarger = fa.size >= fb.size
+        if (aLarger) {
+          cats.compat.Seq.zipWith(fa, fb)(Ior.both) ++ fa.drop(fb.size).map(Ior.left)
+        } else {
+          cats.compat.Seq.zipWith(fa, fb)(Ior.both) ++ fb.drop(fa.size).map(Ior.right)
+        }
+      }
+
+      override def collectFirst[A, B](fa: Seq[A])(pf: PartialFunction[A, B]): Option[B] = fa.collectFirst(pf)
+
+      override def collectFirstSome[A, B](fa: Seq[A])(f: A => Option[B]): Option[B] =
+        fa.collectFirst(Function.unlift(f))
+    }
+
+  implicit val catsStdTraverseFilterForSeq: TraverseFilter[Seq] = new TraverseFilter[Seq] {
+    val traverse: Traverse[Seq] = cats.instances.seq.catsStdInstancesForSeq
+
+    override def mapFilter[A, B](fa: Seq[A])(f: (A) => Option[B]): Seq[B] =
+      fa.collect(Function.unlift(f))
+
+    override def filter[A](fa: Seq[A])(f: (A) => Boolean): Seq[A] = fa.filter(f)
+
+    override def filterNot[A](fa: Seq[A])(f: A => Boolean): Seq[A] = fa.filterNot(f)
+
+    override def collect[A, B](fa: Seq[A])(f: PartialFunction[A, B]): Seq[B] = fa.collect(f)
+
+    override def flattenOption[A](fa: Seq[Option[A]]): Seq[A] = fa.flatten
+
+    def traverseFilter[G[_], A, B](fa: Seq[A])(f: (A) => G[Option[B]])(implicit G: Applicative[G]): G[Seq[B]] =
+      G.map(Chain.traverseFilterViaChain(fa.toIndexedSeq)(f))(_.toVector)
+
+    override def filterA[G[_], A](fa: Seq[A])(f: (A) => G[Boolean])(implicit G: Applicative[G]): G[Seq[A]] =
+      traverse
+        .foldRight(fa, Eval.now(G.pure(Seq.empty[A])))((x, xse) =>
+          G.map2Eval(f(x), xse)((b, Seq) => if (b) x +: Seq else Seq)
+        )
+        .value
+  }
+
+  implicit def catsStdShowForSeq[A: Show]: Show[Seq[A]] =
+    new Show[Seq[A]] {
+      def show(fa: Seq[A]): String =
+        fa.iterator.map(_.show).mkString("Seq(", ", ", ")")
+    }
+
+  implicit def catsStdNonEmptyParallelForSeqZipSeq: NonEmptyParallel.Aux[Seq, ZipSeq] =
+    new NonEmptyParallel[Seq] {
+      type F[x] = ZipSeq[x]
+
+      def flatMap: FlatMap[Seq] = cats.instances.seq.catsStdInstancesForSeq
+      def apply: Apply[ZipSeq] = ZipSeq.catsDataCommutativeApplyForZipSeq
+
+      def sequential: ZipSeq ~> Seq =
+        new (ZipSeq ~> Seq) { def apply[A](a: ZipSeq[A]): Seq[A] = a.value }
+
+      def parallel: Seq ~> ZipSeq =
+        new (Seq ~> ZipSeq) { def apply[A](v: Seq[A]): ZipSeq[A] = new ZipSeq(v) }
+    }
+}

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -10,6 +10,7 @@ abstract class AllSyntaxBinCompat
     with AllSyntaxBinCompat4
     with AllSyntaxBinCompat5
     with AllSyntaxBinCompat6
+    with AllSyntaxBinCompat7
 
 trait AllSyntax
     extends AlternativeSyntax
@@ -96,3 +97,5 @@ trait AllSyntaxBinCompat4
 trait AllSyntaxBinCompat5 extends ParallelBitraverseSyntax
 
 trait AllSyntaxBinCompat6 extends ParallelUnorderedTraverseSyntax
+
+trait AllSyntaxBinCompat7 extends SeqSyntax

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -57,6 +57,7 @@ package object syntax {
   object semigroup extends SemigroupSyntax
   object semigroupal extends SemigroupalSyntax
   object semigroupk extends SemigroupKSyntax
+  object seq extends SeqSyntax
   object show extends ShowSyntax
   object strong extends StrongSyntax
   object try_ extends TrySyntax

--- a/core/src/main/scala/cats/syntax/seq.scala
+++ b/core/src/main/scala/cats/syntax/seq.scala
@@ -1,0 +1,12 @@
+package cats.syntax
+
+import cats.data.NonEmptySeq
+import scala.collection.immutable.Seq
+
+trait SeqSyntax {
+  implicit final def catsSyntaxSeqs[A](va: Seq[A]): SeqOps[A] = new SeqOps(va)
+}
+
+final class SeqOps[A](private val va: Seq[A]) extends AnyVal {
+  def toNeSeq: Option[NonEmptySeq[A]] = NonEmptySeq.fromSeq(va)
+}

--- a/kernel/src/main/scala-2.12/cats/kernel/instances/AllInstances.scala
+++ b/kernel/src/main/scala-2.12/cats/kernel/instances/AllInstances.scala
@@ -24,6 +24,7 @@ trait AllInstances
     with PartialOrderInstances
     with QueueInstances
     with SetInstances
+    with SeqInstances
     with ShortInstances
     with StreamInstances
     with StringInstances

--- a/kernel/src/main/scala-2.13+/cats/kernel/instances/AllInstances.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/instances/AllInstances.scala
@@ -26,6 +26,7 @@ trait AllInstances
     with PartialOrderInstances
     with QueueInstances
     with SetInstances
+    with SeqInstances
     with ShortInstances
     with StreamInstances
     with StringInstances

--- a/kernel/src/main/scala/cats/kernel/Eq.scala
+++ b/kernel/src/main/scala/cats/kernel/Eq.scala
@@ -4,7 +4,7 @@ import java.util.UUID
 
 import cats.kernel.compat.scalaVersionSpecific._
 
-import scala.collection.immutable.{BitSet, Queue, SortedMap, SortedSet}
+import scala.collection.immutable.{BitSet, Queue, Seq, SortedMap, SortedSet}
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.math.Equiv
 import scala.util.{Failure, Success, Try}
@@ -194,6 +194,8 @@ object Eq
     cats.kernel.instances.option.catsKernelStdOrderForOption[A]
   implicit def catsKernelOrderForList[A: Order]: Order[List[A]] =
     cats.kernel.instances.list.catsKernelStdOrderForList[A]
+  implicit def catsKernelOrderForSeq[A: Order]: Order[Seq[A]] =
+    cats.kernel.instances.seq.catsKernelStdOrderForSeq[A]
   implicit def catsKernelOrderForVector[A: Order]: Order[Vector[A]] =
     cats.kernel.instances.vector.catsKernelStdOrderForVector[A]
   implicit def catsKernelOrderForQueue[A: Order]: Order[Queue[A]] =
@@ -224,6 +226,8 @@ private[kernel] trait PartialOrderInstances extends HashInstances {
     cats.kernel.instances.option.catsKernelStdPartialOrderForOption[A]
   implicit def catsKernelPartialOrderForList[A: PartialOrder]: PartialOrder[List[A]] =
     cats.kernel.instances.list.catsKernelStdPartialOrderForList[A]
+  implicit def catsKernelPartialOrderForSeq[A: PartialOrder]: PartialOrder[Seq[A]] =
+    cats.kernel.instances.seq.catsKernelStdPartialOrderForSeq[A]
   implicit def catsKernelPartialOrderForVector[A: PartialOrder]: PartialOrder[Vector[A]] =
     cats.kernel.instances.vector.catsKernelStdPartialOrderForVector[A]
   implicit def catsKernelPartialOrderForQueue[A: PartialOrder]: PartialOrder[Queue[A]] =
@@ -237,6 +241,7 @@ private[kernel] trait HashInstances extends EqInstances {
   implicit def catsKernelHashForOption[A: Hash]: Hash[Option[A]] =
     cats.kernel.instances.option.catsKernelStdHashForOption[A]
   implicit def catsKernelHashForList[A: Hash]: Hash[List[A]] = cats.kernel.instances.list.catsKernelStdHashForList[A]
+  implicit def catsKernelHashForSeq[A: Hash]: Hash[Seq[A]] = cats.kernel.instances.seq.catsKernelStdHashForSeq[A]
   implicit def catsKernelHashForVector[A: Hash]: Hash[Vector[A]] =
     cats.kernel.instances.vector.catsKernelStdHashForVector[A]
   implicit def catsKernelHashForQueue[A: Hash]: Hash[Queue[A]] =
@@ -256,6 +261,7 @@ private[kernel] trait HashInstances extends EqInstances {
 private[kernel] trait EqInstances {
   implicit def catsKernelEqForOption[A: Eq]: Eq[Option[A]] = cats.kernel.instances.option.catsKernelStdEqForOption[A]
   implicit def catsKernelEqForList[A: Eq]: Eq[List[A]] = cats.kernel.instances.list.catsKernelStdEqForList[A]
+  implicit def catsKernelEqForSeq[A: Eq]: Eq[Seq[A]] = cats.kernel.instances.seq.catsKernelStdEqForSeq[A]
   implicit def catsKernelEqForVector[A: Eq]: Eq[Vector[A]] = cats.kernel.instances.vector.catsKernelStdEqForVector[A]
   implicit def catsKernelEqForQueue[A: Eq]: Eq[Queue[A]] = cats.kernel.instances.queue.catsKernelStdEqForQueue[A]
   implicit def catsKernelEqForFunction0[A: Eq]: Eq[() => A] = cats.kernel.instances.function.catsKernelEqForFunction0[A]

--- a/kernel/src/main/scala/cats/kernel/instances/SeqInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/SeqInstances.scala
@@ -1,0 +1,59 @@
+package cats.kernel
+package instances
+
+import compat.scalaVersionSpecific._
+import scala.collection.immutable.Seq
+
+@suppressUnusedImportWarningForScalaVersionSpecific
+trait SeqInstances extends SeqInstances1 {
+  implicit def catsKernelStdOrderForSeq[A: Order]: Order[Seq[A]] =
+    new SeqOrder[A]
+  implicit def catsKernelStdMonoidForSeq[A]: Monoid[Seq[A]] =
+    new SeqMonoid[A]
+}
+
+private[instances] trait SeqInstances1 extends SeqInstances2 {
+  implicit def catsKernelStdPartialOrderForSeq[A: PartialOrder]: PartialOrder[Seq[A]] =
+    new SeqPartialOrder[A]
+
+  implicit def catsKernelStdHashForSeq[A: Hash]: Hash[Seq[A]] =
+    new SeqHash[A]
+}
+
+private[instances] trait SeqInstances2 {
+  implicit def catsKernelStdEqForSeq[A: Eq]: Eq[Seq[A]] =
+    new SeqEq[A]
+}
+
+class SeqOrder[A](implicit ev: Order[A]) extends Order[Seq[A]] {
+  def compare(xs: Seq[A], ys: Seq[A]): Int =
+    if (xs eq ys) 0
+    else StaticMethods.iteratorCompare(xs.iterator, ys.iterator)
+}
+
+class SeqPartialOrder[A](implicit ev: PartialOrder[A]) extends PartialOrder[Seq[A]] {
+  def partialCompare(xs: Seq[A], ys: Seq[A]): Double =
+    if (xs eq ys) 0.0
+    else StaticMethods.iteratorPartialCompare(xs.iterator, ys.iterator)
+}
+
+class SeqHash[A](implicit ev: Hash[A]) extends SeqEq[A] with Hash[Seq[A]] {
+  def hash(xs: Seq[A]): Int = StaticMethods.orderedHash(xs)
+}
+
+class SeqEq[A](implicit ev: Eq[A]) extends Eq[Seq[A]] {
+  def eqv(xs: Seq[A], ys: Seq[A]): Boolean =
+    if (xs eq ys) true
+    else StaticMethods.iteratorEq(xs.iterator, ys.iterator)
+}
+
+class SeqMonoid[A] extends Monoid[Seq[A]] {
+  def empty: Seq[A] = Seq.empty
+  def combine(x: Seq[A], y: Seq[A]): Seq[A] = x ++ y
+
+  override def combineN(x: Seq[A], n: Int): Seq[A] =
+    StaticMethods.combineNIterable(Seq.newBuilder[A], x, n)
+
+  override def combineAll(xs: IterableOnce[Seq[A]]): Seq[A] =
+    StaticMethods.combineAllIterable(Seq.newBuilder[A], xs)
+}

--- a/kernel/src/main/scala/cats/kernel/instances/seq/package.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/seq/package.scala
@@ -1,0 +1,4 @@
+package cats.kernel
+package instances
+
+package object seq extends SeqInstances

--- a/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
@@ -70,6 +70,9 @@ object arbitrary extends ArbitraryInstances0 with ScalaVersionSpecific.Arbitrary
   implicit def catsLawsCogenForNonEmptySet[A: Order: Cogen]: Cogen[NonEmptySet[A]] =
     Cogen[SortedSet[A]].contramap(_.toSortedSet)
 
+  implicit def catsLawsArbitraryForZipSeq[A](implicit A: Arbitrary[A]): Arbitrary[ZipSeq[A]] =
+    Arbitrary(implicitly[Arbitrary[Seq[A]]].arbitrary.map(v => new ZipSeq(v)))
+
   implicit def catsLawsArbitraryForZipVector[A](implicit A: Arbitrary[A]): Arbitrary[ZipVector[A]] =
     Arbitrary(implicitly[Arbitrary[Vector[A]]].arbitrary.map(v => new ZipVector(v)))
 

--- a/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
@@ -6,7 +6,7 @@ import cats.data.NonEmptyList.ZipNonEmptyList
 import cats.data.NonEmptyVector.ZipNonEmptyVector
 
 import scala.util.{Failure, Success, Try}
-import scala.collection.immutable.{SortedMap, SortedSet}
+import scala.collection.immutable.{SortedMap, SortedSet, Seq}
 import cats.data._
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import org.scalacheck.Arbitrary.{arbitrary => getArbitrary}
@@ -51,6 +51,12 @@ object arbitrary extends ArbitraryInstances0 with ScalaVersionSpecific.Arbitrary
 
   implicit def catsLawsCogenForOneAnd[F[_], A](implicit A: Cogen[A], F: Cogen[F[A]]): Cogen[OneAnd[F, A]] =
     Cogen((seed, x) => F.perturb(A.perturb(seed, x.head), x.tail))
+
+  implicit def catsLawsArbitraryForNonEmptySeq[A](implicit A: Arbitrary[A]): Arbitrary[NonEmptySeq[A]] =
+    Arbitrary(implicitly[Arbitrary[Seq[A]]].arbitrary.flatMap(fa => A.arbitrary.map(a => NonEmptySeq(a, fa))))
+
+  implicit def catsLawsCogenForNonEmptySeq[A](implicit A: Cogen[A]): Cogen[NonEmptySeq[A]] =
+    Cogen[Seq[A]].contramap(_.toSeq)
 
   implicit def catsLawsArbitraryForNonEmptyVector[A](implicit A: Arbitrary[A]): Arbitrary[NonEmptyVector[A]] =
     Arbitrary(implicitly[Arbitrary[Vector[A]]].arbitrary.flatMap(fa => A.arbitrary.map(a => NonEmptyVector(a, fa))))

--- a/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
@@ -6,7 +6,7 @@ import cats.data.NonEmptyList.ZipNonEmptyList
 import cats.data.NonEmptyVector.ZipNonEmptyVector
 
 import scala.util.{Failure, Success, Try}
-import scala.collection.immutable.{SortedMap, SortedSet, Seq}
+import scala.collection.immutable.{Seq, SortedMap, SortedSet}
 import cats.data._
 import org.scalacheck.{Arbitrary, Cogen, Gen}
 import org.scalacheck.Arbitrary.{arbitrary => getArbitrary}

--- a/tests/src/test/scala/cats/tests/SeqSuite.scala
+++ b/tests/src/test/scala/cats/tests/SeqSuite.scala
@@ -49,10 +49,6 @@ class SeqSuite extends CatsSuite {
   checkAll("ZipSeq[Int]", CommutativeApplyTests[ZipSeq].commutativeApply[Int, Int, Int])
 
   test("show") {
-    assert(Seq(1, 2, 3).show === "Seq(1, 2, 3)")
-
-    assert(Seq.empty[Int].show === "Seq()")
-
     forAll { (seq: Seq[String]) =>
       assert(seq.show === (seq.toString))
     }

--- a/tests/src/test/scala/cats/tests/SeqSuite.scala
+++ b/tests/src/test/scala/cats/tests/SeqSuite.scala
@@ -1,0 +1,90 @@
+package cats.tests
+
+import cats.{Align, Alternative, CoflatMap, Monad, Semigroupal, Traverse, TraverseFilter}
+import cats.data.{NonEmptySeq, ZipSeq}
+import cats.laws.discipline.{
+  AlignTests,
+  AlternativeTests,
+  CoflatMapTests,
+  CommutativeApplyTests,
+  MonadTests,
+  SemigroupalTests,
+  SerializableTests,
+  ShortCircuitingTests,
+  TraverseFilterTests,
+  TraverseTests
+}
+import cats.laws.discipline.arbitrary._
+import cats.syntax.show._
+import cats.syntax.seq._
+import cats.syntax.eq._
+import org.scalacheck.Prop._
+import scala.collection.immutable.Seq
+
+class SeqSuite extends CatsSuite {
+  checkAll("Seq[Int]", SemigroupalTests[Seq].semigroupal[Int, Int, Int])
+  checkAll("Semigroupal[Seq]", SerializableTests.serializable(Semigroupal[Seq]))
+
+  checkAll("Seq[Int]", CoflatMapTests[Seq].coflatMap[Int, Int, Int])
+  checkAll("CoflatMap[Seq]", SerializableTests.serializable(CoflatMap[Seq]))
+
+  checkAll("Seq[Int]", AlternativeTests[Seq].alternative[Int, Int, Int])
+  checkAll("Alternative[Seq]", SerializableTests.serializable(Alternative[Seq]))
+
+  checkAll("Seq[Int] with Option", TraverseTests[Seq].traverse[Int, Int, Int, Set[Int], Option, Option])
+  checkAll("Traverse[Seq]", SerializableTests.serializable(Traverse[Seq]))
+
+  checkAll("Seq[Int]", MonadTests[Seq].monad[Int, Int, Int])
+  checkAll("Monad[Seq]", SerializableTests.serializable(Monad[Seq]))
+
+  checkAll("Seq[Int]", TraverseFilterTests[Seq].traverseFilter[Int, Int, Int])
+  checkAll("TraverseFilter[Seq]", SerializableTests.serializable(TraverseFilter[Seq]))
+
+  checkAll("Seq[Int]", AlignTests[Seq].align[Int, Int, Int, Int])
+  checkAll("Align[Seq]", SerializableTests.serializable(Align[Seq]))
+
+  checkAll("Seq[Int]", ShortCircuitingTests[Seq].traverseFilter[Int])
+  checkAll("Seq[Int]", ShortCircuitingTests[Seq].foldable[Int])
+
+  checkAll("ZipSeq[Int]", CommutativeApplyTests[ZipSeq].commutativeApply[Int, Int, Int])
+
+  test("show") {
+    assert(Seq(1, 2, 3).show === "Seq(1, 2, 3)")
+
+    assert(Seq.empty[Int].show === "Seq()")
+
+    forAll { (seq: Seq[String]) =>
+      assert(seq.show === (seq.toString))
+    }
+  }
+
+  test("neSeq => Seq => neSeq returns original neSeq")(
+    forAll { (fa: NonEmptySeq[Int]) =>
+      assert(fa.toSeq.toNeSeq == Some(fa))
+    }
+  )
+
+  test("toNeSeq on empty Seq returns None") {
+    assert(Seq.empty[Int].toNeSeq == None)
+  }
+
+  test("traverse is stack-safe") {
+    val seq = (0 until 100000).toSeq
+    val sumAll = Traverse[Seq]
+      .traverse(seq) { i => () => i }
+      .apply
+      .sum
+
+    assert(sumAll == seq.sum)
+  }
+}
+
+final class SeqInstancesSuite extends munit.FunSuite {
+
+  test("NonEmptyParallel instance in cats.instances.seq") {
+    import cats.instances.seq._
+    import cats.syntax.parallel._
+
+    (Seq(1, 2, 3), Seq("A", "B", "C")).parTupled
+  }
+}


### PR DESCRIPTION
Adds type class instances for `immutable.Seq`. This is based off of the implementations of the `List` and `Vector` typeclasses.

Closes #1222 
