### PR TITLE
improve WriterT factory methods with PartiallyApplied technique

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -414,7 +414,7 @@ def mimaSettings(moduleName: String, includeCats1: Boolean = true) =
           exclude[DirectMissingMethodProblem]("cats.data.WriterT.tell"),
           exclude[DirectMissingMethodProblem]("cats.data.WriterT.value"),
           exclude[DirectMissingMethodProblem]("cats.data.WriterT.valueT"),
-          exclude[DirectMissingMethodProblem]("cats.data.package#Writer.value"),
+          exclude[DirectMissingMethodProblem]("cats.data.package#Writer.value")
         )
     }
   )

--- a/build.sbt
+++ b/build.sbt
@@ -401,6 +401,20 @@ def mimaSettings(moduleName: String, includeCats1: Boolean = true) =
         ) ++ // Only narrowing of types allowed here
         Seq(
           exclude[IncompatibleSignatureProblem]("*")
+        ) ++ // Added to get a feedback
+        Seq(
+          exclude[DirectMissingMethodProblem]("cats.data.WriterTFunctions.putT"),
+          exclude[DirectMissingMethodProblem]("cats.data.WriterTFunctions.put"),
+          exclude[DirectMissingMethodProblem]("cats.data.WriterTFunctions.tell"),
+          exclude[DirectMissingMethodProblem]("cats.data.WriterTFunctions.value"),
+          exclude[DirectMissingMethodProblem]("cats.data.WriterTFunctions.valueT"),
+          exclude[DirectMissingMethodProblem]("cats.data.WriterTFunctions.putT"),
+          exclude[DirectMissingMethodProblem]("cats.data.WriterT.put"),
+          exclude[DirectMissingMethodProblem]("cats.data.WriterT.putT"),
+          exclude[DirectMissingMethodProblem]("cats.data.WriterT.tell"),
+          exclude[DirectMissingMethodProblem]("cats.data.WriterT.value"),
+          exclude[DirectMissingMethodProblem]("cats.data.WriterT.valueT"),
+          exclude[DirectMissingMethodProblem]("cats.data.package#Writer.value"),
         )
     }
   )

--- a/core/src/main/scala/cats/data/package.scala
+++ b/core/src/main/scala/cats/data/package.scala
@@ -33,9 +33,13 @@ package object data extends ScalaVersionSpecificPackage {
 
   type Writer[L, V] = WriterT[Id, L, V]
   object Writer {
+    final class ValuePartiallyApplied[L](private val dummy: Boolean = true) extends AnyVal {
+      def apply[V](v: V)(implicit monoid: Monoid[L]): Writer[L, V] = WriterT.value(v)
+    }
+
     def apply[L, V](l: L, v: V): WriterT[Id, L, V] = WriterT[Id, L, V]((l, v))
 
-    def value[L: Monoid, V](v: V): Writer[L, V] = WriterT.value(v)
+    def value[L] = new ValuePartiallyApplied[L]
 
     def tell[L](l: L): Writer[L, Unit] = WriterT.tell(l)
 

--- a/tests/src/test/scala/cats/tests/WriterTSuite.scala
+++ b/tests/src/test/scala/cats/tests/WriterTSuite.scala
@@ -58,49 +58,49 @@ class WriterTSuite extends CatsSuite {
 
   test("tell + written is identity") {
     forAll { (i: Int) =>
-      assert(WriterT.tell[Id, Int](i).written === i)
+      assert(WriterT.tell[Id](i).written === i)
     }
   }
 
   test("value + value is identity") {
     forAll { (i: Int) =>
-      assert(WriterT.value[Id, Int, Int](i).value === i)
+      assert(WriterT.value[Id, Int](i).value === i)
     }
   }
 
   test("valueT + value is identity") {
     forAll { (i: Int) =>
-      assert(WriterT.valueT[Id, Int, Int](i).value === i)
+      assert(WriterT.valueT[Id, Int](i).value === i)
     }
   }
 
   test("value + listen + map(_._1) + value is identity") {
     forAll { (i: Int) =>
-      assert(WriterT.value[Id, Int, Int](i).listen.map(_._1).value === i)
+      assert(WriterT.value[Id, Int](i).listen.map(_._1).value === i)
     }
   }
 
   test("tell + listen + map(_._2) + value is identity") {
     forAll { (i: Int) =>
-      assert(WriterT.tell[Id, Int](i).listen.map(_._2).value === i)
+      assert(WriterT.tell[Id](i).listen.map(_._2).value === i)
     }
   }
 
   test("Writer.pure and WriterT.liftF are consistent") {
     forAll { (i: Int) =>
-      val writer: Writer[String, Int] = Writer.value(i)
+      val writer = Writer.value[String](i)
       val writerT: WriterT[Option, String, Int] = WriterT.liftF(Some(i))
-      assert(writer.run.some === (writerT.run))
+      assert(writer.run.some === writerT.run)
     }
   }
 
   test("show") {
-    val writerT: WriterT[Id, List[String], String] = WriterT.put("foo")(List("Some log message"))
+    val writerT = WriterT.put[Id]("foo")(List("Some log message"))
     assert(writerT.show === "(List(Some log message),foo)")
   }
 
   test("tell appends to log") {
-    val w1: Writer[String, Int] = Writer.value(3)
+    val w1 = Writer.value[String](3)
     val w2 = w1.tell("foo")
     assert(w2 === (Writer("foo", 3)))
     assert(w2.tell("bar") === (Writer("foobar", 3)))
@@ -111,7 +111,7 @@ class WriterTSuite extends CatsSuite {
   }
 
   test("listen returns a tuple of value and log") {
-    val w: Writer[String, Int] = Writer("foo", 3)
+    val w = Writer("foo", 3)
     assert(w.listen === (Writer("foo", (3, "foo"))))
   }
 


### PR DESCRIPTION
The goal of PR is to change
```
WriterT.putT[F[_], L, V] -> WriterT.putT[F[_]]
WriterT.put[F[_], L, V] -> WriterT.put[F[_]]
WriterT.tell[F[_], L] -> WriterT.tell[F[_]]
WriterT.value[F[_], L, V] -> WriterT.value[F[_], L]
WriterT.valueT[F[_], L, V] -> WriterT.valueT[F[_], L]

Writer.value[L: Monoid, V] -> value[L]
```
So that you have to provide only those types, that can't be inferred automatically.

The biggest downside I see in this PR is that it backward incompatible, in a sense that it forces clients to change all the places, where mentioned methods are used. But the change is obvious - you just have to reduce the amount of information you provide to the compiler `putT[F, L, V](l)(v) -> putT[F](l)(v)`
