### PR TITLE
immutable.Seq missing semigroup

### DIFF
--- a/kernel/src/main/scala/cats/kernel/Semigroup.scala
+++ b/kernel/src/main/scala/cats/kernel/Semigroup.scala
@@ -1,7 +1,7 @@
 package cats.kernel
 
 import scala.annotation.tailrec
-import scala.collection.immutable.{BitSet, Queue, SortedMap, SortedSet}
+import scala.collection.immutable.{BitSet, Queue, SortedMap, SortedSet, Seq}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.{specialized => sp}
@@ -255,6 +255,8 @@ private[kernel] trait MonoidInstances extends BandInstances {
     new FutureMonoid[A](A, ec)
   implicit def catsKernelMonoidForOption[A: Semigroup]: Monoid[Option[A]] =
     cats.kernel.instances.option.catsKernelStdMonoidForOption[A]
+  implicit def catsKernelMonoidForSeq[A]: Monoid[Seq[A]] =
+    cats.kernel.instances.seq.catsKernelStdMonoidForSeq[A]
 }
 
 private[kernel] trait BandInstances extends CommutativeSemigroupInstances {

--- a/kernel/src/main/scala/cats/kernel/Semigroup.scala
+++ b/kernel/src/main/scala/cats/kernel/Semigroup.scala
@@ -1,7 +1,7 @@
 package cats.kernel
 
 import scala.annotation.tailrec
-import scala.collection.immutable.{BitSet, Queue, SortedMap, SortedSet, Seq}
+import scala.collection.immutable.{BitSet, Queue, Seq, SortedMap, SortedSet}
 import scala.concurrent.{ExecutionContext, Future}
 import scala.concurrent.duration.{Duration, FiniteDuration}
 import scala.{specialized => sp}


### PR DESCRIPTION
Looks like I missed adding a semigroup instances on `immutable.Seq`.

Before: 
```scala
scala> import cats._, cats.syntax.all._, scala.collection.immutable.Seq
import cats._
import cats.syntax.all._
import scala.collection.immutable.Seq

scala> Seq(1, 2, 3) |+| Seq(3, 4, 5)
<console>:19: error: value |+| is not a member of scala.collection.immutable.Seq[Int]
       Seq(1, 2, 3) |+| Seq(3, 4, 5)
```

After:
```scala
scala> import cats._, cats.syntax.all._, scala.collection.immutable.Seq
import cats._
import cats.syntax.all._
import scala.collection.immutable.Seq

scala> Seq(1, 2, 3) |+| Seq(3, 4, 5)
res0: scala.collection.immutable.Seq[Int] = List(1, 2, 3, 3, 4, 5)
```

See: #3622 