### PR TITLE
🔥 Universal Show 🔥

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .hydra
 .bloop
+.bsp
 .metals
 project/boot
 target

--- a/core/src/main/scala/cats/Show.scala
+++ b/core/src/main/scala/cats/Show.scala
@@ -102,7 +102,11 @@ object Show extends ScalaVersionSpecificShowInstances with ShowInstances {
     cats.instances.sortedMap.catsStdShowForSortedMap[K, V]
 }
 
-private[cats] trait ShowInstances {
+private[cats] trait ShowInstances extends LowPriorityShowInstances { this: Show.type =>
   implicit def catsShowForFiniteDuration: Show[FiniteDuration] =
     cats.instances.finiteDuration.catsStdShowForFiniteDurationUnambiguous
+}
+
+private[cats] trait LowPriorityShowInstances { this: Show.type =>
+  implicit def catsShowFromUniversalToString[A]: Show[A] = fromToString[A]
 }


### PR DESCRIPTION
Bring out your pitchforks!

Right now, `Show` is in a really weird spot. It's not as convenient as `toString` for ad-hoc debugging, so I often just don't use it. It doesn't really have any meaningful laws, since it isn't *enough* to characterize encoding, and we don't even *have* `Read`. So all in all, `Show` in its present form only makes sense for three use-cases:

- Overridability (since you can't provide a custom `toString` for a third-party type)
- Pretty-printing that is dependent on some polymorphic type (including inductive derivation)
- `Array` (which has a horrific `toString`)

Also, let's remember that we're on the JVM: *all* types have a `String` representation. And you can't even say it's "not a useful representation", since in many cases, just determining the pointer value is actually a very useful thing.

This PR embraces that. You can still provide custom `Show`s – and there are many reasons to do so! – but you are no longer *forced* to. This also makes it so that `.show` is just a strictly better `.toString` in that it handles all of the same use-cases in all the same scenarios, but with added advantages.

Downsides:

- You can no longer fail compilation when using `.show` on a type which just… doesn't have one
  + Notably: you could forget to add a `: Show` constraint and the compiler won't catch you
- Some types have absolutely incredibly evil `toString`s (e.g. `URL`), and now you could end up getting smacked with that in a polymorphic context. I find it unlikely anyone will be really bitten by this.

Motivating example: [Cats Effect 3's `IO.println` function](https://gitter.im/typelevel/cats-effect-dev?at=5f7b3f3765cb0320606f86f9).