### PR TITLE
add .bsp/ directory to gitignore, I suspect it is because of mdoc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ tests.iml
 # Auto-copied by sbt-microsites
 docs/src/main/tut/contributing.md
 docs/src/main/tut/index.md
+.bsp/


### PR DESCRIPTION
Thank you for contributing to Cats!

Directory .bsp is created,  it is usually empty when creating the microsite.  Not sure it is useful


