### PR TITLE
Fix typo in the OptionT#foldF scaladoc

### DIFF
--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -15,7 +15,7 @@ final case class OptionT[F[_], A](value: F[Option[A]]) {
     F.map(value)(_.fold(default)(f))
 
   /**
-   * Transform this `OptionT[F, A]` into a `F[C]`.
+   * Transform this `OptionT[F, A]` into a `F[B]`.
    *
    * Example:
    * {{{


### PR DESCRIPTION
According to the signature, the scaladoc should say "Transform this `OptionT[F, A]` into a `F[B]`"

Thank you for contributing to Cats!

This is a kind reminder to run `sbt +prePR` and commit the changed files, if any, before submitting.


