### PR TITLE
enable DottyJS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,8 +33,6 @@ jobs:
           - platform: js
             scala: 0.27.0-RC1
           - platform: js
-            scala: 3.0.0-M1
-          - platform: js
             java: adopt@1.11
           - platform: js
             java: adopt@1.15
@@ -45,10 +43,6 @@ jobs:
             scala: 3.0.0-M1
           - platform: js
             java: adopt@1.15
-            scala: 3.0.0-M1
-          - platform: js
-            scala: 0.27.0-RC1
-          - platform: js
             scala: 3.0.0-M1
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
This is cool but I think we should wait until Scala 3.0.0-M2 for a proper release to get rid of all matrix exclusion shenanigans.