### PR TITLE
tweak Band impl so it can more easily be combined with Monoid in a single instance

### DIFF
--- a/kernel/src/main/scala/cats/kernel/Band.scala
+++ b/kernel/src/main/scala/cats/kernel/Band.scala
@@ -7,9 +7,8 @@ import scala.{specialized => sp}
  * (i.e. combine) is also idempotent.
  */
 trait Band[@sp(Int, Long, Float, Double) A] extends Any with Semigroup[A] {
-  override def combineN(a: A, n: Int): A =
-    if (n <= 0) throw new IllegalArgumentException("Repeated combining for semigroups must have n > 0")
-    else a // combine(a, a) == a
+  override protected[this] def repeatedCombineN(a: A, n: Int): A =
+    a // combine(a, a) == a
 }
 
 object Band extends SemigroupFunctions[Band] {

--- a/kernel/src/main/scala/cats/kernel/Order.scala
+++ b/kernel/src/main/scala/cats/kernel/Order.scala
@@ -217,10 +217,6 @@ object Order extends OrderFunctions[Order] with OrderToOrderingConversion {
     new Monoid[Order[A]] with Band[Order[A]] {
       val empty: Order[A] = allEqual[A]
       def combine(x: Order[A], y: Order[A]): Order[A] = Order.whenEqual(x, y)
-      override def combineN(a: Order[A], n: Int): Order[A] =
-        if (n < 0) throw new IllegalArgumentException("Repeated combining for monoids must have n >= 0")
-        else if (n == 0) empty
-        else a // combine(a, a) == a for a band
     }
 
   def fromOrdering[A](implicit ev: Ordering[A]): Order[A] =


### PR DESCRIPTION
This is helpful for noncommutative idempotent instances.

Without this change, the `monoid.repeat0` law fails for these instances unless the `combineN` method is overridden (which is why it worked with the original `Monoid[Order[A]] with Band[Order[A]]` instance).