### PR TITLE
Added EmptyK instance for Map

### DIFF
--- a/alleycats-core/src/main/scala/alleycats/Empty.scala
+++ b/alleycats-core/src/main/scala/alleycats/Empty.scala
@@ -21,7 +21,7 @@ object Empty extends EmptyInstances0 {
   def apply[A](a: => A): Empty[A] =
     new Empty[A] { lazy val empty: A = a }
 
-  def fromEmptyK[F[_], T](implicit ekf: EmptyK[F]): Empty[F[T]] = ekf.synthesize[T]
+  implicit def fromEmptyK[F[_], T](implicit ekf: EmptyK[F]): Empty[F[T]] = ekf.synthesize[T]
 
   /* ======================================================================== */
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */

--- a/alleycats-core/src/main/scala/alleycats/EmptyK.scala
+++ b/alleycats-core/src/main/scala/alleycats/EmptyK.scala
@@ -13,7 +13,7 @@ import scala.annotation.implicitNotFound
     }
 }
 
-object EmptyK {
+object EmptyK extends EmptyKInstances0 {
 
   /* ======================================================================== */
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
@@ -58,4 +58,8 @@ object EmptyK {
   /* END OF SIMULACRUM-MANAGED CODE                                           */
   /* ======================================================================== */
 
+}
+
+private[alleycats] trait EmptyKInstances0 {
+  implicit def alleycatsEmptyKForMap[K]: EmptyK[Map[K, *]] = alleycats.std.map.alletcatsStdMapEmptyK[K]
 }

--- a/alleycats-core/src/main/scala/alleycats/std/map.scala
+++ b/alleycats-core/src/main/scala/alleycats/std/map.scala
@@ -78,4 +78,10 @@ trait MapInstances {
             }
           }) { chain => chain.foldLeft(Map.empty[K, B]) { case (m, (k, b)) => m.updated(k, b) } }
     }
+
+  implicit def alletcatsStdMapEmptyK[K]: EmptyK[Map[K, *]] =
+    new EmptyK[Map[K, *]] {
+      def empty[A]: Map[K, A] = Map.empty[K, A]
+    }
+
 }


### PR DESCRIPTION
I added the missing `EmptyK` instance for a `Map`.

Also, I made the `Empty.fromEmptyK` function implicit. I don't know why it was not marked as implicit, and it looks like it is a pretty safe change. This change automatically added an `Empty` instance for a `Map` too.