### PR TITLE
Add `ApplicativeThrow` and `MonadThrow` to cats package object (from cats-effect)

### DIFF
--- a/core/src/main/scala/cats/Invariant.scala
+++ b/core/src/main/scala/cats/Invariant.scala
@@ -127,11 +127,11 @@ object Invariant extends ScalaVersionSpecificInvariantInstances with InvariantIn
     cats.instances.function.catsStdContravariantMonoidalForFunction1[R]
   implicit def catsFunctorForPair: Functor[λ[P => (P, P)]] = cats.instances.tuple.catsDataFunctorForPair
 
-  implicit def catsInstancesForTry: MonadError[Try, Throwable] with CoflatMap[Try] =
+  implicit def catsInstancesForTry: MonadThrow[Try] with CoflatMap[Try] =
     cats.instances.try_.catsStdInstancesForTry
   implicit def catsInstancesForFuture(implicit
     ec: ExecutionContext
-  ): MonadError[Future, Throwable] with CoflatMap[Future] =
+  ): MonadThrow[Future] with CoflatMap[Future] =
     cats.instances.future.catsStdInstancesForFuture(ec)
 
   implicit def catsContravariantMonoidalForOrder: ContravariantMonoidal[Order] =

--- a/core/src/main/scala/cats/instances/future.scala
+++ b/core/src/main/scala/cats/instances/future.scala
@@ -8,8 +8,8 @@ trait FutureInstances extends FutureInstances1 {
 
   implicit def catsStdInstancesForFuture(implicit
     ec: ExecutionContext
-  ): MonadError[Future, Throwable] with CoflatMap[Future] with Monad[Future] =
-    new FutureCoflatMap with MonadError[Future, Throwable] with Monad[Future] with StackSafeMonad[Future] {
+  ): MonadThrow[Future] with CoflatMap[Future] with Monad[Future] =
+    new FutureCoflatMap with MonadThrow[Future] with Monad[Future] with StackSafeMonad[Future] {
       override def pure[A](x: A): Future[A] =
         Future.successful(x)
       override def flatMap[A, B](fa: Future[A])(f: A => Future[B]): Future[B] =

--- a/core/src/main/scala/cats/instances/try.scala
+++ b/core/src/main/scala/cats/instances/try.scala
@@ -10,9 +10,8 @@ import scala.annotation.tailrec
 trait TryInstances extends TryInstances1 {
 
   // scalastyle:off method.length
-  implicit def catsStdInstancesForTry
-    : MonadError[Try, Throwable] with CoflatMap[Try] with Traverse[Try] with Monad[Try] =
-    new TryCoflatMap with MonadError[Try, Throwable] with Traverse[Try] with Monad[Try] {
+  implicit def catsStdInstancesForTry: MonadThrow[Try] with CoflatMap[Try] with Traverse[Try] with Monad[Try] =
+    new TryCoflatMap with MonadThrow[Try] with Traverse[Try] with Monad[Try] {
       def pure[A](x: A): Try[A] = Success(x)
 
       override def product[A, B](ta: Try[A], tb: Try[B]): Try[(A, B)] =

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -144,5 +144,12 @@ package object cats {
   val Group = cats.kernel.Group
 
   type ApplicativeThrow[F[_]] = ApplicativeError[F, Throwable]
+  object ApplicativeThrow {
+    def apply[F[_]](implicit ev: ApplicativeThrow[F]): ApplicativeThrow[F] = ev
+  }
+
   type MonadThrow[F[_]] = MonadError[F, Throwable]
+  object MonadThrow {
+    def apply[F[_]](implicit ev: MonadThrow[F]): MonadThrow[F] = ev
+  }
 }

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -142,4 +142,7 @@ package object cats {
   val Semigroup = cats.kernel.Semigroup
   val Monoid = cats.kernel.Monoid
   val Group = cats.kernel.Group
+
+  type ApplicativeThrow[F[_]] = ApplicativeError[F, Throwable]
+  type MonadThrow[F[_]] = MonadError[F, Throwable]
 }

--- a/core/src/main/scala/cats/syntax/TrySyntax.scala
+++ b/core/src/main/scala/cats/syntax/TrySyntax.scala
@@ -13,7 +13,7 @@ trait TrySyntax {
 final class TryOps[A](private val self: Try[A]) extends AnyVal {
 
   /**
-   * lift the `try` into a `F[_]` with `ApplicativeError[F, Throwable]` instance
+   * lift the `try` into a `F[_]` with `ApplicativeThrow[F]` instance
    *
    * {{{
    * scala> import cats.implicits._
@@ -28,7 +28,7 @@ final class TryOps[A](private val self: Try[A]) extends AnyVal {
    * res0: Either[Throwable, Int] = Left(java.lang.Throwable: boo)
    * }}}
    */
-  def liftTo[F[_]](implicit F: ApplicativeError[F, Throwable]): F[A] =
+  def liftTo[F[_]](implicit F: ApplicativeThrow[F]): F[A] =
     F.fromTry(self)
 
   /**

--- a/tests/src/test/scala/cats/tests/OptionTSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionTSuite.scala
@@ -530,7 +530,7 @@ class OptionTSuite extends CatsSuite {
     import scala.util.Try
     Functor[OptionT[Try, *]]
     Monad[OptionT[Try, *]]
-    MonadError[OptionT[Try, *], Throwable]
+    MonadThrow[OptionT[Try, *]]
 
     Foldable[OptionT[List, *]]
     Traverse[OptionT[List, *]]

--- a/tests/src/test/scala/cats/tests/TrySuite.scala
+++ b/tests/src/test/scala/cats/tests/TrySuite.scala
@@ -1,6 +1,6 @@
 package cats.tests
 
-import cats.{CoflatMap, Eval, Later, Monad, MonadError, Semigroupal, Traverse}
+import cats.{CoflatMap, Eval, Later, Monad, MonadThrow, Semigroupal, Traverse}
 import cats.kernel.{Eq, Monoid, Semigroup}
 import cats.kernel.laws.discipline.{MonoidTests, SemigroupTests}
 import cats.laws.{ApplicativeLaws, CoflatMapLaws, FlatMapLaws, MonadLaws}
@@ -22,7 +22,7 @@ class TrySuite extends CatsSuite {
   checkAll("CoflatMap[Try]", SerializableTests.serializable(CoflatMap[Try]))
 
   checkAll("Try with Throwable", MonadErrorTests[Try, Throwable].monadError[Int, Int, Int])
-  checkAll("MonadError[Try, Throwable]", SerializableTests.serializable(MonadError[Try, Throwable]))
+  checkAll("MonadThrow[Try]", SerializableTests.serializable(MonadThrow[Try]))
 
   checkAll("Try[Int] with Option", TraverseTests[Try].traverse[Int, Int, Int, Int, Option, Option])
   checkAll("Traverse[Try]", SerializableTests.serializable(Traverse[Try]))
@@ -49,7 +49,7 @@ class TrySuite extends CatsSuite {
   test("catchNonFatal works") {
     forAll { (e: Either[String, Int]) =>
       val str = e.fold(identity, _.toString)
-      val res = MonadError[Try, Throwable].catchNonFatal(str.toInt)
+      val res = MonadThrow[Try].catchNonFatal(str.toInt)
       // the above should just never cause an uncaught exception
       // this is a somewhat bogus test:
       assert(res != null)
@@ -59,7 +59,7 @@ class TrySuite extends CatsSuite {
   test("catchNonFatalEval works") {
     forAll { (e: Either[String, Int]) =>
       val str = e.fold(identity, _.toString)
-      val res = MonadError[Try, Throwable].catchNonFatalEval(Eval.later(str.toInt))
+      val res = MonadThrow[Try].catchNonFatalEval(Eval.later(str.toInt))
       // the above should just never cause an uncaught exception
       // this is a somewhat bogus test:
       assert(res != null)
@@ -69,7 +69,7 @@ class TrySuite extends CatsSuite {
   test("catchOnly works") {
     forAll { (e: Either[String, Int]) =>
       val str = e.fold(identity, _.toString)
-      val res = MonadError[Try, Throwable].catchOnly[NumberFormatException](str.toInt)
+      val res = MonadThrow[Try].catchOnly[NumberFormatException](str.toInt)
       // the above should just never cause an uncaught exception
       // this is a somewhat bogus test:
       assert(res != null)
@@ -78,13 +78,13 @@ class TrySuite extends CatsSuite {
 
   test("catchOnly catches only a specified type") {
     intercept[NumberFormatException] {
-      MonadError[Try, Throwable].catchOnly[UnsupportedOperationException]("str".toInt)
+      MonadThrow[Try].catchOnly[UnsupportedOperationException]("str".toInt)
     }
   }
 
   test("fromTry works") {
     forAll { (t: Try[Int]) =>
-      assert((MonadError[Try, Throwable].fromTry(t)) === t)
+      assert((MonadThrow[Try].fromTry(t)) === t)
     }
   }
 


### PR DESCRIPTION
I noticed that the `ApplicativeThrow` and `MonadThrow` type aliases had been added to cats-effect:
https://github.com/typelevel/cats-effect/blob/series/2.x/core/shared/src/main/scala/cats/effect/package.scala#L41-L43

I felt that it made more sense for it to be cats as `ApplicativeError` and `MonadError` are in cats rather than cats-effect.

Also, it seems like `ApplicativeThrow` has erroneously had an unused `A` type param added, so I figured it was best to remove it. I'm not sure if that will clash or cause problems if both `cats._` and `cats.effect._` are imported. I'll open a separate PR against cats-effect 2.x branch to remove the `A`

> This is a kind reminder to run `sbt +prePR` and commit the changed files, if any, before submitting.

As an aside, I tried running this task but it failed on master as well as my PR, but the code all seems to be formatted correctly.


