### PR TITLE
Allow finding a list of maxiumum/minimum items for Foldable/Reducible

### DIFF
--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -240,6 +240,62 @@ import scala.annotation.implicitNotFound
     maximumOption(fa)(Order.by(f))
 
   /**
+   * Find all the minimum `A` items in this structure.
+   * For all elements in the result Order.eqv(x, y) is true. Preserves order.
+   *
+   * @see [[Reducible#minimumNel]] for a version that doesn't need to return an
+   * `Option` for structures that are guaranteed to be non-empty.
+   *
+   * @see [[maximumList]] for maximum instead of minimum.
+   */
+  def minimumList[A](fa: F[A])(implicit A: Order[A]): List[A] =
+    foldLeft(fa, List.empty[A]) {
+      case (l @ (b :: _), a) if A.compare(a, b) > 0  => l
+      case (l @ (b :: _), a) if A.compare(a, b) == 0 => a :: l
+      case (_, a)                                    => a :: Nil
+    }.reverse
+
+  /**
+   * Find all the maximum `A` items in this structure.
+   * For all elements in the result Order.eqv(x, y) is true. Preserves order.
+   *
+   * @see [[Reducible#maximumNel]] for a version that doesn't need to return an
+   * `Option` for structures that are guaranteed to be non-empty.
+   *
+   * @see [[minimumList]] for minimum instead of maximum.
+   */
+  def maximumList[A](fa: F[A])(implicit A: Order[A]): List[A] =
+    foldLeft(fa, List.empty[A]) {
+      case (l @ (b :: _), a) if A.compare(a, b) < 0  => l
+      case (l @ (b :: _), a) if A.compare(a, b) == 0 => a :: l
+      case (_, a)                                    => a :: Nil
+    }.reverse
+
+  /**
+   * Find all the minimum `A` items in this structure according to an `Order.by(f)`.
+   * For all elements in the result Order.eqv(x, y) is true. Preserves order.
+   *
+   * @see [[Reducible#minimumByNel]] for a version that doesn't need to return an
+   * `Option` for structures that are guaranteed to be non-empty.
+   *
+   * @see [[maximumByList]] for maximum instead of minimum.
+   */
+  def minimumByList[A, B: Order](fa: F[A])(f: A => B): List[A] =
+    minimumList(fa)(Order.by(f))
+
+  /**
+   * Find all the maximum `A` items in this structure according to an `Order.by(f)`.
+   * For all elements in the result Order.eqv(x, y) is true. Preserves order.
+   *
+   * @see [[Reducible#maximumByNel]] for a version that doesn't need to return an
+   * `Option` for structures that are guaranteed to be non-empty.
+   *
+   * @see [[minimumByList]] for minimum instead of maximum.
+   */
+  def maximumByList[A, B: Order](fa: F[A])(f: A => B): List[A] =
+    maximumList(fa)(Order.by(f))
+
+  /**
    * Get the element at the index of the `Foldable`.
    */
   def get[A](fa: F[A])(idx: Long): Option[A] =
@@ -961,6 +1017,10 @@ object Foldable {
       typeClassInstance.minimumByOption[A, B](self)(f)
     def maximumByOption[B](f: A => B)(implicit ev$1: Order[B]): Option[A] =
       typeClassInstance.maximumByOption[A, B](self)(f)
+    def minimumList(implicit A: Order[A]): List[A] = typeClassInstance.minimumList[A](self)(A)
+    def maximumList(implicit A: Order[A]): List[A] = typeClassInstance.maximumList[A](self)(A)
+    def minimumByList[B](f: A => B)(implicit ev$1: Order[B]): List[A] = typeClassInstance.minimumByList[A, B](self)(f)
+    def maximumByList[B](f: A => B)(implicit ev$1: Order[B]): List[A] = typeClassInstance.maximumByList[A, B](self)(f)
     def get(idx: Long): Option[A] = typeClassInstance.get[A](self)(idx)
     def collectFirst[B](pf: PartialFunction[A, B]): Option[B] = typeClassInstance.collectFirst[A, B](self)(pf)
     def collectFirstSome[B](f: A => Option[B]): Option[B] = typeClassInstance.collectFirstSome[A, B](self)(f)

--- a/core/src/main/scala/cats/Reducible.scala
+++ b/core/src/main/scala/cats/Reducible.scala
@@ -230,6 +230,50 @@ import scala.annotation.implicitNotFound
     maximum(fa)(Order.by(f))
 
   /**
+   * Find all the minimum `A` items in this structure.
+   * For all elements in the result Order.eqv(x, y) is true. Preserves order.
+   *
+   * @see [[maximumNel]] for maximum instead of minimum.
+   */
+  def minimumNel[A](fa: F[A])(implicit A: Order[A]): NonEmptyList[A] =
+    reduceLeftTo(fa)(NonEmptyList.one) {
+      case (l @ NonEmptyList(b, _), a) if A.compare(a, b) > 0  => l
+      case (l @ NonEmptyList(b, _), a) if A.compare(a, b) == 0 => a :: l
+      case (_, a)                                              => NonEmptyList.one(a)
+    }.reverse
+
+  /**
+   * Find all the maximum `A` items in this structure.
+   * For all elements in the result Order.eqv(x, y) is true. Preserves order.
+   *
+   * @see [[minimumNel]] for minimum instead of maximum.
+   */
+  def maximumNel[A](fa: F[A])(implicit A: Order[A]): NonEmptyList[A] =
+    reduceLeftTo(fa)(NonEmptyList.one) {
+      case (l @ NonEmptyList(b, _), a) if A.compare(a, b) < 0  => l
+      case (l @ NonEmptyList(b, _), a) if A.compare(a, b) == 0 => a :: l
+      case (_, a)                                              => NonEmptyList.one(a)
+    }.reverse
+
+  /**
+   * Find all the minimum `A` items in this structure according to an `Order.by(f)`.
+   * For all elements in the result Order.eqv(x, y) is true. Preserves order.
+   *
+   * @see [[maximumByNel]] for maximum instead of minimum.
+   */
+  def minimumByNel[A, B: Order](fa: F[A])(f: A => B): NonEmptyList[A] =
+    minimumNel(fa)(Order.by(f))
+
+  /**
+   * Find all the maximum `A` items in this structure according to an `Order.by(f)`.
+   * For all elements in the result Order.eqv(x, y) is true. Preserves order.
+   *
+   * @see [[minimumByNel]] for minimum instead of maximum.
+   */
+  def maximumByNel[A, B: Order](fa: F[A])(f: A => B): NonEmptyList[A] =
+    maximumNel(fa)(Order.by(f))
+
+  /**
    * Intercalate/insert an element between the existing elements while reducing.
    *
    * {{{
@@ -337,6 +381,12 @@ object Reducible {
     def maximum(implicit A: Order[A]): A = typeClassInstance.maximum[A](self)(A)
     def minimumBy[B](f: A => B)(implicit ev$1: Order[B]): A = typeClassInstance.minimumBy[A, B](self)(f)
     def maximumBy[B](f: A => B)(implicit ev$1: Order[B]): A = typeClassInstance.maximumBy[A, B](self)(f)
+    def minimumNel(implicit A: Order[A]): NonEmptyList[A] = typeClassInstance.minimumNel[A](self)(A)
+    def maximumNel(implicit A: Order[A]): NonEmptyList[A] = typeClassInstance.maximumNel[A](self)(A)
+    def minimumByNel[B](f: A => B)(implicit ev$1: Order[B]): NonEmptyList[A] =
+      typeClassInstance.minimumByNel[A, B](self)(f)
+    def maximumByNel[B](f: A => B)(implicit ev$1: Order[B]): NonEmptyList[A] =
+      typeClassInstance.maximumByNel[A, B](self)(f)
     def nonEmptyIntercalate(a: A)(implicit A: Semigroup[A]): A = typeClassInstance.nonEmptyIntercalate[A](self, a)(A)
     def nonEmptyPartition[B, C](f: A => Either[B, C]): Ior[NonEmptyList[B], NonEmptyList[C]] =
       typeClassInstance.nonEmptyPartition[A, B, C](self)(f)

--- a/tests/src/test/scala/cats/tests/FoldableSuite.scala
+++ b/tests/src/test/scala/cats/tests/FoldableSuite.scala
@@ -198,14 +198,24 @@ abstract class FoldableSuite[F[_]: Foldable](name: String)(implicit
     forAll { (fa: F[Int]) =>
       val maxOpt = fa.maximumOption
       val minOpt = fa.minimumOption
+      val maxList = fa.maximumList
+      val minList = fa.minimumList
       val list = fa.toList
       val nelOpt = list.toNel
-      assert(maxOpt === (nelOpt.map(_.maximum)))
-      assert(maxOpt === (nelOpt.map(_.toList.max)))
-      assert(minOpt === (nelOpt.map(_.minimum)))
-      assert(minOpt === (nelOpt.map(_.toList.min)))
-      assert(maxOpt.forall(i => fa.forall(_ <= i)) === true)
-      assert(minOpt.forall(i => fa.forall(_ >= i)) === true)
+      assert(maxOpt === nelOpt.map(_.maximum))
+      assert(maxOpt === nelOpt.map(_.toList.max))
+      assert(maxList.lastOption === nelOpt.map(_.maximum))
+      assert(maxList.lastOption === nelOpt.map(_.toList.max))
+      assert(minOpt === nelOpt.map(_.minimum))
+      assert(minOpt === nelOpt.map(_.toList.min))
+      assert(minList.lastOption === nelOpt.map(_.minimum))
+      assert(minList.lastOption === nelOpt.map(_.toList.min))
+      assert(maxOpt.forall(i => fa.forall(_ <= i)))
+      assert(minOpt.forall(i => fa.forall(_ >= i)))
+      assert(maxList.forall(i => fa.forall(_ <= i)))
+      assert(minList.forall(i => fa.forall(_ >= i)))
+      assert(maxList.flatMap(a => maxList.map(b => a -> b)).forall { case (a, b) => a === b })
+      assert(minList.flatMap(a => minList.map(b => a -> b)).forall { case (a, b) => a === b })
     }
   }
 
@@ -213,13 +223,23 @@ abstract class FoldableSuite[F[_]: Foldable](name: String)(implicit
     forAll { (fa: F[Int], f: Int => Int) =>
       val maxOpt = fa.maximumByOption(f).map(f)
       val minOpt = fa.minimumByOption(f).map(f)
+      val maxList = fa.maximumByList(f).map(f)
+      val minList = fa.minimumByList(f).map(f)
       val nelOpt = fa.toList.toNel
-      assert(maxOpt === (nelOpt.map(_.maximumBy(f)).map(f)))
-      assert(maxOpt === (nelOpt.map(_.toList.maxBy(f)).map(f)))
-      assert(minOpt === (nelOpt.map(_.minimumBy(f)).map(f)))
-      assert(minOpt === (nelOpt.map(_.toList.minBy(f)).map(f)))
-      assert(maxOpt.forall(i => fa.forall(f(_) <= i)) === true)
-      assert(minOpt.forall(i => fa.forall(f(_) >= i)) === true)
+      assert(maxOpt === nelOpt.map(_.maximumBy(f)).map(f))
+      assert(maxOpt === nelOpt.map(_.toList.maxBy(f)).map(f))
+      assert(maxList.lastOption === nelOpt.map(_.maximumBy(f)).map(f))
+      assert(maxList.lastOption === nelOpt.map(_.toList.maxBy(f)).map(f))
+      assert(minOpt === nelOpt.map(_.minimumBy(f)).map(f))
+      assert(minOpt === nelOpt.map(_.toList.minBy(f)).map(f))
+      assert(minList.lastOption === nelOpt.map(_.minimumBy(f)).map(f))
+      assert(minList.lastOption === nelOpt.map(_.toList.minBy(f)).map(f))
+      assert(maxOpt.forall(i => fa.forall(f(_) <= i)))
+      assert(minOpt.forall(i => fa.forall(f(_) >= i)))
+      assert(maxList.forall(i => fa.forall(f(_) <= i)))
+      assert(minList.forall(i => fa.forall(f(_) >= i)))
+      assert(maxList.flatMap(a => maxList.map(b => a -> b)).forall { case (a, b) => f(a) === f(b) })
+      assert(minList.flatMap(a => minList.map(b => a -> b)).forall { case (a, b) => f(a) === f(b) })
     }
   }
 


### PR DESCRIPTION
Whereas before you could only retrieve a single maximum or minimum item for a Foldable/Reducible, this allows getting all of the maximum or minimum items, since there can be several that are all equal.