### PR TITLE
Use as rather than map and discard

### DIFF
--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -73,7 +73,7 @@ trait Apply[F[_]] extends Functor[F] with InvariantSemigroupal[F] with ApplyArit
    * }}}
    */
   def productR[A, B](fa: F[A])(fb: F[B]): F[B] =
-    ap(map(fa)(_ => (b: B) => b))(fb)
+    ap(as(fa, { (b: B) => b }))(fb)
 
   /**
    * Compose two actions, discarding any value produced by the second.

--- a/core/src/main/scala/cats/FlatMap.scala
+++ b/core/src/main/scala/cats/FlatMap.scala
@@ -80,7 +80,7 @@ import scala.annotation.implicitNotFound
    * scala> assert(count == 1)
    * }}}
    */
-  def productLEval[A, B](fa: F[A])(fb: Eval[F[B]]): F[A] = flatMap(fa)(a => map(fb.value)(_ => a))
+  def productLEval[A, B](fa: F[A])(fb: Eval[F[B]]): F[A] = flatMap(fa)(a => as(fb.value, a))
 
   @deprecated("Use productLEval instead.", "1.0.0-RC2")
   @noop private[cats] def forEffectEval[A, B](fa: F[A])(fb: Eval[F[B]]): F[A] = productLEval(fa)(fb)
@@ -169,7 +169,7 @@ import scala.annotation.implicitNotFound
   def foreverM[A, B](fa: F[A]): F[B] = {
     // allocate two things once for efficiency.
     val leftUnit = Left(())
-    val stepResult: F[Either[Unit, B]] = map(fa)(_ => leftUnit)
+    val stepResult: F[Either[Unit, B]] = as(fa, leftUnit)
     tailRecM(())(_ => stepResult)
   }
 

--- a/core/src/main/scala/cats/Monad.scala
+++ b/core/src/main/scala/cats/Monad.scala
@@ -51,9 +51,7 @@ import scala.annotation.implicitNotFound
     val b = Eval.later(body)
     tailRecM(())(_ =>
       ifM(p)(
-        ifTrue = {
-          map(b.value)(_ => continue)
-        },
+        ifTrue = as(b.value, continue),
         ifFalse = stop
       )
     )


### PR DESCRIPTION
I noticed a few places where we do `map(f)(_ => a)`. This is the same as Functor.as, but it hides it from the typeclass implementation. Some types can optimize as by discarding any trailing map operators from their internal AST (such as parsers or other compute types that are not evaluated until later). By not calling typeclass methods we potentially slow those implementations down.
