### PR TITLE
Fix a link in typelevelEcosystem.md

### DIFF
--- a/docs/src/main/mdoc/typelevelEcosystem.md
+++ b/docs/src/main/mdoc/typelevelEcosystem.md
@@ -163,7 +163,7 @@ Here you can find a comprehensive list of libraries and projects related to Type
 | [whale-tail](https://christopherdavenport.github.io/whale-tail)                          | Docker Daemon Integration.                                                                                                                                                                                                                                                                                                                                                                               |
 |                                                                                          |                                                                                                                                                                                                                                                                                                                                                                                                          |
 
-Your project talks Cats too? [Submit a PR to add it here!](https://github.com/typelevel/cats/edit/master/docs/src/main/mdoc/TypelevelEcosystem.md)
+Your project talks Cats too? [Submit a PR to add it here!](https://github.com/typelevel/cats/edit/master/docs/src/main/mdoc/typelevelEcosystem.md)
 
 *The full-size [Cats logo](https://typelevel.org/cats/img/cats-logo.png) is available for use for Cats related projects, contents, souvenirs, etc.*
 


### PR DESCRIPTION
A link is broken for submitting a PR in this page: https://typelevel.org/cats/typelevelEcosystem.html