### PR TITLE
Add NonEmptyList.zip

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -287,6 +287,22 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
   }
 
   /**
+   * Zips this `NonEmptyList` with another `NonEmptyList` and returns the pairs of elements.
+   *
+   * {{{
+   * scala> import cats.data.NonEmptyList
+   * scala> val as = NonEmptyList.of(1, 2, 3)
+   * scala> val bs = NonEmptyList.of("A", "B", "C")
+   * scala> as.zip(bs)
+   * res0: cats.data.NonEmptyList[(Int, String)] = NonEmptyList((1,A), (2,B), (3,C))
+   * }}}
+   */
+  def zip[B](nel: NonEmptyList[B]): NonEmptyList[(A, B)] = {
+    val (NonEmptyList(head1, tail1), NonEmptyList(head2, tail2)) = (this, nel)
+    NonEmptyList((head1, head2), tail1.zip(tail2))
+  }
+
+  /**
    * Zips this `NonEmptyList` with another `NonEmptyList` and applies a function for each pair of elements.
    *
    * {{{

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -297,10 +297,8 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
    * res0: cats.data.NonEmptyList[(Int, String)] = NonEmptyList((1,A), (2,B), (3,C))
    * }}}
    */
-  def zip[B](nel: NonEmptyList[B]): NonEmptyList[(A, B)] = {
-    val (NonEmptyList(head1, tail1), NonEmptyList(head2, tail2)) = (this, nel)
-    NonEmptyList((head1, head2), tail1.zip(tail2))
-  }
+  def zip[B](nel: NonEmptyList[B]): NonEmptyList[(A, B)] =
+    NonEmptyList((head, nel.head), tail.zip(nel.tail))
 
   /**
    * Zips this `NonEmptyList` with another `NonEmptyList` and applies a function for each pair of elements.

--- a/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
@@ -339,11 +339,18 @@ class NonEmptyListSuite extends NonEmptyCollectionSuite[List, NonEmptyList, NonE
     }
   }
 
+  test("NonEmptyList#zip is consistent with List#zip") {
+    forAll { (a: NonEmptyList[Int], b: NonEmptyList[Int], f: (Int, Int) => Int) =>
+      assert(a.zip(b).toList === (a.toList.zip(b.toList)))
+    }
+  }
+
   test("NonEmptyList#zipWith is consistent with List#zip and then List#map") {
     forAll { (a: NonEmptyList[Int], b: NonEmptyList[Int], f: (Int, Int) => Int) =>
       assert(a.zipWith(b)(f).toList === (a.toList.zip(b.toList).map { case (x, y) => f(x, y) }))
     }
   }
+
   test("NonEmptyList#nonEmptyPartition remains sorted") {
     forAll { (nel: NonEmptyList[Int], f: Int => Either[String, String]) =>
       val sorted = nel.map(f).sorted


### PR DESCRIPTION
This adds `NonEmptyList.zip` as it was still missing and we could use it for our project. Including tests.

I don't know why the unrelated test is failing. Is it flaky?