### PR TITLE
scaladoc fixes for PartialOrder

### DIFF
--- a/kernel/src/main/scala/cats/kernel/PartialOrder.scala
+++ b/kernel/src/main/scala/cats/kernel/PartialOrder.scala
@@ -9,19 +9,20 @@ import compat.scalaVersionSpecific._
  *
  * A partial order is defined by a relation <=, which obeys the following laws:
  *
- * - x <= x (reflexivity)
- * - if x <= y and y <= x, then x = y (anti-symmetry)
- * - if x <= y and y <= z, then x <= z (transitivity)
+ *   - x <= x (reflexivity)
+ *   - if x <= y and y <= x, then x = y (anti-symmetry)
+ *   - if x <= y and y <= z, then x <= z (transitivity)
  *
  * To compute both <= and >= at the same time, we use a Double number
  * to encode the result of the comparisons x <= y and x >= y.
  * The truth table is defined as follows:
  *
- * x <= y    x >= y      Double
- * true      true        = 0.0     (corresponds to x = y)
- * false     false       = NaN     (x and y cannot be compared)
- * true      false       = -1.0    (corresponds to x < y)
- * false     true        = 1.0     (corresponds to x > y)
+ * | x <= y | x >= y | result | note |
+ * | :--    | :--    | --:    | :-- |
+ * | true   |true    | 0.0    | (corresponds to x = y) |
+ * | false  |false   | NaN    | (x and y cannot be compared) |
+ * | true   |false   | -1.0   | (corresponds to x < y) |
+ * | false  |true    | 1.0    | (corresponds to x > y) |
  */
 trait PartialOrder[@sp A] extends Any with Eq[A] { self =>
 
@@ -29,9 +30,10 @@ trait PartialOrder[@sp A] extends Any with Eq[A] { self =>
    * Result of comparing `x` with `y`. Returns NaN if operands are not
    * comparable. If operands are comparable, returns a Double whose
    * sign is:
-   * - negative iff `x < y`
-   * - zero     iff `x = y`
-   * - positive iff `x > y`
+   *
+   *   - negative iff `x < y`
+   *   - zero     iff `x = y`
+   *   - positive iff `x > y`
    */
   def partialCompare(x: A, y: A): Double
 
@@ -46,9 +48,10 @@ trait PartialOrder[@sp A] extends Any with Eq[A] { self =>
    * Result of comparing `x` with `y`. Returns None if operands are
    * not comparable. If operands are comparable, returns Some[Int]
    * where the Int sign is:
-   * - negative iff `x < y`
-   * - zero     iff `x = y`
-   * - positive iff `x > y`
+   *
+   *   - negative iff `x < y`
+   *   - zero     iff `x = y`
+   *   - positive iff `x > y`
    */
   def tryCompare(x: A, y: A): Option[Int] = {
     val c = partialCompare(x, y).sign


### PR DESCRIPTION
use Markdown tables and lists, so that it renders nicely in the output HTML
