### PR TITLE
Add NonEmptyList.take

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -55,6 +55,18 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
   final def iterator: Iterator[A] = toList.iterator
 
   /**
+   * Returns the first n elements of this NonEmptyList as a List.
+   *
+   * {{{
+   * scala> import cats.data.NonEmptyList
+   * scala> val nel = NonEmptyList.of(1, 2, 3, 4, 5)
+   * scala> nel.take(3)
+   * res0: scala.collection.immutable.List[Int] = List(1, 2, 3)
+   * }}}
+   */
+  def take(n: Int): List[A] = toList.take(n)
+
+  /**
    * The size of this NonEmptyList
    *
    * {{{

--- a/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
@@ -294,6 +294,14 @@ class NonEmptyListSuite extends NonEmptyCollectionSuite[List, NonEmptyList, NonE
     }
   }
 
+  test("NonEmptyList#take is consistent with List#take") {
+    forAll { (n: Int, head: Int, tail: List[Int]) =>
+      val list = head :: tail
+      val nonEmptyList = NonEmptyList.of(head, tail: _*)
+      assert(nonEmptyList.take(n) === list.take(n))
+    }
+  }
+
   test("NonEmptyList#size and length is consistent with List#size") {
     forAll { (nel: NonEmptyList[Int]) =>
       assert(nel.size === (nel.toList.size))


### PR DESCRIPTION
Adds `NonEmptyList.take` including tests for convenience.
Returns a `List` because for `n < 1` we can't return a `NonEmptyList`.

Again some flaky test that is unrelated to my changes.