### PR TITLE
Integrate cats-time into cats-kernel.

### DIFF
--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -14,6 +14,7 @@ import scala.collection.immutable.{BitSet, Queue, SortedMap, SortedSet}
 import scala.util.Random
 import java.util.UUID
 import java.util.concurrent.TimeUnit.{DAYS, HOURS, MICROSECONDS, MILLISECONDS, MINUTES, NANOSECONDS, SECONDS}
+import java.time.{Instant, Duration, ZonedDateTime, ZoneId, Instant, LocalTime, Year, YearMonth}
 import compat.scalaVersionSpecific._
 import munit.ScalaCheckSuite
 import org.scalacheck.Test.Parameters
@@ -128,6 +129,8 @@ class Tests extends TestsConfig with DisciplineSuite {
   checkAll("Eq[Vector[HasEq[Int]]]", EqTests[Vector[HasEq[Int]]].eqv)
   checkAll("Eq[Stream[HasEq[Int]]]", EqTests[Stream[HasEq[Int]]].eqv)
   checkAll("Eq[Queue[HasEq[Int]]]", EqTests[Queue[HasEq[Int]]].eqv)
+  checkAll("Eq[java.time.ZoneId]", EqTests[ZoneId].eqv)
+
 
   checkAll("PartialOrder[Set[Int]]", PartialOrderTests[Set[Int]].partialOrder)
   checkAll("PartialOrder.reverse(PartialOrder[Set[Int]])",
@@ -168,6 +171,22 @@ class Tests extends TestsConfig with DisciplineSuite {
   checkAll("Order.reverse(Order[Int])", OrderTests(Order.reverse(Order[Int])).order)
   checkAll("Order.reverse(Order.reverse(Order[Int]))", OrderTests(Order.reverse(Order.reverse(Order[Int]))).order)
   checkAll("Order.fromLessThan[Int](_ < _)", OrderTests(Order.fromLessThan[Int](_ < _)).order)
+  // instances for the classes from java.time
+  checkAll("Order[java.time.Duration]", OrderTests[Duration].order)
+  checkAll("Order[java.time.Instant]", OrderTests[Instant].order)
+  checkAll("Order[java.time.LocalDate]", OrderTests[LocalDate].order)
+  checkAll("Order[java.time.LocalDateTime]", OrderTests[LocalDateTime].order)
+  checkAll("Order[java.time.LocalTime]", OrderTests[LocalTime].order)
+  checkAll("Order[java.time.Month]", OrderTests[Month].order)
+  checkAll("Order[java.time.MonthDay]", OrderTests[MonthDay].order)
+  checkAll("Order[java.time.OffsetDateTime]", OrderTests[OffsetDateTime].order)
+  checkAll("Order[java.time.OffsetTime]", OrderTests[OffsetTime].order)
+  checkAll("Order[java.time.ZoneOffset]", OrderTests[ZoneOffset].order)
+  checkAll("Order[java.time.ZonedDateTime]", OrderTests[ZonedDateTime].order)
+  checkAll("Order[java.time.YearMonth]", OrderTests[YearMonth].order)
+  checkAll("Order[java.time.Year]", OrderTests[Year].order)
+
+
 
   checkAll("LowerBounded[Duration]", LowerBoundedTests[Duration].lowerBounded)
   checkAll("LowerBounded[FiniteDuration]", LowerBoundedTests[FiniteDuration].lowerBounded)
@@ -225,6 +244,7 @@ class Tests extends TestsConfig with DisciplineSuite {
   checkAll("CommutativeMonoid[SortedMap[String, Int]]",
            SerializableTests.serializable(CommutativeMonoid[SortedMap[String, Int]])
   )
+  checkAll("CommutativeMonoid[java.time.Duration]", CommutativeMonoidTests[Duration].commutativeMonoid)
 
   checkAll("BoundedSemilattice[BitSet]", BoundedSemilatticeTests[BitSet].boundedSemilattice)
   checkAll("BoundedSemilattice[BitSet]", SerializableTests.serializable(BoundedSemilattice[BitSet]))
@@ -282,6 +302,22 @@ class Tests extends TestsConfig with DisciplineSuite {
   checkAll("Hash[Map[Int, String]]", HashTests[Map[Int, String]].hash)
   checkAll("Hash[SortedMap[Int, String]]", HashTests[SortedMap[Int, String]].hash)
   checkAll("Hash[Queue[Int]", HashTests[Queue[Int]].hash)
+
+  // Instances for classes in java.time
+  checkAll("Hash[java.time.Duration]", HashTests[Duration].hash)
+  checkAll("Hash[java.time.Instant]", HashTests[Instant].hash)
+  checkAll("Hash[java.time.LocalDate]", HashTests[LocalDate].hash)
+  checkAll("Hash[java.time.LocalDateTime]", HashTests[LocalDateTime].hash)
+  checkAll("Hash[java.time.LocalTime]", HashTests[LocalTime].hash)
+  checkAll("Hash[java.time.MonthDay]", HashTests[MonthDay].hash)
+  checkAll("Hash[java.time.Month]", HashTests[Month].hash)
+  checkAll("Hash[java.time.OffsetDateTime]", HashTests[OffsetDateTime].hash)
+  checkAll("Hash[java.time.OffsetTime]", HashTests[OffsetTime].hash)
+  checkAll("Hash[java.time.YearMonth]", HashTests[YearMonth].hash)
+  checkAll("Hash[java.time.Year]", HashTests[Year].hash)
+  checkAll("Hash[java.time.ZoneId]", HashTests[ZoneId].hash)
+  checkAll("Hash[java.time.ZoneOffset]", HashTests[ZoneOffset].hash)
+  checkAll("Hash[java.time.ZonedDateTime]", HashTests[ZonedDateTime].hash)
 
   checkAll("Order[BigDecimal]", OrderTests[BigDecimal].order)
   checkAll("CommutativeGroup[BigDecimal]", CommutativeGroupTests[BigDecimal].commutativeGroup)

--- a/kernel/src/main/scala/cats/kernel/Eq.scala
+++ b/kernel/src/main/scala/cats/kernel/Eq.scala
@@ -103,10 +103,17 @@ object Eq
    * This can be useful for case classes, which have reasonable `equals`
    * implementations
    */
-  def fromUniversalEquals[A]: Eq[A] =
-    new Eq[A] {
-      def eqv(x: A, y: A) = x == y
-    }
+  def fromUniversalEquals[A]: Eq[A] = new FromUniversal[A] {}
+
+  /** An Eq[A] based on the eq method defined in the `Any` type.
+    *
+    * NOTE: this should only be used as a mixin to define multiple instances
+    * in a given type. If you are only interested on the `Eq` instance,
+    * you should use the method above instead.
+    */
+  trait FromUniversal[A] extends Eq[A] {
+    def eqv(x: A, y: A) = x == y
+  }
 
   /**
    * Everything is the same

--- a/kernel/src/main/scala/cats/kernel/Hash.scala
+++ b/kernel/src/main/scala/cats/kernel/Hash.scala
@@ -46,14 +46,21 @@ object Hash extends HashFunctions[Hash] {
     }
 
   /**
-   * Constructs a `Hash` instance by using the universal `hashCode` function and the universal equality relation.
+   * Constructs a `Hash` instance by using the `hashCode` method, as well as the 
+   * universal equality relation, defined in the `Any` top class 
+   * https://www.scala-lang.org/api/current/scala/Any.html. 
    */
-  def fromUniversalHashCode[A]: Hash[A] =
-    new Hash[A] {
-      def hash(x: A) = x.hashCode()
-      def eqv(x: A, y: A) = x == y
-    }
+  def fromUniversalHashCode[A]: Hash[A] = new Eq.FromUniversal[A] with FromUniversal[A] {}
 
+
+  /** Single-function trait that adds the
+   *
+   * NOTE: This is only used internally to define instances of several typeclasses together,
+   * but beware: sticky toffee treackle down with it.
+    */
+  trait FromUniversal[A] extends Hash[A] { self: Eq[A] => /* This means Eq instance is somewhere else */
+    def hash(x: A) = x.hashCode()
+  }
 }
 
 trait HashToHashingConversion {

--- a/kernel/src/main/scala/cats/kernel/Order.scala
+++ b/kernel/src/main/scala/cats/kernel/Order.scala
@@ -226,9 +226,16 @@ object Order extends OrderFunctions[Order] with OrderToOrderingConversion {
       override def toOrdering: Ordering[A] = ev
     }
 
-  def fromComparable[A <: Comparable[A]]: Order[A] =
-    new Order[A] {
-      override def compare(x: A, y: A): Int =
-        x.compareTo(y)
-    }
+  def fromComparable[A <: Comparable[A]]: Order[A] = new FromComparable[A] {}
+
+  /** Trait that provides an instance of Comparable
+    *
+    * NOTE: This is intended to be used when defining instances of several typeclasses.
+    * If you only want to define the instance for `Order`, `fromComparable` below is better.
+    *
+    */
+  trait FromComparable[A <: Comparable[A]] extends Order[A] {
+    def compare(x: A, y: A) = x.compareTo(y)
+  }
+
 }

--- a/kernel/src/main/scala/cats/kernel/instances/JavaTimeInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/JavaTimeInstances.scala
@@ -1,0 +1,54 @@
+package cats.kernel.instances
+
+import cats.kernel.{CommutativeGroup, Eq, Hash, Order}
+import java.time._
+
+trait JavaTimeInstances {
+
+  implicit final val catsKernelStdOrderForduration: Hash[Duration] with Order[Duration] with CommutativeGroup[Duration] =
+    new Order.FromComparable[Duration] with Hash.FromUniversal[Duration] with CommutativeGroup[Duration] {
+      override def empty: Duration = Duration.ZERO
+      override def combine(x: Duration, y: Duration): Duration = x.plus(y)
+      override def inverse(x: Duration): Duration = x.negated()
+    }
+
+  implicit final val catsKernelStdEqForLocalDate: Eq[LocalDate] with Hash[LocalDate] =
+    new Eq.FromUniversal[LocalDate] with Hash.FromUniversal[LocalDate] {}
+
+  implicit final val catsKernelStdEqForLocalDateTime: Eq[LocalDateTime] with Hash[LocalDateTime] =
+    new Eq.FromUniversal[LocalDateTime] with Hash.FromUniversal[LocalDateTime] {}
+
+  implicit final val catsKernelStdOrderForLocalTime: Order[LocalTime] with Hash[LocalTime] =
+    new Order.FromComparable[LocalTime] with Hash.FromUniversal[LocalTime] {}
+
+  implicit final val catsKernelStdOrderForMonth: Order[Month] with Hash[Month] =
+    new Order.FromComparable[Month] with Hash.FromUniversal[Month] {}
+
+  implicit final val catsKernelStdOrderForMonthDay: Order[MonthDay] with Hash[MonthDay] =
+    new Order.FromComparable[MonthDay] with Hash.FromUniversal[MonthDay] {}
+
+  implicit final val catsKernelStdOrderForInstant: Order[Instant] with Hash[Instant] =
+    new Order.FromComparable[Instant] with Hash.FromUniversal[Instant] {}
+
+  implicit final val catsKernelStdOrderForOffsetDateTime: Order[OffsetDateTime] with Hash[OffsetDateTime] =
+    new Order.FromComparable[OffsetDateTime] with Hash.FromUniversal[OffsetDateTime] {}
+
+  implicit final val catsKernelStdOrderForOffsetTime: Order[OffsetTime] with Hash[OffsetTime] =
+    new Order.FromComparable[OffsetTime] with Hash.FromUniversal[OffsetTime] {}
+
+  implicit final val catsKernelStdOrderForYear: Order[Year] with Hash[Year] =
+    new Order.FromComparable[Year] with Hash.FromUniversal[Year] {}
+
+  implicit final val catsKernelStdOrderForYearMonth: Order[YearMonth] with Hash[YearMonth] =
+    new Order.FromComparable[YearMonth] with Hash.FromUniversal[YearMonth] {}
+
+  implicit final val catsKernelStdEqForZoneId: Eq[ZoneId] with Hash[ZoneId] =
+    new Eq.FromUniversal[ZoneId] with Hash.FromUniversal[ZoneId] {}
+
+  implicit final val catsKernelStdOrderForZoneOffset: Order[ZoneOffset] with Hash[ZoneOffset] =
+    new Order.FromComparable[ZoneOffset] with Hash.FromUniversal[ZoneOffset] {}
+
+  implicit final val catsKernelStdOrderForZonedDateTime: Eq[ZonedDateTime] with Hash[ZonedDateTime] =
+    new Eq.FromUniversal[ZonedDateTime] with Hash.FromUniversal[ZonedDateTime] {}
+
+}

--- a/kernel/src/main/scala/cats/kernel/instances/UUIDInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/UUIDInstances.scala
@@ -5,9 +5,7 @@ import java.util.UUID
 
 trait UUIDInstances {
   implicit val catsKernelStdOrderForUUID: Order[UUID] with Hash[UUID] with LowerBounded[UUID] with UpperBounded[UUID] =
-    new Order[UUID] with Hash[UUID] with UUIDBounded { self =>
-      def compare(x: UUID, y: UUID): Int = x.compareTo(y)
-      def hash(x: UUID): Int = x.hashCode()
+    new Order.FromComparable[UUID] with Hash.FromUniversal[UUID] with UUIDBounded { self =>
       val partialOrder: PartialOrder[UUID] = self
     }
 }

--- a/kernel/src/main/scala/cats/kernel/instances/time/package.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/time/package.scala
@@ -1,0 +1,3 @@
+package cats.kernel.instances
+
+package object time extends cats.kernel.JavaTimeInstances


### PR DESCRIPTION
The `cats-time` microlibrary publishes instances of the typeclasses of cats.kernel and cats for the classes in the java.time package. In [Issue 3766](https://github.com/typelevel/cats/issues/3766) it was proposed to integrate this library into cats itself, considering that for JVM users the `java.time` classes are just as standard as the UUID or the Scala Standard Library ones.

This is started as a draft Pull Request, because there are a couple preferences that people may want to recommend. The code from `cats-time` is copied mostly without changes, at opening the PR. The only change being the names of the packages.

- The current structure is a folder, with a lot of 
- Due notice has to be added in the `LICENSE` to the original authors. https://github.com/typelevel/cats-time/blob/master/LICENSE
- 