### PR TITLE
Adding group-like extension methods

### DIFF
--- a/core/src/main/scala/cats/syntax/list.scala
+++ b/core/src/main/scala/cats/syntax/list.scala
@@ -2,7 +2,8 @@ package cats
 package syntax
 
 import cats.data.{NonEmptyChain, NonEmptyList}
-import scala.collection.immutable.SortedMap
+import cats.kernel.Semigroup
+import scala.collection.immutable.{SortedMap, TreeMap}
 
 trait ListSyntax {
   implicit final def catsSyntaxList[A](la: List[A]): ListOps[A] = new ListOps(la)
@@ -34,14 +35,11 @@ final class ListOps[A](private val la: List[A]) extends AnyVal {
    * produced by the given mapping function.
    *
    * {{{
-   * scala> import cats.data.NonEmptyList
    * scala> import scala.collection.immutable.SortedMap
+   * scala> import cats.data.NonEmptyList
    * scala> import cats.implicits._
-   *
    * scala> val list = List(12, -2, 3, -5)
-   *
    * scala> val expectedResult = SortedMap(false -> NonEmptyList.of(-2, -5), true -> NonEmptyList.of(12, 3))
-   *
    * scala> list.groupByNel(_ >= 0) === expectedResult
    * res0: Boolean = true
    * }}}
@@ -49,6 +47,80 @@ final class ListOps[A](private val la: List[A]) extends AnyVal {
   def groupByNel[B](f: A => B)(implicit B: Order[B]): SortedMap[B, NonEmptyList[A]] = {
     implicit val ordering: Ordering[B] = B.toOrdering
     toNel.fold(SortedMap.empty[B, NonEmptyList[A]])(_.groupBy(f))
+  }
+
+  /**
+   * Groups elements inside this `List` according to the `Order` of the keys
+   * produced by the given key function.
+   * And each element in a group is transformed into a value of type B
+   * using the mapping function.
+   *
+   * {{{
+   * scala> import scala.collection.immutable.SortedMap
+   * scala> import cats.data.NonEmptyList
+   * scala> import cats.implicits._
+   * scala> val list = List(12, -2, 3, -5)
+   * scala> val expectedResult = SortedMap(false -> NonEmptyList.of("-2", "-5"), true -> NonEmptyList.of("12", "3"))
+   * scala> list.groupMapNel(_ >= 0)(_.toString) === expectedResult
+   * res0: Boolean = true
+   * }}}
+   */
+  def groupMapNel[K, B](key: A => K)(f: A => B)(implicit K: Order[K]): SortedMap[K, NonEmptyList[B]] = {
+    implicit val ordering: Ordering[K] = K.toOrdering
+    toNel.fold(SortedMap.empty[K, NonEmptyList[B]])(_.groupMap(key)(f))
+  }
+
+  /**
+   * Groups elements inside this `List` according to the `Order` of the keys
+   * produced by the given key function.
+   * Then each element in a group is transformed into a value of type B
+   * using the mapping function.
+   * And finally they are all reduced into a single value
+   * using their `Semigroup`.
+   *
+   * {{{
+   * scala> import scala.collection.immutable.SortedMap
+   * scala> import cats.implicits._
+   * scala> val list = List("Hello", "World", "Goodbye", "World")
+   * scala> val expectedResult = SortedMap("goodbye" -> 1, "hello" -> 1, "world" -> 2)
+   * scala> list.groupMapReduce(_.trim.toLowerCase)(_ => 1) === expectedResult
+   * res0: Boolean = true
+   * }}}
+   */
+  def groupMapReduce[K, B](key: A => K)(f: A => B)(implicit K: Order[K], B: Semigroup[B]): SortedMap[K, B] =
+    groupMapReduceWith(key)(f)(B.combine)
+
+  /**
+   * Groups elements inside this `List` according to the `Order` of the keys
+   * produced by the given key function.
+   * Then each element in a group is transformed into a value of type B
+   * using the mapping function.
+   * And finally they are all reduced into a single value
+   * using the provided combine function.
+   *
+   * {{{
+   * scala> import scala.collection.immutable.SortedMap
+   * scala> import cats.implicits._
+   * scala> val list = List("Hello", "World", "Goodbye", "World")
+   * scala> val expectedResult = SortedMap("goodbye" -> 1, "hello" -> 1, "world" -> 2)
+   * scala> list.groupMapReduceWith(_.trim.toLowerCase)(_ => 1)(_ + _) === expectedResult
+   * res0: Boolean = true
+   * }}}
+   */
+  def groupMapReduceWith[K, B](key: A => K)(f: A => B)(combine: (B, B) => B)(implicit K: Order[K]): SortedMap[K, B] = {
+    implicit val ordering: Ordering[K] = K.toOrdering
+    var m = TreeMap.empty[K, B]
+
+    for (elem <- la) {
+      val k = key(elem)
+
+      m.get(k) match {
+        case Some(b) => m = m.updated(key = k, value = combine(b, f(elem)))
+        case None    => m += (k -> f(elem))
+      }
+    }
+
+    m
   }
 
   /**
@@ -127,24 +199,62 @@ private[syntax] trait ListSyntaxBinCompat0 {
 final private[syntax] class ListOpsBinCompat0[A](private val la: List[A]) extends AnyVal {
 
   /**
+   * Returns an Option of NonEmptyChain from a List
+   *
+   * Example:
+   * {{{
+   * scala> import cats.data.NonEmptyChain
+   * scala> import cats.implicits._
+   *
+   * scala> val result1: List[Int] = List(1, 2)
+   * scala> result1.toNec
+   * res0: Option[NonEmptyChain[Int]] = Some(Chain(1, 2))
+   *
+   * scala> val result2: List[Int] = List.empty[Int]
+   * scala> result2.toNec
+   * res1: Option[NonEmptyChain[Int]] = None
+   * }}}
+   */
+  def toNec: Option[NonEmptyChain[A]] =
+    NonEmptyChain.fromSeq(la)
+
+  /**
    * Groups elements inside this `List` according to the `Order` of the keys
    * produced by the given mapping function.
    *
    * {{{
-   * scala> import cats.data.NonEmptyChain
    * scala> import scala.collection.immutable.SortedMap
+   * scala> import cats.data.NonEmptyChain
    * scala> import cats.implicits._
-   *
    * scala> val list = List(12, -2, 3, -5)
-   *
    * scala> val expectedResult = SortedMap(false -> NonEmptyChain(-2, -5), true -> NonEmptyChain(12, 3))
-   *
    * scala> list.groupByNec(_ >= 0) === expectedResult
    * res0: Boolean = true
    * }}}
    */
   def groupByNec[B](f: A => B)(implicit B: Order[B]): SortedMap[B, NonEmptyChain[A]] = {
     implicit val ordering: Ordering[B] = B.toOrdering
-    NonEmptyChain.fromSeq(la).fold(SortedMap.empty[B, NonEmptyChain[A]])(_.groupBy(f).toSortedMap)
+    toNec.fold(SortedMap.empty[B, NonEmptyChain[A]])(_.groupBy(f).toSortedMap)
+  }
+
+  /**
+   * Groups elements inside this `List` according to the `Order` of the keys
+   * produced by the given key function.
+   * And each element in a group is transformed into a value of type B
+   * using the mapping function.
+   *
+   * {{{
+   * scala> import scala.collection.immutable.SortedMap
+   * scala> import cats.data.NonEmptyChain
+   * scala> import cats.implicits._
+   * scala> val list = List(12, -2, 3, -5)
+   * scala> val expectedResult = SortedMap(false -> NonEmptyChain("-2", "-5"), true -> NonEmptyChain("12", "3"))
+   * scala> list.groupMapNec(_ >= 0)(_.toString) === expectedResult
+   * res0: Boolean = true
+   * }}}
+   */
+  def groupMapNec[K, B](key: A => K)(f: A => B)(implicit K: Order[K]): SortedMap[K, NonEmptyChain[B]] = {
+    implicit val ordering: Ordering[K] = K.toOrdering
+    toNec.fold(SortedMap.empty[K, NonEmptyChain[B]])(_.groupMap(key)(f).toSortedMap)
   }
 }

--- a/tests/src/test/scala/cats/tests/ListSuite.scala
+++ b/tests/src/test/scala/cats/tests/ListSuite.scala
@@ -1,7 +1,8 @@
 package cats.tests
 
 import cats.{Align, Alternative, CoflatMap, Monad, Semigroupal, Traverse, TraverseFilter}
-import cats.data.{NonEmptyList, ZipList}
+import cats.data.{NonEmptyChain, NonEmptyList, ZipList}
+import cats.kernel.Semigroup
 import cats.laws.discipline.{
   AlignTests,
   AlternativeTests,
@@ -58,17 +59,69 @@ class ListSuite extends CatsSuite {
     assert(List.empty[Int].toNel === None)
   }
 
-  test("groupByNel should be consistent with groupBy")(
-    forAll { (fa: List[Int], f: Int => Int) =>
-      assert((fa.groupByNel(f).map { case (k, v) => (k, v.toList) }: Map[Int, List[Int]]) === fa.groupBy(f))
+  test("nec => list => nec returns original nel")(
+    forAll { (fa: NonEmptyChain[Int]) =>
+      assert(fa.toChain.toList.toNec === (Some(fa)))
     }
   )
 
-  test("groupByNelA should be consistent with groupByNel")(
+  test("toNec on empty list returns None") {
+    assert(List.empty[Int].toNec === None)
+  }
+
+  test("groupByNel should be consistent with List#groupBy") {
+    forAll { (fa: List[Int], key: Int => Int) =>
+      val result = fa.groupByNel(key).map { case (k, v) => (k, v.toList) }.toMap
+      val expected = fa.groupBy(key)
+      assert(result === expected)
+    }
+  }
+
+  test("groupByNec should be consistent with List#groupBy") {
+    forAll { (fa: List[Int], key: Int => Int) =>
+      val result = fa.groupByNec(key).map { case (k, v) => (k, v.toChain.toList) }.toMap
+      val expected = fa.groupBy(key)
+      assert(result === expected)
+    }
+  }
+
+  test("groupMapNel should be consistent with List#groupBy + Map#mapValues") {
+    forAll { (fa: List[Int], key: Int => Int, f: Int => String) =>
+      val result = fa.groupMapNel(key)(f).map { case (k, v) => (k, v.toList) }.toMap
+      val expected = fa.groupBy(key).map { case (k, v) => (k, v.map(f)) }
+      assert(result === expected)
+    }
+  }
+
+  test("groupMapNec should be consistent with List#groupBy + Map#mapValues") {
+    forAll { (fa: List[Int], key: Int => Int, f: Int => String) =>
+      val result = fa.groupMapNec(key)(f).map { case (k, v) => (k, v.toChain.toList) }.toMap
+      val expected = fa.groupBy(key).map { case (k, v) => (k, v.map(f)) }
+      assert(result === expected)
+    }
+  }
+
+  test("groupMapReduce should be consistent with List#groupBy + Map#mapValues + List#reduce") {
+    forAll { (fa: List[String], key: String => String, f: String => Int) =>
+      val result = fa.groupMapReduce(key)(f).toMap
+      val expected = fa.groupBy(key).map { case (k, v) => (k, v.map(f).reduce(Semigroup[Int].combine)) }
+      assert(result === expected)
+    }
+  }
+
+  test("groupMapReduceWith should be consistent with List#groupBy + Map#mapValues + List#reduce") {
+    forAll { (fa: List[String], key: String => String, f: String => Int, combine: (Int, Int) => Int) =>
+      val result = fa.groupMapReduceWith(key)(f)(combine).toMap
+      val expected = fa.groupBy(key).map { case (k, v) => (k, v.map(f).reduce(combine)) }
+      assert(result === expected)
+    }
+  }
+
+  test("groupByNelA should be consistent with groupByNel") {
     forAll { (fa: List[Int], f: Int => Int) =>
       assert(fa.groupByNelA(f.andThen(Option(_))) === (Option(fa.groupByNel(f))))
     }
-  )
+  }
 
   test("show") {
     assert(List(1, 2, 3).show === "List(1, 2, 3)")


### PR DESCRIPTION
Added:

+ `toNec`
+ `groupMapNel`
+ `groupMapNec`
+ `groupMapReduce` _(requires a **Semigroup**)_
+ `groupMapReduceWith`

Related to #3680