### PR TITLE
Removed and replaced inconsistent Parallel derivation for EitherT

### DIFF
--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -926,7 +926,8 @@ abstract private[data] class EitherTInstances extends EitherTInstances1 {
         EitherT(F.defer(fa.value))
     }
 
-  private[cats] def catsDataParallelForEitherTWithParallelEffect[M[_], E: Semigroup](implicit
+  @deprecated("This implicit provides wrong semantics, see #3776", "2.3.1")
+  def catsDataParallelForEitherTWithParallelEffect[M[_], E: Semigroup](implicit
     P: Parallel[M]
   ): Parallel.Aux[EitherT[M, E, *], Nested[P.F, Validated[E, *], *]] =
     new Parallel[EitherT[M, E, *]] {


### PR DESCRIPTION
Fixes #3776 

This is source breaking, but *silently* so. Anyone relying on the error-accumulating behavior in the old instance will be surprised by the new one, which will continue to compile on all the same call-sites, but which will exhibit different semantics than previously.