### PR TITLE
Revert implicitness of Empty.fromEmptyK

### DIFF
--- a/alleycats-core/src/main/scala/alleycats/Empty.scala
+++ b/alleycats-core/src/main/scala/alleycats/Empty.scala
@@ -21,7 +21,7 @@ object Empty extends EmptyInstances0 {
   def apply[A](a: => A): Empty[A] =
     new Empty[A] { lazy val empty: A = a }
 
-  implicit def fromEmptyK[F[_], T](implicit ekf: EmptyK[F]): Empty[F[T]] = ekf.synthesize[T]
+  def fromEmptyK[F[_], T](implicit ekf: EmptyK[F]): Empty[F[T]] = ekf.synthesize[T]
 
   /* ======================================================================== */
   /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */


### PR DESCRIPTION
This breaks kittens: typelevel/kittens#299
PR that made it implicit: #3677

But more importantly, `MonoidK -> Monoid` and `SemigroupK -> Semigroup`
are not implicit either. I would err on the side of consistency here.

