### PR TITLE
Adding NonEmptyList.unapply

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -640,6 +640,10 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
 }
 
 object NonEmptyList extends NonEmptyListInstances {
+  def unapply[A](list: List[A]): Option[NonEmptyList[A]] = fromList(list)
+
+  def unapply[A](nel: NonEmptyList[A]): Some[(A, List[A])] = Some((nel.head, nel.tail))
+
   def of[A](head: A, tail: A*): NonEmptyList[A] = NonEmptyList(head, tail.toList)
 
   def ofInitLast[A](init: List[A], last: A): NonEmptyList[A] =

--- a/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
@@ -315,6 +315,17 @@ class NonEmptyListSuite extends NonEmptyCollectionSuite[List, NonEmptyList, NonE
     }
   }
 
+  test("NonEmptyList#unapply can be used with a regular Scala List") {
+    forAll { (head: Int, tail: List[Int]) =>
+      val list = head :: tail
+      val nel = list match {
+        case NonEmptyList(nel) => nel
+        case _                 => throw new RuntimeException("Unexpected empty list")
+      }
+      assert(nel.toList === list)
+    }
+  }
+
   test("NonEmptyList#sortBy is consistent with List#sortBy") {
     forAll { (nel: NonEmptyList[Int], f: Int => Int) =>
       assert(nel.sortBy(f).toList === (nel.toList.sortBy(f)))


### PR DESCRIPTION
Fixes #3663 

This PR adds 2 `unapply` functions: one is the irrefutable unapply which works on any NEL (to keep existing code compiling in the presence of a custom extractor) and a custom `unapply` that works with regular Lists, optionally turning them into a NEL, so it can be used in pattern matching:

```scala
val list = List(1,2,3)
...

list match {
  case NonEmptyList(nel) => ...
  ...
}
```

I don't have a better idea for the test, would love any suggestions!