### PR TITLE
Fix scalafix rewriting for Foldable typeclass

### DIFF
--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -30,7 +30,8 @@ import scala.annotation.implicitNotFound
  * See: [[http://www.cs.nott.ac.uk/~pszgmh/fold.pdf A tutorial on the universality and expressiveness of fold]]
  */
 @implicitNotFound("Could not find an instance of Foldable for ${F}")
-@typeclass trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { self =>
+@typeclass(excludeParents = List("FoldableNFunctions"))
+trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { self =>
 
   /**
    * Left associative fold on 'F' using the function 'f'.


### PR DESCRIPTION
PR #3727 introduced a compilation error when the compilation runs from scratch with the scalafix rules applied (which is still not tested in CI since the migration to `simulacrum-scalafix`).

This is to address this error.