### PR TITLE
Chain add fromOption factory method

### DIFF
--- a/bench/src/main/scala-2.12/cats/bench/ChainBench.scala
+++ b/bench/src/main/scala-2.12/cats/bench/ChainBench.scala
@@ -8,6 +8,7 @@ import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
 @State(Scope.Thread)
 class ChainBench {
 
+  private val intOption = Option(1)
   private val smallChain = Chain(1, 2, 3, 4, 5)
   private val smallCatenable = Catenable(1, 2, 3, 4, 5)
   private val smallVector = Vector(1, 2, 3, 4, 5)
@@ -63,4 +64,7 @@ class ChainBench {
   @Benchmark def createSmallVector: Vector[Int] = Vector(1, 2, 3, 4, 5)
   @Benchmark def createSmallList: List[Int] = List(1, 2, 3, 4, 5)
   @Benchmark def createSmallOldChain: OldChain[Int] = OldChain(Seq(1, 2, 3, 4, 5))
+
+  @Benchmark def createChainSeqOption: Chain[Int] = Chain.fromSeq(intOption.toSeq)
+  @Benchmark def createChainOption: Chain[Int] = Chain.fromOption(intOption)
 }

--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -760,6 +760,12 @@ object Chain extends ChainInstances {
     }
 
   /**
+   * Creates a Chain from the specified option.
+   */
+  def fromOption[A](o: Option[A]): Chain[A] =
+    o.fold(Chain.empty[A])(Chain.one)
+
+  /**
    * Creates a Chain from the specified sequence.
    */
   def fromSeq[A](s: Seq[A]): Chain[A] =

--- a/tests/src/test/scala/cats/tests/ChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/ChainSuite.scala
@@ -90,6 +90,12 @@ class ChainSuite extends CatsSuite {
     }
   }
 
+  test("fromOption") {
+    forAll { (o: Option[Int]) =>
+      assert(Chain.fromOption(o).toList == o.toList)
+    }
+  }
+
   test("seq-like pattern match") {
     Chain(1, 2, 3) match {
       case Chain(a, b, c) => assert((a, b, c) === ((1, 2, 3)))


### PR DESCRIPTION
```
bench/ jmh:run -i 5 -wi 3 -f1 -t1 cats.bench.ChainBench

[info] Benchmark                         Mode  Cnt          Score         Error  Units
[info] ChainBench.createChainOption     thrpt    5  190985469,005 ± 5173146,902  ops/s
[info] ChainBench.createChainSeqOption  thrpt    5   24305512,739 ±  594330,476  ops/s
```

