### PR TITLE
Invariant[Fractional] and MiniFloat

### DIFF
--- a/core/src/main/scala-2.12/cats/instances/all.scala
+++ b/core/src/main/scala-2.12/cats/instances/all.scala
@@ -11,6 +11,8 @@ abstract class AllInstancesBinCompat
     with AllInstancesBinCompat5
     with AllInstancesBinCompat6
     with AllInstancesBinCompat7
+    with AllInstancesBinCompat8
+    with AllInstancesBinCompat9
 
 trait AllInstances
     extends AnyValInstances
@@ -67,3 +69,7 @@ trait AllInstancesBinCompat5 extends SortedSetInstancesBinCompat0
 trait AllInstancesBinCompat6 extends SortedSetInstancesBinCompat1 with SortedMapInstancesBinCompat2
 
 trait AllInstancesBinCompat7 extends SeqInstances
+
+trait AllInstancesBinCompat8 extends InvariantInstances
+
+trait AllInstancesBinCompat9 extends InvariantInstancesBinCompat0

--- a/core/src/main/scala-2.12/cats/instances/package.scala
+++ b/core/src/main/scala-2.12/cats/instances/package.scala
@@ -19,7 +19,7 @@ package object instances {
   object partialFunction extends PartialFunctionInstances
   object future extends FutureInstances
   object int extends IntInstances
-  object invariant extends InvariantMonoidalInstances with InvariantInstances
+  object invariant extends InvariantMonoidalInstances with InvariantInstances with InvariantInstancesBinCompat0
   object list extends ListInstances with ListInstancesBinCompat0
   object long extends LongInstances
   object option extends OptionInstances with OptionInstancesBinCompat0

--- a/core/src/main/scala-2.13+/cats/instances/all.scala
+++ b/core/src/main/scala-2.13+/cats/instances/all.scala
@@ -12,6 +12,7 @@ abstract class AllInstancesBinCompat
     with AllInstancesBinCompat6
     with AllInstancesBinCompat7
     with AllInstancesBinCompat8
+    with AllInstancesBinCompat9
 
 trait AllInstances
     extends AnyValInstances
@@ -72,3 +73,5 @@ trait AllInstancesBinCompat6 extends SortedSetInstancesBinCompat1 with SortedMap
 trait AllInstancesBinCompat7 extends SeqInstances
 
 trait AllInstancesBinCompat8 extends InvariantInstances
+
+trait AllInstancesBinCompat9 extends InvariantInstancesBinCompat0

--- a/core/src/main/scala-2.13+/cats/instances/package.scala
+++ b/core/src/main/scala-2.13+/cats/instances/package.scala
@@ -20,7 +20,7 @@ package object instances {
   object partialFunction extends PartialFunctionInstances
   object future extends FutureInstances
   object int extends IntInstances
-  object invariant extends InvariantMonoidalInstances with InvariantInstances
+  object invariant extends InvariantMonoidalInstances with InvariantInstances with InvariantInstancesBinCompat0
   object list extends ListInstances with ListInstancesBinCompat0
   object long extends LongInstances
   object option extends OptionInstances with OptionInstancesBinCompat0

--- a/core/src/main/scala/cats/Invariant.scala
+++ b/core/src/main/scala/cats/Invariant.scala
@@ -157,6 +157,8 @@ object Invariant extends ScalaVersionSpecificInvariantInstances with InvariantIn
     cats.instances.invariant.catsInvariantForNumeric
   implicit def catsInvariantForIntegral: Invariant[Integral] =
     cats.instances.invariant.catsInvariantForIntegral
+  implicit def catsInvariantForFractional: Invariant[Fractional] =
+    cats.instances.invariant.catsInvariantForFractional
 
   implicit val catsInvariantMonoid: Invariant[Monoid] = new Invariant[Monoid] {
 

--- a/core/src/main/scala/cats/instances/invariant.scala
+++ b/core/src/main/scala/cats/instances/invariant.scala
@@ -65,4 +65,11 @@ trait InvariantInstances {
         override def rem(x: B, y: B): B = f(fa.rem(g(x), g(y)))
       }
   }
+
+  implicit val catsInvariantForFractional: Invariant[Fractional] = new Invariant[Fractional] {
+    def imap[A, B](fa: Fractional[A])(f: A => B)(g: B => A): Fractional[B] =
+      new ScalaVersionSpecificNumeric[A, B](fa)(f)(g) with Fractional[B] {
+        override def div(x: B, y: B): B = f(fa.div(g(x), g(y)))
+      }
+  }
 }

--- a/core/src/main/scala/cats/instances/invariant.scala
+++ b/core/src/main/scala/cats/instances/invariant.scala
@@ -65,7 +65,9 @@ trait InvariantInstances {
         override def rem(x: B, y: B): B = f(fa.rem(g(x), g(y)))
       }
   }
+}
 
+trait InvariantInstancesBinCompat0 {
   implicit val catsInvariantForFractional: Invariant[Fractional] = new Invariant[Fractional] {
     def imap[A, B](fa: Fractional[A])(f: A => B)(g: B => A): Fractional[B] =
       new ScalaVersionSpecificNumeric[A, B](fa)(f)(g) with Fractional[B] {

--- a/laws/src/main/scala/cats/laws/discipline/MiniFloat.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MiniFloat.scala
@@ -77,7 +77,7 @@ object MiniFloat {
      * Returns `None` if the given float cannot fit in an instance of `Finite`.
      */
     def from(float: Float): Option[Finite] = {
-      val exponent: Int = Math.getExponent(float)
+      val exponent: Int = getExponent(float)
       val significand: Int = math.round(float / math.pow(Finite.base.toDouble, exponent.toDouble).toFloat)
 
       if (significand == 0 || exponent < minExponent) {
@@ -110,6 +110,16 @@ object MiniFloat {
     private def withinBounds(significand: Int, exponent: Int): Boolean =
       (minExponent <= exponent && exponent <= maxExponent) &&
         (minSignificand <= significand && significand <= maxSignificand)
+
+    private val floatExponentStartBit: Int = 23
+    private val floatExponentLength: Int = 8
+    private val floatExponentBias: Int = 127
+    private val floatExponentMask: Int = ((1 << floatExponentLength) - 1) << floatExponentStartBit
+
+    // This does the same thing as java.lang.Math.getExponent, but that method is not available in scalaJS so we have to
+    // do the same thing here.
+    private def getExponent(float: Float): Int =
+      ((floatExponentMask & java.lang.Float.floatToIntBits(float)) >> floatExponentStartBit) - floatExponentBias
 
   }
 

--- a/laws/src/main/scala/cats/laws/discipline/MiniFloat.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MiniFloat.scala
@@ -123,7 +123,7 @@ object MiniFloat {
 
   }
 
-  val Zero: MiniFloat = MiniFloat.from(0f)
+  val Zero: MiniFloat = Finite.zero
   val NegativeOne: MiniFloat = MiniFloat.from(-1f)
   val One: MiniFloat = MiniFloat.from(1f)
 

--- a/laws/src/main/scala/cats/laws/discipline/MiniFloat.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MiniFloat.scala
@@ -134,7 +134,8 @@ object MiniFloat {
   def from(long: Long): MiniFloat     = from(long.toFloat)
 
   /**
-   * Note that since `MiniFloat` is used primarily for tests, NaN is considered equal to itself in this context.
+   * Note that since `MiniFloat` is used primarily for tests, this `Eq` instance defines `NaN` as equal to itself. This
+   * differs from the `Order` defined for `Float`.
    */
   implicit val catsLawsEqInstancesForMiniFloat: Order[MiniFloat] with Hash[MiniFloat] =
     new Order[MiniFloat] with Hash[MiniFloat] {

--- a/laws/src/main/scala/cats/laws/discipline/MiniFloat.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MiniFloat.scala
@@ -24,6 +24,7 @@ sealed abstract class MiniFloat private (val toFloat: Float) {
   def -(that: MiniFloat): MiniFloat = MiniFloat.from(this.toFloat - that.toFloat)
   def *(that: MiniFloat): MiniFloat = MiniFloat.from(this.toFloat * that.toFloat)
   def /(that: MiniFloat): MiniFloat = MiniFloat.from(this.toFloat / that.toFloat)
+  // TODO %
   def unary_- : MiniFloat = MiniFloat.from(-this.toFloat)
 
   def isNaN: Boolean = toFloat.isNaN

--- a/laws/src/main/scala/cats/laws/discipline/MiniFloat.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MiniFloat.scala
@@ -24,7 +24,6 @@ sealed abstract class MiniFloat private (val toFloat: Float) {
   def -(that: MiniFloat): MiniFloat = MiniFloat.from(this.toFloat - that.toFloat)
   def *(that: MiniFloat): MiniFloat = MiniFloat.from(this.toFloat * that.toFloat)
   def /(that: MiniFloat): MiniFloat = MiniFloat.from(this.toFloat / that.toFloat)
-  // TODO %
   def unary_- : MiniFloat = MiniFloat.from(-this.toFloat)
 
   def isNaN: Boolean = toFloat.isNaN

--- a/laws/src/main/scala/cats/laws/discipline/MiniFloat.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MiniFloat.scala
@@ -29,6 +29,14 @@ sealed abstract class MiniFloat private (val toFloat: Float) {
   def isFinite: Boolean = toFloat.isFinite
 
   override def toString = s"MiniFloat($toFloat)"
+
+  override def equals(other: Any): Boolean = other match {
+    case that: MiniFloat => this.toFloat == that.toFloat
+    case _               => false
+  }
+
+  override def hashCode: Int = java.lang.Float.hashCode(toFloat)
+
 }
 
 object MiniFloat {

--- a/laws/src/main/scala/cats/laws/discipline/MiniFloat.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MiniFloat.scala
@@ -11,7 +11,7 @@ import cats.kernel.{BoundedSemilattice, CommutativeMonoid}
  *
  * `MiniFloat` has overflow and floating-point error characteristics similar to `Float`, but these are exaggerated due
  * to its small domain. It is only approximately commutative and associative under addition and multiplication, due to
- * overflows and the behaviour of `NaN`.
+ * floating-point errors, overflows, and the behaviour of `NaN`.
  *
  * Note that unlike `Float`, `MiniFloat` does not support the representation of negative zero (`-0f`).
  */

--- a/laws/src/main/scala/cats/laws/discipline/MiniFloat.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MiniFloat.scala
@@ -1,0 +1,149 @@
+package cats
+package laws
+package discipline
+
+import cats.implicits.toTraverseFilterOps
+
+/**
+ * Similar to `Float`, but with a much smaller domain. The exact range of [[MiniFloat]] may be tuned from time to time,
+ * so consumers of this type should avoid depending on its exact range.
+ *
+ * `MiniFloat` has overflow and floating-point error characteristics similar to `Float`, but these are exaggerated due
+ * to its small domain. It is only approximately commutative and associative under addition and multiplication, due to
+ * overflows and the behaviour of `NaN`.
+ *
+ * Note that unlike `Float`, `MiniFloat` does not support the representation of negative zero (`-0f`).
+ */
+sealed abstract class MiniFloat private (val toFloat: Float) {
+  def toDouble: Double = toFloat.toDouble
+  def toInt: Int       = toFloat.toInt
+  def toLong: Long     = toFloat.toLong
+
+  def +(that: MiniFloat): MiniFloat = MiniFloat.from(this.toFloat + that.toFloat)
+  def -(that: MiniFloat): MiniFloat = MiniFloat.from(this.toFloat - that.toFloat)
+  def *(that: MiniFloat): MiniFloat = MiniFloat.from(this.toFloat * that.toFloat)
+  def /(that: MiniFloat): MiniFloat = MiniFloat.from(this.toFloat / that.toFloat)
+  def unary_- : MiniFloat           = MiniFloat.from(-this.toFloat)
+
+  def isNaN: Boolean    = toFloat.isNaN
+  def isFinite: Boolean = toFloat.isFinite
+
+  override def toString = s"MiniFloat($toFloat)"
+}
+
+object MiniFloat {
+
+  object PositiveInfinity extends MiniFloat(Float.PositiveInfinity)
+  object NegativeInfinity extends MiniFloat(Float.NegativeInfinity)
+  object NaN              extends MiniFloat(Float.NaN)
+
+  private final class Finite private (significand: Int, exponent: Int)
+    extends MiniFloat(significand * math.pow(Finite.base.toDouble, exponent.toDouble).toFloat)
+
+  private[MiniFloat] object Finite {
+
+    private[MiniFloat] val base = 2
+
+    private val minSignificand = -2
+    private val maxSignificand = 2
+
+    private val minExponent = -1
+    private val maxExponent = 2
+
+    val allValues: List[Finite] = {
+      for {
+        significand <- Range.inclusive(minSignificand, maxSignificand)
+        exponent    <- Range.inclusive(minExponent, maxExponent)
+      } yield new Finite(significand, exponent)
+    }.to(List).ordDistinct(Order.by(_.toFloat)).sortBy(_.toFloat)
+
+    private[MiniFloat] val allValuesAsFloats: List[Float] = allValues.map(_.toFloat)
+
+    val zero        = new Finite(0, 0)
+    val max         = new Finite(maxSignificand, maxExponent)
+    val min         = new Finite(minSignificand, maxExponent)
+    val minPositive = new Finite(significand = 1, exponent = minExponent)
+
+    /**
+     * Returns `None` if the given float cannot fit in an instance of `Finite`.
+     */
+    def from(float: Float): Option[Finite] = {
+      val exponent: Int    = math.getExponent(float)
+      val significand: Int = math.round(float / math.pow(Finite.base.toDouble, exponent.toDouble).toFloat)
+
+      if (significand == 0 || exponent < minExponent) {
+        Some(zero)
+      } else if (withinBounds(significand, exponent)) {
+        Some(new Finite(significand, exponent))
+      } else if (exponent > maxExponent) {
+        try {
+          val ordersOfMagnitudeToShift = math.subtractExact(exponent, maxExponent)
+
+          val proposedSignificand: Int = math.multiplyExact(
+            significand,
+            math.pow(base.toDouble, ordersOfMagnitudeToShift.toDouble).toInt,
+          )
+          val proposedExponent: Int = math.subtractExact(exponent, ordersOfMagnitudeToShift)
+
+          Option.when(withinBounds(proposedSignificand, proposedExponent)) {
+            new Finite(proposedSignificand, proposedExponent)
+          }
+        } catch {
+          case e: ArithmeticException => None
+        }
+      } else {
+        None
+      }
+    }
+
+    private def withinBounds(significand: Int, exponent: Int): Boolean =
+      (minExponent <= exponent && exponent <= maxExponent) &&
+        (minSignificand <= significand && significand <= maxSignificand)
+
+  }
+
+  val Zero: MiniFloat        = MiniFloat.from(0f)
+  val NegativeOne: MiniFloat = MiniFloat.from(-1f)
+  val One: MiniFloat         = MiniFloat.from(1f)
+
+  val MaxValue: MiniFloat         = Finite.max
+  val MinValue: MiniFloat         = Finite.min
+  val MinPositiveValue: MiniFloat = Finite.minPositive
+
+  def allValues: List[MiniFloat] =
+    List(NegativeInfinity) ++
+      Finite.allValues :+
+      PositiveInfinity :+
+      NaN
+
+  def from(float: Float): MiniFloat =
+    float match {
+      case Float.PositiveInfinity => PositiveInfinity
+      case Float.NegativeInfinity => NegativeInfinity
+      case f if f.isNaN           => NaN
+      case _ =>
+        Finite
+          .from(float)
+          .getOrElse {
+            if (float > 0) PositiveInfinity else NegativeInfinity
+          }
+    }
+
+  def from(double: Double): MiniFloat = from(double.toFloat)
+  def from(int: Int): MiniFloat       = from(int.toFloat)
+  def from(long: Long): MiniFloat     = from(long.toFloat)
+
+  /**
+   * Note that since `MiniFloat` is used primarily for tests, NaN is considered equal to itself in this context.
+   */
+  implicit val catsLawsEqInstancesForMiniFloat: Order[MiniFloat] with Hash[MiniFloat] =
+    new Order[MiniFloat] with Hash[MiniFloat] {
+      override def compare(x: MiniFloat, y: MiniFloat): Int = Order[Float].compare(x.toFloat, y.toFloat)
+      override def hash(x: MiniFloat): Int = Hash[Float].hash(x.toFloat)
+    }
+
+  implicit val catsLawsExhaustiveCheckForMiniInt: ExhaustiveCheck[MiniFloat] = new ExhaustiveCheck[MiniFloat] {
+    override def allValues: List[MiniFloat] = MiniFloat.allValues
+  }
+
+}

--- a/laws/src/main/scala/cats/laws/discipline/MiniFloat.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MiniFloat.scala
@@ -2,8 +2,8 @@ package cats
 package laws
 package discipline
 
-import cats.implicits.toTraverseFilterOps
-import java.lang.Math
+import cats.implicits.{catsSyntaxPartialOrder, toTraverseFilterOps}
+import cats.kernel.{BoundedSemilattice, CommutativeMonoid}
 
 /**
  * Similar to `Float`, but with a much smaller domain. The exact range of [[MiniFloat]] may be tuned from time to time,
@@ -157,5 +157,11 @@ object MiniFloat {
   implicit val catsLawsExhaustiveCheckForMiniInt: ExhaustiveCheck[MiniFloat] = new ExhaustiveCheck[MiniFloat] {
     override def allValues: List[MiniFloat] = MiniFloat.allValues
   }
+
+  val miniFloatMax: CommutativeMonoid[MiniFloat] with BoundedSemilattice[MiniFloat] =
+    new CommutativeMonoid[MiniFloat] with BoundedSemilattice[MiniFloat] {
+      override def empty: MiniFloat = MiniFloat.NegativeInfinity
+      override def combine(x: MiniFloat, y: MiniFloat): MiniFloat = if (x > y) x else y
+    }
 
 }

--- a/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
@@ -376,6 +376,13 @@ object arbitrary extends ArbitraryInstances0 with ScalaVersionSpecific.Arbitrary
 
   implicit val catsLawsArbitraryForMiniInt: Arbitrary[MiniInt] =
     Arbitrary(Gen.oneOf(MiniInt.allValues))
+
+  implicit val catsLawsCogenForMiniFloat: Cogen[MiniFloat] =
+    Cogen[Float].contramap(_.toFloat)
+
+  implicit val catsLawsArbitraryForMiniFloat: Arbitrary[MiniFloat] =
+    Arbitrary(Gen.oneOf(MiniFloat.allValues))
+
 }
 
 sealed private[discipline] trait ArbitraryInstances0 {

--- a/tests/src/test/scala-2.12/cats/tests/ScalaVersionSpecific.scala
+++ b/tests/src/test/scala-2.12/cats/tests/ScalaVersionSpecific.scala
@@ -2,7 +2,6 @@ package cats.tests
 
 import cats.laws.discipline.{ExhaustiveCheck, MiniInt, MiniFloat}
 import cats.laws.discipline.MiniInt._
-import cats.laws.discipline.eq._
 import cats.kernel.{Eq, Order}
 
 trait ScalaVersionSpecificFoldableSuite

--- a/tests/src/test/scala-2.12/cats/tests/ScalaVersionSpecific.scala
+++ b/tests/src/test/scala-2.12/cats/tests/ScalaVersionSpecific.scala
@@ -1,6 +1,6 @@
 package cats.tests
 
-import cats.laws.discipline.{ExhaustiveCheck, MiniInt, MiniFloat}
+import cats.laws.discipline.{ExhaustiveCheck, MiniFloat, MiniInt}
 import cats.laws.discipline.MiniInt._
 import cats.kernel.{Eq, Order}
 

--- a/tests/src/test/scala/cats/tests/MiniFloatSuite.scala
+++ b/tests/src/test/scala/cats/tests/MiniFloatSuite.scala
@@ -1,7 +1,13 @@
 package cats.tests
 
-import cats.kernel.laws.discipline.{HashTests, OrderTests, SerializableTests}
-import cats.kernel.{Hash, Order}
+import cats.kernel.laws.discipline.{
+  BoundedSemilatticeTests,
+  CommutativeMonoidTests,
+  HashTests,
+  OrderTests,
+  SerializableTests
+}
+import cats.kernel.{BoundedSemilattice, CommutativeMonoid, Hash, Order}
 import cats.laws.discipline.MiniFloat
 import cats.laws.discipline.MiniFloat._
 import cats.laws.discipline.arbitrary._
@@ -356,6 +362,13 @@ class MiniFloatSuite extends CatsSuite {
 
   checkAll("MiniFloat", HashTests[MiniFloat].hash)
   checkAll("Hash[MiniFloat]", SerializableTests.serializable(Hash[MiniFloat]))
+
+  {
+    implicit val m: CommutativeMonoid[MiniFloat] with BoundedSemilattice[MiniFloat] = miniFloatMax
+    checkAll("CommutativeMonoid[MiniFloat] maximum", CommutativeMonoidTests[MiniFloat].commutativeMonoid)
+    checkAll("BoundedSemilatticeMonoid[MiniFloat] maximum", BoundedSemilatticeTests[MiniFloat].boundedSemilattice)
+    checkAll("CommutativeMonoid[MiniFloat] maximum", SerializableTests.serializable(miniFloatMax))
+  }
 
 }
 

--- a/tests/src/test/scala/cats/tests/MiniFloatSuite.scala
+++ b/tests/src/test/scala/cats/tests/MiniFloatSuite.scala
@@ -1,15 +1,15 @@
 package cats.tests
 
-import cats.kernel.{Hash, Order}
 import cats.kernel.laws.discipline.{HashTests, OrderTests, SerializableTests}
+import cats.kernel.{Hash, Order}
 import cats.laws.discipline.MiniFloat
 import cats.laws.discipline.MiniFloat._
 import cats.laws.discipline.arbitrary._
-import org.scalacheck.{Arbitrary, Gen}
 import cats.syntax.eq._
 import cats.tests.MiniFloatSuite.FloatArithmeticOp
 import munit.Location
 import org.scalacheck.Prop._
+import org.scalacheck.{Arbitrary, Gen}
 
 import scala.collection.MapView
 
@@ -358,8 +358,6 @@ class MiniFloatSuite extends CatsSuite {
 
   checkAll("MiniFloat", HashTests[MiniFloat].hash)
   checkAll("Hash[MiniFloat]", SerializableTests.serializable(Hash[MiniFloat]))
-
-  // TODO semigroup tests
 
 }
 

--- a/tests/src/test/scala/cats/tests/MiniFloatSuite.scala
+++ b/tests/src/test/scala/cats/tests/MiniFloatSuite.scala
@@ -11,18 +11,16 @@ import munit.Location
 import org.scalacheck.Prop._
 import org.scalacheck.{Arbitrary, Gen}
 
-import scala.collection.MapView
-
 class MiniFloatSuite extends CatsSuite {
 
   // checks on allValues
 
   test("allValues contains no duplicates") {
-    val occurrencesPerFloatValue: MapView[Float, List[MiniFloat]] = MiniFloat.allValues
+    val occurrencesPerFloatValue = MiniFloat.allValues
       .groupBy(_.toFloat)
       .view
 
-    val duplicates: List[(Float, List[MiniFloat])] = occurrencesPerFloatValue.to(List).filter(_._2.size > 1)
+    val duplicates: List[(Float, List[MiniFloat])] = occurrencesPerFloatValue.toList.filter(_._2.size > 1)
 
     assert(duplicates.isEmpty, s"Minifloats with duplicate values $duplicates")
   }
@@ -100,32 +98,32 @@ class MiniFloatSuite extends CatsSuite {
   testFloatConversion(Float.NegativeInfinity, MiniFloat.NegativeInfinity)
   testFloatConversion(Float.MinValue, MiniFloat.NegativeInfinity)
   testFloatConversion(-16f, MiniFloat.NegativeInfinity)
-  testFloatConversion(math.nextDown(-12f), MiniFloat.NegativeInfinity)
+  testFloatConversion(Math.nextDown(-12f), MiniFloat.NegativeInfinity)
   testFloatConversion(-12f, -8f)
-  testFloatConversion(math.nextDown(-6f), -8f)
+  testFloatConversion(Math.nextDown(-6f), -8f)
   testFloatConversion(-6f, -4f)
-  testFloatConversion(math.nextDown(-3f), -4f)
+  testFloatConversion(Math.nextDown(-3f), -4f)
   testFloatConversion(-3f, -2f)
   testFloatConversion(-1f, MiniFloat.NegativeOne)
   testFloatConversion(1f, MiniFloat.One)
   testFloatConversion(0f, MiniFloat.Zero)
   testFloatConversion(Float.MinPositiveValue, MiniFloat.Zero)
   testFloatConversion(-0f, MiniFloat.Zero)
-  testFloatConversion(math.nextDown(0.125f), MiniFloat.Zero)
+  testFloatConversion(Math.nextDown(0.125f), MiniFloat.Zero)
   testFloatConversion(0.125f, MiniFloat.Zero)
-  testFloatConversion(math.nextDown(0.25f), MiniFloat.Zero)
+  testFloatConversion(Math.nextDown(0.25f), MiniFloat.Zero)
   testFloatConversion(0.25f, MiniFloat.Zero)
   testFloatConversion(0.5f, 0.5f)
   testFloatConversion(1f, 1f)
   testFloatConversion(2f, 2f)
-  testFloatConversion(math.nextDown(3f), 2f)
+  testFloatConversion(Math.nextDown(3f), 2f)
   testFloatConversion(3f, 4f)
   testFloatConversion(4f, 4f)
   testFloatConversion(5f, 4f)
   testFloatConversion(6f, 8f)
   testFloatConversion(7f, 8f)
   testFloatConversion(8f, 8f)
-  testFloatConversion(math.nextDown(12f), 8f)
+  testFloatConversion(Math.nextDown(12f), 8f)
   testFloatConversion(12f, MiniFloat.PositiveInfinity)
   testFloatConversion(16f, MiniFloat.PositiveInfinity)
   testFloatConversion(Float.MaxValue, MiniFloat.PositiveInfinity)
@@ -205,7 +203,7 @@ class MiniFloatSuite extends CatsSuite {
   }
 
   test("negation inverse") {
-    forAll { mf: MiniFloat =>
+    forAll { (mf: MiniFloat) =>
       assert((-(-mf) === mf) || mf.isNaN)
     }
   }
@@ -219,7 +217,7 @@ class MiniFloatSuite extends CatsSuite {
   }
 
   test("zero addition identity") {
-    forAll { mf: MiniFloat =>
+    forAll { (mf: MiniFloat) =>
       assert(mf + MiniFloat.Zero === mf)
     }
   }
@@ -245,7 +243,7 @@ class MiniFloatSuite extends CatsSuite {
   }
 
   test("NaN addition") {
-    forAll { mf: MiniFloat =>
+    forAll { (mf: MiniFloat) =>
       assert((mf + MiniFloat.NaN).isNaN)
     }
   }
@@ -259,7 +257,7 @@ class MiniFloatSuite extends CatsSuite {
   }
 
   test("NaN subtraction") {
-    forAll { mf: MiniFloat =>
+    forAll { (mf: MiniFloat) =>
       assert((mf - MiniFloat.NaN).isNaN)
     }
   }
@@ -277,7 +275,7 @@ class MiniFloatSuite extends CatsSuite {
   }
 
   test("one multiplicative identity") {
-    forAll { mf: MiniFloat =>
+    forAll { (mf: MiniFloat) =>
       assert(mf * MiniFloat.One === mf)
     }
   }
@@ -303,7 +301,7 @@ class MiniFloatSuite extends CatsSuite {
   }
 
   test("NaN multiplication") {
-    forAll { mf: MiniFloat =>
+    forAll { (mf: MiniFloat) =>
       assert((mf * MiniFloat.NaN).isNaN)
     }
   }
@@ -311,7 +309,7 @@ class MiniFloatSuite extends CatsSuite {
   // Division
 
   test("divide by zero") {
-    forAll { mf: MiniFloat =>
+    forAll { (mf: MiniFloat) =>
       val result = mf / MiniFloat.Zero
 
       if (mf.isNaN || mf === MiniFloat.Zero) {

--- a/tests/src/test/scala/cats/tests/MiniFloatSuite.scala
+++ b/tests/src/test/scala/cats/tests/MiniFloatSuite.scala
@@ -1,0 +1,378 @@
+package cats.tests
+
+import cats.kernel.Order
+import cats.laws.discipline.MiniFloat
+import cats.laws.discipline.MiniFloat._
+import cats.laws.discipline.arbitrary._
+import org.scalacheck.{Arbitrary, Gen}
+import cats.syntax.eq._
+import cats.tests.MiniFloatSuite.FloatArithmeticOp
+import munit.Location
+import org.scalacheck.Prop._
+
+import scala.collection.MapView
+
+class MiniFloatSuite extends CatsSuite {
+
+  // checks on allValues
+
+  test("allValues contains no duplicates") {
+    val occurrencesPerFloatValue: MapView[Float, List[MiniFloat]] = MiniFloat.allValues
+      .groupBy(_.toFloat)
+      .view
+
+    val duplicates: List[(Float, List[MiniFloat])] = occurrencesPerFloatValue.to(List).filter(_._2.size > 1)
+
+    assert(duplicates.isEmpty, s"Minifloats with duplicate values $duplicates")
+  }
+
+  private def testAllValuesContains(value: MiniFloat)(implicit loc: Location): Unit =
+    test(s"allValues contains $value") {
+      MiniFloat.allValues.contains(value)
+    }
+
+  testAllValuesContains(MiniFloat.Zero)
+  testAllValuesContains(MiniFloat.NegativeOne)
+  testAllValuesContains(MiniFloat.One)
+  testAllValuesContains(MiniFloat.MaxValue)
+  testAllValuesContains(MiniFloat.MinValue)
+  testAllValuesContains(MiniFloat.MinPositiveValue)
+  testAllValuesContains(MiniFloat.PositiveInfinity)
+  testAllValuesContains(MiniFloat.NegativeInfinity)
+  testAllValuesContains(MiniFloat.NaN)
+
+  test("allValues has max") {
+    val maxInAllValues = MiniFloat.allValues.filter(_.isFinite).maxBy(_.toFloat)
+
+    assert(maxInAllValues === MiniFloat.MaxValue)
+  }
+
+  test("allValues has min") {
+    val minInAllValues = MiniFloat.allValues.filter(_.isFinite).minBy(_.toFloat)
+
+    assert(minInAllValues === MiniFloat.MinValue)
+  }
+
+  test("behaves the same as Float for all operations on some key values") {
+    val genKeyMiniFloatValues: Gen[MiniFloat] = Gen.oneOf(
+      MiniFloat.NegativeInfinity,
+      MiniFloat.NegativeOne,
+      MiniFloat.Zero,
+      MiniFloat.One,
+      MiniFloat.PositiveInfinity,
+      MiniFloat.NaN
+    )
+
+    forAll(FloatArithmeticOp.arb.arbitrary, genKeyMiniFloatValues, genKeyMiniFloatValues) {
+      (op: FloatArithmeticOp, left: MiniFloat, right: MiniFloat) =>
+        val testHint = s"$left ${op.char} $right"
+        val expectedAsFloat: Float = op.forFloat(left.toFloat, right.toFloat)
+
+        // This is necessary since Float.NaN != Float.NaN
+        if (expectedAsFloat.isNaN) {
+          assert(op.forMiniFloat(left, right).isNaN, testHint)
+        } else {
+          assert(op.forMiniFloat(left, right).toFloat === expectedAsFloat, testHint)
+        }
+    }
+  }
+
+  // Float conversions
+
+  private def testFloatConversion(float: Float, expected: MiniFloat)(implicit loc: Location): Unit =
+    test(s"MiniFloat.fromFloat($float) === $expected") {
+      assert(MiniFloat.from(float) === expected)
+    }
+
+  private def testFloatConversion(float: Float, expected: Float)(implicit loc: Location): Unit =
+    test(s"MiniFloat.fromFloat($float) === $expected") {
+      val miniFloat = MiniFloat.from(float)
+
+      // This is necessary since Float.NaN != Float.NaN
+      if (miniFloat.isNaN) {
+        assert(expected.isNaN)
+      } else {
+        assert(miniFloat.toFloat === expected)
+      }
+    }
+
+  testFloatConversion(Float.NegativeInfinity, MiniFloat.NegativeInfinity)
+  testFloatConversion(Float.MinValue, MiniFloat.NegativeInfinity)
+  testFloatConversion(-16f, MiniFloat.NegativeInfinity)
+  testFloatConversion(math.nextDown(-12f), MiniFloat.NegativeInfinity)
+  testFloatConversion(-12f, -8f)
+  testFloatConversion(math.nextDown(-6f), -8f)
+  testFloatConversion(-6f, -4f)
+  testFloatConversion(math.nextDown(-3f), -4f)
+  testFloatConversion(-3f, -2f)
+  testFloatConversion(-1f, MiniFloat.NegativeOne)
+  testFloatConversion(1f, MiniFloat.One)
+  testFloatConversion(0f, MiniFloat.Zero)
+  testFloatConversion(Float.MinPositiveValue, MiniFloat.Zero)
+  testFloatConversion(-0f, MiniFloat.Zero)
+  testFloatConversion(math.nextDown(0.125f), MiniFloat.Zero)
+  testFloatConversion(0.125f, MiniFloat.Zero)
+  testFloatConversion(math.nextDown(0.25f), MiniFloat.Zero)
+  testFloatConversion(0.25f, MiniFloat.Zero)
+  testFloatConversion(0.5f, 0.5f)
+  testFloatConversion(1f, 1f)
+  testFloatConversion(2f, 2f)
+  testFloatConversion(math.nextDown(3f), 2f)
+  testFloatConversion(3f, 4f)
+  testFloatConversion(4f, 4f)
+  testFloatConversion(5f, 4f)
+  testFloatConversion(6f, 8f)
+  testFloatConversion(7f, 8f)
+  testFloatConversion(8f, 8f)
+  testFloatConversion(math.nextDown(12f), 8f)
+  testFloatConversion(12f, MiniFloat.PositiveInfinity)
+  testFloatConversion(16f, MiniFloat.PositiveInfinity)
+  testFloatConversion(Float.MaxValue, MiniFloat.PositiveInfinity)
+  testFloatConversion(Float.PositiveInfinity, MiniFloat.PositiveInfinity)
+  testFloatConversion(Float.NaN, MiniFloat.NaN)
+
+  test("MiniFloat.fromFloat(-0) is not negative") {
+    assert(!(MiniFloat.from(-0).toFloat < 0))
+  }
+
+  test(s"fromDouble consistent with fromFloat") {
+    forAll { (n: Double) =>
+      assert(MiniFloat.from(n) === MiniFloat.from(n.toFloat), n)
+    }
+  }
+
+  test(s"toDouble consistent with toFloat") {
+    forAll { (mf: MiniFloat) =>
+      val fromToDouble = mf.toDouble.toFloat
+      val fromToFloat = mf.toFloat
+
+      // This is necessary since Float.NaN != Float.NaN
+      if (fromToDouble.isNaN) {
+        assert(fromToFloat.isNaN)
+      } else {
+        assert(fromToDouble === fromToFloat, mf)
+      }
+    }
+  }
+
+  // Special number tests and behaviours
+
+  private def testSpecialNumberExpectations(
+    mf: MiniFloat,
+    expectIsNaN: Boolean,
+    expectIsFinite: Boolean
+  )(implicit
+    loc: Location
+  ): Unit = {
+    test(s"$mf isNan $expectIsNaN") {
+      assert(mf.isNaN === expectIsNaN)
+    }
+
+    test(s"$mf isFinite $expectIsFinite") {
+      assert(mf.isFinite === expectIsFinite)
+    }
+  }
+
+  testSpecialNumberExpectations(MiniFloat.NaN, expectIsNaN = true, expectIsFinite = false)
+  testSpecialNumberExpectations(MiniFloat.PositiveInfinity, expectIsNaN = false, expectIsFinite = false)
+  testSpecialNumberExpectations(MiniFloat.NegativeInfinity, expectIsNaN = false, expectIsFinite = false)
+  testSpecialNumberExpectations(MiniFloat.Zero, expectIsNaN = false, expectIsFinite = true)
+  testSpecialNumberExpectations(MiniFloat.MaxValue, expectIsNaN = false, expectIsFinite = true)
+  testSpecialNumberExpectations(MiniFloat.MinValue, expectIsNaN = false, expectIsFinite = true)
+  testSpecialNumberExpectations(MiniFloat.MinPositiveValue, expectIsNaN = false, expectIsFinite = true)
+
+  // Negation
+
+  test("negate zero is zero") {
+    assert(-MiniFloat.Zero === MiniFloat.Zero)
+  }
+
+  test("negate one is one") {
+    assert(-MiniFloat.One === MiniFloat.NegativeOne)
+  }
+
+  test("negate ∞ is -∞") {
+    assert(-MiniFloat.PositiveInfinity === MiniFloat.NegativeInfinity)
+  }
+
+  test("negate -∞ is ∞") {
+    assert(-MiniFloat.NegativeInfinity === MiniFloat.PositiveInfinity)
+  }
+
+  test("negate NaN is NaN") {
+    assert((-MiniFloat.NaN).isNaN)
+  }
+
+  test("negation inverse") {
+    forAll { mf: MiniFloat =>
+      assert((-(-mf) === mf) || mf.isNaN)
+    }
+  }
+
+  // Addition
+
+  test("add commutative") {
+    forAll { (left: MiniFloat, right: MiniFloat) =>
+      assert(left + right === right + left)
+    }
+  }
+
+  test("zero addition identity") {
+    forAll { mf: MiniFloat =>
+      assert(mf + MiniFloat.Zero === mf)
+    }
+  }
+
+  test("max plus 1") {
+    assert(MiniFloat.MaxValue + MiniFloat.One === MiniFloat.MaxValue)
+  }
+
+  test("max plus max") {
+    assert(MiniFloat.MaxValue + MiniFloat.MaxValue === MiniFloat.PositiveInfinity)
+  }
+
+  test("∞ + ∞") {
+    assert(MiniFloat.PositiveInfinity + MiniFloat.PositiveInfinity === MiniFloat.PositiveInfinity)
+  }
+
+  test("∞ + 1") {
+    assert(MiniFloat.PositiveInfinity + MiniFloat.One === MiniFloat.PositiveInfinity)
+  }
+
+  test("∞ + (-∞)") {
+    assert((MiniFloat.PositiveInfinity + MiniFloat.NegativeInfinity).isNaN)
+  }
+
+  test("NaN addition") {
+    forAll { mf: MiniFloat =>
+      assert((mf + MiniFloat.NaN).isNaN)
+    }
+  }
+
+  // Subtraction
+
+  test("subtract consistent with addition") {
+    forAll { (left: MiniFloat, right: MiniFloat) =>
+      assert((left + (-right)) === left - right)
+    }
+  }
+
+  test("NaN subtraction") {
+    forAll { mf: MiniFloat =>
+      assert((mf - MiniFloat.NaN).isNaN)
+    }
+  }
+
+  test("∞ - ∞") {
+    assert((MiniFloat.PositiveInfinity - MiniFloat.PositiveInfinity).isNaN)
+  }
+
+  // Multiplication
+
+  test("multiplication commutative") {
+    forAll { (left: MiniFloat, right: MiniFloat) =>
+      assert(left * right === right * left)
+    }
+  }
+
+  test("one multiplicative identity") {
+    forAll { mf: MiniFloat =>
+      assert(mf * MiniFloat.One === mf)
+    }
+  }
+
+  test("max * 1") {
+    assert(MiniFloat.MaxValue * MiniFloat.One === MiniFloat.MaxValue)
+  }
+
+  test("max * max") {
+    assert(MiniFloat.MaxValue * MiniFloat.MaxValue === MiniFloat.PositiveInfinity)
+  }
+
+  test("∞ * ∞") {
+    assert(MiniFloat.PositiveInfinity * MiniFloat.PositiveInfinity === MiniFloat.PositiveInfinity)
+  }
+
+  test("∞ * 1") {
+    assert(MiniFloat.PositiveInfinity * MiniFloat.One === MiniFloat.PositiveInfinity)
+  }
+
+  test("∞ * (-∞)") {
+    assert(MiniFloat.PositiveInfinity * MiniFloat.NegativeInfinity === MiniFloat.NegativeInfinity)
+  }
+
+  test("NaN multiplication") {
+    forAll { mf: MiniFloat =>
+      assert((mf * MiniFloat.NaN).isNaN)
+    }
+  }
+
+  // Division
+
+  test("divide by zero") {
+    forAll { mf: MiniFloat =>
+      val result = mf / MiniFloat.Zero
+
+      if (mf.isNaN || mf === MiniFloat.Zero) {
+        assert(result.isNaN)
+      } else if (mf.toFloat < 0f) {
+        assert(result === MiniFloat.NegativeInfinity)
+      } else {
+        assert(result === MiniFloat.PositiveInfinity)
+      }
+    }
+  }
+
+  test("division consistent with float division") {
+    forAll { (left: MiniFloat, right: MiniFloat) =>
+      val result = left / right
+
+      if (result.isNaN) {
+        assert(MiniFloat.from(left.toFloat / right.toFloat).isNaN)
+      } else {
+        assert(result === MiniFloat.from(left.toFloat / right.toFloat))
+      }
+    }
+  }
+
+  // Order
+
+  test("ordering consistent with float") {
+    forAll { (left: MiniFloat, right: MiniFloat) =>
+      assert(
+        implicitly[Order[MiniFloat]].compare(left, right) ===
+          implicitly[Order[Float]].compare(left.toFloat, right.toFloat)
+      )
+    }
+  }
+
+  // TODO roundtrip
+  // TODO bounds
+  // TODO order tests
+  // TODO order serializable tests
+  // TODO hash tests
+  // TODO hash serializable tests
+
+  // TODO semigroup tests
+
+}
+
+object MiniFloatSuite {
+
+  sealed abstract private class FloatArithmeticOp(
+    val char: Char,
+    val forMiniFloat: (MiniFloat, MiniFloat) => MiniFloat,
+    val forFloat: (Float, Float) => Float
+  )
+
+  private object FloatArithmeticOp {
+    case object Addition extends FloatArithmeticOp('+', _ + _, _ + _)
+    case object Multiplication extends FloatArithmeticOp('*', _ * _, _ * _)
+    case object Subtraction extends FloatArithmeticOp('-', _ - _, _ - _)
+    case object Division extends FloatArithmeticOp('/', _ / _, _ / _)
+
+    implicit val arb: Arbitrary[FloatArithmeticOp] =
+      Arbitrary(Gen.oneOf(Addition, Multiplication, Subtraction, Division))
+  }
+
+}

--- a/tests/src/test/scala/cats/tests/MiniFloatSuite.scala
+++ b/tests/src/test/scala/cats/tests/MiniFloatSuite.scala
@@ -1,6 +1,7 @@
 package cats.tests
 
-import cats.kernel.Order
+import cats.kernel.{Hash, Order}
+import cats.kernel.laws.discipline.{HashTests, OrderTests, SerializableTests}
 import cats.laws.discipline.MiniFloat
 import cats.laws.discipline.MiniFloat._
 import cats.laws.discipline.arbitrary._
@@ -346,12 +347,17 @@ class MiniFloatSuite extends CatsSuite {
     }
   }
 
-  // TODO roundtrip
-  // TODO bounds
-  // TODO order tests
-  // TODO order serializable tests
-  // TODO hash tests
-  // TODO hash serializable tests
+  test("float roundtrip") {
+    forAll { (f: MiniFloat) =>
+      assert(MiniFloat.from(f.toFloat) === f)
+    }
+  }
+
+  checkAll("MiniFloat", OrderTests[MiniFloat].order)
+  checkAll("Order[MiniFloat]", SerializableTests.serializable(Order[MiniFloat]))
+
+  checkAll("MiniFloat", HashTests[MiniFloat].hash)
+  checkAll("Hash[MiniFloat]", SerializableTests.serializable(Hash[MiniFloat]))
 
   // TODO semigroup tests
 

--- a/tests/src/test/scala/cats/tests/MiniFloatSuite.scala
+++ b/tests/src/test/scala/cats/tests/MiniFloatSuite.scala
@@ -47,15 +47,14 @@ class MiniFloatSuite extends CatsSuite {
   testAllValuesContains(MiniFloat.NegativeInfinity)
   testAllValuesContains(MiniFloat.NaN)
 
-  // https://github.com/scala-native/scala-native/issues/2178
-  test(failOnScalaNative("allValues has max")) {
-    val maxInAllValues = MiniFloat.allValues.filter(_.isFinite).maxBy(_.toFloat)
+  test("allValues has max") {
+    val maxInAllValues = MiniFloat.allValues.filter(mf => !mf.isNaN && mf.isFinite).maxBy(_.toFloat)
 
     assert(maxInAllValues === MiniFloat.MaxValue)
   }
 
   test("allValues has min") {
-    val minInAllValues = MiniFloat.allValues.filter(_.isFinite).minBy(_.toFloat)
+    val minInAllValues = MiniFloat.allValues.filter(mf => !mf.isNaN && mf.isFinite).minBy(_.toFloat)
 
     assert(minInAllValues === MiniFloat.MinValue)
   }

--- a/tests/src/test/scala/cats/tests/MiniIntSuite.scala
+++ b/tests/src/test/scala/cats/tests/MiniIntSuite.scala
@@ -24,7 +24,7 @@ class MiniIntSuite extends CatsSuite {
 
   {
     implicit val m: CommutativeMonoid[MiniInt] = miniIntMultiplication
-    checkAll("MiniInt addition", CommutativeMonoidTests[MiniInt].commutativeMonoid)
+    checkAll("MiniInt multiplication", CommutativeMonoidTests[MiniInt].commutativeMonoid)
     checkAll("CommutativeMonoid[MiniInt] multiplication", SerializableTests.serializable(miniIntMultiplication))
   }
 


### PR DESCRIPTION
Fixes #3794

This PR adds `Invariant[Fractional]`. In order to test this instance, I have provided a new class `MiniFloat`, which is the floating-point analogue to `MiniInt`. Its range is small enough that an `ExhaustiveCheck` instance can be defined.

I'm conscious that a class like `MiniFloat` is a more significant addition than might be strictly necessary to add an instance like `Invariant[Fractional]`, but I'm hoping that it's judged to be sufficiently useful to be included in the `discipline` library.

I'll make more explanatory comments inline on the PR.

Note that the build is failing due to a [bug in the Scala Native implementation of isFinite](https://github.com/scala-native/scala-native/issues/2178). I'll try to find a solution to ignore this test.