### PR TITLE
Update applicativemonaderror.md

### DIFF
--- a/docs/src/main/mdoc/typeclasses/applicativemonaderror.md
+++ b/docs/src/main/mdoc/typeclasses/applicativemonaderror.md
@@ -128,7 +128,7 @@ def attemptDivideApplicativeErrorWithMap2[F[_]](x: Int, y: Int)(implicit ae: App
    else {
      val fa = ae.pure(x)
      val fb = ae.pure(y)
-     ae.map2(fa, fb)(_ + _)
+     ae.map2(fa, fb)(_ / _)
    }
 }
 ```


### PR DESCRIPTION
The attemptDivideApplicativeError should divide instead of add.

Thank you for contributing to Cats!

This is a kind reminder to run `sbt +prePR` and commit the changed files, if any, before submitting.


