### PR TITLE
Provide instance of `Alternative[Set]` in alleycats

### DIFF
--- a/alleycats-tests/shared/src/test/scala/alleycats/tests/SetSuite.scala
+++ b/alleycats-tests/shared/src/test/scala/alleycats/tests/SetSuite.scala
@@ -2,18 +2,24 @@ package alleycats.tests
 
 import alleycats.laws.discipline._
 import alleycats.std.all._
-import cats.Foldable
+import cats.{Alternative, Foldable}
 import cats.instances.all._
 import cats.kernel.laws.discipline.SerializableTests
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline.arbitrary._
-import cats.laws.discipline.{ShortCircuitingTests, TraverseFilterTests}
+import cats.laws.discipline.{AlternativeTests, ShortCircuitingTests, TraverseFilterTests}
 
 class SetSuite extends AlleycatsSuite {
+  implicit val iso: Isomorphisms[Set] = Isomorphisms.invariant[Set](alleyCatsStdSetMonad)
+
   checkAll("FlatMapRec[Set]", FlatMapRecTests[Set].tailRecM[Int])
 
   checkAll("Foldable[Set]", SerializableTests.serializable(Foldable[Set]))
 
   checkAll("TraverseFilter[Set]", TraverseFilterTests[Set].traverseFilter[Int, Int, Int])
+
+  checkAll("Set[Int]", AlternativeTests[Set].alternative[Int, Int, Int])
+  checkAll("Alternative[Set]", SerializableTests.serializable(Alternative[Set]))
 
   checkAll("Set[Int]", ShortCircuitingTests[Set].traverseFilter[Int])
 }


### PR DESCRIPTION
This allows the use of methods from [`Alternative`](https://typelevel.org/cats/typeclasses/alternative.html) on a `Set` - for instance, I want to be able to use `separate` on a `Set`:

```scala
import cats.implicits._
import alleycats.std.set._

val stringsAndInts: Set[Either[String, Int]] = Set(Right(6),Left("Foo"))
val (strings: Set[String], ints: Set[Int]) = stringsAndInts.separate
```

The `Alternative` typeclass just requires `MonoidK` (already provided for `Set` in `cats-core`) & `Applicative` (already provided for `Set` by [`Monad`](https://typelevel.org/cats/typeclasses/monad.html) in [`alleycats`](https://github.com/typelevel/cats/tree/main/alleycats-core#set_-instances)), so adding it to `alleycats` is a small change.

Here's a diagram I drew mainly for myself (!), as a novice contributing to Cats, to understand the typeclass relationships involved:

![CatsAlternativeForSet](https://user-images.githubusercontent.com/52038/113162999-a9873880-9237-11eb-82ba-80a6dc6f95ca.jpeg)



> This is a kind reminder to run `sbt +prePR` and commit the changed files, if any, before submitting.

I did try running this - but it crashed on unrelated files like this:

```
[info] Forcing Scala version to 3.0.0-M3 on all projects.
[info] Reapplying settings...
[info] set current project to cats (in build file:/home/roberto/development/cats/)
[info] Formatting 2 Scala sources...
[info] Formatting 2 Scala sources...
[info] Formatting 2 Scala sources...
[info] Formatting 1 Scala sources...
[info] Formatting 1 Scala sources...
[info] Formatting 1 Scala sources...
[error] /home/roberto/development/cats/free/src/main/scala-3.x/cats/free/FreeFoldStep.scala:19: error: identifier expected but [ found
[error]     onFlatMapped: [X] => (S[X], X => Free[S, A]) => B
```

