### PR TITLE
drop ScalaTest in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,8 +145,8 @@ possible, include the original authors' names and a link to the original work.
 
 - Tests for cats-core go into the tests module, under the `cats.tests` package.
 - Tests for additional modules, such as 'jvm', go into the tests directory within that module.
-- Cats tests should extend `CatsSuite`.  `CatsSuite` integrates [ScalaTest](http://www.scalatest.org/)
-with [Discipline](https://github.com/typelevel/discipline) for law checking, and imports all syntax and standard instances for convenience.
+- Cats tests should extend `CatsSuite`.  `CatsSuite` integrates with [Discipline](https://github.com/typelevel/discipline)
+for law checking, and imports all syntax and standard instances for convenience.
 - The first parameter to the `checkAll` method provided by
  [Discipline](https://github.com/typelevel/discipline), is the name of the test and will be output to the
  console as part of the test execution. By convention:

--- a/build.sbt
+++ b/build.sbt
@@ -20,7 +20,6 @@ val scalaCheckVersion = "1.15.3"
 
 val disciplineVersion = "1.1.4"
 
-val disciplineScalatestVersion = "2.0.1"
 val disciplineMunitVersion = "1.0.7"
 
 val kindProjectorVersion = "0.11.3"
@@ -218,10 +217,6 @@ lazy val commonNativeSettings = Seq(
 )
 
 lazy val commonJvmSettings = Seq(
-  testOptions in Test += {
-    val flag = if (githubIsWorkflowBuild.value) "-oCI" else "-oDF"
-    Tests.Argument(TestFrameworks.ScalaTest, flag)
-  },
   Test / fork := true,
   Test / javaOptions := Seq("-Xmx3G")
 )
@@ -532,7 +527,7 @@ lazy val docs = project
   .settings(commonJvmSettings)
   .settings(
     libraryDependencies ++= Seq(
-      "org.typelevel" %%% "discipline-scalatest" % disciplineScalatestVersion
+      "org.typelevel" %%% "discipline-munit" % disciplineMunitVersion
     ),
     scalacOptions in (ScalaUnidoc, unidoc) ~= { _.filter(_ != "-Xlint:-unused,_") }
   )

--- a/docs/src/main/mdoc/typeclasses/lawtesting.md
+++ b/docs/src/main/mdoc/typeclasses/lawtesting.md
@@ -91,17 +91,15 @@ this conversion for three test frameworks: `ScalaTest`, `Specs2` and `MUnit`.
 * For other test frameworks, you need to resort to their integration with `ScalaCheck` to test
 the `ScalaCheck` `Properties` provided by `cats-laws`.
 
-The following example is for ScalaTest.
+The following example is for MUnit.
 
 ```scala mdoc
 import cats.implicits._
 import cats.laws.discipline.FunctorTests
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatestplus.scalacheck.Checkers
-import org.typelevel.discipline.scalatest.FunSuiteDiscipline
+import munit.DisciplineSuite
 import arbitraries._
 
-class TreeLawTests extends AnyFunSuite with FunSuiteDiscipline with Checkers {
+class TreeLawTests extends DisciplineSuite {
   checkAll("Tree.FunctorLaws", FunctorTests[Tree].functor[Int, Int, String])
 }
 ```
@@ -112,9 +110,6 @@ class TreeLawTests extends AnyFunSuite with FunSuiteDiscipline with Checkers {
 * `FunSuiteDiscipline` provides `checkAll`, and must be mixed into `AnyFunSuite`
 * `arbitraries._` imports the `Arbitrary[Tree[_]]` instances needed to check the laws.
 
-Alternatively, you can use the `CatsSuite` provided by [Cats-testkit-scalatest](https://github.com/typelevel/cats-testkit-scalatest),
-which used to be what Cats used internally to test all instances.
-
 Now when we run `test` in our sbt console, ScalaCheck will test if the `Functor` laws hold for our `Tree` type.
 You should see something like this:
 
@@ -124,12 +119,6 @@ You should see something like this:
 [info] - Tree.FunctorLaws.functor.covariant identity (3 milliseconds)
 [info] - Tree.FunctorLaws.functor.invariant composition (19 milliseconds)
 [info] - Tree.FunctorLaws.functor.invariant identity (3 milliseconds)
-[info] ScalaTest
-[info] Run completed in 1 second, 362 milliseconds.
-[info] Total number of tests run: 4
-[info] Suites: completed 1, aborted 0
-[info] Tests: succeeded 4, failed 0, canceled 0, ignored 0, pending 0
-[info] All tests passed.
 [info] Passed: Total 4, Failed 0, Errors 0, Passed 4
 [success] Total time: 2 s, completed Aug 2, 2019 12:01:17 AM
 ```
@@ -163,12 +152,10 @@ Then we can add the Semigroup tests to our suite:
 import cats.implicits._
 import cats.kernel.laws.discipline.SemigroupTests
 import cats.laws.discipline.FunctorTests
-import org.scalatest.funsuite.AnyFunSuite
-import org.scalatestplus.scalacheck.Checkers
-import org.typelevel.discipline.scalatest.FunSuiteDiscipline
+import munit.DisciplineSuite
 import arbitraries._
 
-class TreeLawTests extends AnyFunSuite with FunSuiteDiscipline with Checkers {
+class TreeLawTests extends DisciplineSuite {
   checkAll("Tree.FunctorLaws", FunctorTests[Tree].functor[Int, Int, String])
   checkAll("Tree[Int].SemigroupLaws", SemigroupTests[Tree[Int]].semigroup)
 }


### PR DESCRIPTION
Use discipline-munit in documentation. Reduces our set of dependencies.