### PR TITLE
Make deprecated catsDataInstancesForNonEmptyMap not implicit

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -302,7 +302,7 @@ sealed abstract private[data] class NonEmptyMapInstances extends NonEmptyMapInst
     }
 
   @deprecated("Use catsDataInstancesForNonEmptyMap override without Order", "2.2.0-M3")
-  implicit def catsDataInstancesForNonEmptyMap[K](
+  def catsDataInstancesForNonEmptyMap[K](
     orderK: Order[K]
   ): SemigroupK[NonEmptyMap[K, *]] with NonEmptyTraverse[NonEmptyMap[K, *]] with Align[NonEmptyMap[K, *]] =
     catsDataInstancesForNonEmptyMap[K]


### PR DESCRIPTION
Followup #3397


