### PR TITLE
Deprecate ifA.

### DIFF
--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -224,35 +224,8 @@ trait Apply[F[_]] extends Functor[F] with InvariantSemigroupal[F] with ApplyArit
       val G = Apply[G]
     }
 
-  /**
-   * An `if-then-else` lifted into the `F` context.
-   * This function combines the effects of the `fcond` condition and of the two branches,
-   * in the order in which they are given.
-   *
-   * The value of the result is, depending on the value of the condition,
-   * the value of the first argument, or the value of the second argument.
-   *
-   * Example:
-   * {{{
-   * scala> import cats.implicits._
-   *
-   * scala> val b1: Option[Boolean] = Some(true)
-   * scala> val asInt1: Option[Int] = Apply[Option].ifA(b1)(Some(1), Some(0))
-   * scala> asInt1.get
-   * res0: Int = 1
-   *
-   * scala> val b2: Option[Boolean] = Some(false)
-   * scala> val asInt2: Option[Int] = Apply[Option].ifA(b2)(Some(1), Some(0))
-   * scala> asInt2.get
-   * res1: Int = 0
-   *
-   * scala> val b3: Option[Boolean] = Some(true)
-   * scala> val asInt3: Option[Int] = Apply[Option].ifA(b3)(Some(1), None)
-   * asInt2: Option[Int] = None
-   *
-   * }}}
-   */
   @noop
+  @deprecated("Dangerous method, use ifM (a flatMap) or ifF (a map) instead", "2.6.2")
   def ifA[A](fcond: F[Boolean])(ifTrue: F[A], ifFalse: F[A]): F[A] = {
     def ite(b: Boolean)(ifTrue: A, ifFalse: A) = if (b) ifTrue else ifFalse
     ap2(map(fcond)(ite))(ifTrue, ifFalse)

--- a/core/src/main/scala/cats/syntax/apply.scala
+++ b/core/src/main/scala/cats/syntax/apply.scala
@@ -21,34 +21,7 @@ private[syntax] trait ApplySyntaxBinCompat0 {
 
 final class IfApplyOps[F[_]](private val fcond: F[Boolean]) extends AnyVal {
 
-  /**
-   * An `if-then-else` lifted into the `F` context.
-   * This function combines the effects of the `fcond` condition and of the two branches,
-   * in the order in which they are given.
-   *
-   * The value of the result is, depending on the value of the condition,
-   * the value of the first argument, or the value of the second argument.
-   *
-   * Example:
-   * {{{
-   * scala> import cats.implicits._
-   *
-   * scala> val b1: Option[Boolean] = Some(true)
-   * scala> val asInt1: Option[Int] = b1.ifA(Some(1), Some(0))
-   * scala> asInt1.get
-   * res0: Int = 1
-   *
-   * scala> val b2: Option[Boolean] = Some(false)
-   * scala> val asInt2: Option[Int] = b2.ifA(Some(1), Some(0))
-   * scala> asInt2.get
-   * res1: Int = 0
-   *
-   * scala> val b3: Option[Boolean] = Some(true)
-   * scala> val asInt3: Option[Int] = b3.ifA(Some(1), None)
-   * asInt2: Option[Int] = None
-   *
-   * }}}
-   */
+  @deprecated("Dangerous method, use ifM (a flatMap) or ifF (a map) instead", "2.6.2")
   def ifA[A](ifTrue: F[A], ifFalse: F[A])(implicit F: Apply[F]): F[A] = F.ifA(fcond)(ifTrue, ifFalse)
 }
 


### PR DESCRIPTION
So, a year and a half ago, [somebody thought](https://github.com/typelevel/cats/pull/2609) that having an `ifA` method, an _applicative_ counterpart of the `ifM` method from `FlatMap` (or M for Monad), would be a good idea. Turns out, having an "If-then-else" that actually performs  _both_ effects is hardly ever desirable, but the name naturally suggests it would not, so that was quite misleading. This has tripped some people. Thus the time has come to deprecate it, and retire it soon.

Resolves https://github.com/typelevel/cats/issues/3889
