### PR TITLE
Applicative whenA/unlessA syntax extensions should respect call-by-name parameter

### DIFF
--- a/core/src/main/scala/cats/syntax/applicative.scala
+++ b/core/src/main/scala/cats/syntax/applicative.scala
@@ -6,6 +6,8 @@ trait ApplicativeSyntax {
     new ApplicativeIdOps[A](a)
   implicit final def catsSyntaxApplicative[F[_], A](fa: F[A]): ApplicativeOps[F, A] =
     new ApplicativeOps[F, A](fa)
+  implicit final def catsSyntaxApplicativeByName[F[_], A](fa: => F[A]): ApplicativeByNameOps[F, A] =
+    new ApplicativeByNameOps[F, A](() => fa)
 }
 
 final class ApplicativeIdOps[A](private val a: A) extends AnyVal {
@@ -16,4 +18,9 @@ final class ApplicativeOps[F[_], A](private val fa: F[A]) extends AnyVal {
   def replicateA(n: Int)(implicit F: Applicative[F]): F[List[A]] = F.replicateA(n, fa)
   def unlessA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.unlessA(cond)(fa)
   def whenA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.whenA(cond)(fa)
+}
+
+final class ApplicativeByNameOps[F[_], A](private val fa: () => F[A]) extends AnyVal {
+  def unlessA_(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.unlessA(cond)(fa())
+  def whenA_(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.whenA(cond)(fa())
 }


### PR DESCRIPTION
The current implementation of the `.whenA`/`.unlessA` syntax extensions doesn't respect `F[A]` being passed as call-by-name.

This leads to issues where it's important.
See: https://github.com/typelevel/fs2/pull/2412

Unfortunately we can't change whenA/unlessA directly due to bincompat guarantees.
But the new method names even better reflect that we throw `A` out (as in `traverse_`). I would also deprecate the old ones.

Closes #3687