### PR TITLE
Save a few allocations in Applicative.replicateA

### DIFF
--- a/core/src/main/scala/cats/Applicative.scala
+++ b/core/src/main/scala/cats/Applicative.scala
@@ -1,8 +1,10 @@
 package cats
 
 import cats.arrow.Arrow
+import cats.data.Chain
 import simulacrum.typeclass
 import scala.annotation.implicitNotFound
+import scala.collection.immutable.IndexedSeq
 
 /**
  * Applicative functor.
@@ -65,7 +67,13 @@ import scala.annotation.implicitNotFound
    * }}}
    */
   def replicateA[A](n: Int, fa: F[A]): F[List[A]] =
-    Traverse[List].sequence(List.fill(n)(fa))(this)
+    if (n <= 0) pure(Nil)
+    else {
+      map(Chain.traverseViaChain(new IndexedSeq[F[A]] {
+        override def length = n
+        override def apply(i: Int) = fa
+      })(identity)(this))(_.toList)
+    }
 
   /**
    * Compose an `Applicative[F]` and an `Applicative[G]` into an


### PR DESCRIPTION
Cheat by creating an IndexedSeq that always returns the same element

 * Before: List -> ArrayBuffer -> Chain -> List
 * After: Chain -> List



