### PR TITLE
Add `ReferentialEq[A]` to Alley Cats

### DIFF
--- a/alleycats-core/src/main/scala/alleycats/ReferentialEq.scala
+++ b/alleycats-core/src/main/scala/alleycats/ReferentialEq.scala
@@ -1,0 +1,13 @@
+package alleycats
+
+import cats.Eq
+
+/**
+ * An `Eq[A]` that delegates to referential equality (`eq`).
+ * Note that it is not referentially transparent!
+ */
+object ReferentialEq {
+  def apply[A <: AnyRef]: Eq[A] = new Eq[A] {
+    def eqv(x: A, y: A) = x eq y
+  }
+}

--- a/alleycats-tests/shared/src/test/scala/alleycats/tests/ReferentialEqSuite.scala
+++ b/alleycats-tests/shared/src/test/scala/alleycats/tests/ReferentialEqSuite.scala
@@ -1,0 +1,33 @@
+package alleycats.tests
+
+import alleycats.ReferentialEq
+import cats.kernel.Eq
+import cats.kernel.laws.discipline._
+import cats.kernel.laws.EqLaws
+import org.scalacheck.Arbitrary
+import org.scalacheck.Prop.forAll
+import org.typelevel.discipline.Laws
+
+class ReferentialEqSuite extends AlleycatsSuite {
+
+  class ReferentialEqTests[A](eq: Eq[A]) extends Laws {
+    def laws = EqLaws(eq)
+
+    def eqv(implicit arbA: Arbitrary[A]): RuleSet = {
+      implicit val eqA: Eq[A] = laws.E
+      new DefaultRuleSet(
+        "referentialEq",
+        None,
+        "reflexivity eq" -> forAll(laws.reflexivityEq _),
+        "symmetry eq" -> forAll(laws.symmetryEq _),
+        "transitivity eq" -> forAll(laws.transitivityEq _)
+      )
+    }
+  }
+
+  implicit val arbObject: Arbitrary[Object] = Arbitrary(Arbitrary.arbUnit.arbitrary.map(_ => new Object))
+  implicit val eqObject: Eq[Object] = ReferentialEq[Object]
+
+  checkAll("ReferentialEq[Object]", new ReferentialEqTests(ReferentialEq[Object]).eqv)
+
+}

--- a/alleycats-tests/shared/src/test/scala/alleycats/tests/ReferentialEqSuite.scala
+++ b/alleycats-tests/shared/src/test/scala/alleycats/tests/ReferentialEqSuite.scala
@@ -5,6 +5,7 @@ import cats.kernel.Eq
 import cats.kernel.laws.discipline._
 import cats.kernel.laws.EqLaws
 import org.scalacheck.Arbitrary
+import org.scalacheck.Gen
 import org.scalacheck.Prop.forAll
 import org.typelevel.discipline.Laws
 
@@ -25,7 +26,17 @@ class ReferentialEqSuite extends AlleycatsSuite {
     }
   }
 
-  implicit val arbObject: Arbitrary[Object] = Arbitrary(Arbitrary.arbUnit.arbitrary.map(_ => new Object))
+  implicit val arbObject: Arbitrary[Object] =
+    // with some probability we select from a small set of objects
+    // otherwise make a totally new one
+    // courtesy of @johnynek
+    Arbitrary(
+      Gen.oneOf(
+        Gen.oneOf(List.fill(5)(new Object)),
+        Arbitrary.arbUnit.arbitrary.map(_ => new Object)
+      )
+    )
+
   implicit val eqObject: Eq[Object] = ReferentialEq[Object]
 
   checkAll("ReferentialEq[Object]", new ReferentialEqTests(ReferentialEq[Object]).eqv)

--- a/kernel/src/main/scala/cats/kernel/Eq.scala
+++ b/kernel/src/main/scala/cats/kernel/Eq.scala
@@ -109,7 +109,19 @@ object Eq
     }
 
   /**
-   * Everything is the same
+   * An `Eq[A]` that delegates to referential equality (`eq`).
+   *
+   * This is the finest possible equivalence relation.
+   */
+  def fromReferentialEquals[A <: AnyRef]: Eq[A] =
+    new Eq[A] {
+      def eqv(x: A, y: A) = x eq y
+    }
+
+  /**
+   * Everything is the same.
+   *
+   * This is the coarsest possible equivalence relation.
    */
   def allEqual[A]: Eq[A] =
     new Eq[A] {

--- a/kernel/src/main/scala/cats/kernel/Eq.scala
+++ b/kernel/src/main/scala/cats/kernel/Eq.scala
@@ -109,19 +109,7 @@ object Eq
     }
 
   /**
-   * An `Eq[A]` that delegates to referential equality (`eq`).
-   *
-   * This is the finest possible equivalence relation.
-   */
-  def fromReferentialEquals[A <: AnyRef]: Eq[A] =
-    new Eq[A] {
-      def eqv(x: A, y: A) = x eq y
-    }
-
-  /**
-   * Everything is the same.
-   *
-   * This is the coarsest possible equivalence relation.
+   * Everything is the same
    */
   def allEqual[A]: Eq[A] =
     new Eq[A] {


### PR DESCRIPTION
This PR implements a helper `Eq.fromReferentialEquals[A]` to provide an instance of `Eq[A]` based on referential equality `eq`.

It is similar in spirit to `Eq.fromUniversalEquals[A]` and, as the [finest](https://en.wikipedia.org/wiki/Equivalence_relation#Comparing_equivalence_relations) possible equivalence relation, I believe makes it the dual of the coarsest `Eq.allEqual[A]`.

My use case is for fast equivalence comparisons in certain situations with nested case classes (where using universal equals could involve traversing the entire object hierarchy).