### PR TITLE
Add missing methods to VectorOps

### DIFF
--- a/core/src/main/scala/cats/syntax/vector.scala
+++ b/core/src/main/scala/cats/syntax/vector.scala
@@ -82,4 +82,46 @@ final class VectorOps[A](private val va: Vector[A]) extends AnyVal {
       }
     }
   }
+
+  /**
+   * Produces a `NonEmptyVector` containing cumulative results of applying the
+   * operator going left to right.
+   *
+   * Example:
+   * {{{
+   * scala> import cats.data.NonEmptyVector
+   * scala> import cats.implicits._
+   *
+   * scala> val result1: Vector[Int] = Vector(1, 2)
+   * scala> result1.scanLeftNev(100)(_ + _)
+   * res0: NonEmptyVector[Int] = NonEmptyVector(100, 101, 103)
+   *
+   * scala> val result2: Vector[Int] = Vector.empty[Int]
+   * scala> result2.scanLeftNev(1)(_ + _)
+   * res1: NonEmptyVector[Int] = NonEmptyVector(1)
+   * }}}
+   */
+  def scanLeftNev[B](b: B)(f: (B, A) => B): NonEmptyVector[B] =
+    NonEmptyVector.fromVectorUnsafe(va.scanLeft(b)(f))
+
+  /**
+   * Produces a `NonEmptyVector` containing cumulative results of applying the
+   * operator going right to left.
+   *
+   * Example:
+   * {{{
+   * scala> import cats.data.NonEmptyVector
+   * scala> import cats.implicits._
+   *
+   * scala> val result1: Vector[Int] = Vector(1, 2)
+   * scala> result1.scanRightNev(100)(_ + _)
+   * res0: NonEmptyVector[Int] = NonEmptyVector(103, 102, 100)
+   *
+   * scala> val result2: Vector[Int] = Vector.empty[Int]
+   * scala> result2.scanRightNev(1)(_ + _)
+   * res1: NonEmptyVector[Int] = NonEmptyVector(1)
+   * }}}
+   */
+  def scanRightNev[B](b: B)(f: (A, B) => B): NonEmptyVector[B] =
+    NonEmptyVector.fromVectorUnsafe(va.scanRight(b)(f))
 }

--- a/core/src/main/scala/cats/syntax/vector.scala
+++ b/core/src/main/scala/cats/syntax/vector.scala
@@ -7,5 +7,23 @@ trait VectorSyntax {
 }
 
 final class VectorOps[A](private val va: Vector[A]) extends AnyVal {
+
+  /**
+   * Returns an Option of NonEmptyVector from a Vector
+   *
+   * Example:
+   * {{{
+   * scala> import cats.data.NonEmptyVector
+   * scala> import cats.implicits._
+   *
+   * scala> val result1: Vector[Int] = Vector(1, 2)
+   * scala> result1.toNev
+   * res0: Option[NonEmptyVector[Int]] = Some(NonEmptyVector(1, 2))
+   *
+   * scala> val result2: Vector[Int] = Vector.empty[Int]
+   * scala> result2.toNev
+   * res1: Option[NonEmptyVector[Int]] = None
+   * }}}
+   */
   def toNev: Option[NonEmptyVector[A]] = NonEmptyVector.fromVector(va)
 }

--- a/core/src/main/scala/cats/syntax/vector.scala
+++ b/core/src/main/scala/cats/syntax/vector.scala
@@ -1,6 +1,9 @@
 package cats.syntax
 
+import cats.Order
 import cats.data.NonEmptyVector
+
+import scala.collection.immutable.SortedMap
 
 trait VectorSyntax {
   implicit final def catsSyntaxVectors[A](va: Vector[A]): VectorOps[A] = new VectorOps(va)
@@ -26,4 +29,26 @@ final class VectorOps[A](private val va: Vector[A]) extends AnyVal {
    * }}}
    */
   def toNev: Option[NonEmptyVector[A]] = NonEmptyVector.fromVector(va)
+
+  /**
+   * Groups elements inside this `Vector` according to the `Order` of the keys
+   * produced by the given mapping function.
+   *
+   * {{{
+   * scala> import cats.data.NonEmptyVector
+   * scala> import scala.collection.immutable.SortedMap
+   * scala> import cats.implicits._
+   *
+   * scala> val vector = Vector(12, -2, 3, -5)
+   *
+   * scala> val expectedResult = SortedMap(false -> NonEmptyVector.of(-2, -5), true -> NonEmptyVector.of(12, 3))
+   *
+   * scala> vector.groupByNev(_ >= 0) === expectedResult
+   * res0: Boolean = true
+   * }}}
+   */
+  def groupByNev[B](f: A => B)(implicit B: Order[B]): SortedMap[B, NonEmptyVector[A]] = {
+    implicit val ordering: Ordering[B] = B.toOrdering
+    toNev.fold(SortedMap.empty[B, NonEmptyVector[A]])(_.groupBy(f))
+  }
 }

--- a/tests/src/test/scala/cats/tests/ListSuite.scala
+++ b/tests/src/test/scala/cats/tests/ListSuite.scala
@@ -70,6 +70,18 @@ class ListSuite extends CatsSuite {
     }
   )
 
+  test("scanLeftNel should be consistent with scanLeft")(
+    forAll { (fa: List[Int], b: Int, f: (Int, Int) => Int) =>
+      assert(fa.scanLeftNel(b)(f).toList === fa.scanLeft(b)(f))
+    }
+  )
+
+  test("scanRightNel should be consistent with scanRight")(
+    forAll { (fa: List[Int], b: Int, f: (Int, Int) => Int) =>
+      assert(fa.scanRightNel(b)(f).toList === fa.scanRight(b)(f))
+    }
+  )
+
   test("show") {
     assert(List(1, 2, 3).show === "List(1, 2, 3)")
     assert((Nil: List[Int]).show === "List()")

--- a/tests/src/test/scala/cats/tests/VectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/VectorSuite.scala
@@ -67,6 +67,12 @@ class VectorSuite extends CatsSuite {
     assert(Vector.empty[Int].toNev == None)
   }
 
+  test("groupByNev should be consistent with groupBy")(
+    forAll { (fa: Vector[Int], f: Int => Int) =>
+      assert((fa.groupByNev(f).map { case (k, v) => (k, v.toVector) }: Map[Int, Vector[Int]]) === fa.groupBy(f))
+    }
+  )
+
   test("traverse is stack-safe") {
     val vec = (0 until 100000).toVector
     val sumAll = Traverse[Vector]

--- a/tests/src/test/scala/cats/tests/VectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/VectorSuite.scala
@@ -79,6 +79,18 @@ class VectorSuite extends CatsSuite {
     }
   )
 
+  test("scanLeftNev should be consistent with scanLeft")(
+    forAll { (fa: Vector[Int], b: Int, f: (Int, Int) => Int) =>
+      assert(fa.scanLeftNev(b)(f).toVector === fa.scanLeft(b)(f))
+    }
+  )
+
+  test("scanRightNev should be consistent with scanRight")(
+    forAll { (fa: Vector[Int], b: Int, f: (Int, Int) => Int) =>
+      assert(fa.scanRightNev(b)(f).toVector === fa.scanRight(b)(f))
+    }
+  )
+
   test("traverse is stack-safe") {
     val vec = (0 until 100000).toVector
     val sumAll = Traverse[Vector]

--- a/tests/src/test/scala/cats/tests/VectorSuite.scala
+++ b/tests/src/test/scala/cats/tests/VectorSuite.scala
@@ -73,6 +73,12 @@ class VectorSuite extends CatsSuite {
     }
   )
 
+  test("groupByNevA should be consistent with groupByNev")(
+    forAll { (fa: Vector[Int], f: Int => Int) =>
+      assert(fa.groupByNevA(f.andThen(Option(_))) === Option(fa.groupByNev(f)))
+    }
+  )
+
   test("traverse is stack-safe") {
     val vec = (0 until 100000).toVector
     val sumAll = Traverse[Vector]


### PR DESCRIPTION
Adds methods `groupByNev`, `groupByNevA`, `scanLeftNev` and `scanRightNev` to `VectorOps`,
which are similar to the methods found in `ListOps`.

The implementation is mostly copied from `ListOps` and adjusted accordingly.

Initial discussion is [here](https://discord.com/channels/632277896739946517/632278570512678923/857709871448588309).