### PR TITLE
Add NonEmptyList.min and NonEmptyList.max

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -388,6 +388,29 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
     NonEmptyList.fromListUnsafe(toList.sorted(AA.toOrdering))
 
   /**
+   * Returns the minimum value of this `NonEmptyList` according to an `Ordering`
+   *
+   * {{{
+   * scala> import cats.data.NonEmptyList
+   * scala> val nel = NonEmptyList.of(12, 4, 3, 9)
+   * scala> nel.min
+   * res0: Int = 3
+   * }}}
+   */
+  def min[AA >: A](implicit ord: Ordering[AA]): A = reduceLeft(ord.min[A])
+  /**
+   * Returns the maximum value of this `NonEmptyList` according to an `Ordering`
+   *
+   * {{{
+   * scala> import cats.data.NonEmptyList
+   * scala> val nel = NonEmptyList.of(12, 4, 3, 9)
+   * scala> nel.max
+   * res0: Int = 12
+   * }}}
+   */
+  def max[AA >: A](implicit ord: Ordering[AA]): A = reduceLeft(ord.max[A])
+
+  /**
    * Groups elements inside this `NonEmptyList` according to the `Order`
    * of the keys produced by the given mapping function.
    *

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -398,6 +398,7 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
    * }}}
    */
   def min[AA >: A](implicit ord: Ordering[AA]): A = reduceLeft(ord.min[A])
+
   /**
    * Returns the maximum value of this `NonEmptyList` according to an `Ordering`
    *

--- a/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyListSuite.scala
@@ -321,6 +321,18 @@ class NonEmptyListSuite extends NonEmptyCollectionSuite[List, NonEmptyList, NonE
     }
   }
 
+  test("NonEmptyList#min is consistent with List#min") {
+    forAll { (nel: NonEmptyList[Int]) =>
+      assert(nel.min === nel.toList.min)
+    }
+  }
+
+  test("NonEmptyList#max is consistent with List#max") {
+    forAll { (nel: NonEmptyList[Int]) =>
+      assert(nel.max === nel.toList.max)
+    }
+  }
+
   test("NonEmptyList#groupBy is consistent with List#groupBy") {
     forAll { (nel: NonEmptyList[Int], key: Int => Int) =>
       val result = nel.groupBy(key).map { case (k, v) => (k, v.toList) }.toMap


### PR DESCRIPTION
This adds `.min` and `.max` to `NonEmptyList[A]` if there's an Ordering for `A`.

---------

Background: We ran into the issue that scapegoat complained that `List(a, b, c).min` isn't safe. Since we _know_ the list is not empty, we tried `NonEmptyList`, but `min` and `max` don't exist there. 

The implementation uses `reduceLeft`, same as the standard lib for `IterableOnce`: https://github.com/scala/scala/blob/262c97250a614bf19a0e9e8994ee59abea82a5db/src/library/scala/collection/IterableOnce.scala#L912-L916


Note: I did run `+prePR`, and it failed in `free/src/main/scala-3.x/cats/free/FreeFoldStep.scala`, but not in any file touched by this PR.