### PR TITLE
Add implicit OrderFromOrderingConversion

### DIFF
--- a/kernel/src/main/scala/cats/kernel/Order.scala
+++ b/kernel/src/main/scala/cats/kernel/Order.scala
@@ -125,7 +125,16 @@ trait OrderToOrderingConversion {
 
 }
 
-object Order extends OrderFunctions[Order] with OrderToOrderingConversion {
+trait OrderFromOrderingConversion {
+
+  /**
+   * Implicitly derive a `Order[A]` from a `scala.math.Ordering[A]`
+   * instance.
+   */
+  implicit def catsKernelOrderForOrdering[A](implicit ev: Ordering[A]): Order[A] = Order.fromOrdering
+}
+
+object Order extends OrderFunctions[Order] with OrderToOrderingConversion with OrderFromOrderingConversion {
 
   /**
    * Access an implicit `Order[A]`.


### PR DESCRIPTION
https://github.com/typelevel/cats/pull/3935 wants to add `min` and `max` to `NonEmptyList`.

I guess we already have these in `Reducible` if you import `cats.syntax.all._` and provide a `cats.Order[A]`.

This can be achieved using `cats.Order.fromOrdering` but it would be so much easier for users of the library to have an implicit conversion between `Order[A]` and `Ordering[A]`.

This PR adds this in a new `trait` that extends `cats.Order`.
One could debate whether this should always be available or a separate import.

