### PR TITLE
Add DeadlineInstances

### DIFF
--- a/core/src/main/scala-2.12/cats/instances/all.scala
+++ b/core/src/main/scala-2.12/cats/instances/all.scala
@@ -11,6 +11,7 @@ abstract class AllInstancesBinCompat
     with AllInstancesBinCompat5
     with AllInstancesBinCompat6
     with AllInstancesBinCompat7
+    with AllInstancesBinCompat8
 
 trait AllInstances
     extends AnyValInstances
@@ -56,7 +57,7 @@ trait AllInstancesBinCompat1
     with MapInstancesBinCompat0
     with SortedMapInstancesBinCompat0
 
-trait AllInstancesBinCompat2 extends DurationInstances with FiniteDurationInstances with DeadlineInstances
+trait AllInstancesBinCompat2 extends DurationInstances with FiniteDurationInstances
 
 trait AllInstancesBinCompat3 extends AllCoreDurationInstances
 
@@ -67,3 +68,5 @@ trait AllInstancesBinCompat5 extends SortedSetInstancesBinCompat0
 trait AllInstancesBinCompat6 extends SortedSetInstancesBinCompat1 with SortedMapInstancesBinCompat2
 
 trait AllInstancesBinCompat7 extends SeqInstances
+
+trait AllInstancesBinCompat8 extends DeadlineInstances

--- a/core/src/main/scala-2.12/cats/instances/all.scala
+++ b/core/src/main/scala-2.12/cats/instances/all.scala
@@ -56,7 +56,7 @@ trait AllInstancesBinCompat1
     with MapInstancesBinCompat0
     with SortedMapInstancesBinCompat0
 
-trait AllInstancesBinCompat2 extends DurationInstances with FiniteDurationInstances
+trait AllInstancesBinCompat2 extends DurationInstances with FiniteDurationInstances with DeadlineInstances
 
 trait AllInstancesBinCompat3 extends AllCoreDurationInstances
 

--- a/core/src/main/scala-2.12/cats/instances/package.scala
+++ b/core/src/main/scala-2.12/cats/instances/package.scala
@@ -15,6 +15,7 @@ package object instances {
   object equiv extends EquivInstances
   object float extends FloatInstances
   object finiteDuration extends CoreFiniteDurationInstances with FiniteDurationInstances
+  object deadline extends DeadlineInstances
   object function extends FunctionInstances with FunctionInstancesBinCompat0
   object partialFunction extends PartialFunctionInstances
   object future extends FutureInstances

--- a/core/src/main/scala-2.13+/cats/instances/all.scala
+++ b/core/src/main/scala-2.13+/cats/instances/all.scala
@@ -59,7 +59,7 @@ trait AllInstancesBinCompat1
     with MapInstancesBinCompat0
     with SortedMapInstancesBinCompat0
 
-trait AllInstancesBinCompat2 extends DurationInstances with FiniteDurationInstances
+trait AllInstancesBinCompat2 extends DurationInstances with FiniteDurationInstances with DeadlineInstances
 
 trait AllInstancesBinCompat3 extends AllCoreDurationInstances
 

--- a/core/src/main/scala-2.13+/cats/instances/all.scala
+++ b/core/src/main/scala-2.13+/cats/instances/all.scala
@@ -12,6 +12,7 @@ abstract class AllInstancesBinCompat
     with AllInstancesBinCompat6
     with AllInstancesBinCompat7
     with AllInstancesBinCompat8
+    with AllInstancesBinCompat9
 
 trait AllInstances
     extends AnyValInstances
@@ -59,7 +60,7 @@ trait AllInstancesBinCompat1
     with MapInstancesBinCompat0
     with SortedMapInstancesBinCompat0
 
-trait AllInstancesBinCompat2 extends DurationInstances with FiniteDurationInstances with DeadlineInstances
+trait AllInstancesBinCompat2 extends DurationInstances with FiniteDurationInstances
 
 trait AllInstancesBinCompat3 extends AllCoreDurationInstances
 
@@ -72,3 +73,5 @@ trait AllInstancesBinCompat6 extends SortedSetInstancesBinCompat1 with SortedMap
 trait AllInstancesBinCompat7 extends SeqInstances
 
 trait AllInstancesBinCompat8 extends InvariantInstances
+
+trait AllInstancesBinCompat9 extends DeadlineInstances

--- a/core/src/main/scala-2.13+/cats/instances/package.scala
+++ b/core/src/main/scala-2.13+/cats/instances/package.scala
@@ -16,6 +16,7 @@ package object instances {
   object equiv extends EquivInstances
   object float extends FloatInstances
   object finiteDuration extends CoreFiniteDurationInstances with FiniteDurationInstances
+  object deadline extends DeadlineInstances
   object function extends FunctionInstances with FunctionInstancesBinCompat0
   object partialFunction extends PartialFunctionInstances
   object future extends FutureInstances

--- a/core/src/main/scala/cats/instances/deadline.scala
+++ b/core/src/main/scala/cats/instances/deadline.scala
@@ -1,0 +1,4 @@
+package cats
+package instances
+
+trait DeadlineInstances extends cats.kernel.instances.DeadlineInstances

--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -3,13 +3,13 @@ package laws
 
 import cats.kernel.laws.discipline._
 import cats.platform.Platform
-
 import munit.DisciplineSuite
 import org.scalacheck.{Arbitrary, Cogen, Gen, Prop}
 import Prop.forAll
 import Arbitrary.arbitrary
+import cats.kernel.instances.all.catsKernelStdOrderForDeadline
 
-import scala.concurrent.duration.{Duration, FiniteDuration}
+import scala.concurrent.duration.{Deadline, Duration, FiniteDuration}
 import scala.collection.immutable.{BitSet, Queue, SortedMap, SortedSet}
 import scala.util.Random
 import java.util.UUID
@@ -46,6 +46,9 @@ object KernelCheck {
       )
     )
   }
+
+  implicit val arbitraryDeadline: Arbitrary[Deadline] =
+    Arbitrary(arbitraryFiniteDuration.arbitrary.map(Deadline.apply))
 
   // `Duration.Undefined`, `Duration.Inf` and `Duration.MinusInf` break the tests
   implicit val arbitraryDuration: Arbitrary[Duration] =
@@ -88,6 +91,9 @@ object KernelCheck {
 
   implicit val cogenUUID: Cogen[UUID] =
     Cogen[(Long, Long)].contramap(u => (u.getMostSignificantBits, u.getLeastSignificantBits))
+
+  implicit val cogenDeadline: Cogen[Deadline] =
+    Cogen[FiniteDuration].contramap(_.time)
 }
 
 class TestsConfig extends ScalaCheckSuite {
@@ -156,6 +162,7 @@ class Tests extends TestsConfig with DisciplineSuite {
   checkAll("Order[BigInt]", OrderTests[BigInt].order)
   checkAll("Order[Duration]", OrderTests[Duration].order)
   checkAll("Order[FiniteDuration]", OrderTests[FiniteDuration].order)
+  checkAll("Order[Deadline]", OrderTests[Deadline].order)
   checkAll("Order[UUID]", OrderTests[UUID].order)
   checkAll("Order[List[Int]]", OrderTests[List[Int]].order)
   checkAll("Order[Option[String]]", OrderTests[Option[String]].order)

--- a/kernel/src/main/scala-2.12/cats/kernel/instances/AllInstances.scala
+++ b/kernel/src/main/scala-2.12/cats/kernel/instances/AllInstances.scala
@@ -34,6 +34,8 @@ trait AllInstances
     with UUIDInstances
     with VectorInstances
 
-private[instances] trait AllInstancesBinCompat0 extends FiniteDurationInstances with DeadlineInstances
+private[instances] trait AllInstancesBinCompat0 extends FiniteDurationInstances
 
 private[instances] trait AllInstancesBinCompat1 extends SortedMapInstances with SortedSetInstances
+
+private[instances] trait AllInstancesBinCompat2 extends DeadlineInstances

--- a/kernel/src/main/scala-2.12/cats/kernel/instances/AllInstances.scala
+++ b/kernel/src/main/scala-2.12/cats/kernel/instances/AllInstances.scala
@@ -34,6 +34,6 @@ trait AllInstances
     with UUIDInstances
     with VectorInstances
 
-private[instances] trait AllInstancesBinCompat0 extends FiniteDurationInstances
+private[instances] trait AllInstancesBinCompat0 extends FiniteDurationInstances with DeadlineInstances
 
 private[instances] trait AllInstancesBinCompat1 extends SortedMapInstances with SortedSetInstances

--- a/kernel/src/main/scala-2.13+/cats/kernel/instances/AllInstances.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/instances/AllInstances.scala
@@ -36,6 +36,6 @@ trait AllInstances
     with UUIDInstances
     with VectorInstances
 
-private[instances] trait AllInstancesBinCompat0 extends FiniteDurationInstances
+private[instances] trait AllInstancesBinCompat0 extends FiniteDurationInstances with DeadlineInstances
 
 private[instances] trait AllInstancesBinCompat1 extends SortedMapInstances with SortedSetInstances

--- a/kernel/src/main/scala-2.13+/cats/kernel/instances/AllInstances.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/instances/AllInstances.scala
@@ -36,6 +36,8 @@ trait AllInstances
     with UUIDInstances
     with VectorInstances
 
-private[instances] trait AllInstancesBinCompat0 extends FiniteDurationInstances with DeadlineInstances
+private[instances] trait AllInstancesBinCompat0 extends FiniteDurationInstances
 
 private[instances] trait AllInstancesBinCompat1 extends SortedMapInstances with SortedSetInstances
+
+private[instances] trait AllInstancesBinCompat2 extends DeadlineInstances

--- a/kernel/src/main/scala/cats/kernel/instances/DeadlineInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/DeadlineInstances.scala
@@ -1,0 +1,34 @@
+package cats.kernel
+package instances
+
+import java.util.concurrent.TimeUnit
+import scala.concurrent.duration.{Deadline, FiniteDuration}
+
+trait DeadlineInstances {
+  implicit val catsKernelStdOrderForDeadline
+    : Order[Deadline] with Hash[Deadline] with LowerBounded[Deadline] with UpperBounded[Deadline] = new DeadlineOrder
+}
+
+trait DeadlineBounded extends LowerBounded[Deadline] with UpperBounded[Deadline] {
+  override def minBound: Deadline = Deadline(FiniteDuration(-Long.MaxValue, TimeUnit.NANOSECONDS))
+  override def maxBound: Deadline = Deadline(FiniteDuration(Long.MaxValue, TimeUnit.NANOSECONDS))
+}
+
+class DeadlineOrder extends Order[Deadline] with Hash[Deadline] with DeadlineBounded { self =>
+
+  def hash(x: Deadline): Int = x.hashCode()
+  def compare(x: Deadline, y: Deadline): Int =
+    if (x == y) 0 else if (x > y) 1 else -1
+
+  override def eqv(x: Deadline, y: Deadline): Boolean = x == y
+  override def neqv(x: Deadline, y: Deadline): Boolean = x != y
+  override def gt(x: Deadline, y: Deadline): Boolean = x > y && x != y
+  override def lt(x: Deadline, y: Deadline): Boolean = x < y && x != y
+  override def gteqv(x: Deadline, y: Deadline): Boolean = x == y || x > y
+  override def lteqv(x: Deadline, y: Deadline): Boolean = x == y || y > x
+
+  override def min(x: Deadline, y: Deadline): Deadline = if (x < y) x else y
+  override def max(x: Deadline, y: Deadline): Deadline = if (x > y) x else y
+
+  override val partialOrder: PartialOrder[Deadline] = self
+}

--- a/kernel/src/main/scala/cats/kernel/instances/all/package.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/all/package.scala
@@ -1,4 +1,8 @@
 package cats.kernel
 package instances
 
-package object all extends AllInstances with AllInstancesBinCompat0 with AllInstancesBinCompat1 with AllInstancesBinCompat2
+package object all
+    extends AllInstances
+    with AllInstancesBinCompat0
+    with AllInstancesBinCompat1
+    with AllInstancesBinCompat2

--- a/kernel/src/main/scala/cats/kernel/instances/all/package.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/all/package.scala
@@ -1,4 +1,4 @@
 package cats.kernel
 package instances
 
-package object all extends AllInstances with AllInstancesBinCompat0 with AllInstancesBinCompat1
+package object all extends AllInstances with AllInstancesBinCompat0 with AllInstancesBinCompat1 with AllInstancesBinCompat2

--- a/kernel/src/main/scala/cats/kernel/instances/deadline/package.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/deadline/package.scala
@@ -1,0 +1,4 @@
+package cats.kernel
+package instances
+
+package object deadline extends DeadlineInstances

--- a/tests/src/test/scala/cats/tests/OrderSuite.scala
+++ b/tests/src/test/scala/cats/tests/OrderSuite.scala
@@ -8,7 +8,10 @@ import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
 import cats.tests.Helpers.Ord
 import cats.implicits._
+import cats.kernel.laws.KernelCheck.{arbitraryDeadline, cogenDeadline}
 import org.scalacheck.Prop._
+
+import scala.concurrent.duration.Deadline
 
 class OrderSuite extends CatsSuite {
   {
@@ -21,6 +24,7 @@ class OrderSuite extends CatsSuite {
   checkAll("Double", OrderTests[Double].order)
   checkAll("Float", OrderTests[Float].order)
   checkAll("Long", OrderTests[Long].order)
+  checkAll("Deadline", OrderTests[Deadline].order)
 
   checkAll("Order", ContravariantMonoidalTests[Order].contravariantMonoidal[MiniInt, Boolean, Boolean])
   checkAll("ContravariantMonoidal[Order]", SerializableTests.serializable(ContravariantMonoidal[Order]))

--- a/tests/src/test/scala/cats/tests/OrderSuite.scala
+++ b/tests/src/test/scala/cats/tests/OrderSuite.scala
@@ -8,10 +8,7 @@ import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
 import cats.tests.Helpers.Ord
 import cats.implicits._
-import cats.kernel.laws.KernelCheck.{arbitraryDeadline, cogenDeadline}
 import org.scalacheck.Prop._
-
-import scala.concurrent.duration.Deadline
 
 class OrderSuite extends CatsSuite {
   {
@@ -24,7 +21,6 @@ class OrderSuite extends CatsSuite {
   checkAll("Double", OrderTests[Double].order)
   checkAll("Float", OrderTests[Float].order)
   checkAll("Long", OrderTests[Long].order)
-  checkAll("Deadline", OrderTests[Deadline].order)
 
   checkAll("Order", ContravariantMonoidalTests[Order].contravariantMonoidal[MiniInt, Boolean, Boolean])
   checkAll("ContravariantMonoidal[Order]", SerializableTests.serializable(ContravariantMonoidal[Order]))


### PR DESCRIPTION
We wanted to have `min` and `max` on a `NonEmptyList`. That requires a `cats.Order[A]`.
For the standard library's `Deadline` no instances were defined. This adds it.

(I'm sure I need to touch some other places to make it available everywhere. Please tell me where. Thanks!)