### PR TITLE
add methods for creating generic errors from string

### DIFF
--- a/core/src/main/scala/cats/MonadError.scala
+++ b/core/src/main/scala/cats/MonadError.scala
@@ -92,7 +92,7 @@ trait MonadError[F[_], E] extends ApplicativeError[F, E] with Monad[F] {
    *
    * scala> def checkError(result: Either[Throwable, Int]): Try[String] = result.fold(_ => Failure(new java.lang.Exception), _ => Success("success"))
    *
-   * scala> val a: Try[Int] = Failure(new Throwable("failed"))
+   * scala> val a: Try[Int] = Failure("failed".asThrowable)
    * scala> a.attemptTap(checkError)
    * res0: scala.util.Try[Int] = Failure(java.lang.Exception)
    *

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -196,13 +196,12 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
    * res1: Option[Int] = None
    *
    * scala> import scala.util.Try
-   * scala> import java.lang.Exception
    *
-   * scala> val e3: EitherT[Try, Throwable, String] = EitherT[Try, Throwable, String](Try(Right("happy cats")))
+   * scala> val e3: EitherT[Try, Throwable, String] = EitherT[Try, Throwable, String](Try("happy cats".asRight))
    * scala> e3.rethrowT
    * res2: util.Try[String] = Success(happy cats)
    *
-   * scala> val e4: EitherT[Try, Throwable, String] = EitherT[Try, Throwable, String](Try(Left(new Exception("sad cats"))))
+   * scala> val e4: EitherT[Try, Throwable, String] = EitherT[Try, Throwable, String](Try("sad cats".asException.asLeft))
    * scala> e4.rethrowT
    * res3: util.Try[String] = Failure(java.lang.Exception: sad cats)
    * }}}

--- a/core/src/main/scala/cats/syntax/TrySyntax.scala
+++ b/core/src/main/scala/cats/syntax/TrySyntax.scala
@@ -23,7 +23,7 @@ final class TryOps[A](private val self: Try[A]) extends AnyVal {
    * scala> s.liftTo[Either[Throwable, *]]
    * res0: Either[Throwable, Int] = Right(3)
    *
-   * scala> val f: Try[Int] = Try(throw new Throwable("boo"))
+   * scala> val f: Try[Int] = Try(throw "boo".asThrowable)
    * scala> f.liftTo[Either[Throwable, *]]
    * res0: Either[Throwable, Int] = Left(java.lang.Throwable: boo)
    * }}}
@@ -35,7 +35,7 @@ final class TryOps[A](private val self: Try[A]) extends AnyVal {
    * transforms the try to a Validated[Throwable, A] instance
    *
    * {{{
-   * scala> import cats.syntax.try_._
+   * scala> import cats.implicits._
    * scala> import cats.data.Validated
    * scala> import util.Try
    *
@@ -43,7 +43,7 @@ final class TryOps[A](private val self: Try[A]) extends AnyVal {
    * scala> s.toValidated
    * res0: Validated[Throwable, Int] = Valid(3)
    *
-   * scala> val f: Try[Int] = Try(throw new Throwable("boo"))
+   * scala> val f: Try[Int] = Try(throw "boo".asThrowable)
    * scala> f.toValidated
    * res0: Validated[Throwable, Int] = Invalid(java.lang.Throwable: boo)
    * }}}

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -54,6 +54,7 @@ trait AllSyntax
     with SemigroupSyntax
     with SemigroupKSyntax
     with ShowSyntax
+    with StringSyntax
     with StrongSyntax
     with TraverseSyntax
     with NonEmptyTraverseSyntax

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -59,6 +59,7 @@ package object syntax {
   object semigroupk extends SemigroupKSyntax
   object seq extends SeqSyntax
   object show extends ShowSyntax
+  object string extends StringSyntax
   object strong extends StrongSyntax
   object try_ extends TrySyntax
   object traverse extends TraverseSyntax

--- a/core/src/main/scala/cats/syntax/string.scala
+++ b/core/src/main/scala/cats/syntax/string.scala
@@ -1,0 +1,40 @@
+package cats.syntax
+
+trait StringSyntax {
+  implicit final def catsSyntaxString(s: String): StringOps = new StringOps(s)
+}
+
+final class StringOps(private val s: String) extends AnyVal {
+
+  /**
+   * Wraps a `String` in `Throwable`.
+   *
+   * {{{
+   *  scala> import cats.syntax.string._
+   *
+   *  scala> "new throwable".asThrowable
+   *  res0: Throwable = java.lang.Throwable: new throwable
+   * }}}
+   */
+  def asThrowable: Throwable = new Throwable(s)
+
+  /**
+   * Wraps a `String` in `Error`.
+   *
+   * {{{
+   *  scala> import cats.syntax.string._
+   *
+   *  scala> "new error".asError
+   *  res0: Error = java.lang.Error: new error
+   * }}}
+   */
+  def asError: Error = new Error(s)
+
+  /**
+   * Wraps a `String` in `Exception`.
+   *
+   * TODO:  doctest v0.9.9 is having import conflicts between `java.lang.Exception`
+   *        and `org.scalacheck.Prop.Exception`, add example when fixed
+   */
+  def asException: Exception = new Exception(s)
+}

--- a/tests/src/test/scala/cats/tests/EitherSuite.scala
+++ b/tests/src/test/scala/cats/tests/EitherSuite.scala
@@ -7,6 +7,7 @@ import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.syntax.either._
+import cats.syntax.string._
 import scala.util.Try
 import cats.syntax.eq._
 import org.scalacheck.Prop._
@@ -110,7 +111,7 @@ class EitherSuite extends CatsSuite {
 
   test("catchNonFatal catches non-fatal exceptions") {
     assert(Either.catchNonFatal("foo".toInt).isLeft)
-    assert(Either.catchNonFatal(throw new Throwable("blargh")).isLeft)
+    assert(Either.catchNonFatal(throw "blargh".asThrowable).isLeft)
   }
 
   test("fromTry is left for failed Try") {

--- a/tests/src/test/scala/cats/tests/ValidatedSuite.scala
+++ b/tests/src/test/scala/cats/tests/ValidatedSuite.scala
@@ -21,6 +21,7 @@ import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.laws.discipline.arbitrary._
 import cats.syntax.apply._
 import cats.syntax.either._
+import cats.syntax.string._
 import cats.syntax.validated._
 import org.scalacheck.Arbitrary._
 import scala.util.Try
@@ -113,7 +114,7 @@ class ValidatedSuite extends CatsSuite {
 
   test("catchNonFatal catches non-fatal exceptions") {
     assert(Validated.catchNonFatal("foo".toInt).isInvalid)
-    assert(Validated.catchNonFatal(throw new Throwable("blargh")).isInvalid)
+    assert(Validated.catchNonFatal(throw "blargh".asThrowable).isInvalid)
   }
 
   test("fromTry is invalid for failed try") {


### PR DESCRIPTION
Getting quick-and-dirty errors from string error messages is a pretty common use case. This PR is similar to `asLeft`/`asRight` and `some`/`none` but not widened for `Error`/`Exception` subtypes as they are not ADTs.

Instead of writing this:
```scala
val leftError = Left(new Error("error"))
val ioThrow = new Throwable("error").raiseError[IO, Unit]
```
this PR lets you do this:
```scala
val leftError = "error".asError.asLeft
val ioThrow = "error".asThrowable.raiseError[IO, Unit]
```
Saves you from writing the `new` keyword and parentheses.