### PR TITLE
Add missing import in string |+| example

### DIFF
--- a/docs/src/main/mdoc/typeclasses/imports.md
+++ b/docs/src/main/mdoc/typeclasses/imports.md
@@ -45,6 +45,7 @@ For example, if you'd like to import the `Monoid` instance for `String` and the 
 
 ```scala mdoc
 import cats.instances.string._
+import cats.syntax.semigroup._
 
 "Hello, " |+| "World!"
 ```


### PR DESCRIPTION
String |+| example discussion mentions "the second import" but
that import is missing.


