### PR TITLE
Use new sbt syntax for fmt commands

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -912,8 +912,8 @@ lazy val publishSettings = Seq(
 ) ++ sharedPublishSettings ++ sharedReleaseProcess
 
 // Scalafmt
-addCommandAlias("fmt", "; compile:scalafmt; test:scalafmt; scalafmtSbt")
-addCommandAlias("fmtCheck", "; compile:scalafmtCheck; test:scalafmtCheck; scalafmtSbtCheck")
+addCommandAlias("fmt", "; Compile / scalafmt; Test / scalafmt; scalafmtSbt")
+addCommandAlias("fmtCheck", "; Compile / scalafmtCheck; Test / scalafmtCheck; scalafmtSbtCheck")
 
 // These aliases serialise the build for the benefit of Travis-CI.
 addCommandAlias("buildKernelJVM", ";kernelJVM/test;kernelLawsJVM/test")


### PR DESCRIPTION
This is a minor thing but cleans up warnings in the console.