### PR TITLE
Added implementation of Eq[Free]

### DIFF
--- a/free/src/main/scala-2.12/cats/free/FreeStructuralInstances.scala
+++ b/free/src/main/scala-2.12/cats/free/FreeStructuralInstances.scala
@@ -1,0 +1,3 @@
+package cats.free
+
+private trait FreeStructuralInstances

--- a/free/src/main/scala-2.13+/cats/free/FreeStructuralInstances.scala
+++ b/free/src/main/scala-2.13+/cats/free/FreeStructuralInstances.scala
@@ -1,0 +1,42 @@
+package cats
+package free
+
+/**
+ * Free may be viewed either as a sort of sequential program construction mechanism, wherein
+ * programs are assembled and then finally interpreted via foldMap, or it may be viewed as a
+ * recursive data structure shaped by the ''pattern'' of its suspension functor. In this view,
+ * it is helpful to think of Free as being the following recursive type alias:
+ *
+ * {{{
+ * type Free[S[_], A] = Either[S[Free[S, A]], A]
+ * }}}
+ *
+ * Thus, a Free is a tree of Either(s) in which the data (of type A) is at the leaves, and each
+ * branching point is defined by the shape of the S functor. This kind of structural interpretation
+ * of Free is very useful in certain contexts, such as when representing expression trees in
+ * compilers and interpreters.
+ *
+ * Using this interpretation, we can define many common instances over the ''data structure'' of
+ * Free, most notably Eq and Traverse (Show is also possible, though far less useful). This makes
+ * it much more convenient to use Free structures as if they were conventional data structures.
+ *
+ * Unfortunately, this functionality fundamentally requires recursive implicit resolution. This
+ * feature was added to Scala in 2.13 (and retained in Scala 3) in the form of by-name implicits,
+ * but is fundamentally unavailable in Scala 2.12 and earlier without using something like Shapeless.
+ * For that reason, all of these instances are only available on 2.13 and above.
+ */
+private trait FreeStructuralInstances {
+  implicit def catsFreeEqForFree[S[_]: Functor, A: Eq](implicit S: => Eq[S[Free[S, A]]]): Eq[Free[S, A]] =
+    Eq instance { (left, right) =>
+      (left.resume, right.resume) match {
+        case (Right(leftA), Right(rightA)) =>
+          Eq[A].eqv(leftA, rightA)
+
+        case (Left(leftS), Left(rightS)) =>
+          S.eqv(leftS, rightS)
+
+        case (Left(_), Right(_)) | (Right(_), Left(_)) =>
+          false
+      }
+    }
+}

--- a/free/src/main/scala-2.13+/cats/free/FreeStructuralInstances.scala
+++ b/free/src/main/scala-2.13+/cats/free/FreeStructuralInstances.scala
@@ -27,7 +27,7 @@ package free
  */
 private trait FreeStructuralInstances {
   implicit def catsFreeEqForFree[S[_]: Functor, A: Eq](implicit S: => Eq[S[Free[S, A]]]): Eq[Free[S, A]] =
-    Eq instance { (left, right) =>
+    Eq.instance { (left, right) =>
       (left.resume, right.resume) match {
         case (Right(leftA), Right(rightA)) =>
           Eq[A].eqv(leftA, rightA)

--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -361,6 +361,20 @@ sealed abstract private[free] class FreeInstances extends FreeInstances1 {
       def defer[A](fa: => Free[S, A]): Free[S, A] =
         Free.defer(fa)
     }
+
+  implicit def catsFreeEqForFree[S[_]: Functor, A: Eq](implicit S: => Eq[S[Free[S, A]]]): Eq[Free[S, A]] =
+    Eq instance { (left, right) =>
+      (left.resume, right.resume) match {
+        case (Right(leftA), Right(rightA)) =>
+          Eq[A].eqv(leftA, rightA)
+
+        case (Left(leftS), Left(rightS)) =>
+          S.eqv(leftS, rightS)
+
+        case (Left(_), Right(_)) | (Right(_), Left(_)) =>
+          false
+      }
+    }
 }
 
 sealed abstract private[free] class FreeInstances1 {

--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -344,7 +344,7 @@ private trait FreeTraverse[F[_]] extends Traverse[Free[F, *]] with FreeFoldable[
   final override def map[A, B](fa: Free[F, A])(f: A => B): Free[F, B] = fa.map(f)
 }
 
-sealed abstract private[free] class FreeInstances extends FreeInstances1 {
+sealed abstract private[free] class FreeInstances extends FreeInstances1 with FreeStructuralInstances {
 
   /**
    * `Free[S, *]` has a monad for any type constructor `S[_]`.

--- a/free/src/main/scala/cats/free/Free.scala
+++ b/free/src/main/scala/cats/free/Free.scala
@@ -361,20 +361,6 @@ sealed abstract private[free] class FreeInstances extends FreeInstances1 {
       def defer[A](fa: => Free[S, A]): Free[S, A] =
         Free.defer(fa)
     }
-
-  implicit def catsFreeEqForFree[S[_]: Functor, A: Eq](implicit S: => Eq[S[Free[S, A]]]): Eq[Free[S, A]] =
-    Eq instance { (left, right) =>
-      (left.resume, right.resume) match {
-        case (Right(leftA), Right(rightA)) =>
-          Eq[A].eqv(leftA, rightA)
-
-        case (Left(leftS), Left(rightS)) =>
-          S.eqv(leftS, rightS)
-
-        case (Left(_), Right(_)) | (Right(_), Left(_)) =>
-          false
-      }
-    }
 }
 
 sealed abstract private[free] class FreeInstances1 {

--- a/free/src/test/scala-2.13+/cats/free/FreeStructuralSuite.scala
+++ b/free/src/test/scala-2.13+/cats/free/FreeStructuralSuite.scala
@@ -1,0 +1,25 @@
+package cats.free
+
+import cats.Functor
+import cats.kernel.laws.discipline.EqTests
+import cats.tests.CatsSuite
+
+import org.scalacheck.Cogen
+
+// this functionality doesn't exist on Scala 2.12
+class FreeStructuralSuite extends CatsSuite {
+  import FreeSuite.freeArbitrary
+
+  implicit def freeCogen[S[_]: Functor, A](implicit S: => Cogen[S[Free[S, A]]], A: Cogen[A]): Cogen[Free[S, A]] =
+    Cogen { (seed, f) =>
+      f.resume match {
+        case Left(sf) =>
+          S.perturb(seed, sf)
+
+        case Right(a) =>
+          A.perturb(seed, a)
+      }
+    }
+
+  checkAll("Free[Option, Int]", EqTests[Free[Option, Int]].eqv)
+}

--- a/free/src/test/scala-2.13+/cats/free/FreeStructuralSuite.scala
+++ b/free/src/test/scala-2.13+/cats/free/FreeStructuralSuite.scala
@@ -1,7 +1,7 @@
 package cats.free
 
 import cats.Functor
-import cats.kernel.laws.discipline.EqTests
+import cats.kernel.laws.discipline.{/*HashTests,*/ PartialOrderTests}
 import cats.tests.CatsSuite
 
 import org.scalacheck.Cogen
@@ -21,5 +21,7 @@ class FreeStructuralSuite extends CatsSuite {
       }
     }
 
-  checkAll("Free[Option, Int]", EqTests[Free[Option, Int]].eqv)
+  // TODO HashLaws#sameAsUniversalHash is really dodgy
+  // checkAll("Free[Option, Int]", HashTests[Free[Option, Int]].hash)
+  checkAll("Free[Option, Int]", PartialOrderTests[Free[Option, Int]].partialOrder)
 }

--- a/free/src/test/scala-2.13+/cats/free/FreeStructuralSuite.scala
+++ b/free/src/test/scala-2.13+/cats/free/FreeStructuralSuite.scala
@@ -1,6 +1,6 @@
 package cats.free
 
-import cats.{Applicative, Eq, Eval, Functor, Traverse}
+import cats.{Applicative, Eq, Eval, Functor, Show, Traverse}
 import cats.kernel.laws.discipline.{EqTests, /*HashTests,*/ PartialOrderTests}
 import cats.syntax.all._
 import cats.tests.CatsSuite
@@ -22,6 +22,8 @@ class FreeStructuralSuite extends CatsSuite {
           A.perturb(seed, a)
       }
     }
+
+  Show[Free[Option, Int]]
 
   // TODO HashLaws#sameAsUniversalHash is really dodgy
   // checkAll("Free[Option, Int]", HashTests[Free[Option, Int]].hash)

--- a/free/src/test/scala-2.13+/cats/free/FreeStructuralSuite.scala
+++ b/free/src/test/scala-2.13+/cats/free/FreeStructuralSuite.scala
@@ -1,14 +1,16 @@
 package cats.free
 
-import cats.Functor
-import cats.kernel.laws.discipline.{/*HashTests,*/ PartialOrderTests}
+import cats.{Applicative, Eq, Eval, Functor, Traverse}
+import cats.kernel.laws.discipline.{EqTests, /*HashTests,*/ PartialOrderTests}
+import cats.syntax.all._
 import cats.tests.CatsSuite
 
-import org.scalacheck.Cogen
+import org.scalacheck.{Arbitrary, Cogen, Gen}
 
 // this functionality doesn't exist on Scala 2.12
 class FreeStructuralSuite extends CatsSuite {
   import FreeSuite.freeArbitrary
+  import FreeStructuralSuite._
 
   implicit def freeCogen[S[_]: Functor, A](implicit S: => Cogen[S[Free[S, A]]], A: Cogen[A]): Cogen[Free[S, A]] =
     Cogen { (seed, f) =>
@@ -24,4 +26,106 @@ class FreeStructuralSuite extends CatsSuite {
   // TODO HashLaws#sameAsUniversalHash is really dodgy
   // checkAll("Free[Option, Int]", HashTests[Free[Option, Int]].hash)
   checkAll("Free[Option, Int]", PartialOrderTests[Free[Option, Int]].partialOrder)
+  checkAll("Free[ExprF, String]", EqTests[Free[ExprF, String]].eqv)
+}
+
+object FreeStructuralSuite {
+  type Expr[A] = Free[ExprF, A]
+
+  // a pattern functor for a simple expression language
+  sealed trait ExprF[A] extends Product with Serializable
+
+  object ExprF {
+
+    implicit def eq[A: Eq]: Eq[ExprF[A]] =
+      Eq.instance {
+        case (Add(left1, right1), Add(left2, right2)) =>
+          left1 === left2 && right1 === right2
+
+        case (Neg(inner1), Neg(inner2)) =>
+          inner1 === inner2
+
+        case (Num(value1), Num(value2)) =>
+          value1 === value2
+
+        case (_, _) =>
+          false
+      }
+
+    implicit def traverse: Traverse[ExprF] =
+      new Traverse[ExprF] {
+
+        def foldLeft[A, B](fa: ExprF[A], b: B)(f: (B, A) => B): B =
+          fa match {
+            case Add(left, right) =>
+              f(f(b, left), right)
+
+            case Neg(inner) =>
+              f(b, inner)
+
+            case Num(_) =>
+              b
+          }
+
+        def foldRight[A, B](fa: ExprF[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
+          fa match {
+            case Add(left, right) =>
+              f(left, f(right, lb))
+
+            case Neg(inner) =>
+              f(inner, lb)
+
+            case Num(_) =>
+              lb
+          }
+
+        def traverse[G[_]: Applicative, A, B](fa: ExprF[A])(f: A => G[B]): G[ExprF[B]] =
+          fa match {
+            case Add(left, right) =>
+              (f(left), f(right)).mapN(Add(_, _))
+
+            case Neg(inner) =>
+              f(inner).map(Neg(_))
+
+            case Num(value) =>
+              Applicative[G].pure(Num(value))
+          }
+      }
+
+    implicit def arbitraryExprF[A: Arbitrary](implicit gnum: Arbitrary[Int]): Arbitrary[ExprF[A]] =
+      Arbitrary {
+        import Arbitrary.arbitrary
+
+        val genAdd: Gen[Add[A]] =
+          for {
+            left <- arbitrary[A]
+            right <- arbitrary[A]
+          } yield Add(left, right)
+
+        val genNeg: Gen[Neg[A]] =
+          arbitrary[A].map(Neg(_))
+
+        val genNum: Gen[Num[A]] = gnum.arbitrary.map(Num(_))
+
+        Gen.oneOf(genAdd, genNeg, genNum)
+      }
+
+    implicit def cogenExprF[A](implicit cg: Cogen[A], cgnum: Cogen[Int]): Cogen[ExprF[A]] =
+      Cogen { (seed, ef) =>
+        ef match {
+          case Add(left, right) =>
+            cg.perturb(cg.perturb(seed, left), right)
+
+          case Neg(inner) =>
+            cg.perturb(seed, inner)
+
+          case Num(value) =>
+            cgnum.perturb(seed, value)
+        }
+      }
+
+    final case class Add[A](left: A, right: A) extends ExprF[A]
+    final case class Neg[A](inner: A) extends ExprF[A]
+    final case class Num[A](value: Int) extends ExprF[A]
+  }
 }


### PR DESCRIPTION
Look ma, no documentation! Okay that's not *entirely* true, but it's close to true. Documentation coming.

So this probably looks a little odd if you're unfamiliar with recursion schemes. `Free` *is* a fixed point (similar to `Fix` or `Mu`), but we don't normally think of it that way. IMO `Free` is a lot more useful in this role than `Fix` is, and this `Eq` instance is one of the first steps in being able to unlock this power on top of vanilla Cats (rather than requiring something like Droste for even trivial cases).

Anyway, examples to come. There are some nice ones of how this can be leveraged in practice, I just haven't written them down yet.

Poke @Baccata since I promised you this a while back.