### PR TITLE
Add `raiseWhen` and `raiseUnless` helpers to ApplicativeError

### DIFF
--- a/core/src/main/scala/cats/ApplicativeError.scala
+++ b/core/src/main/scala/cats/ApplicativeError.scala
@@ -39,6 +39,30 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
   def raiseError[A](e: E): F[A]
 
   /**
+   * Returns `raiseError` when the `cond` is true, otherwise `F.unit`
+   *
+   * @example {{{
+   * val tooMany = 5
+   * val x: Int = ???
+   * F.raiseWhen(x >= tooMany)(new IllegalArgumentException("Too many"))
+   * }}}
+   */
+  def raiseWhen(cond: Boolean)(e: => E): F[Unit] =
+    whenA(cond)(raiseError(e))
+
+  /**
+   * Returns `raiseError` when `cond` is false, otherwise `F.unit`
+   *
+   * @example {{{
+   * val tooMany = 5
+   * val x: Int = ???
+   * F.raiseUnless(x < tooMany)(new IllegalArgumentException("Too many"))
+   * }}}
+   */
+  def raiseUnless(cond: Boolean)(e: => E): F[Unit] =
+    unlessA(cond)(raiseError(e))
+
+  /**
    * Handle any error, potentially recovering from it, by mapping it to an
    * `F[A]` value.
    *


### PR DESCRIPTION
I added these to IO previously, but was lazy and didn't add them to the
typeclass. Oops


Also, I ran the `sbt +prePR` step as instructed but it errored out.

<details>
<summary>+prePR errors</summary>


```
[info] Forcing Scala version to 3.0.1 on all projects.
[info] Reapplying settings...
[info] set current project to cats (in build file:/Users/gavin/Code/cats/)
[info] Formatting 2 Scala sources...
[info] Formatting 2 Scala sources...
[info] Formatting 2 Scala sources...
[info] Formatting 1 Scala sources...
[info] Formatting 1 Scala sources...
[info] Formatting 1 Scala sources...
[error] /Users/gavin/Code/cats/free/src/main/scala-3.x/cats/free/FreeFoldStep.scala:19: error: identifier expected but [ found
[error]     onFlatMapped: [X] => (S[X], X => Free[S, A]) => B
[error]                   ^: /Users/gavin/Code/cats/free/src/main/scala-3.x/cats/free/FreeFoldStep.scala
[error] /Users/gavin/Code/cats/free/src/main/scala-3.x/cats/free/FreeFoldStep.scala:19: error: identifier expected but [ found
[error]     onFlatMapped: [X] => (S[X], X => Free[S, A]) => B
[error]                   ^: /Users/gavin/Code/cats/free/src/main/scala-3.x/cats/free/FreeFoldStep.scala
[error] /Users/gavin/Code/cats/free/src/main/scala-3.x/cats/free/FreeFoldStep.scala:19: error: identifier expected but [ found
[error]     onFlatMapped: [X] => (S[X], X => Free[S, A]) => B
[error]                   ^: /Users/gavin/Code/cats/free/src/main/scala-3.x/cats/free/FreeFoldStep.scala
[error] (freeJVM / Compile / scalafmt) /Users/gavin/Code/cats/free/src/main/scala-3.x/cats/free/FreeFoldStep.scala:19: error: identifier expected but [ found
[error]     onFlatMapped: [X] => (S[X], X => Free[S, A]) => B
[error]                   ^: /Users/gavin/Code/cats/free/src/main/scala-3.x/cats/free/FreeFoldStep.scala
[error] (freeJS / Compile / scalafmt) /Users/gavin/Code/cats/free/src/main/scala-3.x/cats/free/FreeFoldStep.scala:19: error: identifier expected but [ found
[error]     onFlatMapped: [X] => (S[X], X => Free[S, A]) => B
[error]                   ^: /Users/gavin/Code/cats/free/src/main/scala-3.x/cats/free/FreeFoldStep.scala
[error] (freeNative / Compile / scalafmt) /Users/gavin/Code/cats/free/src/main/scala-3.x/cats/free/FreeFoldStep.scala:19: error: identifier expected but [ foun
[error]     onFlatMapped: [X] => (S[X], X => Free[S, A]) => B
[error]                   ^: /Users/gavin/Code/cats/free/src/main/scala-3.x/cats/free/FreeFoldStep.scala
[error] Total time: 1 s, completed Jul 23, 2021 2:37:54 PM
```


</details>