### PR TITLE
Configure microsite image directory

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -273,6 +273,7 @@ lazy val docSettings = Seq(
     )
   ),
   micrositeGithubRepo := "cats",
+  micrositeImgDirectory := (LocalRootProject / baseDirectory).value / "docs" / "src" / "main" / "resources" / "microsite" / "img",
   micrositeTheme := "pattern",
   micrositePalette := Map(
     "brand-primary" -> "#5B5988",


### PR DESCRIPTION
Fixes #3690.  I'm just trying to put out a fire, and circling back with a more thoughtful approach from someone who understands jekyll would be good.

Concerns:
* I don't know why the source is in `docs` while the output is in `cats-docs`.
* There are a bunch more directory settings and I don't know what else is subtly broken.  I'm just taking care of the sponsors.