### PR TITLE
Eq[NonEmptySet[A]] now needs Eq[A], not Order[A]

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptySet.scala
+++ b/core/src/main/scala/cats/data/NonEmptySet.scala
@@ -410,7 +410,10 @@ sealed abstract private[data] class NonEmptySetInstances0 extends NonEmptySetIns
 }
 
 sealed abstract private[data] class NonEmptySetInstances1 {
-  implicit def catsDataEqForNonEmptySet[A](implicit A: Order[A]): Eq[NonEmptySet[A]] =
+  private[data] def catsDataEqForNonEmptySet[A](implicit A: Order[A]): Eq[NonEmptySet[A]] =
+    catsDataEqForNonEmptySetFromEqA[A]
+
+  implicit def catsDataEqForNonEmptySetFromEqA[A](implicit A: Eq[A]): Eq[NonEmptySet[A]] =
     new NonEmptySetEq[A] {
       implicit override def A0: Eq[A] = A
     }


### PR DESCRIPTION
Addresses #3957 

`+prePR` failed on my local machine for some reason complaining about code I was nowhere near, so I'm opening it as is for now and I'll fix whatever issues occur on CI if necessary