### PR TITLE
Fix traverse_ for List and Vector to be stack safe.

### DIFF
--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -103,7 +103,7 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
         // the cost of this is O(size)
         // c(n) = n + 2 * c(n/2)
         def runHalf(size: Int, fa: List[A]): Eval[G[Unit]] =
-          if (size > 2) {
+          if (size > 1) {
             val leftSize = size / 2
             val rightSize = size - leftSize
             runHalf(leftSize, fa.take(leftSize))

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -101,7 +101,7 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
       override def traverse_[G[_], A, B](fa: Vector[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] = {
         val empty = Eval.now(G.unit)
         // the cost of this is O(size)
-        // c(n) = n/2 + c(n/2) = n/2 + n/4 + c(n/4) = ... 2 * n
+        // c(n) = n + 2 * c(n/2)
         def runHalf(size: Int, idx: Int): Eval[G[Unit]] =
           if (size > 1) {
             val leftSize = size / 2

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -113,7 +113,16 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
               }
           } else {
             val a = fa(idx)
-            Eval.later {
+            // we evaluate this at most one time,
+            // always is a bit cheaper in such cases
+            //
+            // Here is the point of the laziness using Eval:
+            // we avoid calling f(a) or G.void in the
+            // event that the computation has already
+            // failed. We do not use laziness to avoid
+            // traversing fa, which we will do fully
+            // in all cases.
+            Eval.always {
               val gb = f(a)
               G.void(gb)
             }

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -99,9 +99,9 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
        * This avoids making a very deep stack by building a tree instead
        */
       override def traverse_[G[_], A, B](fa: Vector[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] = {
-        val empty = Eval.now(G.unit)
         // the cost of this is O(size)
-        // c(n) = n + 2 * c(n/2)
+        // c(n) = 1 + 2 * c(n/2)
+        // invariant: size >= 1
         def runHalf(size: Int, idx: Int): Eval[G[Unit]] =
           if (size > 1) {
             val leftSize = size / 2
@@ -111,15 +111,17 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
                 val right = runHalf(rightSize, idx + leftSize)
                 G.map2Eval(left, right) { (_, _) => () }
               }
-          } else if (size == 1) {
+          } else {
             val a = fa(idx)
             Eval.later {
               val gb = f(a)
               G.void(gb)
             }
-          } else empty
+          }
 
-        runHalf(fa.length, 0).value
+        val len = fa.length
+        if (len == 0) G.unit
+        else runHalf(len, 0).value
       }
       override def mapWithIndex[A, B](fa: Vector[A])(f: (A, Int) => B): Vector[B] =
         fa.iterator.zipWithIndex.map(ai => f(ai._1, ai._2)).toVector

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -82,6 +82,7 @@ package object cats {
       override def ap[A, B](ff: A => B)(fa: A): B = ff(fa)
       override def flatten[A](ffa: A): A = ffa
       override def map2[A, B, Z](fa: A, fb: B)(f: (A, B) => Z): Z = f(fa, fb)
+      override def map2Eval[A, B, Z](fa: A, fb: Eval[B])(f: (A, B) => Z): Eval[Z] = fb.map(f(fa, _))
       override def lift[A, B](f: A => B): A => B = f
       override def imap[A, B](fa: A)(f: A => B)(fi: B => A): B = f(fa)
       def foldLeft[A, B](a: A, b: B)(f: (B, A) => B) = f(b, a)

--- a/laws/src/main/scala/cats/laws/TraverseLaws.scala
+++ b/laws/src/main/scala/cats/laws/TraverseLaws.scala
@@ -84,6 +84,7 @@ trait TraverseLaws[F[_]] extends FunctorLaws[F] with FoldableLaws[F] with Unorde
 
     first <-> traverseFirst
   }
+
   def mapWithIndexRef[A, B](fa: F[A], f: (A, Int) => B): IsEq[F[B]] = {
     val lhs = F.mapWithIndex(fa)(f)
     val rhs = F.traverse(fa)(a => State((s: Int) => (s + 1, f(a, s)))).runA(0).value

--- a/tests/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/KleisliSuite.scala
@@ -354,6 +354,19 @@ class KleisliSuite extends CatsSuite {
     assertEquals(program.run(A123), List((1, "2", true)))
   }
 
+  /*
+  test("traverse_ doesn't stack overflow") {
+    // see: https://github.com/typelevel/cats/issues/3947
+    val res2 = (1 to 10000).toList.traverse_(_ => Kleisli.liftF[Id, String, Unit](())).run("") // fails with SO
+    assert(res2 == ())
+  }
+  */
+
+  test("traverse_ doesn't stack overflow with List + Eval") {
+    // see: https://github.com/typelevel/cats/issues/3947
+    (1 to 10000).toList.traverse_(_ => Kleisli.liftF[Eval, String, Unit](Eval.Unit)).run("").value
+  }
+
   /**
    * Testing that implicit resolution works. If it compiles, the "test" passes.
    */

--- a/tests/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/KleisliSuite.scala
@@ -360,7 +360,7 @@ class KleisliSuite extends CatsSuite {
     val res2 = (1 to 10000).toList.traverse_(_ => Kleisli.liftF[Id, String, Unit](())).run("") // fails with SO
     assert(res2 == ())
   }
-  */
+   */
 
   test("traverse_ doesn't stack overflow with List + Eval") {
     // see: https://github.com/typelevel/cats/issues/3947

--- a/tests/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/KleisliSuite.scala
@@ -354,13 +354,12 @@ class KleisliSuite extends CatsSuite {
     assertEquals(program.run(A123), List((1, "2", true)))
   }
 
-  /*
   test("traverse_ doesn't stack overflow") {
     // see: https://github.com/typelevel/cats/issues/3947
-    val res2 = (1 to 10000).toList.traverse_(_ => Kleisli.liftF[Id, String, Unit](())).run("") // fails with SO
-    assert(res2 == ())
+    val resL = (1 to 10000).toList.traverse_(_ => Kleisli.liftF[Id, String, Unit](())).run("")
+    val resV = (1 to 10000).toVector.traverse_(_ => Kleisli.liftF[Id, String, Unit](())).run("")
+    assert(resL == resV)
   }
-   */
 
   test("traverse_ doesn't stack overflow with List + Eval") {
     // see: https://github.com/typelevel/cats/issues/3947

--- a/tests/src/test/scala/cats/tests/TraverseSuite.scala
+++ b/tests/src/test/scala/cats/tests/TraverseSuite.scala
@@ -32,7 +32,7 @@ abstract class TraverseSuite[F[_]: Traverse](name: String)(implicit ArbFInt: Arb
     }
   }
 
-  test(s"Traverse[$name].traverseMatches_ with Option") {
+  test(s"Traverse[$name].traverse matches traverse_ with Option") {
     forAll { (fa: F[Int], fn: Int => Option[Int]) =>
       assert(Applicative[Option].void(fa.traverse(fn)) == fa.traverse_(fn))
     }

--- a/tests/src/test/scala/cats/tests/TraverseSuite.scala
+++ b/tests/src/test/scala/cats/tests/TraverseSuite.scala
@@ -32,6 +32,12 @@ abstract class TraverseSuite[F[_]: Traverse](name: String)(implicit ArbFInt: Arb
     }
   }
 
+  test(s"Traverse[$name].traverseMatches_ with Option") {
+    forAll { (fa: F[Int], fn: Int => Option[Int]) =>
+      assert(Applicative[Option].void(fa.traverse(fn)) == fa.traverse_(fn))
+    }
+  }
+
 }
 
 object TraverseSuite {


### PR DESCRIPTION
This fixes traverse_ for List and Vector to avoid stack overflow errors.

This is a partial fix for #3947