### PR TITLE
Optimize void in several cases

### DIFF
--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -374,6 +374,7 @@ sealed abstract private[cats] class EvalInstances extends EvalInstances0 {
       def extract[A](la: Eval[A]): A = la.value
       def coflatMap[A, B](fa: Eval[A])(f: Eval[A] => B): Eval[B] = Later(f(fa))
       override def unit: Eval[Unit] = Eval.Unit
+      override def void[A](a: Eval[A]): Eval[Unit] = Eval.Unit
     }
 
   implicit val catsDeferForEval: Defer[Eval] =

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -814,6 +814,8 @@ object Validated extends ValidatedInstances with ValidatedFunctions with Validat
   final case class Valid[+A](a: A) extends Validated[Nothing, A]
   final case class Invalid[+E](e: E) extends Validated[E, Nothing]
 
+  private[data] val validUnit: Validated[Nothing, Unit] = Valid(())
+
   /**
    * Evaluates the specified block, catching exceptions of the specified type and returning them on the invalid side of
    * the resulting `Validated`. Uncaught exceptions are propagated.
@@ -1030,6 +1032,10 @@ sealed abstract private[data] class ValidatedInstances2 {
         }
 
       override def isEmpty[A](fa: Validated[E, A]): Boolean = fa.isInvalid
+
+      override def void[A](fa: Validated[E, A]): Validated[E, Unit] =
+        if (fa.isValid) Validated.validUnit
+        else fa.asInstanceOf[Validated[E, Unit]]
     }
 }
 
@@ -1044,6 +1050,8 @@ private[data] class ValidatedApplicative[E: Semigroup] extends CommutativeApplic
 
   override def product[A, B](fa: Validated[E, A], fb: Validated[E, B]): Validated[E, (A, B)] =
     fa.product(fb)(Semigroup[E])
+
+  override def unit: Validated[E, Unit] = Validated.validUnit
 }
 
 private[data] trait ValidatedFunctions {

--- a/core/src/main/scala/cats/instances/either.scala
+++ b/core/src/main/scala/cats/instances/either.scala
@@ -175,6 +175,10 @@ trait EitherInstances extends cats.kernel.instances.EitherInstances {
             }
         }
 
+      override def void[B](e: Either[A, B]): Either[A, Unit] =
+        if (e.isRight) Either.unit
+        else e.asInstanceOf[Either[A, Unit]] // it is Left(a)
+
     }
 
   implicit def catsStdSemigroupKForEither[L]: SemigroupK[Either[L, *]] =

--- a/core/src/main/scala/cats/instances/option.scala
+++ b/core/src/main/scala/cats/instances/option.scala
@@ -19,6 +19,8 @@ trait OptionInstances extends cats.kernel.instances.OptionInstances {
       with CoflatMap[Option]
       with Align[Option] {
 
+      private[this] val someUnit: Option[Unit] = Some(())
+
       def empty[A]: Option[A] = None
 
       def combineK[A](x: Option[A], y: Option[A]): Option[A] = x.orElse(y)
@@ -191,6 +193,10 @@ trait OptionInstances extends cats.kernel.instances.OptionInstances {
           case (None, Some(b))    => Some(f(Ior.right(b)))
           case (Some(a), Some(b)) => Some(f(Ior.both(a, b)))
         }
+
+      override def unit: Option[Unit] = someUnit
+      override def void[A](oa: Option[A]): Option[Unit] =
+        if (oa.isDefined) someUnit else None
     }
 
   implicit def catsStdShowForOption[A](implicit A: Show[A]): Show[Option[A]] =

--- a/core/src/main/scala/cats/instances/tailrec.scala
+++ b/core/src/main/scala/cats/instances/tailrec.scala
@@ -22,5 +22,6 @@ private object TailRecInstances {
         fa.flatMap(f)
 
       override val unit: TailRec[Unit] = done(())
+      override def void[A](ta: TailRec[A]): TailRec[Unit] = unit
     }
 }

--- a/core/src/main/scala/cats/instances/try.scala
+++ b/core/src/main/scala/cats/instances/try.scala
@@ -104,10 +104,7 @@ trait TryInstances extends TryInstances1 {
         if (idx == 0L) fa.toOption else None
 
       override def size[A](fa: Try[A]): Long =
-        fa match {
-          case Failure(_) => 0L
-          case Success(_) => 1L
-        }
+        if (fa.isSuccess) 1L else 0L
 
       override def find[A](fa: Try[A])(f: A => Boolean): Option[A] =
         fa.toOption.filter(f)
@@ -141,6 +138,14 @@ trait TryInstances extends TryInstances1 {
       override def catchNonFatal[A](a: => A)(implicit ev: Throwable <:< Throwable): Try[A] = Try(a)
 
       override def catchNonFatalEval[A](a: Eval[A])(implicit ev: Throwable <:< Throwable): Try[A] = Try(a.value)
+
+      private val successUnit: Try[Unit] = Success(())
+
+      override def void[A](t: Try[A]): Try[Unit] =
+        if (t.isSuccess) successUnit
+        else t.asInstanceOf[Try[Unit]]
+
+      override def unit: Try[Unit] = successUnit
     }
 
   implicit def catsStdShowForTry[A](implicit A: Show[A]): Show[Try[A]] =


### PR DESCRIPTION
`void` in Functor can be a significant optimization in that it can discard work that does not need to be done in a pure setting (which we assume in cats).

Even when we are dealing with a strict data structure, `void` can often be implemented more efficiently than using `map(_ => ())` since we can often allocate a singular `unit` type and cheaply check if we can return that.