### PR TITLE
Make StackSafeMonad extend Defer

### DIFF
--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -375,6 +375,7 @@ sealed abstract private[cats] class EvalInstances extends EvalInstances0 {
       def coflatMap[A, B](fa: Eval[A])(f: Eval[A] => B): Eval[B] = Later(f(fa))
       override def unit: Eval[Unit] = Eval.Unit
       override def void[A](a: Eval[A]): Eval[Unit] = Eval.Unit
+      override def defer[A](fa: => Eval[A]): Eval[A] = Eval.defer(fa)
     }
 
   implicit val catsDeferForEval: Defer[Eval] =

--- a/core/src/main/scala/cats/StackSafeMonad.scala
+++ b/core/src/main/scala/cats/StackSafeMonad.scala
@@ -24,7 +24,7 @@ trait StackSafeMonad[F[_]] extends Monad[F] with Defer[F] {
       case Right(b) => pure(b)
     }
 
-  /**
+  /*
    * This is always safe for a StackSafeMonad.
    * proof: we know flatMap can't blow the stack
    * because if it could, tailRecM would not be safe:

--- a/core/src/main/scala/cats/StackSafeMonad.scala
+++ b/core/src/main/scala/cats/StackSafeMonad.scala
@@ -9,12 +9,38 @@ import scala.util.{Either, Left, Right}
  * will inherit will not be sound, and will result in unexpected stack overflows.  This
  * trait is only provided because a large number of monads ''do'' define a stack-safe
  * flatMap, and so this particular implementation was being repeated over and over again.
+ *
+ * Note, tailRecM being safe and pure implies that the function passed to flatMap
+ * is not called immediately on the current stack (since otherwise tailRecM would
+ * stack overflow for sufficiently deep recursions). This implies we can implement
+ *
+ * defer(fa) = unit.flatMap(_ => fa)
  */
-trait StackSafeMonad[F[_]] extends Monad[F] {
+trait StackSafeMonad[F[_]] extends Monad[F] with Defer[F] {
 
   override def tailRecM[A, B](a: A)(f: A => F[Either[A, B]]): F[B] =
     flatMap(f(a)) {
       case Left(a)  => tailRecM(a)(f)
       case Right(b) => pure(b)
+    }
+
+  /**
+   * This is always safe for a StackSafeMonad.
+   * proof: we know flatMap can't blow the stack
+   * because if it could, tailRecM would not be safe:
+   * if the function was called in the same stack then
+   * the depth would diverse on tailRecM(())(_ => pure(Left(())))
+   *
+   * It may be better to override this for your particular Monad
+   */
+  def defer[A](fa: => F[A]): F[A] =
+    flatMap(unit)(_ => fa)
+}
+
+object StackSafeMonad {
+  def shiftFunctor[F[_], A, B](fn: A => F[B])(implicit F: Functor[F]): A => F[B] =
+    F match {
+      case ssm: StackSafeMonad[F] @unchecked => { a => ssm.defer(fn(a)) }
+      case _                                 => fn
     }
 }

--- a/core/src/main/scala/cats/instances/tailrec.scala
+++ b/core/src/main/scala/cats/instances/tailrec.scala
@@ -11,7 +11,7 @@ trait TailRecInstances {
 private object TailRecInstances {
   val catsInstancesForTailRec: StackSafeMonad[TailRec] with Defer[TailRec] =
     new StackSafeMonad[TailRec] with Defer[TailRec] {
-      def defer[A](fa: => TailRec[A]): TailRec[A] = tailcall(fa)
+      override def defer[A](fa: => TailRec[A]): TailRec[A] = tailcall(fa)
 
       def pure[A](a: A): TailRec[A] = done(a)
 

--- a/core/src/main/scala/cats/instances/tailrec.scala
+++ b/core/src/main/scala/cats/instances/tailrec.scala
@@ -9,8 +9,8 @@ trait TailRecInstances {
 }
 
 private object TailRecInstances {
-  val catsInstancesForTailRec: StackSafeMonad[TailRec] with Defer[TailRec] =
-    new StackSafeMonad[TailRec] with Defer[TailRec] {
+  val catsInstancesForTailRec: StackSafeMonad[TailRec] =
+    new StackSafeMonad[TailRec] {
       override def defer[A](fa: => TailRec[A]): TailRec[A] = tailcall(fa)
 
       def pure[A](a: A): TailRec[A] = done(a)


### PR DESCRIPTION
Make StackSafeMonad extend Defer.

See the discussion in #3790 for more context.

The argument for why this is safe is given in the comments on StackSafeMonad. If they don't seem to make sense, please add a comment there.

cc @djspiewak @non 

I think we can follow up with using an idea similar to `shift` from Kleisli to make an Applicative map2 abstraction. As a sketch:

```scala
trait Map2Strategy[F[_]] {
  type Lazy[_]
  def map2[A, B](fa: F[A], fb: Lazy[F[B]]): Lazy[F[B]]
}
```
and then we can either make `Lazy[A] = Eval[A]` or `Lazy[A] = Id[A]` depending on the `F[_]` which maybe we can reflectively select based on if the `F[_]` is a `StackSafeMonad` or not.

Or something...