### PR TITLE
NonEmptyMap: add new methods

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -79,6 +79,28 @@ sealed class NonEmptyMapOps[K, A](val value: NonEmptyMap[K, A]) {
     NonEmptyMapImpl.create(Functor[SortedMap[K, *]].map(toSortedMap)(f))
 
   /**
+   * Applies f to all the keys leaving elements unchanged.
+   */
+  def leftMap[L](f: K => L)(implicit orderL: Order[L]): NonEmptyMap[L, A] = {
+    implicit val orderingL: Ordering[L] = orderL.toOrdering
+    NonEmptyMapImpl.create(toSortedMap.map(Bifunctor[Tuple2].leftMap(_)(f)))
+  }
+
+  /**
+   * Applies f to both keys and elements simultaneously.
+   */
+  def fullMap[L, B](f: (K, A) => (L, B))(implicit orderL: Order[L]): NonEmptyMap[L, B] = {
+    implicit val orderingL: Ordering[L] = orderL.toOrdering
+    NonEmptyMapImpl.create(toSortedMap.map(Function.tupled(f)))
+  }
+
+  /**
+   * Transforms the elements only by applying f to both elements and associated keys.
+   */
+  def transform[B](f: (K, A) => B): NonEmptyMap[K, B] =
+    NonEmptyMapImpl.create(toSortedMap.transform(f))
+
+  /**
    * Optionally returns the value associated with the given key.
    */
   def lookup(k: K): Option[A] = toSortedMap.get(k)

--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -81,7 +81,7 @@ sealed class NonEmptyMapOps[K, A](val value: NonEmptyMap[K, A]) {
   /**
    * Applies f to all the keys leaving elements unchanged.
    */
-  def leftMap[L](f: K => L)(implicit orderL: Order[L]): NonEmptyMap[L, A] = {
+  def mapKeys[L](f: K => L)(implicit orderL: Order[L]): NonEmptyMap[L, A] = {
     implicit val orderingL: Ordering[L] = orderL.toOrdering
     NonEmptyMapImpl.create(toSortedMap.map(Bifunctor[Tuple2].leftMap(_)(f)))
   }
@@ -89,7 +89,7 @@ sealed class NonEmptyMapOps[K, A](val value: NonEmptyMap[K, A]) {
   /**
    * Applies f to both keys and elements simultaneously.
    */
-  def fullMap[L, B](f: (K, A) => (L, B))(implicit orderL: Order[L]): NonEmptyMap[L, B] = {
+  def mapBoth[L, B](f: (K, A) => (L, B))(implicit orderL: Order[L]): NonEmptyMap[L, B] = {
     implicit val orderingL: Ordering[L] = orderL.toOrdering
     NonEmptyMapImpl.create(toSortedMap.map(Function.tupled(f)))
   }

--- a/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
@@ -5,12 +5,13 @@ import cats.data.{NonEmptyList, NonEmptyMap}
 import cats.kernel.laws.discipline.{SerializableTests => _, _}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
+import cats.syntax.bifunctor._
+import cats.syntax.eq._
 import cats.syntax.foldable._
 import cats.syntax.functor._
-import cats.syntax.show._
 import cats.syntax.reducible._
+import cats.syntax.show._
 import scala.collection.immutable.SortedMap
-import cats.syntax.eq._
 import org.scalacheck.Prop._
 
 class NonEmptyMapSuite extends CatsSuite {
@@ -82,6 +83,27 @@ class NonEmptyMapSuite extends CatsSuite {
     forAll { (nem: NonEmptyMap[String, Int], p: Int => String) =>
       val map = nem.toSortedMap
       assert(nem.map(p).toSortedMap === (map.fmap(p)))
+    }
+  }
+
+  test("NonEmptyMap#leftMap is consistent with Map#map") {
+    forAll { (nem: NonEmptyMap[String, Int], p: String => Int) =>
+      val map = nem.toSortedMap
+      assert(nem.leftMap(p).toSortedMap === map.map(_.leftMap(p)))
+    }
+  }
+
+  test("NonEmptyMap#fullMap is consistent with Map#map") {
+    forAll { (nem: NonEmptyMap[String, Int], p: (String, Int) => (Int, String)) =>
+      val map = nem.toSortedMap
+      assert(nem.fullMap(p).toSortedMap === map.map(Function.tupled(p)))
+    }
+  }
+
+  test("NonEmptyMap#transform is consistent with Map#transform") {
+    forAll { (nem: NonEmptyMap[String, Int], p: (String, Int) => String) =>
+      val map = nem.toSortedMap
+      assert(nem.transform(p).toSortedMap === map.transform(p))
     }
   }
 

--- a/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyMapSuite.scala
@@ -86,17 +86,17 @@ class NonEmptyMapSuite extends CatsSuite {
     }
   }
 
-  test("NonEmptyMap#leftMap is consistent with Map#map") {
+  test("NonEmptyMap#mapKeys is consistent with Map#map") {
     forAll { (nem: NonEmptyMap[String, Int], p: String => Int) =>
       val map = nem.toSortedMap
-      assert(nem.leftMap(p).toSortedMap === map.map(_.leftMap(p)))
+      assert(nem.mapKeys(p).toSortedMap === map.map(_.leftMap(p)))
     }
   }
 
-  test("NonEmptyMap#fullMap is consistent with Map#map") {
+  test("NonEmptyMap#mapBoth is consistent with Map#map") {
     forAll { (nem: NonEmptyMap[String, Int], p: (String, Int) => (Int, String)) =>
       val map = nem.toSortedMap
-      assert(nem.fullMap(p).toSortedMap === map.map(Function.tupled(p)))
+      assert(nem.mapBoth(p).toSortedMap === map.map(Function.tupled(p)))
     }
   }
 


### PR DESCRIPTION
Inspired by [this](https://discord.com/channels/632277896739946517/632278570512678923/875434472735146024) discussion.

Introduces a few new methods which make `NonEmptyMap` more convenient and useful:
  - `leftMap`: maps over the keys rather than values (in contrast to `map` which maps over the values).
    The name `leftMap` looks `Bifunctor`-ish although there's a required `Order` constraint added to the method.
  - `fullMap`: maps over both keys and values. It behaves like a regular `Map.map` from Scala collections, but also includes the `Order` constraint. The name is controversial though, just the best one I managed to come up with. But I am totally open to change it to something better.
  - `transform`: looks and behaves like `Map.transform`. Does not require any additional constraint.

Nothing is "set in stone", of course – feel free to make any suggestions.

**UPD**: Some names are changed: `leftMap` -> `mapKeys`, `fullMap` -> `mapBoth`.
