### PR TITLE
Render sponsors from Open Collective REST API

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,51 +36,39 @@ information about how you can get involved as a developer. If you are looking fo
 
 ### Financial Contributors
 
-[Become a financial contributor](https://opencollective.com/typelevel) and help us sustain our community. Donations directly support office hour for maintainers, better documentation and strategic initiatives. 
+[Become a financial contributor](https://opencollective.com/typelevel) and help us sustain our community. Donations directly support office hours for maintainers, better documentation and strategic initiatives.
 
+<h4>Platinum Sponsors</h4>
+<a href="https://opencollective.com/typelevel/contribute/platinum-sposor-12420/checkout">Platinum sponsorship</a> starts at $950 USD/month.
+<div id="platinum-sponsors">
+  <noscript>Platinum Sponsors appear here at <a href="https://typelevel.org/cats/">https://typelevel.org/cats</a></noscript>
+</div>
 
+<h4>Gold Sponsors</h4>
+<a href="https://opencollective.com/typelevel/contribute/gold-sponsor-12419/checkout">Gold Sponsorship</a> starts at $420 USD/month.
+<div id="gold-sponsors">
+  <noscript>Gold Sponsors appear here at <a href="https://typelevel.org/cats/">https://typelevel.org/cats</a></noscript>
+</div>
 
-### Gold Sponsors 
+<h4>Silver Sponsors</h4>
+<a href="https://opencollective.com/typelevel/contribute/silver-sponsor-11780/checkout">Silver Sponsorship</a> starts at $180 USD/month.
+<div id="silver-sponsors">
+  <noscript>Silver Sponsors appear here at <a href="https://typelevel.org/cats/">https://typelevel.org/cats</a></noscript>
+</div>
 
-Gold Sponsors are those who have pledged $5,000 to $10,000.
+<h4>Backers</h4>
+Become a <a href="https://opencollective.com/typelevel/contribute/backer-11779/checkout">Backer</a> with a recurring donation of just $5 USD/month.
+<div id="backers">
+  <noscript>Backs appear here at <a href="https://typelevel.org/cats/">https://typelevel.org/cats</a></noscript>
+</div>
 
-<a href="http://47deg.com"><img src="https://typelevel.org/img/media/sponsors/47_degrees.png" style="margin-left: 10px; margin-right: 10px" /></a>
-<a href="https://www.iteratorshq.com"><img src="https://typelevel.org/img/media/sponsors/iterators.png" style="margin-bottom:8px;margin-left: 10px; margin-right: 10px"/></a>
-<a href="https://triplequote.com/"><img src="https://typelevel.org/img/media/sponsors/triplequote.png" style="margin-bottom:9px; margin-right: 10px" /></a>
-<a href="http://underscore.io"><img src="https://typelevel.org/img/media/sponsors/underscore.png" style="margin-bottom:5px;margin-left: 10px; margin-right: 10px"/></a>
+<h4>Other contributors</h4>
+We thankfully accept <a href="https://opencollective.com/typelevel/donate">one-time and recurring</a> contributions as well.
+<div id="other-contributors">
+  <noscript>Other contributors appear here at <a href="https://typelevel.org/cats/">https://typelevel.org/cats</a></noscript>
+</div>
 
-
-
-### Silver Sponsors
-
-Silver Sponsors are those who have pledged $2,000 to $5,000.
-
-<a href="https://www.ebiznext.com/"><img src="https://typelevel.org/img/media/sponsors/ebiznext.png" style="margin-bottom:15px; margin-right: 10px" /></a>
-<a href="https://www.inner-product.com/"><img src="https://typelevel.org/img/media/sponsors/inner-product.png" style="margin-bottom:10px; margin-right: 10px"/></a>
-<a href="https://evolutiongaming.com/"><img src="https://typelevel.org/img/media/sponsors/evolution_gaming_engineering.png" style="margin-bottom:10px; margin-right: 10px"/></a>
-
-
-#### Other Organizations
-
-Support this project with your organization. Your logo will show up here with a link to your website. [[Contribute](https://opencollective.com/typelevel/contribute)]
-
-<a href="https://opencollective.com/typelevel/organization/0/website"><img src="https://opencollective.com/typelevel/organization/0/avatar.svg"></a>
-<a href="https://opencollective.com/typelevel/organization/1/website"><img src="https://opencollective.com/typelevel/organization/1/avatar.svg"></a>
-<a href="https://opencollective.com/typelevel/organization/2/website"><img src="https://opencollective.com/typelevel/organization/2/avatar.svg"></a>
-<a href="https://opencollective.com/typelevel/organization/3/website"><img src="https://opencollective.com/typelevel/organization/3/avatar.svg"></a>
-<a href="https://opencollective.com/typelevel/organization/4/website"><img src="https://opencollective.com/typelevel/organization/4/avatar.svg"></a>
-<a href="https://opencollective.com/typelevel/organization/5/website"><img src="https://opencollective.com/typelevel/organization/5/avatar.svg"></a>
-<a href="https://opencollective.com/typelevel/organization/6/website"><img src="https://opencollective.com/typelevel/organization/6/avatar.svg"></a>
-<a href="https://opencollective.com/typelevel/organization/7/website"><img src="https://opencollective.com/typelevel/organization/7/avatar.svg"></a>
-<a href="https://opencollective.com/typelevel/organization/8/website"><img src="https://opencollective.com/typelevel/organization/8/avatar.svg"></a>
-<a href="https://opencollective.com/typelevel/organization/9/website"><img src="https://opencollective.com/typelevel/organization/9/avatar.svg"></a>
-
-
-#### Individuals
-
-<a href="https://opencollective.com/typelevel"><img src="https://opencollective.com/typelevel/individuals.svg?width=890"></a>
-
-
+<script src="/cats/js/sponsors.js"></script>
 
 ### Getting Started
 

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ information about how you can get involved as a developer. If you are looking fo
 <h4>Backers</h4>
 Become a <a href="https://opencollective.com/typelevel/contribute/backer-11779/checkout">Backer</a> with a recurring donation of just $5 USD/month.
 <div id="backers">
-  <noscript>Backs appear here at <a href="https://typelevel.org/cats/">https://typelevel.org/cats</a></noscript>
+  <noscript>Backers appear here at <a href="https://typelevel.org/cats/">https://typelevel.org/cats</a></noscript>
 </div>
 
 <h4>Other contributors</h4>

--- a/build.sbt
+++ b/build.sbt
@@ -274,6 +274,7 @@ lazy val docSettings = Seq(
   ),
   micrositeGithubRepo := "cats",
   micrositeImgDirectory := (LocalRootProject / baseDirectory).value / "docs" / "src" / "main" / "resources" / "microsite" / "img",
+  micrositeJsDirectory := (LocalRootProject / baseDirectory).value / "docs" / "src" / "main" / "resources" / "microsite" / "js",
   micrositeTheme := "pattern",
   micrositePalette := Map(
     "brand-primary" -> "#5B5988",

--- a/docs/src/main/resources/microsite/img/missing-avatar.svg
+++ b/docs/src/main/resources/microsite/img/missing-avatar.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+<svg xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:cc="http://creativecommons.org/ns#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:svg="http://www.w3.org/2000/svg" xmlns="http://www.w3.org/2000/svg" xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd" xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape" width="120mm" height="120.00001mm" viewBox="0 0 120 120.00001" version="1.1" id="svg8" inkscape:version="0.92.1 r15371" sodipodi:docname="Generic avatar.svg">
+  <defs id="defs2"/>
+  <sodipodi:namedview id="base" pagecolor="#ffffff" bordercolor="#666666" borderopacity="1.0" inkscape:pageopacity="0.0" inkscape:pageshadow="2" inkscape:zoom="1.1894531" inkscape:cx="96.728967" inkscape:cy="188.27139" inkscape:document-units="mm" inkscape:current-layer="layer1" showgrid="false" fit-margin-top="0" fit-margin-left="0" fit-margin-right="0" fit-margin-bottom="0" inkscape:window-width="1920" inkscape:window-height="1017" inkscape:window-x="-8" inkscape:window-y="-8" inkscape:window-maximized="1"/>
+  <metadata id="metadata5">
+    <rdf:RDF>
+      <cc:Work rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type rdf:resource="http://purl.org/dc/dcmitype/StillImage"/>
+        <dc:title/>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g inkscape:label="Layer 1" inkscape:groupmode="layer" id="layer1" transform="translate(-43.204007,-85.320039)">
+    <rect style="opacity:0.98999999;fill:#e6e6e6;fill-opacity:0.24637681;stroke:#000000;stroke-width:0.06454252;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" id="rect4576" width="119.49368" height="119.93546" x="43.457169" y="85.35231"/>
+    <g id="g4574" transform="translate(126.12414,-0.65106087)">
+      <path d="m 37.047129,145.97115 a 59.967239,59.967209 0 0 1 -59.715003,59.96667 59.967239,59.967209 0 0 1 -60.217354,-59.46221 59.967239,59.967209 0 0 1 59.208425,-60.466899 59.967239,59.967209 0 0 1 60.715444,58.953529" sodipodi:open="true" sodipodi:end="6.2663603" sodipodi:start="0" sodipodi:ry="59.967209" sodipodi:rx="59.967239" sodipodi:cy="145.97115" sodipodi:cx="-22.920111" sodipodi:type="arc" id="path4498" style="opacity:0.98999999;fill:#999999;fill-opacity:0.77064221;stroke:#000000;stroke-width:0.06547602;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"/>
+      <path id="path4500" transform="scale(0.26458333)" d="m -87.9375,395.13477 a 103.80704,103.80699 0 0 0 -102.49219,104.67187 103.80704,103.80699 0 0 0 41.75391,82.23828 141.61518,141.6151 0 0 0 -79.5625,128.29688 141.61518,141.6151 0 0 0 1.6582,19.33789 226.64785,226.64772 0 0 0 11.15235,8.40234 132.17416,132.17408 0 0 1 -3.36915,-27.82031 132.17416,132.17408 0 0 1 79.32032,-122.10352 103.80704,103.80699 0 0 0 53.285154,14.58008 103.80704,103.80699 0 0 0 52.429687,-14.5957 132.17416,132.17408 0 0 1 79.289063,118.78515 l 0.01953,2.22266 a 132.17416,132.17408 0 0 1 -3.242187,28.64063 226.64785,226.64772 0 0 0 11.042968,-7.89649 141.61518,141.6151 0 0 0 1.640625,-20.74414 l -0.01953,-2.38281 a 141.61518,141.6151 0 0 0 -79.412109,-124.84375 103.80704,103.80699 0 0 1 -0.259766,0.17578 103.80704,103.80699 0 0 0 41.882813,-83.16602 l -0.01367,-1.74804 A 103.80704,103.80699 0 0 0 -87.9375,395.13477 Z m 0.119141,9.43554 A 94.370033,94.36999 0 0 1 7.7285156,497.3457 l 0.013672,1.58789 a 94.370033,94.36999 0 0 1 -93.9726566,94.36914 94.370033,94.36999 0 0 1 -94.763671,-93.57617 94.370033,94.36999 0 0 1 93.175781,-95.15625 z" style="opacity:0.98999999;fill:#e6e6e6;fill-opacity:1;stroke:#000000;stroke-width:0.25984651;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" inkscape:connector-curvature="0"/>
+    </g>
+  </g>
+</svg>

--- a/docs/src/main/resources/microsite/js/sponsors.js
+++ b/docs/src/main/resources/microsite/js/sponsors.js
@@ -1,0 +1,96 @@
+function addSponsor(divId, member, size) {
+    div = document.getElementById(divId);
+    var a = document.createElement('a');
+    a.setAttribute('href', member.website || member.profile || '#');
+    var img = document.createElement('img');
+    img.setAttribute('src', member.image || 'img/missing-avatar.svg');
+    if (size) {
+        img.setAttribute('height', size);
+        img.setAttribute('width', size);
+    }
+    img.setAttribute('alt', member.name);
+    img.setAttribute('style', 'margin:6px;');
+    if (member.marginBottom)
+        img.setAttribute('style', img.getAttribute('style') + 'margin-bottom:' + member.marginBottom + 'px;')
+    a.appendChild(img);
+    div.appendChild(a);
+};
+
+const PlatinumSize = 98;
+const GoldSize = 76;
+const SilverSize = 60;
+const BackerSize = 45;
+const ContributorSize = 36;
+
+var sponsors = function() {
+    var xhr = new XMLHttpRequest();
+    xhr.open('GET', 'https://opencollective.com/typelevel/members/all.json', true);
+    xhr.responseType = 'json';
+    xhr.onload = function() {
+        var status = xhr.status;
+        if (status === 200) {
+            for(i = 0; i < xhr.response.length; i++) {
+                var member = xhr.response[i];
+                if (member.isActive) {
+                    switch (member.tier) {
+                    case 'Platinum Sponsor':
+                        addSponsor('platinum-sponsors', member, PlatinumSize);
+                    case 'Gold Sponsor':
+                        addSponsor('gold-sponsors', member, GoldSize);
+                    case 'Silver Sponsor':
+                        addSponsor('silver-sponsors', member, SilverSize);
+                    case 'backer':
+                        addSponsor('backers', member, BackerSize);
+                        break;
+                    default:
+                        if (member.totalAmountDonated > 0) {
+                            addSponsor('other-contributors', member, ContributorSize);
+                        }
+                    }
+                };
+            }
+        }
+    };
+    xhr.send();
+};
+sponsors();
+// Add sponsors who predate open collective
+addSponsor('gold-sponsors', {
+    name: "47 Degrees",
+    website: "https://47deg.com",
+    image: "https://typelevel.org/cats/img/sponsors/47_degree.png"
+});
+addSponsor('gold-sponsors', {
+    name: "Iterators",
+    website: "https://iteratorshq.com",
+    image: "https://typelevel.org/cats/img/sponsors/iterators.png",
+    marginBottom: 20
+});
+addSponsor('gold-sponsors', {
+    name: "Triplequote",
+    website: "https://triplequote.com",
+    image: "https://typelevel.org/cats/img/sponsors/triplequote.png",
+    marginBottom: 20
+});
+addSponsor('gold-sponsors', {
+    name: "Underscore",
+    website: "https://underscore.com",
+    image: "https://typelevel.org/cats/img/sponsors/underscore.png",
+    marginBottom: 10
+});
+addSponsor('silver-sponsors', {
+    name: "Ebiznext",
+    website: "https://ebiznext.com",
+    image: "https://typelevel.org/cats/img/sponsors/ebiznext.png",
+    marginBottom: 10
+});
+addSponsor('silver-sponsors', {
+    name: "Inner Product",
+    website: "https://inner-product.com",
+    image: "https://typelevel.org/cats/img/sponsors/inner-product.png"
+});
+addSponsor('silver-sponsors', {
+    name: "Evolution Gaming Engineering",
+    website: "https://evolutiongaming.com",
+    image: "https://typelevel.org/cats/img/sponsors/evolution_gaming_engineering.png"
+});


### PR DESCRIPTION
Makes sponsors appear automatically on the site, at the expense of appearing in the README.

1. Call the Open Collective REST API to retrieve all the active sponsors
2. Merge with sponsors who donated through other means
3. Remove obsolete language about previous sponsorship levels

Issues:
* This makes the README a bit unsightly.  Help wanted.
* I don't think it will render in local jekyll without doing unspeakable things to disable CORS.
* I didn't implement pagination, if we get more sponsors.  Help wanted.
* This is more JavaScript than I've written in at least a decade.

Local rendering below:

![Screen Shot 2021-08-24 at 3 00 09 PM](https://user-images.githubusercontent.com/142698/130675285-a7bb21d5-3a7b-4ae0-b359-012de0b35a8d.png)
