### PR TITLE
Add `Semifield` and `CommutativeSemifield` to algebra

### DIFF
--- a/algebra-core/src/main/scala/algebra/ring/CommutativeSemifield.scala
+++ b/algebra-core/src/main/scala/algebra/ring/CommutativeSemifield.scala
@@ -1,0 +1,19 @@
+package algebra
+package ring
+
+import scala.{specialized => sp}
+
+/**
+ * CommutativeSemifield is a Semifield that is commutative under multiplication.
+ */
+trait CommutativeSemifield[@sp(Int, Long, Float, Double) A]
+    extends Any
+    with Semifield[A]
+    with CommutativeRig[A]
+    with MultiplicativeCommutativeGroup[A]
+
+object CommutativeSemifield
+    extends AdditiveMonoidFunctions[CommutativeSemifield]
+    with MultiplicativeGroupFunctions[CommutativeSemifield] {
+  @inline final def apply[A](implicit r: CommutativeSemifield[A]): CommutativeSemifield[A] = r
+}

--- a/algebra-core/src/main/scala/algebra/ring/DivisionRing.scala
+++ b/algebra-core/src/main/scala/algebra/ring/DivisionRing.scala
@@ -3,7 +3,7 @@ package ring
 
 import scala.{specialized => sp}
 
-trait DivisionRing[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Ring[A] with MultiplicativeGroup[A] {
+trait DivisionRing[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any with Ring[A] with Semifield[A] {
   self =>
 
   /**

--- a/algebra-core/src/main/scala/algebra/ring/Field.scala
+++ b/algebra-core/src/main/scala/algebra/ring/Field.scala
@@ -7,7 +7,7 @@ trait Field[@sp(Int, Long, Float, Double) A]
     extends Any
     with EuclideanRing[A]
     with DivisionRing[A]
-    with MultiplicativeCommutativeGroup[A] {
+    with CommutativeSemifield[A] {
   self =>
 
   // default implementations for GCD

--- a/algebra-core/src/main/scala/algebra/ring/Semifield.scala
+++ b/algebra-core/src/main/scala/algebra/ring/Semifield.scala
@@ -1,0 +1,18 @@
+package algebra
+package ring
+
+import scala.{specialized => sp}
+
+/**
+ * Semifield consists of:
+ *
+ *  - a commutative monoid for addition (+)
+ *  - a group for multiplication (*)
+ *
+ * Alternately, a Semifield can be thought of as a DivisionRing without an additive inverse.
+ */
+trait Semifield[@sp(Int, Long, Float, Double) A] extends Any with Rig[A] with MultiplicativeGroup[A]
+
+object Semifield extends AdditiveMonoidFunctions[Semifield] with MultiplicativeGroupFunctions[Semifield] {
+  @inline final def apply[A](implicit ev: Semifield[A]): Semifield[A] = ev
+}

--- a/algebra-laws/shared/src/main/scala/algebra/laws/RingLaws.scala
+++ b/algebra-laws/shared/src/main/scala/algebra/laws/RingLaws.scala
@@ -259,11 +259,25 @@ trait RingLaws[A] extends GroupLaws[A] { self =>
     }
   )
 
+  def semifield(implicit A: Semifield[A]) = new RingProperties(
+    name = "semifield",
+    al = additiveCommutativeMonoid,
+    ml = multiplicativeGroup,
+    parents = Seq(rig)
+  )
+
+  def commutativeSemifield(implicit A: CommutativeSemifield[A]) = new RingProperties(
+    name = "semifield",
+    al = additiveCommutativeMonoid,
+    ml = multiplicativeCommutativeGroup,
+    parents = Seq(semifield, commutativeRig)
+  )
+
   def divisionRing(implicit A: DivisionRing[A]) = new RingProperties(
     name = "division ring",
     al = additiveCommutativeGroup,
     ml = multiplicativeGroup,
-    parents = Seq(ring),
+    parents = Seq(ring, semifield),
     "fromDouble" -> forAll { (n: Double) =>
       if (Platform.isJvm) {
         // TODO: BigDecimal(n) is busted in scalajs, so we skip this test.
@@ -311,7 +325,7 @@ trait RingLaws[A] extends GroupLaws[A] { self =>
     name = "field",
     al = additiveCommutativeGroup,
     ml = multiplicativeCommutativeGroup,
-    parents = Seq(euclideanRing, divisionRing)
+    parents = Seq(euclideanRing, divisionRing, commutativeSemifield)
   )
 
   // Approximate fields such a Float or Double, even through filtered using FPFilter, do not work well with


### PR DESCRIPTION
Introduces a `Semifield` and `CommutativeSemifield` to algebra. I'm going by the [second definition on Wikipedia](https://en.wikipedia.org/wiki/Semifield):
* a commutative monoid for addition (+)
* a group for multiplication (*)

Thanks in advance!