### PR TITLE
Introduce Apply.TraverseStrategy

### DIFF
--- a/core/src/main/scala/cats/Apply.scala
+++ b/core/src/main/scala/cats/Apply.scala
@@ -296,8 +296,8 @@ object Apply {
     def viaEval[F[_]](a: Apply[F]): TraverseStrategy[F] =
       ViaEval(a)
 
-    def composeOuter[F[_], G[_]](self: TraverseStrategy[F], that: Apply[G]): TraverseStrategy[Lambda[x => F[G[x]]]] =
-      new TraverseStrategy[Lambda[x => F[G[x]]]] {
+    def composeOuter[F[_], G[_]](self: TraverseStrategy[F], that: Apply[G]): TraverseStrategy[λ[x => F[G[x]]]] =
+      new TraverseStrategy[λ[x => F[G[x]]]] {
         type Rhs[A] = self.Rhs[G[A]]
 
         def map2[A, B, C](left: Rhs[A], right: Rhs[B])(fn: (A, B) => C): Rhs[C] =

--- a/core/src/main/scala/cats/Composed.scala
+++ b/core/src/main/scala/cats/Composed.scala
@@ -34,6 +34,8 @@ private[cats] trait ComposedApply[F[_], G[_]] extends Apply[λ[α => F[G[α]]]] 
 
   override def product[A, B](fga: F[G[A]], fgb: F[G[B]]): F[G[(A, B)]] =
     F.map2(fga, fgb)(G.product)
+
+  override def traverseStrategy = Apply.TraverseStrategy.composeOuter(F.traverseStrategy, G)
 }
 
 private[cats] trait ComposedApplicative[F[_], G[_]] extends Applicative[λ[α => F[G[α]]]] with ComposedApply[F, G] {

--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -375,6 +375,8 @@ sealed abstract private[cats] class EvalInstances extends EvalInstances0 {
       def coflatMap[A, B](fa: Eval[A])(f: Eval[A] => B): Eval[B] = Later(f(fa))
       override def unit: Eval[Unit] = Eval.Unit
       override def void[A](a: Eval[A]): Eval[Unit] = Eval.Unit
+      // Eval is already lazy
+      override val traverseStrategy: Apply.TraverseStrategy[Eval] = Apply.TraverseStrategy.direct(this)
     }
 
   implicit val catsDeferForEval: Defer[Eval] =

--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -825,7 +825,7 @@ object Chain extends ChainInstances {
       // we branch out by this factor
       val width = 128
       val strat = G.traverseStrategy
-      val toG: A => G[List[B]] = { a: A =>
+      val toG: A => G[List[B]] = { (a: A) =>
         G.map(f(a)) { optB =>
           if (optB.isDefined) optB.get :: Nil
           else Nil

--- a/core/src/main/scala/cats/data/IndexedStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedStateT.scala
@@ -445,6 +445,9 @@ sealed abstract private[data] class IndexedStateTMonad[F[_], S]
         }
       }
     )
+
+  // IndexedStateT is already lazy and sequential
+  override val traverseStrategy = Apply.TraverseStrategy.direct(this)
 }
 
 sealed abstract private[data] class IndexedStateTSemigroupK[F[_], SA, SB]

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -692,17 +692,13 @@ private[data] trait KleisliApply[F[_], A] extends Apply[Kleisli[F, A, *]] with K
           }
 
           def applyToRhs[A0, B](fn: A0 => Kleisli[F, A, B], arg: A0): Rhs[B] = {
-            // the laziness we are looking for is on F, not in the
-            // outer function. We can evalute this here
-            val k: A => F[B] = fn(arg).run
+            lazy val k: A => F[B] = fn(arg).run
 
             { (a: A) => stratF.applyToRhs(k, a) }
           }
 
           def applyOnRhs[A0, B](fn: A0 => Rhs[B], arg: A0): Rhs[B] = {
-            // the laziness we are looking for is on F, not in the
-            // outer function. We can evalute this here
-            val k: A => stratF.Rhs[B] = fn(arg)
+            lazy val k: A => stratF.Rhs[B] = fn(arg)
 
             { (a: A) => stratF.applyOnRhs(k, a) }
           }

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -691,11 +691,11 @@ private[data] trait KleisliApply[F[_], A] extends Apply[Kleisli[F, A, *]] with K
             stratF.map2(l, r)(fn)
           }
 
-          def applyToRhs[A0, B](fn: A0 => Kleisli[F, A, B], arg: A0): Rhs[B] = { a: A =>
+          def applyToRhs[A0, B](fn: A0 => Kleisli[F, A, B], arg: A0): Rhs[B] = { (a: A) =>
             stratF.applyToRhs[A0, B]({ a0 => fn(a0).run(a) }, arg)
           }
 
-          def applyOnRhs[A0, B](fn: A0 => Rhs[B], arg: A0): Rhs[B] = { a: A =>
+          def applyOnRhs[A0, B](fn: A0 => Rhs[B], arg: A0): Rhs[B] = { (a: A) =>
             stratF.applyOnRhs[A0, B]({ a0 => fn(a0)(a) }, arg)
           }
 

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -691,12 +691,20 @@ private[data] trait KleisliApply[F[_], A] extends Apply[Kleisli[F, A, *]] with K
             stratF.map2(l, r)(fn)
           }
 
-          def applyToRhs[A0, B](fn: A0 => Kleisli[F, A, B], arg: A0): Rhs[B] = { (a: A) =>
-            stratF.applyToRhs[A0, B]({ a0 => fn(a0).run(a) }, arg)
+          def applyToRhs[A0, B](fn: A0 => Kleisli[F, A, B], arg: A0): Rhs[B] = {
+            // the laziness we are looking for is on F, not in the
+            // outer function. We can evalute this here
+            val k: A => F[B] = fn(arg).run
+
+            { (a: A) => stratF.applyToRhs(k, a) }
           }
 
-          def applyOnRhs[A0, B](fn: A0 => Rhs[B], arg: A0): Rhs[B] = { (a: A) =>
-            stratF.applyOnRhs[A0, B]({ a0 => fn(a0)(a) }, arg)
+          def applyOnRhs[A0, B](fn: A0 => Rhs[B], arg: A0): Rhs[B] = {
+            // the laziness we are looking for is on F, not in the
+            // outer function. We can evalute this here
+            val k: A => stratF.Rhs[B] = fn(arg)
+
+            { (a: A) => stratF.applyOnRhs(k, a) }
           }
 
           def rhsToF[A0](r: Rhs[A0]): Kleisli[F, A, A0] =

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -701,6 +701,9 @@ object NonEmptyList extends NonEmptyListInstances {
 
         override def product[A, B](fa: ZipNonEmptyList[A], fb: ZipNonEmptyList[B]): ZipNonEmptyList[(A, B)] =
           ZipNonEmptyList(fa.value.zipWith(fb.value) { case (a, b) => (a, b) })
+
+        // We can never stop early on a nonempty list
+        override val traverseStrategy = Apply.TraverseStrategy.direct(this)
       }
 
     @deprecated("Use catsDataEqForZipNonEmptyList", "2.0.0-RC2")
@@ -745,6 +748,9 @@ sealed abstract private[data] class NonEmptyListInstances extends NonEmptyListIn
 
       def flatMap[A, B](fa: NonEmptyList[A])(f: A => NonEmptyList[B]): NonEmptyList[B] =
         fa.flatMap(f)
+
+      // We can never stop early on a nonempty list
+      override val traverseStrategy = Apply.TraverseStrategy.direct(this)
 
       def coflatMap[A, B](fa: NonEmptyList[A])(f: NonEmptyList[A] => B): NonEmptyList[B] =
         fa.coflatMap(f)

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -703,7 +703,7 @@ object NonEmptyList extends NonEmptyListInstances {
           ZipNonEmptyList(fa.value.zipWith(fb.value) { case (a, b) => (a, b) })
 
         // We can never stop early on a nonempty list
-        override val traverseStrategy = Apply.TraverseStrategy.direct(this)
+        override val traverseStrategy: Apply.TraverseStrategy[ZipNonEmptyList] = Apply.TraverseStrategy.direct(this)
       }
 
     @deprecated("Use catsDataEqForZipNonEmptyList", "2.0.0-RC2")
@@ -750,7 +750,7 @@ sealed abstract private[data] class NonEmptyListInstances extends NonEmptyListIn
         fa.flatMap(f)
 
       // We can never stop early on a nonempty list
-      override val traverseStrategy = Apply.TraverseStrategy.direct(this)
+      override val traverseStrategy: Apply.TraverseStrategy[NonEmptyList] = Apply.TraverseStrategy.direct(this)
 
       def coflatMap[A, B](fa: NonEmptyList[A])(f: NonEmptyList[A] => B): NonEmptyList[B] =
         fa.coflatMap(f)

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -389,7 +389,7 @@ sealed abstract private[data] class NonEmptyVectorInstances {
         fa.flatMap(f)
 
       // We can never stop early on a nonempty vector
-      override val traverseStrategy = Apply.TraverseStrategy.direct(this)
+      override val traverseStrategy: Apply.TraverseStrategy[NonEmptyVector] = Apply.TraverseStrategy.direct(this)
 
       def coflatMap[A, B](fa: NonEmptyVector[A])(f: NonEmptyVector[A] => B): NonEmptyVector[B] = {
         @tailrec def consume(as: Vector[A], buf: VectorBuilder[B]): Vector[B] =
@@ -569,7 +569,7 @@ object NonEmptyVector extends NonEmptyVectorInstances with Serializable {
           ZipNonEmptyVector(fa.value.zipWith(fb.value) { case (a, b) => (a, b) })
 
         // We can never stop early on a nonempty vector
-        override val traverseStrategy = Apply.TraverseStrategy.direct(this)
+        override val traverseStrategy: Apply.TraverseStrategy[ZipNonEmptyVector] = Apply.TraverseStrategy.direct(this)
       }
 
     @deprecated("Use catsDataEqForZipNonEmptyVector", "2.0.0-RC2")

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -388,6 +388,9 @@ sealed abstract private[data] class NonEmptyVectorInstances {
       def flatMap[A, B](fa: NonEmptyVector[A])(f: A => NonEmptyVector[B]): NonEmptyVector[B] =
         fa.flatMap(f)
 
+      // We can never stop early on a nonempty vector
+      override val traverseStrategy = Apply.TraverseStrategy.direct(this)
+
       def coflatMap[A, B](fa: NonEmptyVector[A])(f: NonEmptyVector[A] => B): NonEmptyVector[B] = {
         @tailrec def consume(as: Vector[A], buf: VectorBuilder[B]): Vector[B] =
           as match {
@@ -564,6 +567,9 @@ object NonEmptyVector extends NonEmptyVectorInstances with Serializable {
 
         override def product[A, B](fa: ZipNonEmptyVector[A], fb: ZipNonEmptyVector[B]): ZipNonEmptyVector[(A, B)] =
           ZipNonEmptyVector(fa.value.zipWith(fb.value) { case (a, b) => (a, b) })
+
+        // We can never stop early on a nonempty vector
+        override val traverseStrategy = Apply.TraverseStrategy.direct(this)
       }
 
     @deprecated("Use catsDataEqForZipNonEmptyVector", "2.0.0-RC2")

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -1052,6 +1052,9 @@ private[data] class ValidatedApplicative[E: Semigroup] extends CommutativeApplic
     fa.product(fb)(Semigroup[E])
 
   override def unit: Validated[E, Unit] = Validated.validUnit
+
+  // We accumulate all errors so there is no short circuiting here
+  override val traverseStrategy = Apply.TraverseStrategy.direct(this)
 }
 
 private[data] trait ValidatedFunctions {

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -111,7 +111,7 @@ package object cats {
         if (idx == 0L) Some(fa) else None
       override def isEmpty[A](fa: Id[A]): Boolean = false
 
-      override val traverseStrategy = Apply.TraverseStrategy.direct(this)
+      override val traverseStrategy: Apply.TraverseStrategy[Id] = Apply.TraverseStrategy.direct(this)
     }
 
   /**

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -110,6 +110,8 @@ package object cats {
       override def get[A](fa: Id[A])(idx: Long): Option[A] =
         if (idx == 0L) Some(fa) else None
       override def isEmpty[A](fa: Id[A]): Boolean = false
+
+      override val traverseStrategy = Apply.TraverseStrategy.direct(this)
     }
 
   /**


### PR DESCRIPTION
This introduces an extension to Apply designed to make traverse and traverse-like functions faster.

The idea is to have a small set of function, sufficient to implement traverse, that work together to handle the laziness of the type constructor.

This allows strict types such as `Either[E, *]` or `Try` or `List` which can have useful short-circuiting behavior, to allow the Traverse instance to use that via Eval, but types such `Eval`, `IO`, `Validated[E, *]`, `NonEmptyList`, etc.. that don't need that laziness, they can directly use `map2` without the wasteful boxing.

related to #3790 and #3962

interested in your comments @djspiewak @non