### PR TITLE
Relax a constraint for Alternative's unite and separate methods from Monad to FlatMap

### DIFF
--- a/core/src/main/scala/cats/Alternative.scala
+++ b/core/src/main/scala/cats/Alternative.scala
@@ -6,6 +6,15 @@ import scala.annotation.implicitNotFound
 @implicitNotFound("Could not find an instance of Alternative for ${F}")
 @typeclass trait Alternative[F[_]] extends NonEmptyAlternative[F] with MonoidK[F] { self =>
 
+  // Note: `protected` is only necessary to enforce binary compatibility
+  // since neither `private` nor `private[cats]` work properly here.
+  @deprecated("use a FlatMap-constrained version instead", "2.6.2")
+  protected def unite[G[_], A](fga: F[G[A]])(FM: Monad[F], G: Foldable[G]): F[A] = {
+    implicit def FM0: FlatMap[F] = FM
+    implicit def G0: Foldable[G] = G
+    unite(fga)
+  }
+
   /**
    * Fold over the inner structure to combine all of the values with
    * our combine method inherited from MonoidK. The result is for us
@@ -15,29 +24,34 @@ import scala.annotation.implicitNotFound
    *
    * Example:
    * {{{
-   * scala> import cats.implicits._
    * scala> val x: List[Vector[Int]] = List(Vector(1, 2), Vector(3, 4))
    * scala> Alternative[List].unite(x)
    * res0: List[Int] = List(1, 2, 3, 4)
    * }}}
    */
-  def unite[G[_], A](fga: F[G[A]])(implicit FM: Monad[F], G: Foldable[G]): F[A] =
-    FM.flatMap(fga) { ga =>
-      G.foldLeft(ga, empty[A])((acc, a) => appendK(acc, a))
-    }
+  def unite[G[_], A](fga: F[G[A]])(implicit FM: FlatMap[F], G: Foldable[G]): F[A] =
+    FM.flatMap(fga) { G.foldMapK(_)(pure)(self) }
+
+  // Note: `protected` is only necessary to enforce binary compatibility
+  // since neither `private` nor `private[cats]` work properly here.
+  @deprecated("use a FlatMap-constrained version instead", "2.6.2")
+  protected def separate[G[_, _], A, B](fgab: F[G[A, B]])(FM: Monad[F], G: Bifoldable[G]): (F[A], F[B]) = {
+    implicit def FM0: FlatMap[F] = FM
+    implicit def G0: Bifoldable[G] = G
+    separate(fgab)
+  }
 
   /**
-   * Separate the inner foldable values into the "lefts" and "rights"
+   * Separate the inner foldable values into the "lefts" and "rights".
    *
    * Example:
    * {{{
-   * scala> import cats.implicits._
    * scala> val l: List[Either[String, Int]] = List(Right(1), Left("error"))
    * scala> Alternative[List].separate(l)
    * res0: (List[String], List[Int]) = (List(error),List(1))
    * }}}
    */
-  def separate[G[_, _], A, B](fgab: F[G[A, B]])(implicit FM: Monad[F], G: Bifoldable[G]): (F[A], F[B]) = {
+  def separate[G[_, _], A, B](fgab: F[G[A, B]])(implicit FM: FlatMap[F], G: Bifoldable[G]): (F[A], F[B]) = {
     val as = FM.flatMap(fgab)(gab => G.bifoldMap(gab)(pure, _ => empty[A])(algebra[A]))
     val bs = FM.flatMap(fgab)(gab => G.bifoldMap(gab)(_ => empty[B], pure)(algebra[B]))
     (as, bs)
@@ -45,9 +59,9 @@ import scala.annotation.implicitNotFound
 
   /**
    * Separate the inner foldable values into the "lefts" and "rights".
-   * A variant of [[separate]] that is specialized
-   * for Fs that have Foldable instances
-   * which allows for a single-pass implementation
+   * 
+   * A variant of [[[separate[G[_,_],A,B](fgab:F[G[A,B]])(implicitFM:cats\.FlatMap[F]* separate]]]
+   * that is specialized for Fs that have Foldable instances which allows for a single-pass implementation
    * (as opposed to {{{separate}}} which is 2-pass).
    *
    * Example:
@@ -115,9 +129,11 @@ object Alternative {
     def self: F[A]
     val typeClassInstance: TypeClassType
     def unite[G[_], B](implicit ev$1: A <:< G[B], FM: Monad[F], G: Foldable[G]): F[B] =
-      typeClassInstance.unite[G, B](self.asInstanceOf[F[G[B]]])(FM, G)
+      // Note: edited manually since seems Simulacrum is not able to handle the bin-compat redirection properly.
+      typeClassInstance.unite[G, B](self.asInstanceOf[F[G[B]]])
     def separate[G[_, _], B, C](implicit ev$1: A <:< G[B, C], FM: Monad[F], G: Bifoldable[G]): (F[B], F[C]) =
-      typeClassInstance.separate[G, B, C](self.asInstanceOf[F[G[B, C]]])(FM, G)
+      // Note: edited manually since seems Simulacrum is not able to handle the bin-compat redirection properly.
+      typeClassInstance.separate[G, B, C](self.asInstanceOf[F[G[B, C]]])
     def separateFoldable[G[_, _], B, C](implicit ev$1: A <:< G[B, C], G: Bifoldable[G], FF: Foldable[F]): (F[B], F[C]) =
       typeClassInstance.separateFoldable[G, B, C](self.asInstanceOf[F[G[B, C]]])(G, FF)
   }

--- a/core/src/main/scala/cats/syntax/alternative.scala
+++ b/core/src/main/scala/cats/syntax/alternative.scala
@@ -13,11 +13,18 @@ trait AlternativeSyntax {
     new GuardOps(b)
 }
 
-final class UniteOps[F[_], G[_], A](private val fga: F[G[A]]) extends AnyVal {
+final class UniteOps[F[_], G[_], A](protected val fga: F[G[A]]) extends AnyVal with UniteOpsBinCompat0[F, G, A] {
+
+  @deprecated("use a FlatMap-constrained version instead", "2.6.2")
+  protected def unite(F: Monad[F], A: Alternative[F], G: Foldable[G]): F[A] =
+    A.unite(fga)(F, G)
+}
+
+sealed private[syntax] trait UniteOpsBinCompat0[F[_], G[_], A] extends Any { self: UniteOps[F, G, A] =>
 
   /**
-   * @see [[Alternative.unite]]
-   *
+   * See [[[Alternative.unite[G[_],A](fga:F[G[A]])(implicitFM:cats\.FlatMap[F]*]]]
+   * 
    * Example:
    * {{{
    * scala> import cats.implicits._
@@ -26,27 +33,21 @@ final class UniteOps[F[_], G[_], A](private val fga: F[G[A]]) extends AnyVal {
    * res0: List[Int] = List(1, 2, 3, 4)
    * }}}
    */
-  def unite(implicit F: Monad[F], A: Alternative[F], G: Foldable[G]): F[A] = A.unite[G, A](fga)
+  def unite(implicit F: FlatMap[F], A: Alternative[F], G: Foldable[G]): F[A] =
+    A.unite[G, A](fga)
 }
 
-final class SeparateOps[F[_], G[_, _], A, B](private val fgab: F[G[A, B]]) extends AnyVal {
+final class SeparateOps[F[_], G[_, _], A, B](protected val fgab: F[G[A, B]])
+    extends AnyVal
+    with SeparateOpsBinCompat0[F, G, A, B] {
+
+  @deprecated("use a FlatMap-constrained version instead", "2.6.2")
+  protected def separate(F: Monad[F], A: Alternative[F], G: Bifoldable[G]): (F[A], F[B]) =
+    A.separate[G, A, B](fgab)(F, G)
 
   /**
-   * @see [[Alternative.separate]]
-   *
-   * Example:
-   * {{{
-   * scala> import cats.implicits._
-   * scala> val l: List[Either[String, Int]] = List(Right(1), Left("error"))
-   * scala> l.separate
-   * res0: (List[String], List[Int]) = (List(error),List(1))
-   * }}}
-   */
-  def separate(implicit F: Monad[F], A: Alternative[F], G: Bifoldable[G]): (F[A], F[B]) = A.separate[G, A, B](fgab)
-
-  /**
-   * @see [[Alternative.separateFoldable]]
-   *
+   * See [[Alternative.separateFoldable]]
+   * 
    * Example:
    * {{{
    * scala> import cats.implicits._
@@ -59,11 +60,28 @@ final class SeparateOps[F[_], G[_, _], A, B](private val fgab: F[G[A, B]]) exten
     A.separateFoldable[G, A, B](fgab)
 }
 
+sealed private[syntax] trait SeparateOpsBinCompat0[F[_], G[_, _], A, B] extends Any { self: SeparateOps[F, G, A, B] =>
+
+  /**
+   * See [[[Alternative.separate[G[_,_],A,B](fgab:F[G[A,B]])(implicitFM:cats\.FlatMap[F]* Alternative.separate]]]
+   * 
+   * Example:
+   * {{{
+   * scala> import cats.implicits._
+   * scala> val l: List[Either[String, Int]] = List(Right(1), Left("error"))
+   * scala> l.separate
+   * res0: (List[String], List[Int]) = (List(error),List(1))
+   * }}}
+   */
+  def separate(implicit F: FlatMap[F], A: Alternative[F], G: Bifoldable[G]): (F[A], F[B]) =
+    A.separate[G, A, B](fgab)
+}
+
 final class GuardOps(private val condition: Boolean) extends AnyVal {
 
   /**
-   * @see [[Alternative.guard]]
-   *
+   * See [[Alternative.guard]]
+   * 
    * Example:
    * {{{
    * scala> import cats.implicits._

--- a/tests/src/test/scala/cats/tests/SyntaxSuite.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxSuite.scala
@@ -370,7 +370,7 @@ object SyntaxSuite {
     val fa2: F[A] = fa.appendK(a)
   }
 
-  def testAlternativeMonad[F[_]: Alternative: Monad, G[_]: Foldable, H[_, _]: Bifoldable, A, B]: Unit = {
+  def testAlternativeFlatMap[F[_]: Alternative: FlatMap, G[_]: Foldable, H[_, _]: Bifoldable, A, B]: Unit = {
     val fga = mock[F[G[A]]]
     val fa = fga.unite
 


### PR DESCRIPTION
The initial discussion is [here](https://discord.com/channels/632277896739946517/632278570512678923/888660638073749514).

### Rationale

- The `unite` and `separate` methods don't need a `Monad` actually to do their job, because they only use `flatMap` in addition to methods from `Alternative`. Therefore the `FlatMap[F]` constraint is just enough there.
- Moreover, both `Alternative` and `Monad` implement `Applicative`. That means the `Applicative` methods can come by two different paths which creates sort of a loophole for ambiguity:
  ```scala
  implicit val fooMonad: Monad[Foo] = ??? // assume Monad[Foo] is different from Alternative[Foo]
  Alternative[Foo].unite[Bar, Int](Foo(Bar(123)) // which `pure` should it use – one from `Alternative` or `Monad` ? 
  ```

### Discussion

In fact, if it is okay to constraint the `unite` and `separate` methods with a `Monad`, then the `Alternative` typeclass is absolutely redundant in such a case – we can simply put these two methods directly into `MonoidK`.

Another approach (perhaps even better one) could be a new typeclass (let's name it `Monadditive` for the sake of this example) which would inherit to `Monad` and `MonoidK` (via `Alternative`) instead of just `Applicative` and `MonoidK` (which the current `Alternative` inherits to). In this case the definition of those two methods – `unite` and `separate` – could be simplified to the following:
```scala
trait Monadditive[F[_]] extends Alternative[F] with Monad[F] { // implies `MonoidK` as well
  def unite[G[_], A](fga: F[G[A]])(implicit G: Foldable[G]): F[A] = ??? // implementation remains the same
  def separate[G[_, _], A, B](fgab: F[G[A, B]])(implicit G: Bifoldable[G]): (F[A], F[B]) = ??? // implementation remains the same
}
```
In other words, an additional constraint for `F[_]` is not necessary anymore.

Therefore such a new typeclass would allow to reduce number of additional constraints passed to those methods.
And looks like it would make a lot of sense anyway – most of the containers which Cats supports implement corresponding `Monad` instances, not only `Applicative`.