### PR TITLE
Introduce parReplicateA

### DIFF
--- a/core/src/main/scala/cats/Parallel.scala
+++ b/core/src/main/scala/cats/Parallel.scala
@@ -106,6 +106,14 @@ trait Parallel[M[_]] extends NonEmptyParallel[M] {
 
       override def whenA[A](cond: Boolean)(f: => F[A]): F[Unit] = applicative.whenA(cond)(f)
     }
+
+  /**
+   * Like [[Applicative.replicateA]], but uses the apply instance
+   * corresponding to the Parallel instance instead.
+   */
+  def parReplicateA[A](n: Int, ma: M[A]): M[List[A]] =
+    if (n <= 0) monad.pure(List.empty[A])
+    else Parallel.parSequence(List.fill(n)(ma))(UnorderedFoldable.catsTraverseForList, this)
 }
 
 object NonEmptyParallel extends ScalaVersionSpecificParallelInstances {

--- a/core/src/main/scala/cats/syntax/parallel.scala
+++ b/core/src/main/scala/cats/syntax/parallel.scala
@@ -245,6 +245,10 @@ final class ParallelApOps[M[_], A](private val ma: M[A]) extends AnyVal {
 
   def parProduct[B](mb: M[B])(implicit P: Parallel[M]): M[(A, B)] =
     Parallel.parProduct(ma, mb)
+
+  def parReplicateA(n: Int)(implicit P: Parallel[M]): M[List[A]] =
+    if (n <= 0) P.monad.pure(List.empty[A])
+    else Parallel.parSequence(List.fill(n)(ma))
 }
 
 final class ParallelApplyOps[M[_], A, B](private val mab: M[A => B]) extends AnyVal {

--- a/tests/src/test/scala/cats/tests/SyntaxSuite.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxSuite.scala
@@ -184,6 +184,7 @@ object SyntaxSuite {
     val mb4: M[B] = ma.parProductR(mb)
     val mab2: M[(A, B)] = ma.parProduct(mb)
     val mb5: M[B] = mab.parAp(ma)
+    val mla: M[List[A]] = ma.parReplicateA(3)
   }
 
   def testParallelUnorderedTraverse[M[_]: Monad, F[_]: CommutativeApplicative, T[_]: UnorderedTraverse: FlatMap, A, B](


### PR DESCRIPTION
This PR introduces `parReplicateA` as a parallel version of `Applicative.replicateA`.


