### PR TITLE
[proposal] optimize Alternative (part 1): introduce NonEmptyAlternative with prependK and appendK methods

### DIFF
--- a/core/src/main/scala/cats/Composed.scala
+++ b/core/src/main/scala/cats/Composed.scala
@@ -57,11 +57,24 @@ private[cats] trait ComposedMonoidK[F[_], G[_]] extends MonoidK[λ[α => F[G[α]
   override def empty[A]: F[G[A]] = F.empty
 }
 
+private[cats] trait ComposedNonEmptyAlternative[F[_], G[_]]
+    extends NonEmptyAlternative[λ[α => F[G[α]]]]
+    with ComposedApplicative[F, G]
+    with ComposedSemigroupK[F, G] { outer =>
+
+  def F: NonEmptyAlternative[F]
+}
+
 private[cats] trait ComposedAlternative[F[_], G[_]]
     extends Alternative[λ[α => F[G[α]]]]
-    with ComposedApplicative[F, G]
+    with ComposedNonEmptyAlternative[F, G]
     with ComposedMonoidK[F, G] { outer =>
+
   def F: Alternative[F]
+
+  override def prependK[A](a: A, fa: F[G[A]]): F[G[A]] = F.prependK(G.pure(a), fa)
+
+  override def appendK[A](fa: F[G[A]], a: A): F[G[A]] = F.appendK(fa, G.pure(a))
 }
 
 private[cats] trait ComposedFoldable[F[_], G[_]] extends Foldable[λ[α => F[G[α]]]] { outer =>

--- a/core/src/main/scala/cats/Monad.scala
+++ b/core/src/main/scala/cats/Monad.scala
@@ -31,7 +31,7 @@ import scala.annotation.implicitNotFound
       ifM(p)(
         ifTrue = {
           map(b.value) { bv =>
-            Left(G.combineK(xs, G.pure(bv)))
+            Left(G.appendK(xs, bv))
           }
         },
         ifFalse = pure(Right(xs))
@@ -66,7 +66,7 @@ import scala.annotation.implicitNotFound
    */
   def untilM[G[_], A](f: F[A])(cond: => F[Boolean])(implicit G: Alternative[G]): F[G[A]] = {
     val p = Eval.later(cond)
-    flatMap(f)(x => map(whileM(map(p.value)(!_))(f))(xs => G.combineK(G.pure(x), xs)))
+    flatMap(f)(x => map(whileM(map(p.value)(!_))(f))(xs => G.prependK(x, xs)))
   }
 
   /**

--- a/core/src/main/scala/cats/NonEmptyAlternative.scala
+++ b/core/src/main/scala/cats/NonEmptyAlternative.scala
@@ -1,0 +1,84 @@
+package cats
+
+import simulacrum.typeclass
+import scala.annotation.implicitNotFound
+
+@implicitNotFound("Could not find an instance of NonEmptyAlternative for ${F}")
+@typeclass trait NonEmptyAlternative[F[_]] extends Applicative[F] with SemigroupK[F] { self =>
+
+  /**
+   * Lift `a` into `F[_]` and prepend it to `fa`.
+   *
+   * Example:
+   * {{{
+   * scala> NonEmptyAlternative[List].prependK(1, List(2, 3, 4))
+   * res0: List[Int] = List(1, 2, 3, 4)
+   * }}}
+   */
+  def prependK[A](a: A, fa: F[A]): F[A] = combineK(pure(a), fa)
+
+  /**
+   * Lift `a` into `F[_]` and append it to `fa`.
+   *
+   * Example:
+   * {{{
+   * scala> NonEmptyAlternative[List].appendK(List(1, 2, 3), 4)
+   * res0: List[Int] = List(1, 2, 3, 4)
+   * }}}
+   */
+  def appendK[A](fa: F[A], a: A): F[A] = combineK(fa, pure(a))
+
+  override def compose[G[_]: Applicative]: NonEmptyAlternative[λ[α => F[G[α]]]] =
+    new ComposedNonEmptyAlternative[F, G] {
+      val F = self
+      val G = Applicative[G]
+    }
+}
+
+object NonEmptyAlternative {
+  /* ======================================================================== */
+  /* THE FOLLOWING CODE IS MANAGED BY SIMULACRUM; PLEASE DO NOT EDIT!!!!      */
+  /* ======================================================================== */
+
+  /**
+   * Summon an instance of [[NonEmptyAlternative]] for `F`.
+   */
+  @inline def apply[F[_]](implicit instance: NonEmptyAlternative[F]): NonEmptyAlternative[F] = instance
+
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object ops {
+    implicit def toAllNonEmptyAlternativeOps[F[_], A](target: F[A])(implicit tc: NonEmptyAlternative[F]): AllOps[F, A] {
+      type TypeClassType = NonEmptyAlternative[F]
+    } = new AllOps[F, A] {
+      type TypeClassType = NonEmptyAlternative[F]
+      val self: F[A] = target
+      val typeClassInstance: TypeClassType = tc
+    }
+  }
+  trait Ops[F[_], A] extends Serializable {
+    type TypeClassType <: NonEmptyAlternative[F]
+    def self: F[A]
+    val typeClassInstance: TypeClassType
+    // Note: `prependK` has to be added manually since simulacrum is not able to handle `self` as a second parameter.
+    // def prependK(a: A): F[A] = typeClassInstance.prependK[A](a, self)
+    def appendK(a: A): F[A] = typeClassInstance.appendK[A](self, a)
+  }
+  trait AllOps[F[_], A] extends Ops[F, A] with Applicative.AllOps[F, A] with SemigroupK.AllOps[F, A] {
+    type TypeClassType <: NonEmptyAlternative[F]
+  }
+  trait ToNonEmptyAlternativeOps extends Serializable {
+    implicit def toNonEmptyAlternativeOps[F[_], A](target: F[A])(implicit tc: NonEmptyAlternative[F]): Ops[F, A] {
+      type TypeClassType = NonEmptyAlternative[F]
+    } = new Ops[F, A] {
+      type TypeClassType = NonEmptyAlternative[F]
+      val self: F[A] = target
+      val typeClassInstance: TypeClassType = tc
+    }
+  }
+  @deprecated("Use cats.syntax object imports", "2.2.0")
+  object nonInheritedOps extends ToNonEmptyAlternativeOps
+
+  /* ======================================================================== */
+  /* END OF SIMULACRUM-MANAGED CODE                                           */
+  /* ======================================================================== */
+}

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -14,6 +14,7 @@ abstract class AllSyntaxBinCompat
 
 trait AllSyntax
     extends AlternativeSyntax
+    with NonEmptyAlternativeSyntax
     with AlignSyntax
     with ApplicativeSyntax
     with ApplicativeErrorSyntax

--- a/core/src/main/scala/cats/syntax/nonEmptyAlternative.scala
+++ b/core/src/main/scala/cats/syntax/nonEmptyAlternative.scala
@@ -1,0 +1,36 @@
+package cats
+package syntax
+
+trait NonEmptyAlternativeSyntax {
+  implicit final def catsSyntaxNonEmptyAlternative[F[_], A](fa: F[A]): NonEmptyAlternativeOps[F, A] =
+    new NonEmptyAlternativeOps(fa)
+}
+
+final class NonEmptyAlternativeOps[F[_], A] private[syntax] (private val fa: F[A]) extends AnyVal {
+
+  /**
+   * @see [[NonEmptyAlternative.prependK]]
+   *
+   * Example:
+   * {{{
+   * scala> import cats.syntax.all._
+   *
+   * scala> List(2, 3, 4).prependK(1)
+   * res0: List[Int] = List(1, 2, 3, 4)
+   * }}}
+   */
+  def prependK(a: A)(implicit F: NonEmptyAlternative[F]): F[A] = F.prependK(a, fa)
+
+  /**
+   * @see [[NonEmptyAlternative.appendK]]
+   *
+   * Example:
+   * {{{
+   * scala> import cats.syntax.all._
+   *
+   * scala> List(1, 2, 3).appendK(4)
+   * res0: List[Int] = List(1, 2, 3, 4)
+   * }}}
+   */
+  def appendK(a: A)(implicit F: NonEmptyAlternative[F]): F[A] = F.appendK(fa, a)
+}

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -71,4 +71,5 @@ package object syntax {
   object vector extends VectorSyntax
   object writer extends WriterSyntax
   object set extends SetSyntax
+  object nonEmptyAlternative extends NonEmptyAlternativeSyntax
 }

--- a/laws/src/main/scala/cats/laws/AlternativeLaws.scala
+++ b/laws/src/main/scala/cats/laws/AlternativeLaws.scala
@@ -3,19 +3,20 @@ package laws
 
 import cats.syntax.all._
 
-trait AlternativeLaws[F[_]] extends ApplicativeLaws[F] with MonoidKLaws[F] {
+trait AlternativeLaws[F[_]] extends NonEmptyAlternativeLaws[F] with MonoidKLaws[F] {
   implicit override def F: Alternative[F]
-  implicit def algebra[A]: Monoid[F[A]] = F.algebra[A]
+  implicit override def algebra[A]: Monoid[F[A]] = F.algebra[A]
 
   def alternativeRightAbsorption[A, B](ff: F[A => B]): IsEq[F[B]] =
     (ff.ap(F.empty[A])) <-> F.empty[B]
 
+  // Perhaps should be deprecated in favor of nonEmptyAlternativeLeftDistributivity
   def alternativeLeftDistributivity[A, B](fa: F[A], fa2: F[A], f: A => B): IsEq[F[B]] =
-    ((fa |+| fa2).map(f)) <-> ((fa.map(f)) |+| (fa2.map(f)))
+    nonEmptyAlternativeLeftDistributivity[A, B](fa, fa2, f)
 
+  // Perhaps should be deprecated in favor of nonEmptyAlternativeRightDistributivity
   def alternativeRightDistributivity[A, B](fa: F[A], ff: F[A => B], fg: F[A => B]): IsEq[F[B]] =
-    ((ff |+| fg).ap(fa)) <-> ((ff.ap(fa)) |+| (fg.ap(fa)))
-
+    nonEmptyAlternativeRightDistributivity(fa, ff, fg)
 }
 
 object AlternativeLaws {

--- a/laws/src/main/scala/cats/laws/AlternativeLaws.scala
+++ b/laws/src/main/scala/cats/laws/AlternativeLaws.scala
@@ -21,4 +21,9 @@ trait AlternativeLaws[F[_]] extends ApplicativeLaws[F] with MonoidKLaws[F] {
 object AlternativeLaws {
   def apply[F[_]](implicit ev: Alternative[F]): AlternativeLaws[F] =
     new AlternativeLaws[F] { def F: Alternative[F] = ev }
+
+  def composed[M[_], N[_]](implicit M: Alternative[M], N: Applicative[N]): AlternativeLaws[λ[α => M[N[α]]]] =
+    new AlternativeLaws[λ[α => M[N[α]]]] {
+      def F: Alternative[λ[α => M[N[α]]]] = M.compose[N]
+    }
 }

--- a/laws/src/main/scala/cats/laws/NonEmptyAlternativeLaws.scala
+++ b/laws/src/main/scala/cats/laws/NonEmptyAlternativeLaws.scala
@@ -1,0 +1,34 @@
+package cats
+package laws
+
+import cats.syntax.all._
+
+trait NonEmptyAlternativeLaws[F[_]] extends ApplicativeLaws[F] with SemigroupKLaws[F] {
+  implicit override def F: NonEmptyAlternative[F]
+  implicit def algebra[A]: Semigroup[F[A]] = F.algebra[A]
+
+  def nonEmptyAlternativeLeftDistributivity[A, B](fa: F[A], fa2: F[A], f: A => B): IsEq[F[B]] =
+    ((fa |+| fa2).map(f)) <-> ((fa.map(f)) |+| (fa2.map(f)))
+
+  def nonEmptyAlternativeRightDistributivity[A, B](fa: F[A], ff: F[A => B], fg: F[A => B]): IsEq[F[B]] =
+    ((ff |+| fg).ap(fa)) <-> ((ff.ap(fa)) |+| (fg.ap(fa)))
+
+  def nonEmptyAlternativePrependKConsitentWithPureAndCombineK[A](fa: F[A], a: A): IsEq[F[A]] =
+    fa.prependK(a) <-> (a.pure[F] <+> fa)
+
+  def nonEmptyAlternativeAppendKConsitentWithPureAndCombineK[A](fa: F[A], a: A): IsEq[F[A]] =
+    fa.appendK(a) <-> (fa <+> a.pure[F])
+}
+
+object NonEmptyAlternativeLaws {
+  def apply[F[_]](implicit ev: NonEmptyAlternative[F]): NonEmptyAlternativeLaws[F] =
+    new NonEmptyAlternativeLaws[F] { def F: NonEmptyAlternative[F] = ev }
+
+  def composed[M[_], N[_]](implicit
+    M: NonEmptyAlternative[M],
+    N: Applicative[N]
+  ): NonEmptyAlternativeLaws[λ[α => M[N[α]]]] =
+    new NonEmptyAlternativeLaws[λ[α => M[N[α]]]] {
+      def F: NonEmptyAlternative[λ[α => M[N[α]]]] = M.compose[N]
+    }
+}

--- a/laws/src/main/scala/cats/laws/discipline/AlternativeTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/AlternativeTests.scala
@@ -40,4 +40,9 @@ trait AlternativeTests[F[_]] extends ApplicativeTests[F] with MonoidKTests[F] {
 object AlternativeTests {
   def apply[F[_]: Alternative]: AlternativeTests[F] =
     new AlternativeTests[F] { def laws: AlternativeLaws[F] = AlternativeLaws[F] }
+
+  def composed[F[_]: Alternative, G[_]: Applicative]: AlternativeTests[λ[α => F[G[α]]]] =
+    new AlternativeTests[λ[α => F[G[α]]]] {
+      def laws: AlternativeLaws[λ[α => F[G[α]]]] = AlternativeLaws.composed[F, G]
+    }
 }

--- a/laws/src/main/scala/cats/laws/discipline/AlternativeTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/AlternativeTests.scala
@@ -6,7 +6,7 @@ import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import org.scalacheck.{Arbitrary, Cogen, Prop}
 import Prop._
 
-trait AlternativeTests[F[_]] extends ApplicativeTests[F] with MonoidKTests[F] {
+trait AlternativeTests[F[_]] extends NonEmptyAlternativeTests[F] with MonoidKTests[F] {
   def laws: AlternativeLaws[F]
 
   def alternative[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
@@ -27,14 +27,11 @@ trait AlternativeTests[F[_]] extends ApplicativeTests[F] with MonoidKTests[F] {
     new RuleSet {
       val name: String = "alternative"
       val bases: Seq[(String, RuleSet)] = Nil
-      val parents: Seq[RuleSet] = Seq(monoidK[A], applicative[A, B, C])
+      val parents: Seq[RuleSet] = Seq(monoidK[A], nonEmptyAlternative[A, B, C])
       val props: Seq[(String, Prop)] = Seq(
-        "left distributivity" -> forAll(laws.alternativeLeftDistributivity[A, B] _),
-        "right distributivity" -> forAll(laws.alternativeRightDistributivity[A, B] _),
         "right absorption" -> forAll(laws.alternativeRightAbsorption[A, B] _)
       )
     }
-
 }
 
 object AlternativeTests {

--- a/laws/src/main/scala/cats/laws/discipline/NonEmptyAlternativeTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/NonEmptyAlternativeTests.scala
@@ -1,0 +1,50 @@
+package cats
+package laws
+package discipline
+
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
+import org.scalacheck.{Arbitrary, Cogen, Prop}
+import Prop._
+
+trait NonEmptyAlternativeTests[F[_]] extends ApplicativeTests[F] with SemigroupKTests[F] {
+  def laws: NonEmptyAlternativeLaws[F]
+
+  def nonEmptyAlternative[A: Arbitrary, B: Arbitrary, C: Arbitrary](implicit
+    ArbFA: Arbitrary[F[A]],
+    ArbFB: Arbitrary[F[B]],
+    ArbFC: Arbitrary[F[C]],
+    ArbFAtoB: Arbitrary[F[A => B]],
+    ArbFBtoC: Arbitrary[F[B => C]],
+    CogenA: Cogen[A],
+    CogenB: Cogen[B],
+    CogenC: Cogen[C],
+    EqFA: Eq[F[A]],
+    EqFB: Eq[F[B]],
+    EqFC: Eq[F[C]],
+    EqFABC: Eq[F[(A, B, C)]],
+    iso: Isomorphisms[F]
+  ): RuleSet =
+    new RuleSet {
+      val name: String = "nonEmptyAlternative"
+      val bases: Seq[(String, RuleSet)] = Nil
+      val parents: Seq[RuleSet] = Seq(semigroupK[A], applicative[A, B, C])
+      val props: Seq[(String, Prop)] = Seq(
+        "left distributivity" -> forAll(laws.nonEmptyAlternativeLeftDistributivity[A, B] _),
+        "right distributivity" -> forAll(laws.nonEmptyAlternativeRightDistributivity[A, B] _),
+        "prependK consistent with pure and combineK" ->
+          forAll(laws.nonEmptyAlternativePrependKConsitentWithPureAndCombineK[A] _),
+        "appendK consistent with pure and combineK" ->
+          forAll(laws.nonEmptyAlternativeAppendKConsitentWithPureAndCombineK[A] _)
+      )
+    }
+}
+
+object NonEmptyAlternativeTests {
+  def apply[F[_]: NonEmptyAlternative]: NonEmptyAlternativeTests[F] =
+    new NonEmptyAlternativeTests[F] { def laws: NonEmptyAlternativeLaws[F] = NonEmptyAlternativeLaws[F] }
+
+  def composed[F[_]: NonEmptyAlternative, G[_]: Applicative]: NonEmptyAlternativeTests[λ[α => F[G[α]]]] =
+    new NonEmptyAlternativeTests[λ[α => F[G[α]]]] {
+      def laws: NonEmptyAlternativeLaws[λ[α => F[G[α]]]] = NonEmptyAlternativeLaws.composed[F, G]
+    }
+}

--- a/laws/src/main/scala/cats/laws/discipline/SemigroupalTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/SemigroupalTests.scala
@@ -39,8 +39,8 @@ object SemigroupalTests {
   }
 
   object Isomorphisms {
-
     import cats.kernel.laws._
+
     implicit def invariant[F[_]](implicit F: Invariant[F]): Isomorphisms[F] =
       new Isomorphisms[F] {
         def associativity[A, B, C](fs: (F[(A, (B, C))], F[((A, B), C)])): IsEq[F[(A, B, C)]] =
@@ -57,6 +57,11 @@ object SemigroupalTests {
             (a, ())
           } <-> fs._2
       }
-  }
 
+    implicit def composedInvariant[F[_], G[_]](implicit
+      F: Invariant[F],
+      G: Invariant[G]
+    ): Isomorphisms[λ[α => F[G[α]]]] =
+      invariant[λ[α => F[G[α]]]](F.compose[G])
+  }
 }

--- a/testkit/src/main/scala/cats/tests/ListWrapper.scala
+++ b/testkit/src/main/scala/cats/tests/ListWrapper.scala
@@ -116,6 +116,8 @@ object ListWrapper {
     }
   }
 
+  def nonEmptyAlternative: NonEmptyAlternative[ListWrapper] = alternative
+
   val monad: Monad[ListWrapper] = new Monad[ListWrapper] {
     val M = Monad[List]
     def pure[A](x: A): ListWrapper[A] = ListWrapper(x :: Nil)

--- a/tests/src/test/scala/cats/tests/AlternativeSuite.scala
+++ b/tests/src/test/scala/cats/tests/AlternativeSuite.scala
@@ -1,10 +1,22 @@
 package cats.tests
 
 import cats.Alternative
+import cats.laws.discipline.AlternativeTests
 import cats.syntax.eq._
 import org.scalacheck.Prop._
 
 class AlternativeSuite extends CatsSuite {
+
+  // Alternative[ListWrapper] is different from Alternative[List] since the former does not override any default implementation.
+  implicit val listWrapperAlternative: Alternative[ListWrapper] = ListWrapper.alternative
+
+  checkAll("compose List[List[Int]]", AlternativeTests.composed[List, List].alternative[Int, Int, Int])
+  checkAll("compose List[Option[Int]]", AlternativeTests.composed[List, Option].alternative[Int, Int, Int])
+  checkAll("compose Option[List[Int]]", AlternativeTests.composed[Option, List].alternative[Int, Int, Int])
+  checkAll("compose Option[Option[Int]]", AlternativeTests.composed[Option, Option].alternative[Int, Int, Int])
+  checkAll("compose List[ListWrapper[Int]]", AlternativeTests.composed[List, ListWrapper].alternative[Int, Int, Int])
+  checkAll("compose ListWrapper[List[Int]]", AlternativeTests.composed[ListWrapper, List].alternative[Int, Int, Int])
+
   property("unite") {
     forAll { (list: List[Option[String]]) =>
       val expected = list.collect { case Some(s) => s }

--- a/tests/src/test/scala/cats/tests/NonEmptyAlternativeSuite.scala
+++ b/tests/src/test/scala/cats/tests/NonEmptyAlternativeSuite.scala
@@ -1,0 +1,24 @@
+package cats.tests
+
+import cats.NonEmptyAlternative
+import cats.laws.discipline.NonEmptyAlternativeTests
+
+class NonEmptyAlternativeSuite extends CatsSuite {
+  implicit val listWrapperNeAlternative: NonEmptyAlternative[ListWrapper] = ListWrapper.nonEmptyAlternative
+
+  checkAll("Option[Int]", NonEmptyAlternativeTests[Option].nonEmptyAlternative[Int, Int, Int])
+  checkAll("List[Int]", NonEmptyAlternativeTests[List].nonEmptyAlternative[Int, Int, Int])
+  checkAll("ListWrapper[List[Int]]", NonEmptyAlternativeTests[ListWrapper].nonEmptyAlternative[Int, Int, Int])
+  checkAll(
+    "compose ListWrapper[List[Int]]",
+    NonEmptyAlternativeTests.composed[ListWrapper, List].nonEmptyAlternative[Int, Int, Int]
+  )
+  checkAll(
+    "compose List[ListWrapper[Int]]",
+    NonEmptyAlternativeTests.composed[List, ListWrapper].nonEmptyAlternative[Int, Int, Int]
+  )
+  checkAll(
+    "compose ListWrapper[ListWrapper[Int]]",
+    NonEmptyAlternativeTests.composed[ListWrapper, ListWrapper].nonEmptyAlternative[Int, Int, Int]
+  )
+}

--- a/tests/src/test/scala/cats/tests/SyntaxSuite.scala
+++ b/tests/src/test/scala/cats/tests/SyntaxSuite.scala
@@ -362,6 +362,14 @@ object SyntaxSuite {
     val gfab2 = fgab.leftSequence
   }
 
+  def testNonEmptyAlternative[F[_]: NonEmptyAlternative, A]: Unit = {
+    val fa = mock[F[A]]
+    val a = mock[A]
+
+    val fa1: F[A] = fa.prependK(a)
+    val fa2: F[A] = fa.appendK(a)
+  }
+
   def testAlternativeMonad[F[_]: Alternative: Monad, G[_]: Foldable, H[_, _]: Bifoldable, A, B]: Unit = {
     val fga = mock[F[G[A]]]
     val fa = fga.unite


### PR DESCRIPTION
### Rationale

There's a pretty common pattern can be found for `Alternative` even in the Cats sources:
`F.combineK(F.pure(a), fa)` and `F.combineK(fa, F.pure(a))`
which basically means prepending or appending an element `a` lifted into `F[_]`.
But when it is used for some standard collections like `List` or `Vector` it basically results in creating an interim singleton collection on each `F.pure` which gets discarded right after `F.combineK` is completed.

The proposed PR allows to avoid creating the interim singleton collections by various `Alternative` implementations in many cases.

### Description

This PR does the following:
1. Introduces a new type class `NonEmptyAlternative` as a combination of `Applicative` and `SemigroupK`. 
2. Adds `prependK` and `appendK` methods to `NonEmptyAlternative`. These methods have default implementations as shown above. But they can be overridden for a particular `Alternative` implementation.
3. Makes `Alternative` inheriting `NonEmptyAlternative` instead of just `Applicative`. The `MonoidK` mix-in type class remains in place.
4. Switches existing `F.pure + F.combineK` patterns found in core Cats (apart from `cats.data`) to `F.prependK` or `F.appendK` appropriately where it is safe and reasonable.
5. Introduces `NonEmptyAlternativeLaws` which becomes a base for `AlternativeLaws`.
6. Both the laws above get an ability to test composed (via `compose`) type-classes (see `composed` constructor in the corresponding companion objects).

Things to be done in a subsequent PR (see the discussion below):

7. Add `NonEmptyAlternative` instance to non-empty containers in `cats.data`.
8. Override `F.prependK` and `F.appendK` in the `Alternative` and `NonEmptyAlternative` implementations where it reasonable.

Therefore this PR along with the next one will allow to utilize more efficient methods in some collections (e.g. ` :: ` in `List`) while preserving binary and source compatibility with existing `Alternative` implementations. Moreover they should enable further optimizations for non-empty data types too.

### Caveats

- Simulacrum's ScalaFix rules do not recognize the `prependK` method because it is defined in this way:
  ```scala
  def prependK(a: A, fa: F[A]): F[A] // seems Simulacrum cannot understand `fa` as a second parameter
  ```
  I believe it is an issue with Simulacrum itself and not a big deal anyway since neither `Alternative` nor `NonEmptyAlternative` make use of extension methods generated by Simulacrum actually.