### PR TITLE
feat: add `Alternative` instance for `OptionT`

### DIFF
--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -393,13 +393,13 @@ sealed abstract private[data] class OptionTInstances0 extends OptionTInstances1 
       implicit val F = F0
     }
 
+  implicit def catsDataAlternativeForOptionT[F[_]](implicit F0: Monad[F]): Alternative[OptionT[F, *]] =
+    new OptionTAlternative[F] { implicit val F = F0 }
+
   implicit def catsDataContravariantMonoidalForOptionT[F[_]](implicit
     F0: ContravariantMonoidal[F]
   ): ContravariantMonoidal[OptionT[F, *]] =
     new OptionTContravariantMonoidal[F] { implicit val F = F0 }
-
-  implicit def catsDataMonoidKForOptionT[F[_]](implicit F0: Monad[F]): MonoidK[OptionT[F, *]] =
-    new OptionTMonoidK[F] { implicit val F = F0 }
 
   implicit def catsDataSemigroupForOptionT[F[_], A](implicit F0: Semigroup[F[Option[A]]]): Semigroup[OptionT[F, A]] =
     new OptionTSemigroup[F, A] { implicit val F = F0 }
@@ -417,8 +417,8 @@ sealed abstract private[data] class OptionTInstances0 extends OptionTInstances1 
 }
 
 sealed abstract private[data] class OptionTInstances1 extends OptionTInstances2 {
-  implicit def catsDataSemigroupKForOptionT[F[_]](implicit F0: Monad[F]): SemigroupK[OptionT[F, *]] =
-    new OptionTSemigroupK[F] { implicit val F = F0 }
+  implicit def catsDataMonoidKForOptionT[F[_]](implicit F0: Monad[F]): MonoidK[OptionT[F, *]] =
+    new OptionTMonoidK[F] { implicit val F = F0 }
 
   implicit def catsDataEqForOptionT[F[_], A](implicit F0: Eq[F[Option[A]]]): Eq[OptionT[F, A]] =
     new OptionTEq[F, A] { implicit val F = F0 }
@@ -428,6 +428,9 @@ sealed abstract private[data] class OptionTInstances1 extends OptionTInstances2 
 }
 
 sealed abstract private[data] class OptionTInstances2 extends OptionTInstances3 {
+  implicit def catsDataSemigroupKForOptionT[F[_]](implicit F0: Monad[F]): SemigroupK[OptionT[F, *]] =
+    new OptionTSemigroupK[F] { implicit val F = F0 }
+
   implicit def catsDataFoldableForOptionT[F[_]](implicit F0: Foldable[F]): Foldable[OptionT[F, *]] =
     new OptionTFoldable[F] { implicit val F = F0 }
 
@@ -565,6 +568,11 @@ private[data] trait OptionTSemigroupK[F[_]] extends SemigroupK[OptionT[F, *]] {
 private[data] trait OptionTMonoidK[F[_]] extends MonoidK[OptionT[F, *]] with OptionTSemigroupK[F] {
   def empty[A]: OptionT[F, A] = OptionT.none[F, A]
 }
+
+private[data] trait OptionTAlternative[F[_]]
+    extends Alternative[OptionT[F, *]]
+    with OptionTMonad[F]
+    with OptionTMonoidK[F] {}
 
 sealed private[data] trait OptionTEq[F[_], A] extends Eq[OptionT[F, A]] {
   implicit def F: Eq[F[Option[A]]]

--- a/tests/src/test/scala/cats/tests/OptionTSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionTSuite.scala
@@ -125,6 +125,11 @@ class OptionTSuite extends CatsSuite {
     checkAll("OptionT[ListWrapper, Int]", MonoidKTests[OptionT[ListWrapper, *]].monoidK[Int])
     checkAll("MonoidK[OptionT[ListWrapper, *]]", SerializableTests.serializable(MonoidK[OptionT[ListWrapper, *]]))
 
+    checkAll("OptionT[ListWrapper, Int]", AlternativeTests[OptionT[ListWrapper, *]].monoidK[Int])
+    checkAll("Alternative[OptionT[ListWrapper, *]]",
+             SerializableTests.serializable(Alternative[OptionT[ListWrapper, *]])
+    )
+
     Monad[OptionT[ListWrapper, *]]
     FlatMap[OptionT[ListWrapper, *]]
     Applicative[OptionT[ListWrapper, *]]
@@ -132,6 +137,7 @@ class OptionTSuite extends CatsSuite {
     Functor[OptionT[ListWrapper, *]]
     MonoidK[OptionT[ListWrapper, *]]
     SemigroupK[OptionT[ListWrapper, *]]
+    Alternative[OptionT[ListWrapper, *]]
   }
 
   {
@@ -529,6 +535,7 @@ class OptionTSuite extends CatsSuite {
 
     SemigroupK[OptionT[List, *]]
     MonoidK[OptionT[List, *]]
+    Alternative[OptionT[List, *]]
 
     Functor[OptionT[List, *]]
     Monad[OptionT[List, *]]


### PR DESCRIPTION
I was working in `OptionT` and went to write a `guard`. I realized I had to do it in `Option` and then `toOptionT[F]`, so I thought I would submit an `Alternative` instance for `OptionT`, since it already has `Applicative` and `MonoidK`.

I'm a n00b on how the layers of implicit resolution work, so I hope I have done that correctly. I'm very happy to take feedback on what I need to do differently here.


