### PR TITLE
Add parReduceMapA

### DIFF
--- a/core/src/main/scala/cats/Parallel.scala
+++ b/core/src/main/scala/cats/Parallel.scala
@@ -404,6 +404,18 @@ object Parallel extends ParallelArityFunctions2 {
   }
 
   /**
+   * Like `Reducible[A].reduceMapA`, but uses the apply instance corresponding
+   * to the `NonEmptyParallel` instance instead.
+   */
+  def parReduceMapA[T[_], M[_], A, B](
+    ta: T[A]
+  )(f: A => M[B])(implicit T: Reducible[T], P: NonEmptyParallel[M], B: Semigroup[B]): M[B] = {
+    val fb: P.F[B] =
+      T.reduceMapA(ta)(a => P.parallel(f(a)))(P.apply, B)
+    P.sequential(fb)
+  }
+
+  /**
    * Like `Applicative[F].ap`, but uses the applicative instance
    * corresponding to the Parallel instance instead.
    */

--- a/core/src/main/scala/cats/syntax/all.scala
+++ b/core/src/main/scala/cats/syntax/all.scala
@@ -62,6 +62,7 @@ trait AllSyntax
     with WriterSyntax
     with ParallelFoldMapASyntax
     with ParallelTraverseFilterSyntax
+    with ParallelReduceMapASyntax
 
 trait AllSyntaxBinCompat0 extends UnorderedTraverseSyntax with ApplicativeErrorExtension with TrySyntax
 

--- a/core/src/main/scala/cats/syntax/package.scala
+++ b/core/src/main/scala/cats/syntax/package.scala
@@ -50,6 +50,7 @@ package object syntax {
       with ParallelUnorderedTraverseSyntax
       with ParallelFoldMapASyntax
       with ParallelTraverseFilterSyntax
+      with ParallelReduceMapASyntax
   object partialOrder extends PartialOrderSyntax
   object profunctor extends ProfunctorSyntax
   object reducible extends ReducibleSyntax with ReducibleSyntaxBinCompat0

--- a/core/src/main/scala/cats/syntax/parallel.scala
+++ b/core/src/main/scala/cats/syntax/parallel.scala
@@ -7,7 +7,10 @@ import cats.{
   Foldable,
   Monad,
   Monoid,
+  NonEmptyParallel,
   Parallel,
+  Reducible,
+  Semigroup,
   Traverse,
   TraverseFilter,
   UnorderedTraverse
@@ -122,6 +125,11 @@ trait ParallelUnorderedTraverseSyntax {
 trait ParallelFoldMapASyntax {
   implicit final def catsSyntaxParallelFoldMapA[T[_], A](ta: T[A]): ParallelFoldMapAOps[T, A] =
     new ParallelFoldMapAOps(ta)
+}
+
+trait ParallelReduceMapASyntax {
+  implicit final def catsSyntaxParallelReduceMapA[T[_], A](ta: T[A]): ParallelReduceMapAOps[T, A] =
+    new ParallelReduceMapAOps(ta)
 }
 
 @deprecated("Kept for binary compatibility", "2.6.0")
@@ -281,4 +289,9 @@ final class ParallelLeftSequenceOps[T[_, _], M[_], A, B](private val tmab: T[M[A
 final class ParallelFoldMapAOps[T[_], A](private val ma: T[A]) extends AnyVal {
   def parFoldMapA[M[_], B](f: A => M[B])(implicit T: Foldable[T], P: Parallel[M], B: Monoid[B]): M[B] =
     Parallel.parFoldMapA(ma)(f)
+}
+
+final class ParallelReduceMapAOps[T[_], A](private val ma: T[A]) extends AnyVal {
+  def parReduceMapA[M[_], B](f: A => M[B])(implicit T: Reducible[T], P: NonEmptyParallel[M], B: Semigroup[B]): M[B] =
+    Parallel.parReduceMapA(ma)(f)
 }

--- a/tests/src/test/scala/cats/tests/ParallelSuite.scala
+++ b/tests/src/test/scala/cats/tests/ParallelSuite.scala
@@ -257,6 +257,15 @@ class ParallelSuite extends CatsSuite with ApplicativeErrorForEitherTest with Sc
     }
   }
 
+  test("ParReduceMapA should be equivalent to parNonEmptyTraverse map reduce (where it exists)") {
+    forAll { (es: NonEmptyList[Int], f: Int => Either[String, String]) =>
+      assert(
+        Parallel.parReduceMapA(es)(f) ===
+          Parallel.parNonEmptyTraverse(es)(f).map(_.reduce)
+      )
+    }
+  }
+
   test("parAp accumulates errors in order") {
     val right: Either[String, Int => Int] = Left("Hello")
     assert(Parallel.parAp(right)("World".asLeft) === (Left("HelloWorld")))


### PR DESCRIPTION
As `parFoldMapA`, but for `NonEmptyParallel`, `Reducible`, and `Semigroup`.




