### PR TITLE
Incorrect deprecated messages

### DIFF
--- a/core/src/main/scala-2.13+/cats/ScalaVersionSpecificInstances.scala
+++ b/core/src/main/scala-2.13+/cats/ScalaVersionSpecificInstances.scala
@@ -36,7 +36,7 @@ private[cats] trait ScalaVersionSpecificMonoidKInstances {
 }
 
 private[cats] trait ScalaVersionSpecificParallelInstances {
-  @deprecated("Use catsParallelForLazyList", "3.0.0")
+  @deprecated("Use catsStdParallelForZipLazyList", "3.0.0")
   implicit def catsStdParallelForZipStream: Parallel.Aux[Stream, ZipStream] =
     cats.instances.parallel.catsStdParallelForZipStream
 
@@ -69,7 +69,7 @@ private[cats] trait ScalaVersionSpecificTraverseFilterInstances {
 }
 
 private[cats] trait ScalaVersionSpecificAlignInstances {
-  @deprecated("Use catsTraverseFilterForLazyList", "3.0.0")
+  @deprecated("Use catsAlignForLazyList", "3.0.0")
   implicit def catsAlignForStream: Align[Stream] =
     cats.instances.stream.catsStdInstancesForStream
 


### PR DESCRIPTION
The deprecated messages were referring to incorrect methods.

Thank you for contributing to Cats!

This is a kind reminder to run `sbt +prePR` and commit the changed files, if any, before submitting.


