### PR TITLE
4045 Add missing else keyword to example

### DIFF
--- a/docs/src/main/mdoc/typeclasses/applicativemonaderror.md
+++ b/docs/src/main/mdoc/typeclasses/applicativemonaderror.md
@@ -273,7 +273,7 @@ when things go wrong.
 ```scala mdoc:silent
 def getTemperatureFromByCoordinatesAlternate[F[_]](x: (Int, Int))(implicit me: MonadError[F, String]): F[Int] = {
   if (x._1 < 0 || x._2 < 0) me.raiseError("Invalid Coordinates")
-  for { c <- getCityClosestToCoordinate[F](x)
+  else for { c <- getCityClosestToCoordinate[F](x)
         t <- getTemperatureByCity[F](c) } yield t
 }
 ```


### PR DESCRIPTION
Minor correction to an example in documentation for ApplicativeError. Fixes [issue 4045](https://github.com/typelevel/cats/issues/4045)


