### PR TITLE
Fix scalafmt config file

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -10,4 +10,16 @@ docstrings = JavaDoc
 newlines.afterCurlyLambda = preserve
 docstrings.style = keep
 docstrings.oneline = unfold
-project.excludeFilters = [ "core/src/main/scala-3.x" ]
+
+runner.dialect = scala213source3
+fileOverride {
+  "glob:**/*.sbt" {
+    runner.dialect = sbt1
+  }
+  "glob:**/src/{main,test}/scala-2.12/**" {
+    runner.dialect = scala212source3
+  }
+  "glob:**/src/{main,test}/scala-3.x/**" {
+    runner.dialect = scala3
+  }
+}

--- a/core/src/main/scala-3.x/src/main/scala/cats/syntax/MonadOps.scala
+++ b/core/src/main/scala-3.x/src/main/scala/cats/syntax/MonadOps.scala
@@ -1,6 +1,6 @@
 package cats.syntax
 
-import cats.{Monad, Alternative}
+import cats.{Alternative, Monad}
 
 final class MonadOps[F[_], A](private val fa: F[A]) extends AnyVal {
   def whileM[G[_]](using M: Monad[F], G: Alternative[G])(p: F[Boolean]): F[G[A]] = M.whileM(p)(fa)

--- a/free/src/main/scala-3.x/cats/free/FreeFoldStep.scala
+++ b/free/src/main/scala-3.x/cats/free/FreeFoldStep.scala
@@ -1,7 +1,7 @@
 package cats.free
 
 import Free.{FlatMapped, Pure, Suspend}
-import cats.{Foldable, Eval}
+import cats.{Eval, Foldable}
 
 private[free] trait FreeFoldStep[S[_], A] {
 


### PR DESCRIPTION
Addresses #4027 and prepares for upgrading to ScalaFmt 3.1.x.

This also fixes `sbt +prePR` which was broken for Scala3-specific source files.
