### PR TITLE
Upgrade scalafmt version to 3.1.1

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version=3.0.5
+version=3.1.1
 align.openParenCallSite = true
 align.openParenDefnSite = true
 maxColumn = 120

--- a/build.sbt
+++ b/build.sbt
@@ -361,7 +361,7 @@ def mimaSettings(moduleName: String, includeCats1: Boolean = true) =
     mimaBinaryIssueFilters ++= {
       import com.typesafe.tools.mima.core.ProblemFilters._
       import com.typesafe.tools.mima.core._
-      //Only sealed abstract classes that provide implicit instances to companion objects are allowed here, since they don't affect usage outside of the file.
+      // Only sealed abstract classes that provide implicit instances to companion objects are allowed here, since they don't affect usage outside of the file.
       Seq(
         exclude[DirectMissingMethodProblem]("cats.data.OptionTInstances2.catsDataTraverseForOptionT"),
         exclude[DirectMissingMethodProblem]("cats.data.KleisliInstances1.catsDataCommutativeArrowForKleisliId"),
@@ -374,8 +374,8 @@ def mimaSettings(moduleName: String, includeCats1: Boolean = true) =
         exclude[DirectMissingMethodProblem]("cats.data.OptionTInstances1.catsDataMonadErrorMonadForOptionT"),
         exclude[DirectMissingMethodProblem]("cats.data.OptionTInstances1.catsDataMonadErrorForOptionT")
       ) ++
-        //These things are Ops classes that shouldn't have the `value` exposed. These should have never been public because they don't
-        //provide any value. Making them private because of issues like #2514 and #2613.
+        // These things are Ops classes that shouldn't have the `value` exposed. These should have never been public because they don't
+        // provide any value. Making them private because of issues like #2514 and #2613.
         Seq(
           exclude[DirectMissingMethodProblem]("cats.ApplicativeError#LiftFromOptionPartially.dummy"),
           exclude[DirectMissingMethodProblem]("cats.data.Const#OfPartiallyApplied.dummy"),
@@ -465,7 +465,7 @@ def mimaSettings(moduleName: String, includeCats1: Boolean = true) =
           exclude[IncompatibleMethTypeProblem]("cats.arrow.FunctionKMacros#Lifter.this"),
           exclude[IncompatibleResultTypeProblem]("cats.arrow.FunctionKMacros#Lifter.c"),
           exclude[DirectMissingMethodProblem]("cats.arrow.FunctionKMacros.compatNewTypeName")
-        ) ++ //package private classes no longer needed
+        ) ++ // package private classes no longer needed
         Seq(
           exclude[MissingClassProblem]("cats.kernel.compat.scalaVersionMoreSpecific$"),
           exclude[MissingClassProblem]("cats.kernel.compat.scalaVersionMoreSpecific"),
@@ -1091,7 +1091,7 @@ lazy val sharedReleaseProcess = Seq(
     checkSnapshotDependencies,
     inquireVersions,
     runClean,
-    runTest, //temporarily only run test in current scala version because docs won't build in 2.13 yet
+    runTest, // temporarily only run test in current scala version because docs won't build in 2.13 yet
     setReleaseVersion,
     commitReleaseVersion,
     tagRelease,

--- a/tests/src/test/scala/cats/tests/ApplicativeErrorSuite.scala
+++ b/tests/src/test/scala/cats/tests/ApplicativeErrorSuite.scala
@@ -61,7 +61,7 @@ class ApplicativeErrorSuite extends CatsSuite {
     assert(compileErrors("e2.attemptNarrow[Num]").nonEmpty)
 
     val e3: Either[List[T[String]], Unit] = List(Str).asLeft[Unit]
-    //assertEquals(compileErrors("e3.attemptNarrow[List[Str.type]]"), "")
+    // assertEquals(compileErrors("e3.attemptNarrow[List[Str.type]]"), "")
   }
 
   test("attemptT syntax creates an EitherT") {

--- a/tests/src/test/scala/cats/tests/FunctorSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctorSuite.scala
@@ -44,12 +44,12 @@ class FunctorSuite extends CatsSuite {
       assert(Functor[Option].unzip(o.map(i => (i, i))) === ((o, o)))
       assert(Functor[Map[String, *]].unzip(m.map { case (k, v) => (k, (v, v)) }) === ((m, m)))
 
-      //postfix test for Cats datatypes
+      // postfix test for Cats datatypes
       assert(nel.map(i => (i, i)).unzip === ((nel, nel)))
       assert(nem.map(v => (v, v)).unzip === ((nem, nem)))
     }
 
-    //empty test for completeness
+    // empty test for completeness
     val emptyL = List.empty[Int]
     val emptyM = Map.empty[String, Int]
 

--- a/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
@@ -508,7 +508,7 @@ class IndexedStateTSuite extends CatsSuite {
     Alternative[IndexedStateT[ListWrapper, Int, Int, *]]
     Applicative[IndexedStateT[ListWrapper, Int, Int, *]]
     Apply[IndexedStateT[ListWrapper, Int, Int, *]]
-    //Functor[IndexedStateT[ListWrapper, Int, Int, *]]
+    // Functor[IndexedStateT[ListWrapper, Int, Int, *]]
     MonoidK[IndexedStateT[ListWrapper, Int, Int, *]]
     SemigroupK[IndexedStateT[ListWrapper, Int, Int, *]]
   }

--- a/tests/src/test/scala/cats/tests/NestedSuite.scala
+++ b/tests/src/test/scala/cats/tests/NestedSuite.scala
@@ -269,7 +269,7 @@ class NestedSuite extends CatsSuite {
   {
     type Pair[A] = (A, A)
 
-    //Scala 2.12 implicit resolution absolutely loses its mind here
+    // Scala 2.12 implicit resolution absolutely loses its mind here
     implicit val help_scala2_12: Representable.Aux[Nested[Pair, Pair, *], (Boolean, Boolean)] =
       Nested.catsDataRepresentableForNested[Pair, Pair]
 

--- a/tests/src/test/scala/cats/tests/OptionTSuite.scala
+++ b/tests/src/test/scala/cats/tests/OptionTSuite.scala
@@ -542,7 +542,7 @@ class OptionTSuite extends CatsSuite {
     Traverse[OptionT[List, *]]
 
     implicit val T: Traverse[ListWrapper] = ListWrapper.traverse
-    //implicit val M: Monad[ListWrapper] = ListWrapper.monad
+    // implicit val M: Monad[ListWrapper] = ListWrapper.monad
     Functor[OptionT[ListWrapper, *]]
   }
 

--- a/tests/src/test/scala/cats/tests/RepresentableStoreTSuite.scala
+++ b/tests/src/test/scala/cats/tests/RepresentableStoreTSuite.scala
@@ -16,7 +16,7 @@ class RepresentableStoreTSuite extends CatsSuite {
 
   implicit val scala2_12_makes_me_sad: Comonad[StoreT[Id, MiniInt, *]] =
     RepresentableStoreT.comonadForStoreT[Id, Function1[MiniInt, *], MiniInt]
-  //Like, really, really, really sad
+  // Like, really, really, really sad
   val a: Arbitrary[Int] = implicitly[Arbitrary[Int]]
   val b: Eq[Int] = Eq[Int]
   val c: Arbitrary[StoreT[Id, MiniInt, Int]] = implicitly[Arbitrary[StoreT[Id, MiniInt, Int]]]

--- a/tests/src/test/scala/cats/tests/Tuple2KSuite.scala
+++ b/tests/src/test/scala/cats/tests/Tuple2KSuite.scala
@@ -45,7 +45,7 @@ class Tuple2KSuite extends CatsSuite {
   {
     type Pair[A] = (A, A)
 
-    //Scala 2.12 implicit resolution absolutely loses its mind here
+    // Scala 2.12 implicit resolution absolutely loses its mind here
     implicit val help_scala2_12: Representable.Aux[Tuple2K[Pair, Pair, *], Either[Boolean, Boolean]] =
       Tuple2K.catsDataRepresentableForTuple2K[Pair, Pair]
 


### PR DESCRIPTION
Discussion on why to do a manual upgrade: #4031

Things done in this PR:
1 . scalafmt version is set to 3.1.1 in `.scalafmt.conf`
2. `sbt +prePR` is applied.

