### PR TITLE
Optimize Alternative (part 2): add prependK/appendK specializations for std containers

### DIFF
--- a/alleycats-core/src/main/scala/alleycats/std/set.scala
+++ b/alleycats-core/src/main/scala/alleycats/std/set.scala
@@ -73,6 +73,10 @@ trait SetInstances {
       override def empty[A]: Set[A] = Set.empty
 
       override def combineK[A](x: Set[A], y: Set[A]): Set[A] = x | y
+
+      override def prependK[A](a: A, fa: Set[A]): Set[A] = fa + a
+
+      override def appendK[A](fa: Set[A], a: A): Set[A] = fa + a
     }
 
   // Since iteration order is not guaranteed for sets, folds and other

--- a/core/src/main/scala-2.12/cats/instances/stream.scala
+++ b/core/src/main/scala-2.12/cats/instances/stream.scala
@@ -16,6 +16,8 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
 
       def combineK[A](x: Stream[A], y: Stream[A]): Stream[A] = x #::: y
 
+      override def prependK[A](a: A, fa: Stream[A]): Stream[A] = a #:: fa
+
       def pure[A](x: A): Stream[A] = Stream(x)
 
       override def map[A, B](fa: Stream[A])(f: A => B): Stream[B] =

--- a/core/src/main/scala-2.13+/cats/instances/arraySeq.scala
+++ b/core/src/main/scala-2.13+/cats/instances/arraySeq.scala
@@ -34,6 +34,10 @@ private[cats] object ArraySeqInstances {
       def combineK[A](xs: ArraySeq[A], ys: ArraySeq[A]): ArraySeq[A] =
         xs.concat(ys)
 
+      override def prependK[A](a: A, fa: ArraySeq[A]): ArraySeq[A] = fa.prepended(a)
+
+      override def appendK[A](fa: ArraySeq[A], a: A): ArraySeq[A] = fa.appended(a)
+
       override def algebra[A]: Monoid[ArraySeq[A]] =
         new cats.kernel.instances.ArraySeqInstances.ArraySeqMonoid
 

--- a/core/src/main/scala-2.13+/cats/instances/lazyList.scala
+++ b/core/src/main/scala-2.13+/cats/instances/lazyList.scala
@@ -22,6 +22,10 @@ trait LazyListInstances extends cats.kernel.instances.LazyListInstances {
 
       def combineK[A](x: LazyList[A], y: LazyList[A]): LazyList[A] = x.lazyAppendedAll(y)
 
+      override def prependK[A](a: A, fa: LazyList[A]): LazyList[A] = fa.prepended(a)
+
+      override def appendK[A](fa: LazyList[A], a: A): LazyList[A] = fa.appended(a)
+
       def pure[A](x: A): LazyList[A] = LazyList(x)
 
       override def map[A, B](fa: LazyList[A])(f: A => B): LazyList[B] =

--- a/core/src/main/scala-2.13+/cats/instances/stream.scala
+++ b/core/src/main/scala-2.13+/cats/instances/stream.scala
@@ -17,6 +17,8 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
 
       def combineK[A](x: Stream[A], y: Stream[A]): Stream[A] = x #::: y
 
+      override def prependK[A](a: A, fa: Stream[A]): Stream[A] = a #:: fa
+
       def pure[A](x: A): Stream[A] = Stream(x)
 
       override def map[A, B](fa: Stream[A])(f: A => B): Stream[B] =

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -17,7 +17,11 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
     new Traverse[List] with Alternative[List] with Monad[List] with CoflatMap[List] with Align[List] {
       def empty[A]: List[A] = Nil
 
-      def combineK[A](x: List[A], y: List[A]): List[A] = x ++ y
+      def combineK[A](x: List[A], y: List[A]): List[A] = x ::: y
+
+      override def prependK[A](a: A, fa: List[A]): List[A] = a :: fa
+
+      override def appendK[A](fa: List[A], a: A): List[A] = fa :+ a
 
       def pure[A](x: A): List[A] = x :: Nil
 

--- a/core/src/main/scala/cats/instances/option.scala
+++ b/core/src/main/scala/cats/instances/option.scala
@@ -23,7 +23,10 @@ trait OptionInstances extends cats.kernel.instances.OptionInstances {
 
       def empty[A]: Option[A] = None
 
-      def combineK[A](x: Option[A], y: Option[A]): Option[A] = x.orElse(y)
+      def combineK[A](x: Option[A], y: Option[A]): Option[A] = if (x.isDefined) x else y
+
+      override def prependK[A](a: A, fa: Option[A]): Option[A] = Some(a)
+      override def appendK[A](fa: Option[A], a: A): Option[A] = if (fa.isDefined) fa else Some(a)
 
       override def combineKEval[A](x: Option[A], y: Eval[Option[A]]): Eval[Option[A]] =
         x match {

--- a/core/src/main/scala/cats/instances/queue.scala
+++ b/core/src/main/scala/cats/instances/queue.scala
@@ -17,6 +17,10 @@ trait QueueInstances extends cats.kernel.instances.QueueInstances {
 
       def combineK[A](x: Queue[A], y: Queue[A]): Queue[A] = x ++ y
 
+      override def prependK[A](a: A, fa: Queue[A]): Queue[A] = a +: fa
+
+      override def appendK[A](fa: Queue[A], a: A): Queue[A] = fa.enqueue(a)
+
       def pure[A](x: A): Queue[A] = Queue(x)
 
       override def map[A, B](fa: Queue[A])(f: A => B): Queue[B] =

--- a/core/src/main/scala/cats/instances/seq.scala
+++ b/core/src/main/scala/cats/instances/seq.scala
@@ -17,6 +17,10 @@ trait SeqInstances extends cats.kernel.instances.SeqInstances {
 
       def combineK[A](x: Seq[A], y: Seq[A]): Seq[A] = x ++ y
 
+      override def prependK[A](a: A, fa: Seq[A]): Seq[A] = a +: fa
+
+      override def appendK[A](fa: Seq[A], a: A): Seq[A] = fa :+ a
+
       def pure[A](x: A): Seq[A] = Seq(x)
 
       override def map[A, B](fa: Seq[A])(f: A => B): Seq[B] =

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -18,6 +18,10 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
 
       def combineK[A](x: Vector[A], y: Vector[A]): Vector[A] = x ++ y
 
+      override def prependK[A](a: A, fa: Vector[A]): Vector[A] = a +: fa
+
+      override def appendK[A](fa: Vector[A], a: A): Vector[A] = fa :+ a
+
       def pure[A](x: A): Vector[A] = Vector(x)
 
       override def map[A, B](fa: Vector[A])(f: A => B): Vector[B] =


### PR DESCRIPTION
See initial PR #4014 for details.
Subsequent PRs:
- add prependK/appendK specializations for cats.data collections.
- add prependK/appendK specializations for all other cats containers.

This PR adds optimized specializations for the new `prependK`/`appendK` methods introduced in the initial PR.
