### PR TITLE
Optimize `Alternative` (part 3): add `prependK`/`appendK` specializations for Cats NE wrappers

### DIFF
--- a/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
+++ b/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
@@ -509,7 +509,7 @@ sealed abstract private[data] class NonEmptyLazyListInstances extends NonEmptyLa
 
   implicit val catsDataInstancesForNonEmptyLazyList: Bimonad[NonEmptyLazyList]
     with NonEmptyTraverse[NonEmptyLazyList]
-    with SemigroupK[NonEmptyLazyList]
+    with NonEmptyAlternative[NonEmptyLazyList]
     with Align[NonEmptyLazyList] =
     new AbstractNonEmptyInstances[LazyList, NonEmptyLazyList] with Align[NonEmptyLazyList] {
 

--- a/core/src/main/scala/cats/data/AbstractNonEmptyInstances.scala
+++ b/core/src/main/scala/cats/data/AbstractNonEmptyInstances.scala
@@ -26,17 +26,23 @@ abstract private[data] class AbstractNonEmptyInstances[F[_], NonEmptyF[_]](impli
   MF: Monad[F],
   CF: CoflatMap[F],
   TF: Traverse[F],
-  SF: SemigroupK[F]
+  SF: Alternative[F]
 ) extends Bimonad[NonEmptyF]
     with NonEmptyTraverse[NonEmptyF]
-    with SemigroupK[NonEmptyF] {
+    with NonEmptyAlternative[NonEmptyF] {
   val monadInstance = MF.asInstanceOf[Monad[NonEmptyF]]
   val coflatMapInstance = CF.asInstanceOf[CoflatMap[NonEmptyF]]
   val traverseInstance = Traverse[F].asInstanceOf[Traverse[NonEmptyF]]
-  val semiGroupKInstance = SemigroupK[F].asInstanceOf[SemigroupK[NonEmptyF]]
+  val alternativeInstance = Alternative[F].asInstanceOf[Alternative[NonEmptyF]]
 
   def combineK[A](a: NonEmptyF[A], b: NonEmptyF[A]): NonEmptyF[A] =
-    semiGroupKInstance.combineK(a, b)
+    alternativeInstance.combineK(a, b)
+
+  override def prependK[A](a: A, fa: NonEmptyF[A]): NonEmptyF[A] =
+    alternativeInstance.prependK(a, fa)
+
+  override def appendK[A](fa: NonEmptyF[A], a: A): NonEmptyF[A] =
+    alternativeInstance.appendK(fa, a)
 
   def pure[A](x: A): NonEmptyF[A] = monadInstance.pure(x)
 

--- a/core/src/main/scala/cats/data/NonEmptyChain.scala
+++ b/core/src/main/scala/cats/data/NonEmptyChain.scala
@@ -617,10 +617,20 @@ class NonEmptyChainOps[A](private val value: NonEmptyChain[A])
 
 sealed abstract private[data] class NonEmptyChainInstances extends NonEmptyChainInstances1 {
 
-  implicit val catsDataInstancesForNonEmptyChain: SemigroupK[NonEmptyChain]
+  @deprecated(
+    "maintained for the sake of binary compatibility only, use catsDataInstancesForNonEmptyChainBinCompat1 instead",
+    "2.9.0"
+  )
+  def catsDataInstancesForNonEmptyChain: SemigroupK[NonEmptyChain]
     with NonEmptyTraverse[NonEmptyChain]
     with Bimonad[NonEmptyChain]
     with Align[NonEmptyChain] =
+    catsDataInstancesForNonEmptyChainBinCompat1
+
+  implicit val catsDataInstancesForNonEmptyChainBinCompat1: Align[NonEmptyChain]
+    with Bimonad[NonEmptyChain]
+    with NonEmptyAlternative[NonEmptyChain]
+    with NonEmptyTraverse[NonEmptyChain] =
     new AbstractNonEmptyInstances[Chain, NonEmptyChain] with Align[NonEmptyChain] {
       def extract[A](fa: NonEmptyChain[A]): A = fa.head
 

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -788,22 +788,38 @@ object NonEmptyList extends NonEmptyListInstances {
 
 sealed abstract private[data] class NonEmptyListInstances extends NonEmptyListInstances0 {
 
+  @deprecated(
+    "maintained for the sake of binary compatibility only - use catsDataInstancesForNonEmptyListBinCompat1 instead",
+    "2.9.0"
+  )
+  def catsDataInstancesForNonEmptyList
+    : SemigroupK[NonEmptyList] with Bimonad[NonEmptyList] with NonEmptyTraverse[NonEmptyList] with Align[NonEmptyList] =
+    catsDataInstancesForNonEmptyListBinCompat1
+
   /**
    * This is not a bug. The declared type of `catsDataInstancesForNonEmptyList` intentionally ignores
    * `NonEmptyReducible` trait for it not being a typeclass.
    *
    * Also see the discussion: PR #3541 and issue #3069.
    */
-  implicit val catsDataInstancesForNonEmptyList
-    : SemigroupK[NonEmptyList] with Bimonad[NonEmptyList] with NonEmptyTraverse[NonEmptyList] with Align[NonEmptyList] =
+  implicit val catsDataInstancesForNonEmptyListBinCompat1: NonEmptyAlternative[NonEmptyList]
+    with Bimonad[NonEmptyList]
+    with NonEmptyTraverse[NonEmptyList]
+    with Align[NonEmptyList] =
     new NonEmptyReducible[NonEmptyList, List]
-      with SemigroupK[NonEmptyList]
+      with NonEmptyAlternative[NonEmptyList]
       with Bimonad[NonEmptyList]
       with NonEmptyTraverse[NonEmptyList]
       with Align[NonEmptyList] {
 
       def combineK[A](a: NonEmptyList[A], b: NonEmptyList[A]): NonEmptyList[A] =
         a.concatNel(b)
+
+      override def prependK[A](a: A, fa: NonEmptyList[A]): NonEmptyList[A] =
+        fa.prepend(a)
+
+      override def appendK[A](fa: NonEmptyList[A], a: A): NonEmptyList[A] =
+        fa.append(a)
 
       override def split[A](fa: NonEmptyList[A]): (A, List[A]) = (fa.head, fa.tail)
 
@@ -955,7 +971,7 @@ sealed abstract private[data] class NonEmptyListInstances extends NonEmptyListIn
     new NonEmptyParallel[NonEmptyList] {
       type F[x] = ZipNonEmptyList[x]
 
-      def flatMap: FlatMap[NonEmptyList] = NonEmptyList.catsDataInstancesForNonEmptyList
+      def flatMap: FlatMap[NonEmptyList] = NonEmptyList.catsDataInstancesForNonEmptyListBinCompat1
 
       def apply: Apply[ZipNonEmptyList] = ZipNonEmptyList.catsDataCommutativeApplyForZipNonEmptyList
 

--- a/core/src/main/scala/cats/data/NonEmptySeq.scala
+++ b/core/src/main/scala/cats/data/NonEmptySeq.scala
@@ -381,22 +381,38 @@ final class NonEmptySeq[+A] private (val toSeq: Seq[A]) extends AnyVal with NonE
 @suppressUnusedImportWarningForScalaVersionSpecific
 sealed abstract private[data] class NonEmptySeqInstances {
 
+  @deprecated(
+    "maintained for the sake of binary compatibility only - use catsDataInstancesForNonEmptySeqBinCompat1 instead",
+    "2.9.0"
+  )
+  def catsDataInstancesForNonEmptySeq
+    : SemigroupK[NonEmptySeq] with Bimonad[NonEmptySeq] with NonEmptyTraverse[NonEmptySeq] with Align[NonEmptySeq] =
+    catsDataInstancesForNonEmptySeqBinCompat1
+
   /**
    * This is not a bug. The declared type of `catsDataInstancesForNonEmptySeq` intentionally ignores
    * `NonEmptyReducible` trait for it not being a typeclass.
    *
    * Also see the discussion: PR #3541 and issue #3069.
    */
-  implicit val catsDataInstancesForNonEmptySeq
-    : SemigroupK[NonEmptySeq] with Bimonad[NonEmptySeq] with NonEmptyTraverse[NonEmptySeq] with Align[NonEmptySeq] =
+  implicit val catsDataInstancesForNonEmptySeqBinCompat1: NonEmptyAlternative[NonEmptySeq]
+    with Bimonad[NonEmptySeq]
+    with NonEmptyTraverse[NonEmptySeq]
+    with Align[NonEmptySeq] =
     new NonEmptyReducible[NonEmptySeq, Seq]
-      with SemigroupK[NonEmptySeq]
+      with NonEmptyAlternative[NonEmptySeq]
       with Bimonad[NonEmptySeq]
       with NonEmptyTraverse[NonEmptySeq]
       with Align[NonEmptySeq] {
 
       def combineK[A](a: NonEmptySeq[A], b: NonEmptySeq[A]): NonEmptySeq[A] =
         a.concatNeSeq(b)
+
+      override def prependK[A](a: A, fa: NonEmptySeq[A]): NonEmptySeq[A] =
+        fa.prepend(a)
+
+      override def appendK[A](fa: NonEmptySeq[A], a: A): NonEmptySeq[A] =
+        fa.append(a)
 
       override def split[A](fa: NonEmptySeq[A]): (A, Seq[A]) = (fa.head, fa.tail)
 
@@ -532,14 +548,14 @@ sealed abstract private[data] class NonEmptySeqInstances {
   implicit def catsDataShowForNonEmptySeq[A: Show]: Show[NonEmptySeq[A]] = _.show
 
   implicit def catsDataSemigroupForNonEmptySeq[A]: Semigroup[NonEmptySeq[A]] =
-    catsDataInstancesForNonEmptySeq.algebra
+    catsDataInstancesForNonEmptySeqBinCompat1.algebra
 
   implicit def catsDataParallelForNonEmptySeq: NonEmptyParallel.Aux[NonEmptySeq, ZipNonEmptySeq] =
     new NonEmptyParallel[NonEmptySeq] {
       type F[x] = ZipNonEmptySeq[x]
 
       def apply: Apply[ZipNonEmptySeq] = ZipNonEmptySeq.catsDataCommutativeApplyForZipNonEmptySeq
-      def flatMap: FlatMap[NonEmptySeq] = NonEmptySeq.catsDataInstancesForNonEmptySeq
+      def flatMap: FlatMap[NonEmptySeq] = NonEmptySeq.catsDataInstancesForNonEmptySeqBinCompat1
 
       def sequential: ZipNonEmptySeq ~> NonEmptySeq =
         new (ZipNonEmptySeq ~> NonEmptySeq) { def apply[A](a: ZipNonEmptySeq[A]): NonEmptySeq[A] = a.value }

--- a/tests/shared/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
+++ b/tests/shared/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
@@ -21,24 +21,21 @@
 
 package cats.tests
 
-import cats.{Align, Bimonad, SemigroupK, Show, Traverse}
-import cats.data.{NonEmptyLazyList, NonEmptyLazyListOps, NonEmptyVector}
-import cats.kernel.{Eq, Hash, Order, PartialOrder, Semigroup}
-import cats.kernel.laws.discipline.{EqTests, HashTests, OrderTests, PartialOrderTests, SemigroupTests}
-import cats.laws.discipline.{
-  AlignTests,
-  BimonadTests,
-  NonEmptyTraverseTests,
-  SemigroupKTests,
-  SerializableTests,
-  ShortCircuitingTests
-}
+import cats._
+import cats.data.NonEmptyLazyList
+import cats.data.NonEmptyLazyListOps
+import cats.data.NonEmptyVector
+import cats.kernel.laws.discipline.EqTests
+import cats.kernel.laws.discipline.HashTests
+import cats.kernel.laws.discipline.OrderTests
+import cats.kernel.laws.discipline.PartialOrderTests
+import cats.kernel.laws.discipline.SemigroupTests
+import cats.kernel.laws.discipline.SerializableTests
+import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.syntax.either._
-import cats.syntax.foldable._
 import cats.syntax.eq._
-import cats.Reducible
-import cats.Eval
+import cats.syntax.foldable._
 import org.scalacheck.Prop._
 
 class NonEmptyLazyListSuite extends NonEmptyCollectionSuite[LazyList, NonEmptyLazyList, NonEmptyLazyListOps] {
@@ -52,8 +49,10 @@ class NonEmptyLazyListSuite extends NonEmptyCollectionSuite[LazyList, NonEmptyLa
   checkAll(s"NonEmptyLazyList[Int]", HashTests[NonEmptyLazyList[Int]].hash)
   checkAll(s"Hash[NonEmptyLazyList[Int]]", SerializableTests.serializable(Hash[NonEmptyLazyList[Int]]))
 
-  checkAll("NonEmptyLazyList[Int]", SemigroupKTests[NonEmptyLazyList].semigroupK[Int])
-  checkAll("SemigroupK[NonEmptyLazyList]", SerializableTests.serializable(SemigroupK[NonEmptyLazyList]))
+  checkAll("NonEmptyLazyList[Int]", NonEmptyAlternativeTests[NonEmptyLazyList].nonEmptyAlternative[Int, Int, Int])
+  checkAll("NonEmptyAlternative[NonEmptyLazyList]",
+           SerializableTests.serializable(NonEmptyAlternative[NonEmptyLazyList])
+  )
 
   checkAll("NonEmptyLazyList[Int] with Option",
            NonEmptyTraverseTests[NonEmptyLazyList].nonEmptyTraverse[Option, Int, Int, Int, Int, Option, Option]

--- a/tests/shared/src/test/scala/cats/tests/NonEmptyChainSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NonEmptyChainSuite.scala
@@ -21,22 +21,19 @@
 
 package cats.tests
 
-import cats.{Align, Bimonad, SemigroupK, Show, Traverse}
-import cats.data.{Chain, NonEmptyChain, NonEmptyChainOps}
-import cats.kernel.{Eq, Order, PartialOrder, Semigroup}
-import cats.kernel.laws.discipline.{EqTests, OrderTests, PartialOrderTests, SemigroupTests}
-import cats.laws.discipline.{
-  AlignTests,
-  BimonadTests,
-  NonEmptyTraverseTests,
-  SemigroupKTests,
-  SerializableTests,
-  ShortCircuitingTests
-}
+import cats._
+import cats.data.Chain
+import cats.data.NonEmptyChain
+import cats.data.NonEmptyChainOps
+import cats.kernel.laws.discipline.EqTests
+import cats.kernel.laws.discipline.OrderTests
+import cats.kernel.laws.discipline.PartialOrderTests
+import cats.kernel.laws.discipline.SemigroupTests
+import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.syntax.either._
-import cats.syntax.foldable._
 import cats.syntax.eq._
+import cats.syntax.foldable._
 import org.scalacheck.Prop._
 
 class NonEmptyChainSuite extends NonEmptyCollectionSuite[Chain, NonEmptyChain, NonEmptyChainOps] {
@@ -44,8 +41,8 @@ class NonEmptyChainSuite extends NonEmptyCollectionSuite[Chain, NonEmptyChain, N
   protected def underlyingToList[A](underlying: Chain[A]): List[A] = underlying.toList
   protected def toNonEmptyCollection[A](nea: NonEmptyChain[A]): NonEmptyChainOps[A] = nea
 
-  checkAll("NonEmptyChain[Int]", SemigroupKTests[NonEmptyChain].semigroupK[Int])
-  checkAll("SemigroupK[NonEmptyChain]", SerializableTests.serializable(SemigroupK[NonEmptyChain]))
+  checkAll("NonEmptyChain[Int]", NonEmptyAlternativeTests[NonEmptyChain].nonEmptyAlternative[Int, Int, Int])
+  checkAll("NonEmptyAlternative[NonEmptyChain]", SerializableTests.serializable(NonEmptyAlternative[NonEmptyChain]))
 
   checkAll("NonEmptyChain[Int] with Option",
            NonEmptyTraverseTests[NonEmptyChain].nonEmptyTraverse[Option, Int, Int, Int, Int, Option, Option]

--- a/tests/shared/src/test/scala/cats/tests/NonEmptyListSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NonEmptyListSuite.scala
@@ -21,29 +21,27 @@
 
 package cats.tests
 
-import cats.{Align, Bimonad, Eval, NonEmptyTraverse, Now, Reducible, SemigroupK, Show}
-import cats.data.{NonEmptyList, NonEmptyMap, NonEmptySet, NonEmptyVector}
+import cats._
+import cats.data.NonEmptyList
 import cats.data.NonEmptyList.ZipNonEmptyList
-import cats.kernel.{Eq, Order, PartialOrder, Semigroup}
-import cats.kernel.laws.discipline.{EqTests, OrderTests, PartialOrderTests, SemigroupTests}
+import cats.data.NonEmptyMap
+import cats.data.NonEmptySet
+import cats.data.NonEmptyVector
+import cats.kernel.laws.discipline.EqTests
+import cats.kernel.laws.discipline.OrderTests
+import cats.kernel.laws.discipline.PartialOrderTests
+import cats.kernel.laws.discipline.SemigroupTests
+import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
-import cats.laws.discipline.{
-  AlignTests,
-  BimonadTests,
-  CommutativeApplyTests,
-  NonEmptyTraverseTests,
-  ReducibleTests,
-  SemigroupKTests,
-  SerializableTests,
-  ShortCircuitingTests
-}
+import cats.syntax.eq._
 import cats.syntax.foldable._
 import cats.syntax.reducible._
 import cats.syntax.show._
-import scala.collection.immutable.{SortedMap, SortedSet}
-import cats.syntax.eq._
 import org.scalacheck.Prop._
 import org.scalacheck.Test.Parameters
+
+import scala.collection.immutable.SortedMap
+import scala.collection.immutable.SortedSet
 
 class NonEmptyListSuite extends NonEmptyCollectionSuite[List, NonEmptyList, NonEmptyList] {
   protected def toList[A](value: NonEmptyList[A]): List[A] = value.toList
@@ -64,8 +62,8 @@ class NonEmptyListSuite extends NonEmptyCollectionSuite[List, NonEmptyList, NonE
   checkAll("NonEmptyList[Int]", ReducibleTests[NonEmptyList].reducible[Option, Int, Int])
   checkAll("Reducible[NonEmptyList]", SerializableTests.serializable(Reducible[NonEmptyList]))
 
-  checkAll("NonEmptyList[Int]", SemigroupKTests[NonEmptyList].semigroupK[Int])
-  checkAll("SemigroupK[NonEmptyList[A]]", SerializableTests.serializable(SemigroupK[NonEmptyList]))
+  checkAll("NonEmptyList[Int]", NonEmptyAlternativeTests[NonEmptyList].nonEmptyAlternative[Int, Int, Int])
+  checkAll("NonEmptyAlternative[NonEmptyList[A]]", SerializableTests.serializable(NonEmptyAlternative[NonEmptyList]))
 
   checkAll("NonEmptyList[Int]", SemigroupTests[NonEmptyList[Int]].semigroup)
   checkAll("Semigroup[NonEmptyList[Int]]", SerializableTests.serializable(Semigroup[NonEmptyList[Int]]))

--- a/tests/shared/src/test/scala/cats/tests/NonEmptySeqSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NonEmptySeqSuite.scala
@@ -21,17 +21,45 @@
 
 package cats.tests
 
+import cats._
 import cats.data.NonEmptySeq
+import cats.kernel.laws.discipline.SemigroupTests
+import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
-import cats.syntax.seq._
+import cats.syntax.all._
 import org.scalacheck.Prop._
 
 import scala.collection.immutable.Seq
 
 class NonEmptySeqSuite extends NonEmptyCollectionSuite[Seq, NonEmptySeq, NonEmptySeq] {
-  protected def toList[A](value: NonEmptySeq[A]): List[A] = value.toSeq.toList
-  protected def underlyingToList[A](underlying: Seq[A]): List[A] = underlying.toList
-  protected def toNonEmptyCollection[A](value: NonEmptySeq[A]): NonEmptySeq[A] = value
+  override protected def toList[A](value: NonEmptySeq[A]): List[A] = value.toList
+  override protected def underlyingToList[A](underlying: Seq[A]): List[A] = underlying.toList
+  override protected def toNonEmptyCollection[A](value: NonEmptySeq[A]): NonEmptySeq[A] = value
+
+  checkAll(
+    "NonEmptySeq[Int] with Option",
+    NonEmptyTraverseTests[NonEmptySeq].nonEmptyTraverse[Option, Int, Int, Int, Int, Option, Option]
+  )
+  checkAll("NonEmptyTraverse[NonEmptySeq[A]]", SerializableTests.serializable(NonEmptyTraverse[NonEmptySeq]))
+
+  checkAll("NonEmptySeq[Int]", ReducibleTests[NonEmptySeq].reducible[Option, Int, Int])
+  checkAll("Reducible[NonEmptySeq]", SerializableTests.serializable(Reducible[NonEmptySeq]))
+
+  checkAll("NonEmptySeq[Int]", NonEmptyAlternativeTests[NonEmptySeq].nonEmptyAlternative[Int, Int, Int])
+  checkAll("NonEmptyAlternative[NonEmptySeq[A]]", SerializableTests.serializable(NonEmptyAlternative[NonEmptySeq]))
+
+  checkAll("NonEmptySeq[Int]", SemigroupTests[NonEmptySeq[Int]].semigroup)
+  checkAll("Semigroup[NonEmptySeq[Int]]", SerializableTests.serializable(Semigroup[NonEmptySeq[Int]]))
+
+  checkAll("NonEmptySeq[Int]", BimonadTests[NonEmptySeq].bimonad[Int, Int, Int])
+  checkAll("Bimonad[NonEmptySeq]", SerializableTests.serializable(Bimonad[NonEmptySeq]))
+
+  checkAll("NonEmptySeq[Int]", AlignTests[NonEmptySeq].align[Int, Int, Int, Int])
+  checkAll("Align[NonEmptySeq]", SerializableTests.serializable(Align[NonEmptySeq]))
+
+  checkAll("NonEmptySeq[Int]", ShortCircuitingTests[NonEmptySeq].foldable[Int])
+  checkAll("NonEmptySeq[Int]", ShortCircuitingTests[NonEmptySeq].traverse[Int])
+  checkAll("NonEmptySeq[Int]", ShortCircuitingTests[NonEmptySeq].nonEmptyTraverse[Int])
 
   test("neSeq => Seq => neSeq returns original neSeq")(
     forAll { (fa: NonEmptySeq[Int]) =>

--- a/tests/shared/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
@@ -21,48 +21,23 @@
 
 package cats.tests
 
-import cats.{
-  Align,
-  Bimonad,
-  CommutativeApply,
-  Comonad,
-  Eval,
-  Foldable,
-  Functor,
-  Monad,
-  NonEmptyTraverse,
-  Now,
-  Reducible,
-  SemigroupK,
-  Show,
-  Traverse
-}
+import cats._
 import cats.data.NonEmptyVector
 import cats.data.NonEmptyVector.ZipNonEmptyVector
-import cats.kernel.Semigroup
 import cats.kernel.instances.order.catsKernelOrderingForOrder
-import cats.kernel.laws.discipline.{EqTests, SemigroupTests}
-import cats.laws.discipline.{
-  AlignTests,
-  BimonadTests,
-  CommutativeApplyTests,
-  FoldableTests,
-  NonEmptyTraverseTests,
-  ReducibleTests,
-  SemigroupKTests,
-  SerializableTests,
-  ShortCircuitingTests
-}
+import cats.kernel.laws.discipline.EqTests
+import cats.kernel.laws.discipline.SemigroupTests
+import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.platform.Platform
+import cats.syntax.eq._
 import cats.syntax.foldable._
 import cats.syntax.reducible._
 import cats.syntax.show._
-
-import scala.util.Properties
-import cats.syntax.eq._
 import org.scalacheck.Prop._
 import org.scalacheck.Test.Parameters
+
+import scala.util.Properties
 
 class NonEmptyVectorSuite extends NonEmptyCollectionSuite[Vector, NonEmptyVector, NonEmptyVector] {
   protected def toList[A](value: NonEmptyVector[A]): List[A] = value.toList
@@ -85,10 +60,10 @@ class NonEmptyVectorSuite extends NonEmptyCollectionSuite[Vector, NonEmptyVector
 
   // Test instances that have more general constraints
 
-  checkAll("NonEmptyVector[Int]", SemigroupKTests[NonEmptyVector].semigroupK[Int])
-  checkAll("NonEmptyVector[Int]", SemigroupTests[NonEmptyVector[Int]].semigroup)
-  checkAll("SemigroupK[NonEmptyVector]", SerializableTests.serializable(SemigroupK[NonEmptyVector]))
+  checkAll("NonEmptyVector[Int]", NonEmptyAlternativeTests[NonEmptyVector].nonEmptyAlternative[Int, Int, Int])
   checkAll("Semigroup[NonEmptyVector[Int]]", SerializableTests.serializable(Semigroup[NonEmptyVector[Int]]))
+  checkAll("NonEmptyVector[Int]", SemigroupTests[NonEmptyVector[Int]].semigroup)
+  checkAll("NonEmptyAlternative[NonEmptyVector]", SerializableTests.serializable(NonEmptyAlternative[NonEmptyVector]))
 
   checkAll("NonEmptyVector[Int]", FoldableTests[NonEmptyVector].foldable[Int, Int])
   checkAll("Foldable[NonEmptyVector]", SerializableTests.serializable(Foldable[NonEmptyVector]))


### PR DESCRIPTION
Adds optimized specializations for the new `prependK`/`appendK` methods introduced in the initial PR (#4014).

Previous PR:
- add specializations for `NonEmptyAlternative` instances for Scala library collections #4052.

Subsequent PR:
- add specializations for Cats monad transformers.
