### PR TITLE
Add Semigroupal[Id] to implicit scope

### DIFF
--- a/core/src/main/scala/cats/Semigroupal.scala
+++ b/core/src/main/scala/cats/Semigroupal.scala
@@ -49,6 +49,7 @@ import scala.annotation.implicitNotFound
 }
 
 object Semigroupal extends ScalaVersionSpecificSemigroupalInstances with SemigroupalArityFunctions {
+  implicit def catsSemigroupalForId: Semigroupal[Id] = catsInstancesForId
   implicit def catsSemigroupalForOption: Semigroupal[Option] = cats.instances.option.catsStdInstancesForOption
   implicit def catsSemigroupalForTry: Semigroupal[Try] = cats.instances.try_.catsStdInstancesForTry
   implicit def catsSemigroupalForFuture(implicit ec: ExecutionContext): Semigroupal[Future] =

--- a/tests/src/test/scala/cats/tests/IdSuite.scala
+++ b/tests/src/test/scala/cats/tests/IdSuite.scala
@@ -1,9 +1,9 @@
 package cats.tests
 
-import cats.{Bimonad, CommutativeMonad, Id, Reducible, Traverse}
 import cats.laws.discipline._
 import cats.syntax.applicative._
 import cats.syntax.eq._
+import cats.{Bimonad, CommutativeMonad, Id, Reducible, Semigroupal, Traverse}
 import org.scalacheck.Prop._
 
 class IdSuite extends CatsSuite {
@@ -29,5 +29,10 @@ class IdSuite extends CatsSuite {
       assert(id === i.pure[Id])
       assert(id === i)
     }
+  }
+
+  def summonInstances(): Unit = {
+    Semigroupal[Id]
+    ()
   }
 }


### PR DESCRIPTION
I missed that in #3906

I think this is the only instance that is missing.
The rest is covered by `Invariant` and `UnorderedFoldable`.

