### PR TITLE
Reduce compilation warnings in `tests`

### DIFF
--- a/tests/src/test/scala-2.12/cats/tests/ScalaVersionSpecific.scala
+++ b/tests/src/test/scala-2.12/cats/tests/ScalaVersionSpecific.scala
@@ -1,10 +1,10 @@
 package cats.tests
 
+import cats.kernel.{Eq, Order}
 import cats.laws.discipline.{ExhaustiveCheck, MiniInt}
 import cats.laws.discipline.MiniInt._
 import cats.laws.discipline.eq._
 import cats.laws.discipline.DeprecatedEqInstances
-import cats.kernel.{Eq, Order}
 import org.scalacheck.Arbitrary
 
 trait ScalaVersionSpecificFoldableSuite
@@ -55,6 +55,7 @@ trait ScalaVersionSpecificAlgebraInvariantSuite {
   }
 
   // This version-specific instance is required since 2.12 and below do not have parseString on the Numeric class
+  @annotation.nowarn("cat=deprecation")
   implicit protected def eqFractional[A: Eq: Arbitrary]: Eq[Fractional[A]] = {
     import DeprecatedEqInstances.catsLawsEqForFn1
 

--- a/tests/src/test/scala-2.13+/cats/tests/FoldableLazyListSuite.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/FoldableLazyListSuite.scala
@@ -1,0 +1,5 @@
+package cats.tests
+
+class FoldableLazyListSuite extends FoldableSuite[LazyList]("lazyList") {
+  def iterator[T](list: LazyList[T]): Iterator[T] = list.iterator
+}

--- a/tests/src/test/scala-2.13+/cats/tests/ScalaVersionSpecific.scala
+++ b/tests/src/test/scala-2.13+/cats/tests/ScalaVersionSpecific.scala
@@ -1,19 +1,17 @@
 package cats.tests
 
-import cats.{Eval, Foldable, Id, Now}
+import cats._
 import cats.data.NonEmptyLazyList
-import cats.laws.discipline.{ExhaustiveCheck, MiniInt, NonEmptyParallelTests, ParallelTests}
-import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.DeprecatedEqInstances
-import cats.syntax.either._
-import cats.syntax.foldable._
-import cats.syntax.parallel._
-import cats.syntax.traverse._
-import cats.syntax.eq._
-import org.scalacheck.Prop._
-import cats.kernel.{Eq, Order}
+import cats.laws.discipline.ExhaustiveCheck
+import cats.laws.discipline.MiniInt
+import cats.laws.discipline.NonEmptyParallelTests
+import cats.laws.discipline.ParallelTests
+import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.eq._
+import cats.syntax.all._
 import org.scalacheck.Arbitrary
+import org.scalacheck.Prop._
 
 trait ScalaVersionSpecificFoldableSuite { self: FoldableSuiteAdditional =>
   test("Foldable[LazyList] monadic folds stack safety")(checkMonadicFoldsStackSafety(_.to(LazyList)))
@@ -57,7 +55,7 @@ trait ScalaVersionSpecificFoldableSuite { self: FoldableSuiteAdditional =>
   }
 
   test("Foldable[LazyList] laziness of foldM") {
-    assert(dangerous.foldM(0)((acc, a) => if (a < 2) Some(acc + a) else None) === None)
+    assert(dangerousLazyList.foldM(0)((acc, a) => if (a < 2) Some(acc + a) else None) === None)
   }
 
   def foldableLazyListWithDefaultImpl: Foldable[LazyList] =
@@ -220,6 +218,7 @@ trait ScalaVersionSpecificAlgebraInvariantSuite {
   }
 
   // This version-specific instance is required since 2.12 and below do not have parseString on the Numeric class
+  @annotation.nowarn("cat=deprecation")
   implicit protected def eqFractional[A: Eq: Arbitrary]: Eq[Fractional[A]] = {
     // This deprecated instance is required since there is not `ExhaustiveCheck` for any types for which a `Fractional`
     // can easily be defined

--- a/tests/src/test/scala/cats/tests/ChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/ChainSuite.scala
@@ -99,16 +99,18 @@ class ChainSuite extends CatsSuite {
   test("seq-like pattern match") {
     Chain(1, 2, 3) match {
       case Chain(a, b, c) => assert((a, b, c) === ((1, 2, 3)))
+      case other          => fail(other.show)
     }
 
     Chain(1, 2, 3) match {
       case h ==: t => assert((h, t) === 1 -> Chain(2, 3))
+      case other   => fail(other.show)
     }
 
     Chain(1, 2, 3) match {
       case init :== last => assert((init, last) === Chain(1, 2) -> 3)
+      case other         => fail(other.show)
     }
-
   }
 
   test("size is consistent with toList.size") {

--- a/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
+++ b/tests/src/test/scala/cats/tests/IndexedStateTSuite.scala
@@ -1,18 +1,18 @@
 package cats.tests
 
 import cats._
-import cats.arrow.{Profunctor, Strong}
-import cats.data.{EitherT, IndexedStateT, State, StateT}
-import cats.kernel.Eq
-import cats.laws.discipline._
+import cats.arrow.Profunctor
+import cats.arrow.Strong
+import cats.data.EitherT
+import cats.data.IndexedStateT
+import cats.data.State
+import cats.data.StateT
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
-import cats.laws.discipline.eq._
+import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.eq._
 import cats.platform.Platform
-import cats.syntax.apply._
-import cats.syntax.flatMap._
-import cats.syntax.traverse._
-import cats.syntax.eq._
+import cats.syntax.all._
 import org.scalacheck.Prop._
 import org.scalacheck.Test.Parameters
 
@@ -332,7 +332,7 @@ class IndexedStateTSuite extends CatsSuite {
     import cats.implicits.catsStdInstancesForOption
     forAll { (initial: Int) =>
       assert(StateT.fromState(state).run(initial).get === {
-        val (s, Some(result)) = state.run(initial).value
+        val (s, Some(result)) = state.run(initial).value: @unchecked // non-exhaustive match warning
         (s, result)
       })
     }

--- a/tests/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/src/test/scala/cats/tests/KleisliSuite.scala
@@ -358,7 +358,7 @@ class KleisliSuite extends CatsSuite {
     // see: https://github.com/typelevel/cats/issues/3947
     val resL = (1 to 10000).toList.traverse_(_ => Kleisli.liftF[Id, String, Unit](())).run("")
     val resV = (1 to 10000).toVector.traverse_(_ => Kleisli.liftF[Id, String, Unit](())).run("")
-    assert(resL == resV)
+    assert(resL === resV)
   }
 
   test("traverse_ doesn't stack overflow with List + Eval") {

--- a/tests/src/test/scala/cats/tests/RegressionSuite.scala
+++ b/tests/src/test/scala/cats/tests/RegressionSuite.scala
@@ -1,17 +1,14 @@
 package cats.tests
 
-import cats.{Apply, Monad, MonadError, StackSafeMonad, Traverse}
-import cats.data.{Const, NonEmptyList, StateT}
-import cats.kernel.Eq
+import cats._
+import cats.data.Const
+import cats.data.NonEmptyList
+import cats.data.StateT
 import cats.kernel.compat.scalaVersionSpecific._
-import cats.syntax.applicativeError._
-import cats.syntax.either._
-import cats.syntax.foldable._
-import cats.syntax.monadError._
-import cats.syntax.traverse._
-import scala.collection.mutable
+import cats.syntax.all._
+
 import scala.collection.immutable.SortedMap
-import cats.syntax.eq._
+import scala.collection.mutable
 
 @suppressUnusedImportWarningForScalaVersionSpecific
 class RegressionSuite extends CatsSuite with ScalaVersionSpecificRegressionSuite {
@@ -123,7 +120,11 @@ class RegressionSuite extends CatsSuite with ScalaVersionSpecificRegressionSuite
     // shouldn't have ever evaluated validate(8)
     checkAndResetCount(3)
 
-    assert(Stream(1, 2, 6, 8).traverse(validate) === (Either.left("6 is greater than 5")))
+    {
+      @annotation.nowarn("cat=deprecation")
+      val obtained = Stream(1, 2, 6, 8).traverse(validate).void
+      assert(obtained === Either.left("6 is greater than 5"))
+    }
     checkAndResetCount(3)
 
     type StringMap[A] = SortedMap[String, A]
@@ -143,7 +144,11 @@ class RegressionSuite extends CatsSuite with ScalaVersionSpecificRegressionSuite
     assert(List(1, 2, 6, 8).traverse_(validate) === (Either.left("6 is greater than 5")))
     checkAndResetCount(3)
 
-    assert(Stream(1, 2, 6, 8).traverse_(validate) === (Either.left("6 is greater than 5")))
+    {
+      @annotation.nowarn("cat=deprecation")
+      val obtained = Stream(1, 2, 6, 8).traverse_(validate)
+      assert(obtained === Either.left("6 is greater than 5"))
+    }
     checkAndResetCount(3)
 
     assert(Vector(1, 2, 6, 8).traverse_(validate) === (Either.left("6 is greater than 5")))

--- a/tests/src/test/scala/cats/tests/StreamSuite.scala
+++ b/tests/src/test/scala/cats/tests/StreamSuite.scala
@@ -1,24 +1,13 @@
 package cats.tests
 
-import cats.{Align, Alternative, CoflatMap, Monad, Semigroupal, Traverse, TraverseFilter}
+import cats._
 import cats.data.ZipStream
-import cats.laws.discipline.{
-  AlignTests,
-  AlternativeTests,
-  CoflatMapTests,
-  CommutativeApplyTests,
-  MonadTests,
-  SemigroupalTests,
-  SerializableTests,
-  ShortCircuitingTests,
-  TraverseFilterTests,
-  TraverseTests
-}
+import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
-import cats.syntax.show._
-import cats.syntax.eq._
+import cats.syntax.all._
 import org.scalacheck.Prop._
 
+@annotation.nowarn("cat=deprecation")
 class StreamSuite extends CatsSuite {
   checkAll("Stream[Int]", SemigroupalTests[Stream].semigroupal[Int, Int, Int])
   checkAll("Semigroupal[Stream]", SerializableTests.serializable(Semigroupal[Stream]))
@@ -69,14 +58,9 @@ class StreamSuite extends CatsSuite {
     }
   }
 
-}
-
-final class StreamInstancesSuite extends munit.FunSuite {
-
-  test("parallel instance in cats.instances.stream") {
-    import cats.instances.stream._
-    import cats.syntax.parallel._
-
-    (Stream(1, 2, 3), Stream("A", "B", "C")).parTupled
+  test("NonEmptyParallel instance in cats.instances.stream") {
+    forAll { (s1: Stream[Int], s2: Stream[String]) =>
+      assert((s1, s2).parTupled === s1.zip(s2))
+    }
   }
 }

--- a/tests/src/test/scala/cats/tests/TraverseFilterSuite.scala
+++ b/tests/src/test/scala/cats/tests/TraverseFilterSuite.scala
@@ -1,12 +1,10 @@
 package cats.tests
 
+import cats.Traverse
+import cats.TraverseFilter
 import cats.data.Chain
-import cats.instances.all._
 import cats.laws.discipline.arbitrary.catsLawsArbitraryForChain
-import cats.syntax.eq._
-import cats.syntax.foldable._
-import cats.syntax.traverseFilter._
-import cats.{Traverse, TraverseFilter}
+import cats.syntax.all._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Prop.forAll
 
@@ -40,4 +38,5 @@ class TraverseFilterChainSuite extends TraverseFilterSuite[Chain]("chain")
 
 class TraverseFilterQueueSuite extends TraverseFilterSuite[Queue]("queue")
 
+@annotation.nowarn("cat=deprecation")
 class TraverseFilterStreamSuite extends TraverseFilterSuite[Stream]("stream")

--- a/tests/src/test/scala/cats/tests/TraverseSuite.scala
+++ b/tests/src/test/scala/cats/tests/TraverseSuite.scala
@@ -1,12 +1,9 @@
 package cats.tests
 
-import cats.{Applicative, Eval, Traverse}
+import cats._
 import cats.kernel.compat.scalaVersionSpecific._
-import cats.syntax.foldable._
-import cats.syntax.functor._
-import cats.syntax.traverse._
+import cats.syntax.all._
 import org.scalacheck.Arbitrary
-import cats.syntax.eq._
 import org.scalacheck.Prop._
 
 @suppressUnusedImportWarningForScalaVersionSpecific
@@ -59,14 +56,21 @@ object TraverseSuite {
 }
 
 class TraverseListSuite extends TraverseSuite[List]("List")
-class TraverseStreamSuite extends TraverseSuite[Stream]("Stream")
 class TraverseVectorSuite extends TraverseSuite[Vector]("Vector")
 
+@annotation.nowarn("cat=deprecation")
+class TraverseStreamSuite extends TraverseSuite[Stream]("Stream")
+
 class TraverseListSuiteUnderlying extends TraverseSuite.Underlying[List]("List")
-class TraverseStreamSuiteUnderlying extends TraverseSuite.Underlying[Stream]("Stream")
 class TraverseVectorSuiteUnderlying extends TraverseSuite.Underlying[Vector]("Vector")
 
-class TraverseSuiteAdditional extends CatsSuite with ScalaVersionSpecificTraverseSuite {
+@annotation.nowarn("cat=deprecation")
+class TraverseStreamSuiteUnderlying extends TraverseSuite.Underlying[Stream]("Stream")
+
+class TraverseSuiteAdditional
+    extends CatsSuite
+    with ScalaVersionSpecificTraverseSuite
+    with TraverseSuiteAdditionalStreamSpecific {
 
   def checkZipWithIndexedStackSafety[F[_]](fromRange: Range => F[Int])(implicit F: Traverse[F]): Unit = {
     F.zipWithIndex(fromRange(1 to 70000))
@@ -77,11 +81,14 @@ class TraverseSuiteAdditional extends CatsSuite with ScalaVersionSpecificTravers
     checkZipWithIndexedStackSafety[List](_.toList)
   }
 
-  test("Traverse[Stream].zipWithIndex stack safety") {
-    checkZipWithIndexedStackSafety[Stream](_.toStream)
-  }
-
   test("Traverse[Vector].zipWithIndex stack safety") {
     checkZipWithIndexedStackSafety[Vector](_.toVector)
+  }
+}
+
+@annotation.nowarn("cat=deprecation")
+sealed trait TraverseSuiteAdditionalStreamSpecific { self: TraverseSuiteAdditional =>
+  test("Traverse[Stream].zipWithIndex stack safety") {
+    checkZipWithIndexedStackSafety[Stream](_.toStream)
   }
 }


### PR DESCRIPTION
This is an attempt to improve code hygiene a bit by reducing amount of warnings while compiling the `testsJVM`, `testsJS` and `testsNative` modules.

No tests are removed nor disabled, no other changes besides the `tests*` modules. But some tests were tossed over different suites or suite mixins.

Caveat: because `@nowarn` annotation is not supported in Scala 3.0.x, for this cross-build configuration most of the warnings will still remain. But things should get improved once the project upgrades to Scala 3.1.x.

Note: also in all changed files the "Organize Imports" (vs-code+metals) command was applied.