### PR TITLE
Return stack-safe `Function0` and `Function1` from `Semigroup#combine`

### DIFF
--- a/kernel/src/main/scala/cats/kernel/instances/FunctionInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/FunctionInstances.scala
@@ -1,8 +1,10 @@
 package cats.kernel
 package instances
 
+import cats.kernel.compat.scalaVersionSpecific._
 import scala.util.control.TailCalls.{done, tailcall, TailRec}
 
+@suppressUnusedImportWarningForScalaVersionSpecific
 trait FunctionInstances extends FunctionInstances0 {
 
   implicit def catsKernelOrderForFunction0[A](implicit ev: Order[A]): Order[() => A] =
@@ -128,6 +130,13 @@ trait Function1Semigroup[A, B] extends Semigroup[A => B] {
 
   override def combine(x: A => B, y: A => B): A => B =
     CombineFunction1(x, y, B)
+
+  override def combineAllOption(fns: IterableOnce[A => B]): Option[A => B] =
+    if (fns.iterator.isEmpty) None
+    else
+      Some { (a: A) =>
+        B.combineAllOption(fns.iterator.map(_.apply(a))).get
+      }
 }
 
 trait Function1Monoid[A, B] extends Function1Semigroup[A, B] with Monoid[A => B] {
@@ -164,6 +173,13 @@ trait Function0Semigroup[A] extends Semigroup[() => A] {
 
   override def combine(x: () => A, y: () => A): () => A =
     CombineFunction0(x, y, A)
+
+  override def combineAllOption(fns: IterableOnce[() => A]): Option[() => A] =
+    if (fns.iterator.isEmpty) None
+    else
+      Some { () =>
+        A.combineAllOption(fns.iterator.map(_.apply())).get
+      }
 }
 
 trait Function0Monoid[A] extends Function0Semigroup[A] with Monoid[() => A] {

--- a/kernel/src/main/scala/cats/kernel/instances/FunctionInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/FunctionInstances.scala
@@ -114,11 +114,11 @@ final private[instances] case class CombineFunction1[A, B](left: A => B, right: 
     extends (A => B) {
   private def call(fn: A => B, a: A): TailRec[B] =
     fn match {
-      case CombineFunction1(l, r, sg) =>
+      case ref: CombineFunction1[A, B] @unchecked =>
         for {
-          lb <- tailcall(call(l, a))
-          rb <- tailcall(call(r, a))
-        } yield sg.combine(lb, rb)
+          lb <- tailcall(call(ref.left, a))
+          rb <- tailcall(call(ref.right, a))
+        } yield ref.semiB.combine(lb, rb)
       case _ => done(fn(a))
     }
 
@@ -157,11 +157,11 @@ final private[instances] case class CombineFunction0[A](left: () => A, right: ()
     extends (() => A) {
   private def call(fn: () => A): TailRec[A] =
     fn match {
-      case CombineFunction0(l, r, sg) =>
+      case ref: CombineFunction0[A] @unchecked =>
         for {
-          la <- tailcall(call(l))
-          ra <- tailcall(call(r))
-        } yield sg.combine(la, ra)
+          la <- tailcall(call(ref.left))
+          ra <- tailcall(call(ref.right))
+        } yield ref.semiA.combine(la, ra)
       case _ => done(fn())
     }
 

--- a/tests/src/test/scala/cats/tests/FunctionSuite.scala
+++ b/tests/src/test/scala/cats/tests/FunctionSuite.scala
@@ -183,4 +183,18 @@ class FunctionSuite extends CatsSuite {
     val sumAll = bigList.combineAll(MonoidK[Endo].algebra)
     List(1, 1, 1).map(sumAll)
   }
+
+  property("Semigroup[Function0[Semi]] is stack safe on combine") {
+    forAll { (f: Function0[Semi]) =>
+      1.to(50000).foldLeft(f)((acc, _) => Semigroup[Function0[Semi]].combine(acc, f)).apply()
+      true
+    }
+  }
+
+  property("Semigroup[Function1[MiniInt, Semi]] is stack safe on combine") {
+    forAll { (i: MiniInt, f: Function1[MiniInt, Semi]) =>
+      1.to(50000).foldLeft(f)((acc, _) => Semigroup[Function1[MiniInt, Semi]].combine(acc, f)).apply(i)
+      true
+    }
+  }
 }


### PR DESCRIPTION
Fixes #4089.

This adds `CombineFunction0` and `CombineFunction1` classes as suggested by @johnynek in [this comment](https://github.com/typelevel/cats/issues/4089#issuecomment-998166820) to call and combine the results of two functions in a stack-safe way. Two things to note:

- This won't magically make any function passed to `Semigroup#combine` stack-safe, it just ensures that the combined function itself won't be the cause of a `StackOverflowError`
- I haven't added anything special to address the other idea of tracking call depth. If others feel this is important, I can look into doing so but may need some guidance
  > Lastly, you could track the depth of CombineFn when you are building it so you do the expensive apply when the depth gets greater than something like 500 or something, and do the naive thing when depth is < than that (something like AndThen's hack to use a constant amount of stack to do applications).