### PR TITLE
Update scalafmt-core to 3.3.0

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version=3.2.1
+version=3.3.0
 align.openParenCallSite = true
 align.openParenDefnSite = true
 maxColumn = 120

--- a/core/src/main/scala/cats/instances/try.scala
+++ b/core/src/main/scala/cats/instances/try.scala
@@ -75,9 +75,11 @@ trait TryInstances extends TryInstances1 {
         ta match { case Success(a) => Try(map(a)); case Failure(e) => Try(recover(e)) }
 
       override def redeemWith[A, B](ta: Try[A])(recover: Throwable => Try[B], bind: A => Try[B]): Try[B] =
-        try ta match {
-          case Success(a) => bind(a); case Failure(e) => recover(e)
-        } catch { case NonFatal(e) => Failure(e) }
+        try
+          ta match {
+            case Success(a) => bind(a); case Failure(e) => recover(e)
+          }
+        catch { case NonFatal(e) => Failure(e) }
 
       override def recover[A](ta: Try[A])(pf: PartialFunction[Throwable, A]): Try[A] =
         ta.recover(pf)


### PR DESCRIPTION
After #4097 has been closed, Scala Steward is not going to resume updating `scalafmt-core` until we restart it manually.
Therefore this PR restarts these updates.

Note: there's `scalafmt-core` v3.3.1 available already and I tried to jump to that version directly, but seems that the most recent version introduces even more weird formatting changes which need to be discussed separately.