### PR TITLE
Make Monoid SortedSet Lawful

### DIFF
--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -66,14 +66,17 @@ object KernelCheck {
   }
 
   // Copied from cats-laws.
-  implicit def arbitrarySortedSet[A: Arbitrary: Order]: Arbitrary[SortedSet[A]] = Arbitrary {
+  implicit def arbitrarySortedSet[A: Arbitrary: Order: Cogen]: Arbitrary[SortedSet[A]] = Arbitrary {
     // We create an arbitrary Ordering[A] which is either the same as Order[A]
     // or the reverse of it. This is important because the Ordering in use by
     // a given SortedSet[A] may not be derived from our Order and
     // scala.math.Ordering does not imply coherence.
     val ordering: Ordering[A] = Order[A].toOrdering
     val orderingGen: Gen[Ordering[A]] =
-      Gen.oneOf(ordering, ordering.reverse)
+      Gen.oneOf(Gen.const(ordering),
+                Gen.const(ordering.reverse),
+                Arbitrary.arbitrary[A => Long].map(f => Order.by(f).toOrdering)
+      )
     for {
       ordering <- orderingGen
       sortedSet <- arbitrary[Set[A]].map(s => SortedSet.empty[A](ordering) ++ s)

--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -66,7 +66,7 @@ object KernelCheck {
   }
 
   // Copied from cats-laws.
-  implicit def arbitrarySortedSet[A: Arbitrary: Order]: Arbitrary[SortedSet[A]] = Arbitrary{
+  implicit def arbitrarySortedSet[A: Arbitrary: Order]: Arbitrary[SortedSet[A]] = Arbitrary {
     // We create an arbitrary Ordering[A] which is either the same as Order[A]
     // or the reverse of it. This is important because the Ordering in use by
     // a given SortedSet[A] may not be derived from our Order and

--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -72,15 +72,10 @@ object KernelCheck {
     // a given SortedSet[A] may not be derived from our Order and
     // scala.math.Ordering does not imply coherence.
     val orderingGen: Gen[Ordering[A]] =
-      Arbitrary
-        .arbitrary[Boolean]
-        .map(invert =>
-          if (invert) {
-            Order[A].toOrdering.reverse
-          } else {
-            Order[A].toOrdering
-          }
-        )
+      Gen.oneOf(
+        Order[A].toOrdering,
+        Order[A].toOrdering.reverse
+      )
     Arbitrary(
       orderingGen.flatMap(ordering => arbitrary[Set[A]].map(s => SortedSet.empty[A](ordering) ++ s))
     )

--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -66,17 +66,14 @@ object KernelCheck {
   }
 
   // Copied from cats-laws.
-  implicit def arbitrarySortedSet[A: Arbitrary: Order: Cogen]: Arbitrary[SortedSet[A]] = Arbitrary {
+  implicit def arbitrarySortedSet[A: Arbitrary: Order]: Arbitrary[SortedSet[A]] = Arbitrary {
     // We create an arbitrary Ordering[A] which is either the same as Order[A]
     // or the reverse of it. This is important because the Ordering in use by
     // a given SortedSet[A] may not be derived from our Order and
     // scala.math.Ordering does not imply coherence.
     val ordering: Ordering[A] = Order[A].toOrdering
     val orderingGen: Gen[Ordering[A]] =
-      Gen.oneOf(Gen.const(ordering),
-                Gen.const(ordering.reverse),
-                Arbitrary.arbitrary[A => Long].map(f => Order.by(f).toOrdering)
-      )
+      Gen.oneOf(ordering, ordering.reverse)
     for {
       ordering <- orderingGen
       sortedSet <- arbitrary[Set[A]].map(s => SortedSet.empty[A](ordering) ++ s)

--- a/kernel/src/main/scala/cats/kernel/Order.scala
+++ b/kernel/src/main/scala/cats/kernel/Order.scala
@@ -239,7 +239,7 @@ final private[kernel] class OrderFromOrdering[A] private (val value: Ordering[A]
 
   override def equals(that: Any): Boolean =
     that match {
-      case that: OrderFromOrdering[A] =>
+      case that: OrderFromOrdering[A] @unchecked =>
         value == that.value
       case _ =>
         false
@@ -269,7 +269,7 @@ final private[kernel] class OrderingFromOrder[A] private (val value: Order[A]) e
 
   override def equals(that: Any): Boolean =
     that match {
-      case that: OrderingFromOrder[A] =>
+      case that: OrderingFromOrder[A] @unchecked =>
         value == that.value
       case _ =>
         false

--- a/kernel/src/main/scala/cats/kernel/Order.scala
+++ b/kernel/src/main/scala/cats/kernel/Order.scala
@@ -232,7 +232,7 @@ object Order extends OrderFunctions[Order] with OrderToOrderingConversion {
   * consistent with the given `Ordering` instance. This becomes important when
   * dealing with structures which rely on `Ordering`, e.g. `SortedSet`.
   */
-private[kernel] final class OrderFromOrdering[A] private (val value: Ordering[A]) extends Order[A] {
+final private[kernel] class OrderFromOrdering[A] private (val value: Ordering[A]) extends Order[A] {
   override def compare(x: A, y: A): Int = value.compare(x, y)
 
   override def toOrdering: Ordering[A] = value
@@ -253,7 +253,7 @@ private[kernel] object OrderFromOrdering {
   * consistent with the given `Ordering` instance. This becomes important when
   * dealing with structures which rely on `Ordering`, e.g. `SortedSet`.
   */
-private[kernel] final class OrderingFromOrder[A] private (val value: Order[A]) extends Ordering[A] {
+final private[kernel] class OrderingFromOrder[A] private (val value: Order[A]) extends Ordering[A] {
   override def compare(x: A, y: A): Int = value.compare(x, y)
 }
 

--- a/kernel/src/main/scala/cats/kernel/Order.scala
+++ b/kernel/src/main/scala/cats/kernel/Order.scala
@@ -236,6 +236,17 @@ final private[kernel] class OrderFromOrdering[A] private (val value: Ordering[A]
   override def compare(x: A, y: A): Int = value.compare(x, y)
 
   override def toOrdering: Ordering[A] = value
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case that: OrderFromOrdering[A] =>
+        value == that.value
+      case _ =>
+        false
+    }
+
+  override def hashCode: Int =
+    value.hashCode
 }
 
 private[kernel] object OrderFromOrdering {
@@ -255,6 +266,17 @@ private[kernel] object OrderFromOrdering {
   */
 final private[kernel] class OrderingFromOrder[A] private (val value: Order[A]) extends Ordering[A] {
   override def compare(x: A, y: A): Int = value.compare(x, y)
+
+  override def equals(that: Any): Boolean =
+    that match {
+      case that: OrderingFromOrder[A] =>
+        value == that.value
+      case _ =>
+        false
+    }
+
+  override def hashCode: Int =
+    value.hashCode
 }
 
 private[kernel] object OrderingFromOrder {

--- a/kernel/src/main/scala/cats/kernel/instances/SortedSetInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/SortedSetInstances.scala
@@ -33,7 +33,7 @@ class SortedSetOrder[A: Order] extends Order[SortedSet[A]] {
           StaticMethods.iteratorCompare(a1.iterator, a2.iterator)
         } else {
           val ordering: Ordering[A] = Order[A].toOrdering
-          StaticMethods.iteratorCompare(SortedSet.from(a1)(ordering).iterator, SortedSet.from(a2)(ordering).iterator)
+          StaticMethods.iteratorCompare(a1.toSeq.sorted(ordering).iterator, a2.toSeq.sorted(ordering).iterator)
         }
       case x => x
     }

--- a/kernel/src/main/scala/cats/kernel/instances/SortedSetInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/SortedSetInstances.scala
@@ -40,7 +40,7 @@ class SortedSetOrder[A: Order] extends Order[SortedSet[A]] {
 
   // Could be removed, but MiMa complains
   override def eqv(a1: SortedSet[A], a2: SortedSet[A]): Boolean =
-    compare(a1, a2) == 0
+    super.eqv(a1, a2)
 }
 
 // FIXME use context bound in 3.x

--- a/kernel/src/main/scala/cats/kernel/instances/SortedSetInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/SortedSetInstances.scala
@@ -37,6 +37,10 @@ class SortedSetOrder[A: Order] extends Order[SortedSet[A]] {
         }
       case x => x
     }
+
+  // Could be removed, but MiMa complains
+  override def eqv(a1: SortedSet[A], a2: SortedSet[A]): Boolean =
+    compare(a1, a2) == 0
 }
 
 // FIXME use context bound in 3.x

--- a/kernel/src/main/scala/cats/kernel/instances/SortedSetInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/SortedSetInstances.scala
@@ -27,7 +27,7 @@ class SortedSetOrder[A: Order] extends Order[SortedSet[A]] {
         // In the event that the ordering instances are not _exactly_ the
         // same, we have to sort/rebuild the sets. If we don't we risk
         // violating the Monoid identity law.
-        if (a1.ordering eq a2.ordering) {
+        if (a1.ordering == a2.ordering) {
           // Hopefully this is the branch we hit the vast majority of the
           // time.
           StaticMethods.iteratorCompare(a1.iterator, a2.iterator)


### PR DESCRIPTION
This makes `SortedSet[A]` lawful in terms of the identity law for Monoids. Previously it was not so if the two `SortedSet[A]` values were not using a logically equivalent `Ordering` instance, e.g. `Ordering[A].reverse`.

See: https://github.com/typelevel/cats/issues/4103

