### PR TITLE
OrderedSet/OrderedMap

### DIFF
--- a/core/src/main/scala/cats/data/OrderedSet.scala
+++ b/core/src/main/scala/cats/data/OrderedSet.scala
@@ -48,14 +48,8 @@ private[data] object OrderedSetImpl extends OrderedSetInstances with Newtype {
 @suppressUnusedImportWarningForScalaVersionSpecific
 final class OrderedSetOps[A](override val set: OrderedSet[A]) extends SetOpsForOrderedSets[OrderedSet, OrderedSet, A] {
 
-  def toSortedSet: SortedSet[A] =
+  override def toSortedSet: SortedSet[A] =
     OrderedSetImpl.unwrap(set)
-
-  def nonEmpty: Boolean =
-    toSortedSet.nonEmpty
-
-  def isEmpty: Boolean =
-    !nonEmpty
 
   def headOption: Option[A] =
     toSortedSet.headOption
@@ -101,29 +95,8 @@ final class OrderedSetOps[A](override val set: OrderedSet[A]) extends SetOpsForO
   override def union(xs: OrderedSet[A]): OrderedSet[A] =
     OrderedSetImpl.create(set.toSortedSet ++ xs.toSortedSet)
 
-  override def apply(a: A): Boolean =
-    toSortedSet(a)
-
   override def diff(xs: OrderedSet[A]): OrderedSet[A] =
     OrderedSetImpl.create(toSortedSet -- xs.toSortedSet)
-
-  override def length: Int =
-    toSortedSet.size
-
-  override def foldLeft[B](b: B)(f: (B, A) => B): B =
-    toSortedSet.foldLeft(b)(f)
-
-  override def foldRight[B](lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
-    Foldable.iterateRight(toSortedSet, lb)(f)
-
-  override def exists(f: A => Boolean): Boolean =
-    toSortedSet.exists(f)
-
-  override def forall(f: A => Boolean): Boolean =
-    toSortedSet.forall(f)
-
-  override def find(f: A => Boolean): Option[A] =
-    toSortedSet.find(f)
 
   override def filter(p: A => Boolean): OrderedSet[A] =
     OrderedSetImpl.create(toSortedSet.filter(p))

--- a/core/src/main/scala/cats/data/OrderedSet.scala
+++ b/core/src/main/scala/cats/data/OrderedSet.scala
@@ -1,0 +1,245 @@
+package cats
+package data
+
+import cats.kernel._
+import scala.annotation.tailrec
+import scala.collection.immutable.SortedSet
+
+/** A newtype over a `SortedSet` the construction of which is guaranteed to
+  * only use an [[Order]] instance, rather than `Ordering`. The intent here is
+  * that an `OrderedSet` will always use the coherent [[Order]] for a given
+  * type, implying for all `OrderedSet[A]` they will have the same
+  * ordering. If you bypass this restriction then your `OrderedSet` will be
+  * unlawful for many of the cats typeclasses.
+  *
+  * This differs from `SortedSet` in that any given instance of a `SortedSet`
+  * may be using any lawful, but not necessarily coherent, `Ordering`.
+  */
+private[data] object OrderedSetImpl extends OrderedSetInstances with Newtype {
+  private[data] def create[A](s: SortedSet[A]): Type[A] =
+    s.asInstanceOf[Type[A]]
+
+  private[data] def unwrap[A](s: Type[A]): SortedSet[A] =
+    s.asInstanceOf[SortedSet[A]]
+
+  def empty[A](implicit A: Order[A]): OrderedSet[A] =
+    create(SortedSet.empty(A.toOrdering))
+
+  def from[G[_], A](value: G[A])(implicit G: Foldable[G], A: Order[A]): OrderedSet[A] =
+    G.foldLeft(value, empty[A])(_.add(_))
+
+  def of[A: Order](x: A, xs: A*): OrderedSet[A] =
+    from(x +: xs)
+
+  def apply[A: Order](x: A, xs: A*): OrderedSet[A] =
+    from(x +: xs)
+
+  def one[A: Order](x: A): OrderedSet[A] =
+    of(x)
+
+  implicit def catsSetOpsForOrderedSet[A](value: OrderedSet[A]): OrderedSetOps[A] =
+    new OrderedSetOps[A](value)
+}
+
+final class OrderedSetOps[A](override val set: OrderedSet[A]) extends SetOpsForOrderedSets[OrderedSet, OrderedSet, A] {
+
+  def toSortedSet: SortedSet[A] =
+    OrderedSetImpl.unwrap(set)
+
+  def nonEmpty: Boolean =
+    toSortedSet.nonEmpty
+
+  def isEmpty: Boolean =
+    !nonEmpty
+
+  def headOption: Option[A] =
+    toSortedSet.headOption
+
+  def lastOption: Option[A] =
+    toSortedSet.lastOption
+
+  def max: Option[A] =
+    lastOption
+
+  def min: Option[A] =
+    headOption
+
+  def minBy[B: Order](f: A => B): Option[A] =
+    if (toSortedSet.isEmpty) {
+      None
+    } else {
+      implicit val ordering: Ordering[B] = Order[B].toOrdering
+      Some(toSortedSet.minBy(f))
+    }
+
+  def maxBy[B: Order](f: A => B): Option[A] =
+    if (toSortedSet.isEmpty) {
+      None
+    } else {
+      implicit val ordering: Ordering[B] = Order[B].toOrdering
+      Some(toSortedSet.maxBy(f))
+    }
+
+  override def show(implicit A: Show[A]): String =
+    toSortedSet.iterator.map(A.show).mkString("OrderedSet(", ", ", ")")
+
+  override def ===(that: OrderedSet[A])(implicit A: Eq[A]): Boolean =
+    Eq[Int].eqv(length, that.length) && cats.kernel.instances.StaticMethods
+      .iteratorEq(toSortedSet.iterator, that.toSortedSet.iterator)
+
+  override def add(x: A): OrderedSet[A] =
+    OrderedSetImpl.create(toSortedSet + x)
+
+  override def remove(x: A): OrderedSet[A] =
+    OrderedSetImpl.create(toSortedSet - x)
+
+  override def union(xs: OrderedSet[A]): OrderedSet[A] =
+    OrderedSetImpl.create(set.toSortedSet ++ xs.toSortedSet)
+
+  override def apply(a: A): Boolean =
+    toSortedSet(a)
+
+  override def diff(xs: OrderedSet[A]): OrderedSet[A] =
+    OrderedSetImpl.create(toSortedSet -- xs.toSortedSet)
+
+  override def length: Int =
+    toSortedSet.size
+
+  override def foldLeft[B](b: B)(f: (B, A) => B): B =
+    toSortedSet.foldLeft(b)(f)
+
+  override def foldRight[B](lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
+    Foldable.iterateRight(toSortedSet, lb)(f)
+
+  override def exists(f: A => Boolean): Boolean =
+    toSortedSet.exists(f)
+
+  override def forall(f: A => Boolean): Boolean =
+    toSortedSet.forall(f)
+
+  override def find(f: A => Boolean): Option[A] =
+    toSortedSet.find(f)
+
+  override def filter(p: A => Boolean): OrderedSet[A] =
+    OrderedSetImpl.create(toSortedSet.filter(p))
+
+  override def intersect(xs: OrderedSet[A]): OrderedSet[A] =
+    OrderedSetImpl.create(toSortedSet.filter(xs.contains))
+
+  override def map[B](f: A => B)(implicit B: Order[B]): OrderedSet[B] =
+    OrderedSetImpl.create(toSortedSet.map(f)(B.toOrdering))
+
+  override def concatMap[B](f: A => OrderedSet[B])(implicit B: Order[B]): OrderedSet[B] =
+    OrderedSetImpl.create(toSortedSet.flatMap(a => f(a).toSortedSet)(B.toOrdering))
+
+  override def collect[B](pf: PartialFunction[A, B])(implicit B: Order[B]): OrderedSet[B] =
+    foldLeft(OrderedSet.empty[B]) { case (acc, value) =>
+      pf.lift(value).fold(acc)(value => acc.add(value))
+    }
+
+  override def zipWith[B, C](b: OrderedSet[B])(f: (A, B) => C)(implicit C: Order[C]): OrderedSet[C] = {
+    implicit val ordering: Ordering[C] = C.toOrdering
+    OrderedSetImpl.create(toSortedSet.lazyZip(b.toSortedSet).map(f))
+  }
+
+  override def zipWithIndex(implicit A: Order[A]): OrderedSet[(A, Int)] = {
+    implicit val ordering: Ordering[A] = A.toOrdering
+    OrderedSetImpl.create(cats.compat.SortedSet.zipWithIndex(toSortedSet))
+  }
+}
+
+sealed abstract private[data] class OrderedSetInstances {
+
+  implicit val catsStdInstancesForOrderedSet: Foldable[OrderedSet] with SemigroupK[OrderedSet] =
+    new Foldable[OrderedSet] with SemigroupK[OrderedSet] {
+
+      def combineK[A](x: OrderedSet[A], y: OrderedSet[A]): OrderedSet[A] = x | y
+
+      def foldLeft[A, B](fa: OrderedSet[A], b: B)(f: (B, A) => B): B =
+        fa.foldLeft(b)(f)
+
+      def foldRight[A, B](fa: OrderedSet[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
+        Foldable.iterateRight(fa.toSortedSet, lb)(f)
+
+      override def foldMap[A, B](fa: OrderedSet[A])(f: A => B)(implicit B: Monoid[B]): B =
+        B.combineAll(fa.toSortedSet.iterator.map(f))
+
+      override def get[A](fa: OrderedSet[A])(idx: Long): Option[A] = {
+        @tailrec
+        def go(idx: Int, it: Iterator[A]): Option[A] =
+          if (it.hasNext) {
+            if (idx == 0) Some(it.next())
+            else {
+              it.next()
+              go(idx - 1, it)
+            }
+          } else None
+        if (idx < Int.MaxValue && idx >= 0L) go(idx.toInt, fa.toSortedSet.iterator) else None
+      }
+
+      override def size[A](fa: OrderedSet[A]): Long = fa.length.toLong
+
+      override def exists[A](fa: OrderedSet[A])(p: A => Boolean): Boolean =
+        fa.exists(p)
+
+      override def forall[A](fa: OrderedSet[A])(p: A => Boolean): Boolean =
+        fa.forall(p)
+
+      override def isEmpty[A](fa: OrderedSet[A]): Boolean = fa.isEmpty
+
+      override def fold[A](fa: OrderedSet[A])(implicit A: Monoid[A]): A = A.combineAll(fa.toSortedSet)
+
+      override def toList[A](fa: OrderedSet[A]): List[A] = fa.toSortedSet.toList
+
+      override def toIterable[A](fa: OrderedSet[A]): Iterable[A] = fa.toSortedSet
+
+      override def reduceLeftOption[A](fa: OrderedSet[A])(f: (A, A) => A): Option[A] =
+        fa.toSortedSet.reduceLeftOption(f)
+
+      override def find[A](fa: OrderedSet[A])(f: A => Boolean): Option[A] = fa.toSortedSet.find(f)
+
+      override def collectFirst[A, B](fa: OrderedSet[A])(pf: PartialFunction[A, B]): Option[B] =
+        fa.toSortedSet.collectFirst(pf)
+
+      override def collectFirstSome[A, B](fa: OrderedSet[A])(f: A => Option[B]): Option[B] =
+        collectFirst(fa)(Function.unlift(f))
+    }
+
+  implicit def catsStdShowForOrderedSet[A: Show]: Show[OrderedSet[A]] =
+    Show.show(_.show)
+
+  implicit def catsStdHashAndOrderForOrderedSet[A: Order]: Hash[OrderedSet[A]] with Order[OrderedSet[A]] =
+    new Hash[OrderedSet[A]] with Order[OrderedSet[A]] {
+      override def hash(x: OrderedSet[A]): Int =
+        x.hashCode
+
+      override def compare(x: OrderedSet[A], y: OrderedSet[A]): Int =
+        Order[Int].compare(x.length, y.length) match {
+          case 0 =>
+            cats.kernel.instances.StaticMethods.iteratorCompare(
+              x.toSortedSet.iterator,
+              y.toSortedSet.iterator
+            )
+          case otherwise =>
+            otherwise
+        }
+    }
+
+  implicit def catsStdBoundedSemilatticeForOrderedSet[A: Order]: BoundedSemilattice[OrderedSet[A]] =
+    new BoundedSemilattice[OrderedSet[A]] {
+      override def empty: OrderedSet[A] = OrderedSet.empty[A]
+      override def combine(x: OrderedSet[A], y: OrderedSet[A]): OrderedSet[A] = x | y
+    }
+
+  implicit val catsStdSemigroupalForOrderedSet: Semigroupal[OrderedSet] = new Semigroupal[OrderedSet] {
+    override def product[A, B](fa: OrderedSet[A], fb: OrderedSet[B]): OrderedSet[(A, B)] = {
+      val fa2: SortedSet[A] = fa.toSortedSet
+      val fb2: SortedSet[B] = fb.toSortedSet
+      implicit val orderingA: Ordering[A] = fa.toSortedSet.ordering
+      implicit val orderingB: Ordering[B] = fb.toSortedSet.ordering
+      implicit val orderAB: Order[(A, B)] = Order.fromOrdering(Ordering[(A, B)])
+
+      OrderedSetImpl.create(fa2.flatMap(a => fb2.map(b => a -> b)))
+    }
+  }
+}

--- a/core/src/main/scala/cats/data/SetOps.scala
+++ b/core/src/main/scala/cats/data/SetOps.scala
@@ -1,0 +1,88 @@
+package cats
+package data
+
+/** A set of ops methods which should be implemented for all set like
+  * structures, both the normal and non-empty variants.
+  *
+  * The purpose of this trait is merely to help ensure consistent
+  * implementation between the different concrete types.
+  *
+  * @tparam F This is the input type we are operating on. It is the result
+  *           type for operations which can never yield an empty set.
+  * @tparam G This is the the result type for operations which ''may'' yield
+  *           an empty set.
+  *
+  * The use of the types `F` and `G` allow us to share this trait between set
+  * types which may be have an empty state, and those which many not,
+  * e.g. `OrderedSet` and `NonEmptySet`.
+  */
+private[data] trait SetOps[F[_], G[_], A] {
+
+  // Abstract
+
+  def set: F[A]
+
+  def add(a: A): F[A]
+
+  def remove(a: A): G[A]
+
+  def apply(a: A): Boolean
+
+  def diff(as: F[A]): G[A]
+
+  def union(as: F[A]): F[A]
+
+  def length: Int
+
+  def foldLeft[B](b: B)(f: (B, A) => B): B
+
+  def foldRight[B](lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B]
+
+  def exists(f: A => Boolean): Boolean
+
+  def forall(f: A => Boolean): Boolean
+
+  def show(implicit A: Show[A]): String
+
+  def ===(that: F[A])(implicit A: Eq[A]): Boolean
+
+  def find(f: A => Boolean): Option[A]
+
+  def intersect(as: F[A]): G[A]
+
+  def filter(p: A => Boolean): G[A]
+
+  // NonAbstract
+
+  def +(a: A): F[A] = add(a)
+
+  def -(a: A): G[A] = remove(a)
+
+  def contains(a: A): Boolean = apply(a)
+
+  def ++(as: F[A]): F[A] = union(as)
+
+  def |(as: F[A]): F[A] = union(as)
+
+  def --(as: F[A]): G[A] = diff(as)
+
+  def &~(as: F[A]): G[A] = diff(as)
+
+  def filterNot(p: A => Boolean): G[A] = filter(t => !p(t))
+}
+
+/** As `SetOps`, but adds methods which require an [[Order]] constraint if the
+  * underlying set like structure is ordered.
+  */
+private[data] trait SetOpsForOrderedSets[F[_], G[_], A] extends SetOps[F, G, A] {
+
+  def map[B](f: A => B)(implicit B: Order[B]): F[B]
+
+  def concatMap[B](f: A => F[B])(implicit B: Order[B]): F[B]
+
+  def zipWith[B, C](b: F[B])(f: (A, B) => C)(implicit C: Order[C]): F[C]
+
+  def zipWithIndex(implicit A: Order[A]): F[(A, Int)]
+
+  def collect[B](pf: PartialFunction[A, B])(implicit B: Order[B]): G[B]
+}

--- a/core/src/main/scala/cats/data/package.scala
+++ b/core/src/main/scala/cats/data/package.scala
@@ -17,6 +17,9 @@ package object data extends ScalaVersionSpecificPackage {
   type NonEmptySet[A] = NonEmptySetImpl.Type[A]
   val NonEmptySet = NonEmptySetImpl
 
+  type OrderedSet[A] = OrderedSetImpl.Type[A]
+  val OrderedSet = OrderedSetImpl
+
   type NonEmptyChain[+A] = NonEmptyChainImpl.Type[A]
   val NonEmptyChain = NonEmptyChainImpl
 

--- a/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
@@ -70,6 +70,12 @@ object arbitrary extends ArbitraryInstances0 with ScalaVersionSpecific.Arbitrary
   implicit def catsLawsCogenForNonEmptySet[A: Order: Cogen]: Cogen[NonEmptySet[A]] =
     Cogen[SortedSet[A]].contramap(_.toSortedSet)
 
+  implicit def catsLawsArbitraryForOrderedSet[A](implicit A: Arbitrary[A], B: Order[A]): Arbitrary[OrderedSet[A]] =
+    Arbitrary(Arbitrary.arbitrary[List[A]].map(OrderedSet.from[List, A]))
+
+  implicit def catsLawsCogenForOrderedSet[A: Order: Cogen]: Cogen[OrderedSet[A]] =
+    Cogen[Seq[A]].contramap(_.toSortedSet.toSeq)
+
   implicit def catsLawsArbitraryForZipSeq[A](implicit A: Arbitrary[A]): Arbitrary[ZipSeq[A]] =
     Arbitrary(implicitly[Arbitrary[Seq[A]]].arbitrary.map(v => new ZipSeq(v)))
 

--- a/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
@@ -74,7 +74,7 @@ object arbitrary extends ArbitraryInstances0 with ScalaVersionSpecific.Arbitrary
     Arbitrary(Arbitrary.arbitrary[List[A]].map(OrderedSet.from[List, A]))
 
   implicit def catsLawsCogenForOrderedSet[A: Order: Cogen]: Cogen[OrderedSet[A]] =
-    Cogen[Seq[A]].contramap(_.toSortedSet.toSeq)
+    Cogen[List[A]].contramap(_.toSortedSet.toList)
 
   implicit def catsLawsArbitraryForZipSeq[A](implicit A: Arbitrary[A]): Arbitrary[ZipSeq[A]] =
     Arbitrary(implicitly[Arbitrary[Seq[A]]].arbitrary.map(v => new ZipSeq(v)))

--- a/tests/src/test/scala/cats/tests/OrderedSetSuite.scala
+++ b/tests/src/test/scala/cats/tests/OrderedSetSuite.scala
@@ -1,0 +1,83 @@
+package cats.tests
+
+import cats.{SemigroupK, Semigroupal, Show}
+import cats.kernel.{Order, PartialOrder}
+import cats.kernel.laws.discipline.{BoundedSemilatticeTests, HashTests, OrderTests, PartialOrderTests}
+import cats.kernel.{BoundedSemilattice, Semilattice}
+import cats.laws._
+import cats.laws.discipline.SemigroupalTests.Isomorphisms
+import cats.laws.discipline.arbitrary._
+import cats.laws.discipline.{FoldableTests, SemigroupKTests, SemigroupalTests, SerializableTests, ShortCircuitingTests}
+import cats.syntax.show._
+import cats.data.OrderedSet
+import cats.syntax.eq._
+
+class OrderedSetSuite extends CatsSuite {
+  implicit val iso: Isomorphisms[OrderedSet] = OrderedSetIsomorphism
+
+  checkAll("OrderedSet[Int]", SemigroupKTests[OrderedSet].semigroupK[Int])
+  checkAll("OrderedSet[Int]", SemigroupalTests[OrderedSet].semigroupal[Int, Int, Int])
+  checkAll("SemigroupK[OrderedSet]", SerializableTests.serializable(SemigroupK[OrderedSet]))
+  checkAll("Semigroupal[OrderedSet]", SerializableTests.serializable(Semigroupal[OrderedSet]))
+
+  checkAll("OrderedSet[Int]", FoldableTests[OrderedSet].foldable[Int, Int])
+  checkAll("Order[OrderedSet[Int]]", OrderTests[OrderedSet[Int]].order)
+  checkAll("Order.reverse(Order[OrderedSet[Int]])", OrderTests(Order.reverse(Order[OrderedSet[Int]])).order)
+  checkAll("PartialOrder[OrderedSet[Int]]", PartialOrderTests[OrderedSet[Int]].partialOrder)
+  checkAll("PartialOrder.reverse(PartialOrder[OrderedSet[Int]])",
+           PartialOrderTests(PartialOrder.reverse(PartialOrder[OrderedSet[Int]])).partialOrder
+  )
+  checkAll(
+    "PartialOrder.reverse(PartialOrder.reverse(PartialOrder[OrderedSet[Int]]))",
+    PartialOrderTests(PartialOrder.reverse(PartialOrder.reverse(PartialOrder[OrderedSet[Int]]))).partialOrder
+  )
+
+  checkAll("BoundedSemilattice[OrderedSet[String]]", BoundedSemilatticeTests[OrderedSet[String]].boundedSemilattice)
+  checkAll("BoundedSemilattice[OrderedSet[String]]",
+           SerializableTests.serializable(BoundedSemilattice[OrderedSet[String]])
+  )
+
+  checkAll("Semilattice.asMeetPartialOrder[OrderedSet[Int]]",
+           PartialOrderTests(Semilattice.asMeetPartialOrder[OrderedSet[Int]]).partialOrder
+  )
+  checkAll("Semilattice.asJoinPartialOrder[OrderedSet[Int]]",
+           PartialOrderTests(Semilattice.asJoinPartialOrder[OrderedSet[Int]]).partialOrder
+  )
+  checkAll("Hash[OrderedSet[Int]]", HashTests[OrderedSet[Int]].hash)
+
+  checkAll("OrderedSet[Int]", ShortCircuitingTests[OrderedSet].foldable[Int])
+
+  test("show keeps separate entries for items that map to identical strings") {
+    // note: this val name has to be the same to shadow the cats.instances instance
+    implicit val catsStdShowForInt: Show[Int] = Show.show(_ => "1")
+    // an implementation implemented as set.map(_.show).mkString(", ") would
+    // only show one entry in the result instead of 3, because OrderedSet.map combines
+    // duplicate items in the codomain.
+    assert(OrderedSet.of(1, 2, 3).show === "OrderedSet(1, 1, 1)")
+  }
+}
+
+object OrderedSetIsomorphism extends Isomorphisms[OrderedSet] {
+
+  override def associativity[A, B, C](
+    fs: (OrderedSet[(A, (B, C))], OrderedSet[((A, B), C)])
+  ): IsEq[OrderedSet[(A, B, C)]] = {
+    implicit val ordering: Ordering[(A, (B, C))] =
+      fs._1.toSortedSet.ordering
+    implicit val order: Order[(A, B, C)] =
+      Order.fromOrdering(Ordering.by[(A, B, C), (A, (B, C))] { case (a, b, c) => (a, (b, c)) })
+
+    fs._1.map { case (a, (b, c)) => (a, b, c) } <->
+      fs._2.map { case ((a, b), c) => (a, b, c) }
+  }
+
+  override def leftIdentity[A](fs: (OrderedSet[(Unit, A)], OrderedSet[A])): IsEq[OrderedSet[A]] = {
+    implicit val order: Order[A] = Order.fromOrdering(fs._2.toSortedSet.ordering)
+    fs._1.map(_._2) <-> fs._2
+  }
+
+  override def rightIdentity[A](fs: (OrderedSet[(A, Unit)], OrderedSet[A])): IsEq[OrderedSet[A]] = {
+    implicit val order: Order[A] = Order.fromOrdering(fs._2.toSortedSet.ordering)
+    fs._1.map(_._1) <-> fs._2
+  }
+}


### PR DESCRIPTION
`OrderedSet` is an newtype over `SortedSet`, but it enforces that all construction use an `Order`. The intent here is to guarantee that we are working with the coherent `Order` instance for some type `A`, allowing us to trivially construct lawful instances for `OrderedSet` which become non-trivial for `SortedSet` where we might be dealing with a non-coherent `Ordering`.

This is a proposed alternative to #4104. By taking this route, we just assume that any instance of `OrderedSet` is using the coherent `Order`, and for such instances all the typeclass implementations are trivial and lawful.

If this approach is generally accepted, I intend to make the following changes.

- [ ] Add an similar `OrderedMap` newtype
- [ ] Rewrite `NonEmptySet` in terms of `OrderedSet`. This should be doable in a binary compatible manner, as our newtypes _are_ actually `SortedSet` values.
- [ ] Rewrite `NonEmptyMap` in terms of `OrderedMap` and `OrdredSet`.
- [ ] Add all the missing ScalaDoc.

We also might consider,

* Deprecating the `SortedSet` instances.
* Moving the `SortedSet` instances to alleycats?
