### PR TITLE
Remove unused type parameter in Choice typeclass doc

### DIFF
--- a/docs/src/main/mdoc/typeclasses/arrowchoice.md
+++ b/docs/src/main/mdoc/typeclasses/arrowchoice.md
@@ -19,7 +19,7 @@ This is exactly typeclass `Choice` provided, if we make `=>` more generic such a
 
 ```scala
 trait Choice[F[_, _]] {
-  def choice[A,B,C,D](fac: F[A, C], fbc: F[B, C]): F[Either[A, B], C]
+  def choice[A, B, C](fac: F[A, C], fbc: F[B, C]): F[Either[A, B], C]
 }
 ```
 


### PR DESCRIPTION
The `choice` function in the `Choice` typeclass documentation has an unused/unnecessary type parameter `D`.