### PR TITLE
Add F[Boolean] syntax

### DIFF
--- a/core/src/main/scala/cats/syntax/functor.scala
+++ b/core/src/main/scala/cats/syntax/functor.scala
@@ -4,6 +4,9 @@ package syntax
 trait FunctorSyntax extends Functor.ToFunctorOps {
   implicit final def catsSyntaxFunctorTuple2Ops[F[_], A, B](fab: F[(A, B)]): FunctorTuple2Ops[F, A, B] =
     new FunctorTuple2Ops[F, A, B](fab)
+
+  implicit final def catsSyntaxFunctorBooleanOps[F[_]](fa: F[Boolean]): FunctorBooleanOps[F] =
+    new FunctorBooleanOps[F](fa)
 }
 
 final class FunctorTuple2Ops[F[_], A, B](private val fab: F[(A, B)]) extends AnyVal {
@@ -61,4 +64,13 @@ final class FunctorTuple2Ops[F[_], A, B](private val fab: F[(A, B)]) extends Any
    * }}}
    */
   def unzip(implicit F: Functor[F]): (F[A], F[B]) = F.unzip(fab)
+}
+
+final class FunctorBooleanOps[F[_]](private val fa: F[Boolean]) extends AnyVal {
+
+  /**
+   * Transforms this `F[Boolean]` by negating the `Boolean`
+   */
+  def not(implicit F: Functor[F]): F[Boolean] =
+    F.map(fa)(b => !b)
 }

--- a/core/src/main/scala/cats/syntax/monad.scala
+++ b/core/src/main/scala/cats/syntax/monad.scala
@@ -2,10 +2,14 @@ package cats
 package syntax
 
 trait MonadSyntax {
-  implicit final def catsSyntaxMonad[F[_], A](fa: F[A]): MonadOps[F, A] = new MonadOps(fa)
+  implicit final def catsSyntaxMonad[F[_], A](fa: F[A]): MonadOps[F, A] =
+    new MonadOps(fa)
 
   implicit final def catsSyntaxMonadIdOps[A](a: A): MonadIdOps[A] =
     new MonadIdOps[A](a)
+
+  implicit final def catsSyntaxMonadBooleanOps[F[_]](fa: F[Boolean]): MonadBooleanOps[F] =
+    new MonadBooleanOps[F](fa)
 }
 
 final class MonadIdOps[A](private val a: A) extends AnyVal {
@@ -19,4 +23,29 @@ final class MonadIdOps[A](private val a: A) extends AnyVal {
    * Iterative application of `f` until `p` holds.
    */
   def iterateUntilM[F[_]](f: A => F[A])(p: A => Boolean)(implicit M: Monad[F]): F[A] = M.iterateUntilM(a)(f)(p)
+}
+
+final class MonadBooleanOps[F[_]](private val fa: F[Boolean]) extends AnyVal {
+
+  /**
+   * Behaves like `&&` but inside the `F` context.
+   *
+   * Wont evaluate `other` unless this evaluates to `true`
+   */
+  def andM(other: => F[Boolean])(implicit F: Monad[F]): F[Boolean] =
+    F.flatMap(fa) {
+      case true  => other
+      case false => F.pure(false)
+    }
+
+  /**
+   * Behaves like `||` but inside the `F` context.
+   *
+   * Wont evaluate `other` unless this evaluates to `false`
+   */
+  def orM(other: => F[Boolean])(implicit F: Monad[F]): F[Boolean] =
+    F.flatMap(fa) {
+      case true  => F.pure(false)
+      case false => other
+    }
 }


### PR DESCRIPTION
I know that, in general, we prefer to avoid `F[Boolean]` but sometimes we have those values and I personally think this syntax can be very useful.

Let me know what you think about this change and the **Scaladoc** _(I couldn't come up with something better)_.
Also, for testing this change I could only think on a simple truth table but I am not sure if that is a good test.

