### PR TITLE
Add A Law For Eq Which Ensures Consistency With Universal Equality

### DIFF
--- a/kernel-laws/shared/src/main/scala/cats/kernel/laws/EqLaws.scala
+++ b/kernel-laws/shared/src/main/scala/cats/kernel/laws/EqLaws.scala
@@ -18,6 +18,8 @@ trait EqLaws[A] {
   def transitivityEq(x: A, y: A, z: A): IsEq[Boolean] =
     (!(E.eqv(x, y) && E.eqv(y, z)) || E.eqv(x, z)) <-> true
 
+  def sameAsUniversalEquals(x: A, y: A): IsEq[Boolean] =
+    (E.eqv(x, y)) <-> (x == y)
 }
 
 object EqLaws {


### PR DESCRIPTION
This commit adds a law `sameAsUniversalEquals` which ensures that the result of `Eq.eqv` is the same for `==` for any type which implements `Eq`. This similar to the `Hash` law `sameAsUniversalHash`.

I can't think of any instance where we wouldn't want to ensure this behavior for a lawful `Eq` instance. A good sign is that all the cats tests pass without any changes here.

My motivation for this change is I ran into a lawful `Eq` instance for a type in the wild recently, which did not agree with `==`. This was a bug, but wasn't caught by the law tests for the type.


