### PR TITLE
Add `INothing` and `Pure` types

### DIFF
--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -81,7 +81,10 @@ package object cats {
    *
    * {{{
    * scala> type Alg[F[_], A] = Either[F[A], A]
+   * scala> def extract[A](p: Alg[Pure, A]): A = p.merge
    * scala> val pureAlg: Alg[Pure, Int] = Right(3)
+   * scala> extract(pureAlg)
+   * res0: Int = 3
    * scala> val optAlg: Alg[Option, Int] = pureAlg
    * scala> val listAlg: Alg[List, Int] = pureAlg
    * }}}

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -180,11 +180,3 @@ package object cats {
     def apply[F[_]](implicit ev: MonadThrow[F]): MonadThrow[F] = ev
   }
 }
-
-object Test {
-  type PureOrF[F[_], A] = Either[F[A], A]
-
-  val v: PureOrF[Pure, Int] = Right(10)
-  val v1: PureOrF[List, Int] = v
-
-}

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -1,5 +1,3 @@
-import cats.Pure
-
 import scala.annotation.tailrec
 
 /**

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -68,6 +68,16 @@ package object cats {
     def apply[A](a: A): Id[A] = a
   }
 
+  /**
+   * Like `Nothing` but works better with type inference.
+   */
+  type INothing <: Nothing
+
+  /**
+   * Like `INothing` but as a type constructor.
+   */
+  type Pure[A] <: Nothing
+
   type Endo[A] = A => A
 
   val catsInstancesForId: Bimonad[Id] with CommutativeMonad[Id] with NonEmptyTraverse[Id] with Distributive[Id] =

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -1,3 +1,5 @@
+import cats.Pure
+
 import scala.annotation.tailrec
 
 /**
@@ -74,7 +76,17 @@ package object cats {
   type INothing <: Nothing
 
   /**
-   * Like `INothing` but as a type constructor.
+   * Like `INothing` but as a type constructor. When used as a parameter to a coproduct type
+   * with effectful and non-effectful cases (such as [[https://github.com/typelevel/fs2 fs2 Stream]],
+   * where it originates), prevents the effectful cases from being inhabited and allows covariance up to
+   * arbitrary effect types.
+   *
+   * {{{
+   * scala> type Alg[F[_], A] = Either[F[A], A]
+   * scala> val pureAlg: Alg[Pure, Int] = Right(3)
+   * scala> val optAlg: Alg[Option, Int] = pureAlg
+   * scala> val listAlg: Alg[List, Int] = pureAlg
+   * }}}
    */
   type Pure[A] <: Nothing
 
@@ -167,4 +179,12 @@ package object cats {
   object MonadThrow {
     def apply[F[_]](implicit ev: MonadThrow[F]): MonadThrow[F] = ev
   }
+}
+
+object Test {
+  type PureOrF[F[_], A] = Either[F[A], A]
+
+  val v: PureOrF[Pure, Int] = Right(10)
+  val v1: PureOrF[List, Int] = v
+
 }


### PR DESCRIPTION
Prompted by discussion on https://github.com/http4s/http4s/pull/5712#discussion_r841249712. Because these types are defined as inequalities, separate identical definitions of them aren't unified by the compiler - therefore, http4s needs to refer to fs2's definitions of them in order to interoperate with fs2, even though they're not intrinsically specific to fs2. Moving the definition up to cats would avoid this.