### PR TITLE
Add Chain#knownSize and Chain#lengthCompare (sizeCompare) methods

### DIFF
--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -586,6 +586,51 @@ sealed abstract class Chain[+A] {
     }
 
   /**
+   * Compares the length of this chain to a test value.
+   * 
+   * The method does not call `length` directly; its running time
+   * is `O(length min len)` instead of `O(length)`.
+   * 
+   * @param  len the test value that gets compared with the length.
+   * @return a negative value if `this.length < len`,
+   *         zero if `this.length == len` or
+   *         a positive value if `this.length > len`.
+   * @note   This is an adapted version of
+             [[https://github.com/scala/scala/blob/v2.13.8/src/library/scala/collection/Iterable.scala#L272-L288 Iterable#sizeCompare]]
+             from Scala Library v2.13.8
+   * 
+   * {{{
+   * scala> import cats.data.Chain
+   * scala> val chain = Chain(1, 2, 3)
+   * scala> val isLessThan4 = chain.lengthCompare(4) < 0
+   * scala> val isEqualTo3 = chain.lengthCompare(3) == 0
+   * scala> val isGreaterThan2 = chain.lengthCompare(2) > 0
+   * scala> isLessThan4 && isEqualTo3 && isGreaterThan2
+   * res0: Boolean = true
+   * }}}
+   */
+  final def lengthCompare(len: Long): Int =
+    if (len < 0) 1
+    else {
+      var sz = knownSize
+      if (sz < 0) {
+        sz = 0L
+        val it = iterator
+        while (it.hasNext) {
+          if (sz == len) return 1
+          it.next()
+          sz += 1L
+        }
+      }
+      sz.compareTo(len)
+    }
+
+  /**
+   * Alias for lengthCompare
+   */
+  final def sizeCompare(size: Long): Int = lengthCompare(size)
+
+  /**
    * Converts to a list.
    */
   final def toList: List[A] =

--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -575,6 +575,17 @@ sealed abstract class Chain[+A] {
   final def size: Long = length
 
   /**
+   * The number of elements in this chain, if it can be cheaply computed, -1 otherwise.
+   * Cheaply usually means: Not requiring a collection traversal.
+   */
+  final def knownSize: Long =
+    this match {
+      case _ if isEmpty       => 0
+      case Chain.Singleton(_) => 1
+      case _                  => -1
+    }
+
+  /**
    * Converts to a list.
    */
   final def toList: List[A] =

--- a/tests/src/test/scala/cats/tests/ChainSuite.scala
+++ b/tests/src/test/scala/cats/tests/ChainSuite.scala
@@ -124,6 +124,22 @@ class ChainSuite extends CatsSuite {
     }
   }
 
+  test("lengthCompare and sizeCompare should be consistent with length and size") {
+    forAll { (cu: Chain[Unit], diff: Byte) =>
+      val testLen = cu.length + diff
+      val testSize = cu.size + diff
+
+      val expectedSignumLen = math.signum(cu.length.compareTo(testLen))
+      val expectedSignumSize = math.signum(cu.size.compareTo(testLen))
+
+      val obtainedSignumLen = math.signum(cu.lengthCompare(testLen))
+      val obtainedSignumSize = math.signum(cu.sizeCompare(testSize))
+
+      assertEquals(obtainedSignumLen, expectedSignumLen)
+      assertEquals(obtainedSignumSize, expectedSignumSize)
+    }
+  }
+
   test("filterNot and then exists should always be false") {
     forAll { (ci: Chain[Int], f: Int => Boolean) =>
       assert(ci.filterNot(f).exists(f) === false)


### PR DESCRIPTION
Adds quite useful `knownSize`, `lengthCompare` (and `sizeCompare` as an alias) which can be found in Scala Library.
