### PR TITLE
Deprecate Future instances

### DIFF
--- a/alleycats-core/src/main/scala/alleycats/std/future.scala
+++ b/alleycats-core/src/main/scala/alleycats/std/future.scala
@@ -26,7 +26,7 @@ import scala.concurrent.Future
 
 object future extends FutureInstances
 
-trait FutureInstances {
+trait FutureInstances extends cats.instances.FutureInstances {
 
   implicit val alleycatsStdFuturePure: Pure[Future] =
     new Pure[Future] {

--- a/core/src/main/scala/cats/Invariant.scala
+++ b/core/src/main/scala/cats/Invariant.scala
@@ -153,6 +153,30 @@ object Invariant extends ScalaVersionSpecificInvariantInstances with InvariantIn
 
   implicit def catsInstancesForTry: MonadThrow[Try] with CoflatMap[Try] =
     cats.instances.try_.catsStdInstancesForTry
+
+  @deprecated(
+    // format: off
+    message =
+"""
+Instances for scala.concurrent.Future have been deprecated,
+and will be moved into alleycats-core in cats 3.
+
+The rationale for the change is that given the nature of Future
+cats can't guarantee the appropriate behaviour of its instance.
+
+If you want to silence this warning you can add this to your scalacOptions:
+"-Wconf:cat=deprecation&origin=cats\\..*\\..*ForFuture:s"
+
+You may also prepare for this change and use alleycats right now.
+Import the library: "org.typelevel" %% "alleycats-core" % "..."
+And import alleycats.std.future._ in this file;
+if you require the future instances in multiple files
+you can add the following scalacOptions to automatically add the import in all files:
+"-Yimports", "java.lang", "scala", "scala.Predef", "alleycats.std.future"
+""",
+    // format: on
+    since = "2.8.0"
+  )
   implicit def catsInstancesForFuture(implicit
     ec: ExecutionContext
   ): MonadThrow[Future] with CoflatMap[Future] =

--- a/core/src/main/scala/cats/Semigroupal.scala
+++ b/core/src/main/scala/cats/Semigroupal.scala
@@ -71,8 +71,33 @@ object Semigroupal extends ScalaVersionSpecificSemigroupalInstances with Semigro
   implicit def catsSemigroupalForId: Semigroupal[Id] = catsInstancesForId
   implicit def catsSemigroupalForOption: Semigroupal[Option] = cats.instances.option.catsStdInstancesForOption
   implicit def catsSemigroupalForTry: Semigroupal[Try] = cats.instances.try_.catsStdInstancesForTry
+
+  @deprecated(
+    // format: off
+    message =
+"""
+Instances for scala.concurrent.Future have been deprecated,
+and will be moved into alleycats-core in cats 3.
+
+The rationale for the change is that given the nature of Future
+cats can't guarantee the appropriate behaviour of its instance.
+
+If you want to silence this warning you can add this to your scalacOptions:
+"-Wconf:cat=deprecation&origin=cats\\..*\\..*ForFuture:s"
+
+You may also prepare for this change and use alleycats right now.
+Import the library: "org.typelevel" %% "alleycats-core" % "..."
+And import alleycats.std.future._ in this file;
+if you require the future instances in multiple files
+you can add the following scalacOptions to automatically add the import in all files:
+"-Yimports", "java.lang", "scala", "scala.Predef", "alleycats.std.future"
+""",
+    // format: on
+    since = "2.8.0"
+  )
   implicit def catsSemigroupalForFuture(implicit ec: ExecutionContext): Semigroupal[Future] =
     cats.instances.future.catsStdInstancesForFuture(ec)
+
   implicit def catsSemigroupalForList: Semigroupal[List] = cats.instances.list.catsStdInstancesForList
   implicit def catsSemigroupalForSeq: Semigroupal[Seq] = cats.instances.seq.catsStdInstancesForSeq
   implicit def catsSemigroupalForVector: Semigroupal[Vector] = cats.instances.vector.catsStdInstancesForVector


### PR DESCRIPTION
If cats should have not provided instances for `Future` is a never-ending discussion.
However, I think the key points of such discussion are:

1. cats can't guarantee a predictable behavior of the instances.
2. cats should not remove the instances right away since that would break a lot of user code.

Thus, I propose _(well, actually it was Gavin's idea :p)_ to deprecate them so that users are aware that their usage is not recommended.
And then move them to alleycats on the release of cats 3

This PR adds the deprecation and allows users to be prepared for the change.
Also, the deprecation message includes detailed instructions on how to suppress it and how to prepare for the change.

Let me know what you all think about it.

Relates to #4176 #2334