### PR TITLE
Make `catsInstancesForIdCompat2_6_1` package-private

### DIFF
--- a/core/src/main/scala/cats/Invariant.scala
+++ b/core/src/main/scala/cats/Invariant.scala
@@ -128,7 +128,7 @@ object Invariant extends ScalaVersionSpecificInvariantInstances with InvariantIn
     cats.catsInstancesForId
   @deprecated("Added for bincompat", "2.8.0")
   @cats.compat.targetName("catsInstancesForId")
-  def catsInstancesForIdCompat2_6_1: Comonad[Id] =
+  private[cats] def catsInstancesForIdCompat2_6_1: Comonad[Id] =
     cats.catsInstancesForId
   implicit def catsMonadErrorForEither[A]: MonadError[Either[A, *], A] =
     cats.instances.either.catsStdInstancesForEither[A]


### PR DESCRIPTION
I initially kept this public, because usually static forwarders go away when a method is package-private, and we need them for complete binary-compatibility. However, I learned in https://github.com/lampepfl/dotty/issues/10842 that this is not the case on Scala 3. So, there is no reason to leak this method in the public API.