### PR TITLE
Add Scala Steward conf

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,3 @@
+updates.ignore = [
+  { groupId = "co.fs2", artifactId = "fs2-core" }
+]


### PR DESCRIPTION
Ross [has suggested](https://github.com/typelevel/cats/pull/4194#issuecomment-1107987610) removing part of benchmarks that depends on fs2. Until that cleanup, we could just ignore updates.