### PR TITLE
`imap` requires an isomorphism

### DIFF
--- a/core/src/main/scala/cats/Invariant.scala
+++ b/core/src/main/scala/cats/Invariant.scala
@@ -36,8 +36,8 @@ import scala.util.control.TailCalls.TailRec
 @typeclass trait Invariant[F[_]] extends Serializable { self =>
 
   /**
-   * Transform an `F[A]` into an `F[B]` by providing a transformation from `A`
-   * to `B` and one from `B` to `A`.
+   * Transform an `F[A]` into an `F[B]` by providing a isomorphism between `A`
+   * and `B`.
    *
    * Example:
    * {{{


### PR DESCRIPTION
One possible fix for https://github.com/typelevel/cats/issues/4199. It seems that at least some of our implementations of `Invariant` have been relying on this precondition anyway, so this is a way forward without retracting those instances.