### PR TITLE
Make `whenA`/`unlessA` syntax by-name lazy

### DIFF
--- a/core/src/main/scala/cats/syntax/applicative.scala
+++ b/core/src/main/scala/cats/syntax/applicative.scala
@@ -29,7 +29,7 @@ trait ApplicativeSyntax {
     new ApplicativeByNameOps[F, A](() => fa)
   implicit final def catsSyntaxApplicativeByValue[F[_], A](fa: F[A]): ApplicativeByValueOps[F, A] =
     new ApplicativeByValueOps[F, A](fa)
-  @deprecated("Use by-name version", "2.8.0")
+  @deprecated("Use by-value or by-name version", "2.8.0")
   final def catsSyntaxApplicative[F[_], A](fa: F[A]): ApplicativeOps[F, A] =
     new ApplicativeOps[F, A](fa)
 }
@@ -38,7 +38,7 @@ final class ApplicativeIdOps[A](private val a: A) extends AnyVal {
   def pure[F[_]](implicit F: Applicative[F]): F[A] = F.pure(a)
 }
 
-@deprecated("Use by-name version", "2.8.0")
+@deprecated("Use by-value or by-name version", "2.8.0")
 final class ApplicativeOps[F[_], A](private val fa: F[A]) extends AnyVal {
   def replicateA(n: Int)(implicit F: Applicative[F]): F[List[A]] = F.replicateA(n, fa)
   def unlessA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.unlessA(cond)(fa)

--- a/core/src/main/scala/cats/syntax/applicative.scala
+++ b/core/src/main/scala/cats/syntax/applicative.scala
@@ -25,18 +25,25 @@ package syntax
 trait ApplicativeSyntax {
   implicit final def catsSyntaxApplicativeId[A](a: A): ApplicativeIdOps[A] =
     new ApplicativeIdOps[A](a)
-  implicit final def catsSyntaxApplicative[F[_], A](fa: => F[A]): ApplicativeOps[F, A] =
-    new ApplicativeOps[F, A](() => fa)
-  @deprecated("Retained for bincompat", "2.8.0")
-  private[syntax] def catsSyntaxApplicative[F[_], A](fa: F[A]): ApplicativeOps[F, A] =
-    new ApplicativeOps[F, A](() => fa)
+  implicit final def catsSyntaxApplicativeByName[F[_], A](fa: => F[A]): ApplicativeOpsByName[F, A] =
+    new ApplicativeOpsByName[F, A](() => fa)
+  @deprecated("Use by-name version", "2.8.0")
+  def catsSyntaxApplicative[F[_], A](fa: F[A]): ApplicativeOps[F, A] =
+    new ApplicativeOps[F, A](fa)
 }
 
 final class ApplicativeIdOps[A](private val a: A) extends AnyVal {
   def pure[F[_]](implicit F: Applicative[F]): F[A] = F.pure(a)
 }
 
-final class ApplicativeOps[F[_], A](private val fa: () => F[A]) extends AnyVal {
+@deprecated("Use by-name version", "2.8.0")
+final class ApplicativeOps[F[_], A](private val fa: F[A]) extends AnyVal {
+  def replicateA(n: Int)(implicit F: Applicative[F]): F[List[A]] = F.replicateA(n, fa)
+  def unlessA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.unlessA(cond)(fa)
+  def whenA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.whenA(cond)(fa)
+}
+
+final class ApplicativeOpsByName[F[_], A](private val fa: () => F[A]) extends AnyVal {
   def replicateA(n: Int)(implicit F: Applicative[F]): F[List[A]] = F.replicateA(n, fa())
   def unlessA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.unlessA(cond)(fa())
   def whenA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.whenA(cond)(fa())

--- a/core/src/main/scala/cats/syntax/applicative.scala
+++ b/core/src/main/scala/cats/syntax/applicative.scala
@@ -25,28 +25,26 @@ package syntax
 trait ApplicativeSyntax {
   implicit final def catsSyntaxApplicativeId[A](a: A): ApplicativeIdOps[A] =
     new ApplicativeIdOps[A](a)
-  implicit final def catsSyntaxApplicative[F[_], A](fa: F[A]): ApplicativeOps[F, A] =
-    new ApplicativeOps[F, A](fa)
   implicit final def catsSyntaxApplicativeByName[F[_], A](fa: => F[A]): ApplicativeByNameOps[F, A] =
     new ApplicativeByNameOps[F, A](() => fa)
+  @deprecated("Use by-name version", "2.8.0")
+  final def catsSyntaxApplicative[F[_], A](fa: F[A]): ApplicativeOps[F, A] =
+    new ApplicativeOps[F, A](fa)
 }
 
 final class ApplicativeIdOps[A](private val a: A) extends AnyVal {
   def pure[F[_]](implicit F: Applicative[F]): F[A] = F.pure(a)
 }
 
+@deprecated("Use by-name version", "2.8.0")
 final class ApplicativeOps[F[_], A](private val fa: F[A]) extends AnyVal {
   def replicateA(n: Int)(implicit F: Applicative[F]): F[List[A]] = F.replicateA(n, fa)
-}
-
-object ApplicativeOps {
-  @deprecated("Use by-name version", "2.8.0")
-  def unlessA$extension[F[_], A](fa: F[A], cond: Boolean, F: Applicative[F]): F[Unit] = F.unlessA(cond)(fa)
-  @deprecated("Use by-name version", "2.8.0")
-  def whenA$extension[F[_], A](fa: F[A], cond: Boolean, F: Applicative[F]): F[Unit] = F.whenA(cond)(fa)
+  def unlessA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.unlessA(cond)(fa)
+  def whenA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.whenA(cond)(fa)
 }
 
 final class ApplicativeByNameOps[F[_], A](private val fa: () => F[A]) extends AnyVal {
+  def replicateA(n: Int)(implicit F: Applicative[F]): F[List[A]] = F.replicateA(n, fa())
   def unlessA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.unlessA(cond)(fa())
   def whenA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.whenA(cond)(fa())
 }

--- a/core/src/main/scala/cats/syntax/applicative.scala
+++ b/core/src/main/scala/cats/syntax/applicative.scala
@@ -25,26 +25,28 @@ package syntax
 trait ApplicativeSyntax {
   implicit final def catsSyntaxApplicativeId[A](a: A): ApplicativeIdOps[A] =
     new ApplicativeIdOps[A](a)
+  implicit final def catsSyntaxApplicative[F[_], A](fa: F[A]): ApplicativeOps[F, A] =
+    new ApplicativeOps[F, A](fa)
   implicit final def catsSyntaxApplicativeByName[F[_], A](fa: => F[A]): ApplicativeByNameOps[F, A] =
     new ApplicativeByNameOps[F, A](() => fa)
-  @deprecated("Use by-name version", "2.8.0")
-  final def catsSyntaxApplicative[F[_], A](fa: F[A]): ApplicativeOps[F, A] =
-    new ApplicativeOps[F, A](fa)
 }
 
 final class ApplicativeIdOps[A](private val a: A) extends AnyVal {
   def pure[F[_]](implicit F: Applicative[F]): F[A] = F.pure(a)
 }
 
-@deprecated("Use by-name version", "2.8.0")
 final class ApplicativeOps[F[_], A](private val fa: F[A]) extends AnyVal {
   def replicateA(n: Int)(implicit F: Applicative[F]): F[List[A]] = F.replicateA(n, fa)
-  def unlessA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.unlessA(cond)(fa)
-  def whenA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.whenA(cond)(fa)
+}
+
+object ApplicativeOps {
+  @deprecated("Use by-name version", "2.8.0")
+  def unlessA$extension[F[_], A](fa: F[A], cond: Boolean, F: Applicative[F]): F[Unit] = F.unlessA(cond)(fa)
+  @deprecated("Use by-name version", "2.8.0")
+  def whenA$extension[F[_], A](fa: F[A], cond: Boolean, F: Applicative[F]): F[Unit] = F.whenA(cond)(fa)
 }
 
 final class ApplicativeByNameOps[F[_], A](private val fa: () => F[A]) extends AnyVal {
-  def replicateA(n: Int)(implicit F: Applicative[F]): F[List[A]] = F.replicateA(n, fa())
   def unlessA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.unlessA(cond)(fa())
   def whenA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.whenA(cond)(fa())
 }

--- a/core/src/main/scala/cats/syntax/applicative.scala
+++ b/core/src/main/scala/cats/syntax/applicative.scala
@@ -25,16 +25,19 @@ package syntax
 trait ApplicativeSyntax {
   implicit final def catsSyntaxApplicativeId[A](a: A): ApplicativeIdOps[A] =
     new ApplicativeIdOps[A](a)
-  implicit final def catsSyntaxApplicative[F[_], A](fa: F[A]): ApplicativeOps[F, A] =
-    new ApplicativeOps[F, A](fa)
+  implicit final def catsSyntaxApplicative[F[_], A](fa: => F[A]): ApplicativeOps[F, A] =
+    new ApplicativeOps[F, A](() => fa)
+  @deprecated("Retained for bincompat", "2.8.0")
+  private[syntax] def catsSyntaxApplicative[F[_], A](fa: F[A]): ApplicativeOps[F, A] =
+    new ApplicativeOps[F, A](() => fa)
 }
 
 final class ApplicativeIdOps[A](private val a: A) extends AnyVal {
   def pure[F[_]](implicit F: Applicative[F]): F[A] = F.pure(a)
 }
 
-final class ApplicativeOps[F[_], A](private val fa: F[A]) extends AnyVal {
-  def replicateA(n: Int)(implicit F: Applicative[F]): F[List[A]] = F.replicateA(n, fa)
-  def unlessA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.unlessA(cond)(fa)
-  def whenA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.whenA(cond)(fa)
+final class ApplicativeOps[F[_], A](private val fa: () => F[A]) extends AnyVal {
+  def replicateA(n: Int)(implicit F: Applicative[F]): F[List[A]] = F.replicateA(n, fa())
+  def unlessA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.unlessA(cond)(fa())
+  def whenA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.whenA(cond)(fa())
 }

--- a/core/src/main/scala/cats/syntax/applicative.scala
+++ b/core/src/main/scala/cats/syntax/applicative.scala
@@ -27,6 +27,8 @@ trait ApplicativeSyntax {
     new ApplicativeIdOps[A](a)
   implicit final def catsSyntaxApplicativeByName[F[_], A](fa: => F[A]): ApplicativeByNameOps[F, A] =
     new ApplicativeByNameOps[F, A](() => fa)
+  implicit final def catsSyntaxApplicativeByValue[F[_], A](fa: F[A]): ApplicativeByValueOps[F, A] =
+    new ApplicativeByValueOps[F, A](fa)
   @deprecated("Use by-name version", "2.8.0")
   final def catsSyntaxApplicative[F[_], A](fa: F[A]): ApplicativeOps[F, A] =
     new ApplicativeOps[F, A](fa)
@@ -43,8 +45,11 @@ final class ApplicativeOps[F[_], A](private val fa: F[A]) extends AnyVal {
   def whenA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.whenA(cond)(fa)
 }
 
+final class ApplicativeByValueOps[F[_], A](private val fa: F[A]) extends AnyVal {
+  def replicateA(n: Int)(implicit F: Applicative[F]): F[List[A]] = F.replicateA(n, fa)
+}
+
 final class ApplicativeByNameOps[F[_], A](private val fa: () => F[A]) extends AnyVal {
-  def replicateA(n: Int)(implicit F: Applicative[F]): F[List[A]] = F.replicateA(n, fa())
   def unlessA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.unlessA(cond)(fa())
   def whenA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.whenA(cond)(fa())
 }

--- a/core/src/main/scala/cats/syntax/applicative.scala
+++ b/core/src/main/scala/cats/syntax/applicative.scala
@@ -25,10 +25,10 @@ package syntax
 trait ApplicativeSyntax {
   implicit final def catsSyntaxApplicativeId[A](a: A): ApplicativeIdOps[A] =
     new ApplicativeIdOps[A](a)
-  implicit final def catsSyntaxApplicativeByName[F[_], A](fa: => F[A]): ApplicativeOpsByName[F, A] =
-    new ApplicativeOpsByName[F, A](() => fa)
+  implicit final def catsSyntaxApplicativeByName[F[_], A](fa: => F[A]): ApplicativeByNameOps[F, A] =
+    new ApplicativeByNameOps[F, A](() => fa)
   @deprecated("Use by-name version", "2.8.0")
-  def catsSyntaxApplicative[F[_], A](fa: F[A]): ApplicativeOps[F, A] =
+  final def catsSyntaxApplicative[F[_], A](fa: F[A]): ApplicativeOps[F, A] =
     new ApplicativeOps[F, A](fa)
 }
 
@@ -43,7 +43,7 @@ final class ApplicativeOps[F[_], A](private val fa: F[A]) extends AnyVal {
   def whenA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.whenA(cond)(fa)
 }
 
-final class ApplicativeOpsByName[F[_], A](private val fa: () => F[A]) extends AnyVal {
+final class ApplicativeByNameOps[F[_], A](private val fa: () => F[A]) extends AnyVal {
   def replicateA(n: Int)(implicit F: Applicative[F]): F[List[A]] = F.replicateA(n, fa())
   def unlessA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.unlessA(cond)(fa())
   def whenA(cond: Boolean)(implicit F: Applicative[F]): F[Unit] = F.whenA(cond)(fa())

--- a/tests/shared/src/test/scala/cats/tests/ApplicativeSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/ApplicativeSuite.scala
@@ -63,6 +63,16 @@ class ApplicativeSuite extends CatsSuite {
     }
   }
 
+  test("by-name ops are lazy") {
+    var i = 0
+    Option(i += 1).whenA(false)
+    assertEquals(i, 0)
+
+    var j = 0
+    Option(j += 1).unlessA(true)
+    assertEquals(j, 0)
+  }
+
   {
     implicit val optionMonoid: Monoid[Option[Int]] = Applicative.monoid[Option, Int]
     checkAll("Applicative[Option].monoid", MonoidTests[Option[Int]](optionMonoid).monoid)


### PR DESCRIPTION
Fixes https://github.com/typelevel/cats/issues/3687, supersedes https://github.com/typelevel/cats/pull/3899.

These changes are based on https://github.com/typelevel/cats/pull/3899 but binary and source compatible without introducing any new methods.

Note that `replicateA` also becomes by-name in these changes. This is unnecessary and possibly a minor de-optimization, but I don't see any way around it. Note that the usual package-private tricks don't work well with syntax e.g. see https://github.com/scala/bug/issues/12578.

Edit: although, I suppose there's an argument that `replicateA` should be made by-name on the typeclass itself for when `n = 0`, but that's another can of worms :)