### PR TITLE
Add getOrRaise for OptionT, EitherT and IorT

### DIFF
--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -133,6 +133,26 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
       case Right(b) => F.pure(b)
     }
 
+  /***
+   * 
+   * Like [[getOrElseF]] but accept an error `E` and raise it when the inner `Either` is `Left`
+   *    
+   * Equivalent to `getOrElseF(F.raiseError(e)))`
+   *    
+   * Example:
+   * {{{
+   * scala> import cats.data.EitherT
+   * scala> import cats.implicits._
+   * scala> import scala.util.{Success, Failure, Try}
+  
+   * scala> val eitherT: EitherT[Try,String,Int] = EitherT[Try,String,Int](Success(Left("abc")))
+   * scala> eitherT.getOrRaise(new RuntimeException("ERROR!"))
+   * res0: Try[Int] = Failure(java.lang.RuntimeException: ERROR!)
+   * }}}
+   */
+  def getOrRaise[E](e: => E)(implicit F: MonadError[F, _ >: E]): F[B] =
+    getOrElseF(F.raiseError(e))
+
   /**
    * Example:
    * {{{

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -140,6 +140,24 @@ final case class OptionT[F[_], A](value: F[Option[A]]) {
     F.flatMap(value)(_.fold(default)(F.pure))
 
   /**
+   * Like [[getOrElseF]] but accept an error `E` and raise it when the inner `Option` is `None`
+   * 
+   * Equivalent to `getOrElseF(F.raiseError(e)))`
+   * 
+   * {{{
+   * scala> import cats.data.OptionT
+   * scala> import cats.implicits._
+   * scala> import scala.util.{Success, Failure, Try}
+   *
+   * scala> val optionT: OptionT[Try, Int] = OptionT[Try, Int](Success(None))
+   * scala> optionT.getOrRaise(new RuntimeException("ERROR!"))
+   * res0: Try[Int] = Failure(java.lang.RuntimeException: ERROR!)
+   * }}}
+   */
+  def getOrRaise[E](e: => E)(implicit F: MonadError[F, _ >: E]): F[A] =
+    getOrElseF(F.raiseError(e))
+
+  /**
    * Example:
    * {{{
    *  scala> import cats.data.OptionT

--- a/tests/shared/src/test/scala/cats/tests/EitherTSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/EitherTSuite.scala
@@ -426,6 +426,24 @@ class EitherTSuite extends CatsSuite {
     }
   }
 
+  test("getOrRaise consistent with EitherT.getOrElseF(F.raiseError(e))") {
+    forAll { (eithert: EitherT[Either[String, *], String, Int], error: String) =>
+      assertEquals(
+        obtained = eithert.getOrRaise(error),
+        expected = eithert.getOrElseF(Left(error))
+      )
+    }
+  }
+
+  test("getOrRaise consistent with EitherT.leftMap(_ => error).rethrowT") {
+    forAll { (eithert: EitherT[Either[String, *], String, Int], error: String) =>
+      assertEquals(
+        obtained = eithert.getOrRaise(error),
+        expected = eithert.leftMap(_ => error).rethrowT
+      )
+    }
+  }
+
   test("orElse with Id consistent with Either orElse") {
     forAll { (eithert: EitherT[Id, String, Int], fallback: EitherT[Id, String, Int]) =>
       assert(eithert.orElse(fallback).value === (eithert.value.orElse(fallback.value)))

--- a/tests/shared/src/test/scala/cats/tests/IorTSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/IorTSuite.scala
@@ -167,7 +167,16 @@ class IorTSuite extends CatsSuite {
 
   test("getOrElseF with Id consistent with Ior getOrElse") {
     forAll { (iort: IorT[Id, String, Int], i: Int) =>
-      assert(iort.getOrElseF(i) === (iort.value.getOrElse(i)))
+      assert(iort.getOrElseF(i) === iort.value.getOrElse(i))
+    }
+  }
+
+  test("getOrRaise consistent with IorT.getOrElseF(F.raiseError(e))") {
+    forAll { (iort: IorT[Either[String, *], String, Int], error: String) =>
+      assertEquals(
+        obtained = iort.getOrRaise(error),
+        expected = iort.getOrElseF(Left(error))
+      )
     }
   }
 

--- a/tests/shared/src/test/scala/cats/tests/OptionTSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/OptionTSuite.scala
@@ -303,6 +303,16 @@ class OptionTSuite extends CatsSuite {
       )
     }
   }
+
+  test("OptionT[Try, A].getOrRaise consistent with OptionT.getOrElseF(F.raiseError(e))") {
+    forAll { (o: Either[String, Option[Int]], error: String) =>
+      assertEquals(
+        obtained = OptionT[Either[String, *], Int](o).getOrRaise(error),
+        expected = OptionT[Either[String, *], Int](o).getOrElseF(Left(error))
+      )
+    }
+  }
+
   test("OptionT[Id, A].collect consistent with Option.collect") {
     forAll { (o: Option[Int], f: Int => Option[String]) =>
       val p = Function.unlift(f)


### PR DESCRIPTION
I've recently opened and merged a PR for mouse adding `getOrRaise` method to `F[Option[A]]` and `F[Either[A, B]]`. 
https://github.com/typelevel/mouse/pull/323

Since I found this method useful I'd like to introduce it to `OptionT`, `EitherT` and `IorT`. 

What do you think ? 


--- 
P.S. For mouse, I've added `getOrRaiseMsg` as well which accepts a `String` and lifts it to `RuntimeException`.
Honestly, I've always missed this feature in cats since in 99% of the cases I've seen this: 
```scala
IO.raiseError(new RuntimeException("ERROR"))
``` 

It would be great to have either 
- `raiseErrorMsg` which accepts a string
- An overload of `raiseError` which accepts a string
- A string interpolator to lift a string to an `Exception` like `val ex: RuntimeException = ex"ERROR"` in order to keep all other API unchanged


