### PR TITLE
override more mapAccumulate methods in Traverse

### DIFF
--- a/alleycats-core/src/main/scala/alleycats/std/iterable.scala
+++ b/alleycats-core/src/main/scala/alleycats/std/iterable.scala
@@ -77,6 +77,12 @@ trait IterableInstances {
         }
         (s, vec.result())
       }
+
+      override def zipWithIndex[A](fa: Iterable[A]): Iterable[(A, Int)] =
+        fa.zipWithIndex
+
+      override def mapWithIndex[A, B](fa: Iterable[A])(f: (A, Int) => B): Iterable[B] =
+        fa.zipWithIndex.map { case (a, i) => f(a, i) }
     }
 
   implicit def alleycatsStdIterableTraverseFilter: TraverseFilter[Iterable] = new TraverseFilter[Iterable] {

--- a/alleycats-core/src/main/scala/alleycats/std/iterable.scala
+++ b/alleycats-core/src/main/scala/alleycats/std/iterable.scala
@@ -65,6 +65,18 @@ trait IterableInstances {
       override def traverse[G[_], A, B](fa: Iterable[A])(f: A => G[B])(implicit G: Applicative[G]): G[Iterable[B]] =
         if (fa.isEmpty) G.pure(Iterable.empty)
         else G.map(Chain.traverseViaChain(toImIndexedSeq(fa))(f))(_.toVector)
+
+      override def mapAccumulate[S, A, B](init: S, fa: Iterable[A])(f: (S, A) => (S, B)): (S, Iterable[B]) = {
+        val iter = fa.iterator
+        var s = init
+        val vec = Vector.newBuilder[B]
+        while (iter.hasNext) {
+          val (snext, b) = f(s, iter.next())
+          vec += b
+          s = snext
+        }
+        (s, vec.result())
+      }
     }
 
   implicit def alleycatsStdIterableTraverseFilter: TraverseFilter[Iterable] = new TraverseFilter[Iterable] {

--- a/alleycats-core/src/main/scala/alleycats/std/map.scala
+++ b/alleycats-core/src/main/scala/alleycats/std/map.scala
@@ -45,11 +45,24 @@ trait MapInstances {
             G.map(f(a))((k, _))
           }) { chain => chain.foldLeft(Map.empty[K, B]) { case (m, (k, b)) => m.updated(k, b) } }
 
+      override def mapAccumulate[S, A, B](init: S, fa: Map[K, A])(f: (S, A) => (S, B)): (S, Map[K, B]) = {
+        val iter = fa.iterator
+        var s = init
+        val m = Map.newBuilder[K, B]
+        while (iter.hasNext) {
+          val (k, a) = iter.next()
+          val (snext, b) = f(s, a)
+          m += k -> b
+          s = snext
+        }
+        (s, m.result())
+      }
+
       override def map[A, B](fa: Map[K, A])(f: A => B): Map[K, B] =
         fa.map { case (k, a) => (k, f(a)) }
 
       def foldLeft[A, B](fa: Map[K, A], b: B)(f: (B, A) => B): B =
-        fa.foldLeft(b) { case (x, (k, a)) => f(x, a) }
+        fa.foldLeft(b) { case (x, (_, a)) => f(x, a) }
 
       def foldRight[A, B](fa: Map[K, A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
         Foldable.iterateRight(fa.values, lb)(f)

--- a/alleycats-core/src/main/scala/alleycats/std/map.scala
+++ b/alleycats-core/src/main/scala/alleycats/std/map.scala
@@ -49,6 +49,7 @@ trait MapInstances {
         val iter = fa.iterator
         var s = init
         val m = Map.newBuilder[K, B]
+        m.sizeHint(fa.size)
         while (iter.hasNext) {
           val (k, a) = iter.next()
           val (snext, b) = f(s, a)

--- a/alleycats-core/src/main/scala/alleycats/std/set.scala
+++ b/alleycats-core/src/main/scala/alleycats/std/set.scala
@@ -120,6 +120,18 @@ trait SetInstances {
         }.value
       }
 
+      override def mapAccumulate[S, A, B](init: S, fa: Set[A])(f: (S, A) => (S, B)): (S, Set[B]) = {
+        val iter = fa.iterator
+        var s = init
+        val set = Set.newBuilder[B]
+        while (iter.hasNext) {
+          val (snext, b) = f(s, iter.next())
+          set += b
+          s = snext
+        }
+        (s, set.result())
+      }
+
       override def get[A](fa: Set[A])(idx: Long): Option[A] = {
         @tailrec
         def go(idx: Int, it: Iterator[A]): Option[A] =

--- a/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
+++ b/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
@@ -213,7 +213,7 @@ class NonEmptyLazyListOps[A](private val value: NonEmptyLazyList[A])
    * Tests if some element is contained in this NonEmptyLazyList
    */
   final def contains(a: A)(implicit A: Eq[A]): Boolean =
-    toLazyList.contains(a)
+    toLazyList.exists(A.eqv(_, a))
 
   /**
    * Tests whether a predicate holds for all elements

--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -120,6 +120,9 @@ sealed abstract private[data] class ConstInstances extends ConstInstances0 {
 
       def traverse[G[_]: Applicative, A, B](fa: Const[C, A])(f: A => G[B]): G[Const[C, B]] =
         fa.traverse(f)
+
+      override def mapAccumulate[S, A, B](init: S, fa: Const[C, A])(f: (S, A) => (S, B)): (S, Const[C, B]) =
+        (init, fa.retag)
     }
 
   implicit def catsDataTraverseFilterForConst[C]: TraverseFilter[Const[C, *]] =

--- a/core/src/main/scala/cats/data/IdT.scala
+++ b/core/src/main/scala/cats/data/IdT.scala
@@ -141,6 +141,11 @@ sealed private[data] trait IdTTraverse[F[_]] extends Traverse[IdT[F, *]] with Id
 
   def traverse[G[_]: Applicative, A, B](fa: IdT[F, A])(f: A => G[B]): G[IdT[F, B]] =
     fa.traverse(f)
+
+  override def mapAccumulate[S, A, B](init: S, fa: IdT[F, A])(f: (S, A) => (S, B)): (S, IdT[F, B]) = {
+    val (snext, fb) = F0.mapAccumulate(init, fa.value)(f)
+    (snext, IdT(fb))
+  }
 }
 
 sealed private[data] trait IdTNonEmptyTraverse[F[_]]

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -187,9 +187,23 @@ sealed abstract class Ior[+A, +B] extends Product with Serializable {
    * res2: Boolean = false
    * }}}
    */
-  final def isLeft: Boolean = fold(_ => true, _ => false, (_, _) => false)
-  final def isRight: Boolean = fold(_ => false, _ => true, (_, _) => false)
-  final def isBoth: Boolean = fold(_ => false, _ => false, (_, _) => true)
+  final def isLeft: Boolean =
+    this match {
+      case Ior.Left(_) => true
+      case _           => false
+    }
+
+  final def isRight: Boolean =
+    this match {
+      case Ior.Right(_) => true
+      case _            => false
+    }
+
+  final def isBoth: Boolean =
+    this match {
+      case Ior.Both(_, _) => true
+      case _              => false
+    }
 
   /**
    * Example:
@@ -969,10 +983,7 @@ sealed abstract private[data] class IorInstances0 {
         fa.foldRight(lc)(f)
 
       override def size[B](fa: A Ior B): Long =
-        fa match {
-          case Ior.Right(_) | Ior.Both(_, _) => 1L
-          case Ior.Left(_)                   => 0L
-        }
+        if (fa.isLeft) 0L else 1L
 
       override def get[B](fa: A Ior B)(idx: Long): Option[B] =
         if (idx == 0L) fa.toOption else None

--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -257,6 +257,12 @@ sealed abstract private[data] class OneAndLowPriority1 extends OneAndLowPriority
       def traverse[G[_], A, B](fa: OneAnd[F, A])(f: (A) => G[B])(implicit G: Applicative[G]): G[OneAnd[F, B]] =
         G.map2Eval(f(fa.head), Always(F.traverse(fa.tail)(f)))(OneAnd(_, _)).value
 
+      override def mapAccumulate[S, A, B](init: S, fa: OneAnd[F, A])(f: (S, A) => (S, B)): (S, OneAnd[F, B]) = {
+        val (s1, b) = f(init, fa.head)
+        val (s2, fb) = F.mapAccumulate(s1, fa.tail)(f)
+        (s2, OneAnd(b, fb))
+      }
+
       def foldLeft[A, B](fa: OneAnd[F, A], b: B)(f: (B, A) => B): B =
         fa.foldLeft(b)(f)
 

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -322,6 +322,11 @@ final case class OptionT[F[_], A](value: F[Option[A]]) {
   def traverse[G[_], B](f: A => G[B])(implicit F: Traverse[F], G: Applicative[G]): G[OptionT[F, B]] =
     G.map(F.compose(Traverse[Option]).traverse(value)(f))(OptionT.apply)
 
+  def mapAccumulate[S, B](init: S)(f: (S, A) => (S, B))(implicit traverseF: Traverse[F]): (S, OptionT[F, B]) = {
+    val (snext, vnext) = traverseF.mapAccumulate(init, value)(Traverse[Option].mapAccumulate(_, _)(f))
+    (snext, OptionT(vnext))
+  }
+
   def foldLeft[B](b: B)(f: (B, A) => B)(implicit F: Foldable[F]): B =
     F.compose(Foldable[Option]).foldLeft(value, b)(f)
 
@@ -690,6 +695,9 @@ sealed private[data] trait OptionTTraverse[F[_]] extends Traverse[OptionT[F, *]]
 
   def traverse[G[_]: Applicative, A, B](fa: OptionT[F, A])(f: A => G[B]): G[OptionT[F, B]] =
     fa.traverse(f)
+
+  override def mapAccumulate[S, A, B](init: S, fa: OptionT[F, A])(f: (S, A) => (S, B)): (S, OptionT[F, B]) =
+    fa.mapAccumulate(init)(f)
 }
 
 private[data] trait OptionTSemigroup[F[_], A] extends Semigroup[OptionT[F, A]] {

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -630,6 +630,15 @@ sealed abstract class Validated[+E, +A] extends Product with Serializable {
       case e @ Invalid(_) => F.pure(e)
     }
 
+  def mapAccumulate[S, EE >: E, B](init: S)(f: (S, A) => (S, B)): (S, Validated[EE, B]) =
+    this match {
+      case Valid(a) =>
+        val (snext, b) = f(init, a)
+        (snext, Valid(b))
+
+      case e @ Invalid(_) => (init, e)
+    }
+
   /**
    * apply the given function to the value with the given B when
    * valid, otherwise return the given B
@@ -998,6 +1007,9 @@ sealed abstract private[data] class ValidatedInstances2 {
 
       override def traverse[G[_]: Applicative, A, B](fa: Validated[E, A])(f: (A) => G[B]): G[Validated[E, B]] =
         fa.traverse(f)
+
+      override def mapAccumulate[S, A, B](init: S, fa: Validated[E, A])(f: (S, A) => (S, B)): (S, Validated[E, B]) =
+        fa.mapAccumulate(init)(f)
 
       override def foldLeft[A, B](fa: Validated[E, A], b: B)(f: (B, A) => B): B =
         fa.foldLeft(b)(f)

--- a/core/src/main/scala/cats/instances/either.scala
+++ b/core/src/main/scala/cats/instances/either.scala
@@ -101,6 +101,15 @@ trait EitherInstances extends cats.kernel.instances.EitherInstances {
           case Right(b)       => F.map(f(b))(Right(_))
         }
 
+      override def mapAccumulate[S, B, C](init: S, fa: Either[A, B])(f: (S, B) => (S, C)): (S, Either[A, C]) = {
+        fa match {
+          case Right(b) =>
+            val (snext, c) = f(init, b)
+            (snext, Right(c))
+          case l @ Left(_) => (init, l.rightCast)
+        }
+      }
+
       def foldLeft[B, C](fa: Either[A, B], c: C)(f: (C, B) => C): C =
         fa match {
           case Left(_)  => c

--- a/core/src/main/scala/cats/instances/option.scala
+++ b/core/src/main/scala/cats/instances/option.scala
@@ -175,6 +175,15 @@ trait OptionInstances extends cats.kernel.instances.OptionInstances {
           case Some(a) => Applicative[G].map(f(a))(Some(_))
         }
 
+      override def mapAccumulate[S, A, B](init: S, fa: Option[A])(f: (S, A) => (S, B)): (S, Option[B]) = {
+        fa match {
+          case Some(a) =>
+            val (snext, b) = f(init, a)
+            (snext, Some(b))
+          case None => (init, None)
+        }
+      }
+
       override def reduceLeftToOption[A, B](fa: Option[A])(f: A => B)(g: (B, A) => B): Option[B] =
         fa.map(f)
 

--- a/core/src/main/scala/cats/instances/sortedMap.scala
+++ b/core/src/main/scala/cats/instances/sortedMap.scala
@@ -65,6 +65,9 @@ trait SortedMapInstances extends SortedMapInstances2 {
           }) { chain => chain.foldLeft(SortedMap.empty[K, B]) { case (m, (k, b)) => m.updated(k, b) } }
       }
 
+      override def mapAccumulate[S, A, B](init: S, fa: SortedMap[K, A])(f: (S, A) => (S, B)): (S, SortedMap[K, B]) =
+        StaticMethods.mapAccumulateFromStrictFunctor(init, fa, f)(this)
+
       def flatMap[A, B](fa: SortedMap[K, A])(f: A => SortedMap[K, B]): SortedMap[K, B] = {
         implicit val ordering: Ordering[K] = fa.ordering
         fa.flatMap { case (k, a) => f(a).get(k).map((k, _)) }

--- a/core/src/main/scala/cats/instances/try.scala
+++ b/core/src/main/scala/cats/instances/try.scala
@@ -74,6 +74,15 @@ trait TryInstances extends TryInstances1 {
           case f: Failure[_] => G.pure(castFailure[B](f))
         }
 
+      override def mapAccumulate[S, A, B](init: S, fa: Try[A])(f: (S, A) => (S, B)): (S, Try[B]) = {
+        fa match {
+          case Success(a) =>
+            val (snext, b) = f(init, a)
+            (snext, Success(b))
+          case f: Failure[_] => (init, castFailure[B](f))
+        }
+      }
+
       @tailrec final def tailRecM[B, C](b: B)(f: B => Try[Either[B, C]]): Try[C] =
         f(b) match {
           case f: Failure[_]     => castFailure[C](f)

--- a/core/src/main/scala/cats/instances/tuple.scala
+++ b/core/src/main/scala/cats/instances/tuple.scala
@@ -88,6 +88,11 @@ sealed private[instances] trait Tuple2Instances extends Tuple2Instances1 {
 
       override def map[A, B](fa: (X, A))(f: A => B): (X, B) = (fa._1, f(fa._2))
 
+      override def mapAccumulate[S, A, B](init: S, fa: (X, A))(f: (S, A) => (S, B)): (S, (X, B)) = {
+        val (snext, b) = f(init, fa._2)
+        (snext, (fa._1, b))
+      }
+
       def coflatMap[A, B](fa: (X, A))(f: ((X, A)) => B): (X, B) = (fa._1, f(fa))
 
       def extract[A](fa: (X, A)): A = fa._2

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -115,6 +115,8 @@ package object cats {
         f(a, lb)
       def nonEmptyTraverse[G[_], A, B](a: A)(f: A => G[B])(implicit G: Apply[G]): G[B] =
         f(a)
+      override def mapAccumulate[S, A, B](init: S, fa: Id[A])(f: (S, A) => (S, B)): (S, Id[B]) =
+        f(init, fa)
       override def foldMap[A, B](fa: Id[A])(f: A => B)(implicit B: Monoid[B]): B = f(fa)
       override def reduce[A](fa: Id[A])(implicit A: Semigroup[A]): A =
         fa


### PR DESCRIPTION
follow up to #4209 to override I think all the remaining values for mapAccumulate.

Also did a few minor changes I noticed along the way.