### PR TITLE
Add `groupByNelMap` method to `List` syntax

### DIFF
--- a/core/src/main/scala/cats/syntax/list.scala
+++ b/core/src/main/scala/cats/syntax/list.scala
@@ -37,7 +37,7 @@ final class ListOps[A](private val la: List[A]) extends AnyVal {
    * Example:
    * {{{
    * scala> import cats.data.NonEmptyList
-   * scala> import cats.syntax.list_
+   * scala> import cats.syntax.list._
    *
    * scala> val result1: List[Int] = List(1, 2)
    * scala> result1.toNel

--- a/tests/shared/src/test/scala/cats/tests/ListSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/ListSuite.scala
@@ -90,7 +90,7 @@ class ListSuite extends CatsSuite {
       assert(
         (fa.groupByNelMap(f, g).map { case (k, v) => (k, v.toList) }: Map[Int, List[Int]]) === fa
           .groupBy(f)
-          .mapValues(_.map(g))
+          .map { case (k, v) => (k, v.map(g)) }
       )
     }
   )


### PR DESCRIPTION
I find this method extremely helpful in my day job. And since there is `List` syntax, it seems natural for me to have this method added. 