### PR TITLE
Use spurious Fractional[MiniInt] to test Invariant[Fractional]

### DIFF
--- a/tests/shared/src/test/scala-2.12/cats/tests/ScalaVersionSpecific.scala
+++ b/tests/shared/src/test/scala-2.12/cats/tests/ScalaVersionSpecific.scala
@@ -25,8 +25,6 @@ import cats.kernel.{Eq, Order}
 import cats.laws.discipline.{ExhaustiveCheck, MiniInt}
 import cats.laws.discipline.MiniInt._
 import cats.laws.discipline.eq._
-import cats.laws.discipline.DeprecatedEqInstances
-import org.scalacheck.Arbitrary
 
 trait ScalaVersionSpecificFoldableSuite
 trait ScalaVersionSpecificParallelSuite
@@ -35,7 +33,7 @@ trait ScalaVersionSpecificTraverseSuite
 
 trait ScalaVersionSpecificAlgebraInvariantSuite {
   // This version-specific instance is required since 2.12 and below do not have parseString on the Numeric class
-  protected val integralForMiniInt: Integral[MiniInt] = new Integral[MiniInt] {
+  protected trait MiniIntNumeric extends Numeric[MiniInt] {
     def compare(x: MiniInt, y: MiniInt): Int = Order[MiniInt].compare(x, y)
     def plus(x: MiniInt, y: MiniInt): MiniInt = x + y
     def minus(x: MiniInt, y: MiniInt): MiniInt = x + (-y)
@@ -46,8 +44,6 @@ trait ScalaVersionSpecificAlgebraInvariantSuite {
     def toLong(x: MiniInt): Long = x.toInt.toLong
     def toFloat(x: MiniInt): Float = x.toInt.toFloat
     def toDouble(x: MiniInt): Double = x.toInt.toDouble
-    def quot(x: MiniInt, y: MiniInt): MiniInt = MiniInt.unsafeFromInt(x.toInt / y.toInt)
-    def rem(x: MiniInt, y: MiniInt): MiniInt = MiniInt.unsafeFromInt(x.toInt % y.toInt)
   }
 
   // This version-specific instance is required since 2.12 and below do not have parseString on the Numeric class
@@ -75,24 +71,4 @@ trait ScalaVersionSpecificAlgebraInvariantSuite {
     )
   }
 
-  // This version-specific instance is required since 2.12 and below do not have parseString on the Numeric class
-  @annotation.nowarn("cat=deprecation")
-  implicit protected def eqFractional[A: Eq: Arbitrary]: Eq[Fractional[A]] = {
-    import DeprecatedEqInstances.catsLawsEqForFn1
-
-    Eq.by { fractional =>
-      (
-        fractional.compare _,
-        fractional.plus _,
-        fractional.minus _,
-        fractional.times _,
-        fractional.negate _,
-        fractional.fromInt _,
-        fractional.toInt _,
-        fractional.toLong _,
-        fractional.toFloat _,
-        fractional.toDouble _
-      )
-    }
-  }
 }


### PR DESCRIPTION
Currently we use `Float` when doing laws testing for `Invariant[Fractional]` [in `AlgebraInvariantSuite`](https://github.com/typelevel/cats/blob/0fd2fdb2d2335992eebd1cd909d59d144700ab81/tests/shared/src/test/scala/cats/tests/AlgebraInvariantSuite.scala#L223). This in turn requires us to define an `Eq[Fractional[Float]]`, which can only be done using `DeprecatedEqInstances.catsLawsEqForFn1` ([here](https://github.com/typelevel/cats/blob/708cbaba2e6ac07a5ac1819b6c18b0c83a2faaba/tests/shared/src/test/scala-2.13%2B/cats/tests/ScalaVersionSpecific.scala#L246)). In order to stop using this deprecated instances, in this change we now use `MiniInt` to do our laws testing for `Invariant[Fractional]`. Because `MiniInt` has an `ExhaustiveCheck` instance, we no longer have to use the deprecated `Eq[A => B]` instance.

Note that this approach is spurious since `MiniInt` is not a fractional number type. But we can use it to test the lawfulness of the `Invariant[Fractional]` instance, and there is no "`MiniFloat`" type that is both small enough to have an `ExhaustiveCheck` instance and fractional. See https://github.com/typelevel/cats/pull/4033 for a broader discussion of this.


