### PR TITLE
Recommend Cats Effect `IO` as a replacement for every use case of `Future`

### DIFF
--- a/core/src/main/scala-2.12/cats/instances/package.scala
+++ b/core/src/main/scala-2.12/cats/instances/package.scala
@@ -44,7 +44,7 @@ package object instances {
    * @deprecated
    *   Any non-pure use of [[scala.concurrent.Future Future]] with Cats is error prone
    *   (particularly the semantics of [[cats.Traverse#traverse traverse]] with regard to execution order are unspecified).
-   *   We recommend using [[https://typelevel.org/cats-effect/ Cats Effect]] as a replacement for ''every'' use case of [[scala.concurrent.Future Future]].
+   *   We recommend using [[https://typelevel.org/cats-effect/ Cats Effect `IO`]] as a replacement for ''every'' use case of [[scala.concurrent.Future Future]].
    *   However, at this time there are no plans to remove these instances from Cats.
    *
    * @see [[https://github.com/typelevel/cats/issues/4176 Changes in Future traverse behavior between 2.6 and 2.7]]

--- a/core/src/main/scala-2.12/cats/instances/package.scala
+++ b/core/src/main/scala-2.12/cats/instances/package.scala
@@ -39,7 +39,18 @@ package object instances {
   object deadline extends DeadlineInstances
   object function extends FunctionInstances with FunctionInstancesBinCompat0
   object partialFunction extends PartialFunctionInstances
+
+  /**
+   * @deprecated
+   *   Any non-pure use of [[scala.concurrent.Future Future]] with Cats is error prone
+   *   (particularly the semantics of [[cats.Traverse#traverse traverse]] with regard to execution order are unspecified).
+   *   We recommend using [[https://typelevel.org/cats-effect/ Cats Effect]] as a replacement for ''every'' use case of [[scala.concurrent.Future Future]].
+   *   However, at this time there are no plans to remove these instances from Cats.
+   *
+   * @see [[https://github.com/typelevel/cats/issues/4176 Changes in Future traverse behavior between 2.6 and 2.7]]
+   */
   object future extends FutureInstances
+
   object int extends IntInstances
   object invariant extends InvariantMonoidalInstances with InvariantInstances with InvariantInstancesBinCompat0
   object list extends ListInstances with ListInstancesBinCompat0

--- a/core/src/main/scala-2.13+/cats/instances/package.scala
+++ b/core/src/main/scala-2.13+/cats/instances/package.scala
@@ -40,7 +40,18 @@ package object instances {
   object deadline extends DeadlineInstances
   object function extends FunctionInstances with FunctionInstancesBinCompat0
   object partialFunction extends PartialFunctionInstances
+
+  /**
+   * @deprecated
+   *   Any non-pure use of [[scala.concurrent.Future Future]] with Cats is error prone
+   *   (particularly the semantics of [[cats.Traverse#traverse traverse]] with regard to execution order are unspecified).
+   *   We recommend using [[https://typelevel.org/cats-effect/ Cats Effect]] as a replacement for ''every'' use case of [[scala.concurrent.Future Future]].
+   *   However, at this time there are no plans to remove these instances from Cats.
+   *
+   * @see [[https://github.com/typelevel/cats/issues/4176 Changes in Future traverse behavior between 2.6 and 2.7]]
+   */
   object future extends FutureInstances
+
   object int extends IntInstances
   object invariant extends InvariantMonoidalInstances with InvariantInstances with InvariantInstancesBinCompat0
   object list extends ListInstances with ListInstancesBinCompat0

--- a/core/src/main/scala-2.13+/cats/instances/package.scala
+++ b/core/src/main/scala-2.13+/cats/instances/package.scala
@@ -45,7 +45,7 @@ package object instances {
    * @deprecated
    *   Any non-pure use of [[scala.concurrent.Future Future]] with Cats is error prone
    *   (particularly the semantics of [[cats.Traverse#traverse traverse]] with regard to execution order are unspecified).
-   *   We recommend using [[https://typelevel.org/cats-effect/ Cats Effect]] as a replacement for ''every'' use case of [[scala.concurrent.Future Future]].
+   *   We recommend using [[https://typelevel.org/cats-effect/ Cats Effect `IO`]] as a replacement for ''every'' use case of [[scala.concurrent.Future Future]].
    *   However, at this time there are no plans to remove these instances from Cats.
    *
    * @see [[https://github.com/typelevel/cats/issues/4176 Changes in Future traverse behavior between 2.6 and 2.7]]

--- a/core/src/main/scala/cats/Invariant.scala
+++ b/core/src/main/scala/cats/Invariant.scala
@@ -158,7 +158,7 @@ object Invariant extends ScalaVersionSpecificInvariantInstances with InvariantIn
    * @deprecated
    *   Any non-pure use of [[scala.concurrent.Future Future]] with Cats is error prone
    *   (particularly the semantics of [[cats.Traverse#traverse traverse]] with regard to execution order are unspecified).
-   *   We recommend using [[https://typelevel.org/cats-effect/ Cats Effect]] as a replacement for ''every'' use case of [[scala.concurrent.Future Future]].
+   *   We recommend using [[https://typelevel.org/cats-effect/ Cats Effect `IO`]] as a replacement for ''every'' use case of [[scala.concurrent.Future Future]].
    *   However, at this time there are no plans to remove these instances from Cats.
    *
    * @see [[https://github.com/typelevel/cats/issues/4176 Changes in Future traverse behavior between 2.6 and 2.7]]

--- a/core/src/main/scala/cats/Invariant.scala
+++ b/core/src/main/scala/cats/Invariant.scala
@@ -153,6 +153,16 @@ object Invariant extends ScalaVersionSpecificInvariantInstances with InvariantIn
 
   implicit def catsInstancesForTry: MonadThrow[Try] with CoflatMap[Try] =
     cats.instances.try_.catsStdInstancesForTry
+
+  /**
+   * @deprecated
+   *   Any non-pure use of [[scala.concurrent.Future Future]] with Cats is error prone
+   *   (particularly the semantics of [[cats.Traverse#traverse traverse]] with regard to execution order are unspecified).
+   *   We recommend using [[https://typelevel.org/cats-effect/ Cats Effect]] as a replacement for ''every'' use case of [[scala.concurrent.Future Future]].
+   *   However, at this time there are no plans to remove these instances from Cats.
+   *
+   * @see [[https://github.com/typelevel/cats/issues/4176 Changes in Future traverse behavior between 2.6 and 2.7]]
+   */
   implicit def catsInstancesForFuture(implicit
     ec: ExecutionContext
   ): MonadThrow[Future] with CoflatMap[Future] =

--- a/core/src/main/scala/cats/Semigroupal.scala
+++ b/core/src/main/scala/cats/Semigroupal.scala
@@ -75,7 +75,7 @@ object Semigroupal extends ScalaVersionSpecificSemigroupalInstances with Semigro
    * @deprecated
    *   Any non-pure use of [[scala.concurrent.Future Future]] with Cats is error prone
    *   (particularly the semantics of [[cats.Traverse#traverse traverse]] with regard to execution order are unspecified).
-   *   We recommend using [[https://typelevel.org/cats-effect/ Cats Effect]] as a replacement for ''every'' use case of [[scala.concurrent.Future Future]].
+   *   We recommend using [[https://typelevel.org/cats-effect/ Cats Effect `IO`]] as a replacement for ''every'' use case of [[scala.concurrent.Future Future]].
    *   However, at this time there are no plans to remove these instances from Cats.
    *
    * @see [[https://github.com/typelevel/cats/issues/4176 Changes in Future traverse behavior between 2.6 and 2.7]]

--- a/core/src/main/scala/cats/Semigroupal.scala
+++ b/core/src/main/scala/cats/Semigroupal.scala
@@ -70,8 +70,19 @@ object Semigroupal extends ScalaVersionSpecificSemigroupalInstances with Semigro
   implicit def catsSemigroupalForId: Semigroupal[Id] = catsInstancesForId
   implicit def catsSemigroupalForOption: Semigroupal[Option] = cats.instances.option.catsStdInstancesForOption
   implicit def catsSemigroupalForTry: Semigroupal[Try] = cats.instances.try_.catsStdInstancesForTry
+
+  /**
+   * @deprecated
+   *   Any non-pure use of [[scala.concurrent.Future Future]] with Cats is error prone
+   *   (particularly the semantics of [[cats.Traverse#traverse traverse]] with regard to execution order are unspecified).
+   *   We recommend using [[https://typelevel.org/cats-effect/ Cats Effect]] as a replacement for ''every'' use case of [[scala.concurrent.Future Future]].
+   *   However, at this time there are no plans to remove these instances from Cats.
+   *
+   * @see [[https://github.com/typelevel/cats/issues/4176 Changes in Future traverse behavior between 2.6 and 2.7]]
+   */
   implicit def catsSemigroupalForFuture(implicit ec: ExecutionContext): Semigroupal[Future] =
     cats.instances.future.catsStdInstancesForFuture(ec)
+
   implicit def catsSemigroupalForList: Semigroupal[List] = cats.instances.list.catsStdInstancesForList
   implicit def catsSemigroupalForSeq: Semigroupal[Seq] = cats.instances.seq.catsStdInstancesForSeq
   implicit def catsSemigroupalForVector: Semigroupal[Vector] = cats.instances.vector.catsStdInstancesForVector

--- a/core/src/main/scala/cats/instances/future.scala
+++ b/core/src/main/scala/cats/instances/future.scala
@@ -25,6 +25,15 @@ package instances
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success}
 
+/**
+ * @deprecated
+ *   Any non-pure use of [[scala.concurrent.Future Future]] with Cats is error prone
+ *   (particularly the semantics of [[cats.Traverse#traverse traverse]] with regard to execution order are unspecified).
+ *   We recommend using [[https://typelevel.org/cats-effect/ Cats Effect]] as a replacement for ''every'' use case of [[scala.concurrent.Future Future]].
+ *   However, at this time there are no plans to remove these instances from Cats.
+ *
+ * @see [[https://github.com/typelevel/cats/issues/4176 Changes in Future traverse behavior between 2.6 and 2.7]]
+ */
 trait FutureInstances extends FutureInstances1 {
 
   implicit def catsStdInstancesForFuture(implicit

--- a/core/src/main/scala/cats/instances/future.scala
+++ b/core/src/main/scala/cats/instances/future.scala
@@ -29,7 +29,7 @@ import scala.util.{Failure, Success}
  * @deprecated
  *   Any non-pure use of [[scala.concurrent.Future Future]] with Cats is error prone
  *   (particularly the semantics of [[cats.Traverse#traverse traverse]] with regard to execution order are unspecified).
- *   We recommend using [[https://typelevel.org/cats-effect/ Cats Effect]] as a replacement for ''every'' use case of [[scala.concurrent.Future Future]].
+ *   We recommend using [[https://typelevel.org/cats-effect/ Cats Effect `IO`]] as a replacement for ''every'' use case of [[scala.concurrent.Future Future]].
  *   However, at this time there are no plans to remove these instances from Cats.
  *
  * @see [[https://github.com/typelevel/cats/issues/4176 Changes in Future traverse behavior between 2.6 and 2.7]]

--- a/kernel/src/main/scala/cats/kernel/Semigroup.scala
+++ b/kernel/src/main/scala/cats/kernel/Semigroup.scala
@@ -288,8 +288,19 @@ private[kernel] trait MonoidInstances extends BandInstances {
     cats.kernel.instances.either.catsDataMonoidForEither[A, B]
   implicit def catsKernelMonoidForTry[A: Monoid]: Monoid[Try[A]] =
     new TryMonoid[A](Monoid[A])
+
+  /**
+   * @deprecated
+   *   Any non-pure use of [[scala.concurrent.Future Future]] with Cats is error prone
+   *   (particularly the semantics of [[cats.Traverse#traverse traverse]] with regard to execution order are unspecified).
+   *   We recommend using [[https://typelevel.org/cats-effect/ Cats Effect]] as a replacement for ''every'' use case of [[scala.concurrent.Future Future]].
+   *   However, at this time there are no plans to remove these instances from Cats.
+   *
+   * @see [[https://github.com/typelevel/cats/issues/4176 Changes in Future traverse behavior between 2.6 and 2.7]]
+   */
   implicit def catsKernelMonoidForFuture[A](implicit A: Monoid[A], ec: ExecutionContext): Monoid[Future[A]] =
     new FutureMonoid[A](A, ec)
+
   implicit def catsKernelMonoidForOption[A: Semigroup]: Monoid[Option[A]] =
     cats.kernel.instances.option.catsKernelStdMonoidForOption[A]
   implicit def catsKernelMonoidForSeq[A]: Monoid[Seq[A]] =
@@ -319,6 +330,15 @@ private[kernel] trait SemigroupInstances {
     cats.kernel.instances.either.catsDataSemigroupForEither[A, B]
   implicit def catsKernelSemigroupForTry[A: Semigroup]: Semigroup[Try[A]] =
     new TrySemigroup[A](Semigroup[A])
+
+  /**
+   * @deprecated
+   *   Any non-pure use of [[scala.concurrent.Future Future]] with Cats is error prone
+   *   (particularly the semantics of [[cats.Traverse#traverse traverse]] with regard to execution order are unspecified).
+   *   We recommend using [[https://typelevel.org/cats-effect/ Cats Effect]] as a replacement for ''every'' use case of [[scala.concurrent.Future Future]].
+   *
+   * @see [[https://github.com/typelevel/cats/issues/4176 Changes in Future traverse behavior between 2.6 and 2.7]]
+   */
   implicit def catsKernelSemigroupForFuture[A](implicit A: Semigroup[A], ec: ExecutionContext): Semigroup[Future[A]] =
     new FutureSemigroup[A](A, ec)
 }

--- a/kernel/src/main/scala/cats/kernel/Semigroup.scala
+++ b/kernel/src/main/scala/cats/kernel/Semigroup.scala
@@ -293,7 +293,7 @@ private[kernel] trait MonoidInstances extends BandInstances {
    * @deprecated
    *   Any non-pure use of [[scala.concurrent.Future Future]] with Cats is error prone
    *   (particularly the semantics of [[cats.Traverse#traverse traverse]] with regard to execution order are unspecified).
-   *   We recommend using [[https://typelevel.org/cats-effect/ Cats Effect]] as a replacement for ''every'' use case of [[scala.concurrent.Future Future]].
+   *   We recommend using [[https://typelevel.org/cats-effect/ Cats Effect `IO`]] as a replacement for ''every'' use case of [[scala.concurrent.Future Future]].
    *   However, at this time there are no plans to remove these instances from Cats.
    *
    * @see [[https://github.com/typelevel/cats/issues/4176 Changes in Future traverse behavior between 2.6 and 2.7]]
@@ -335,7 +335,7 @@ private[kernel] trait SemigroupInstances {
    * @deprecated
    *   Any non-pure use of [[scala.concurrent.Future Future]] with Cats is error prone
    *   (particularly the semantics of [[cats.Traverse#traverse traverse]] with regard to execution order are unspecified).
-   *   We recommend using [[https://typelevel.org/cats-effect/ Cats Effect]] as a replacement for ''every'' use case of [[scala.concurrent.Future Future]].
+   *   We recommend using [[https://typelevel.org/cats-effect/ Cats Effect `IO`]] as a replacement for ''every'' use case of [[scala.concurrent.Future Future]].
    *
    * @see [[https://github.com/typelevel/cats/issues/4176 Changes in Future traverse behavior between 2.6 and 2.7]]
    */


### PR DESCRIPTION
Closes https://github.com/typelevel/cats/issues/4190.

This PR executes a **soft deprecation** of `Future` instances in Cats. The [`@deprecated` annotation](https://www.scala-lang.org/api/2.13.8/scala/deprecated.html) is _not_ used. Instead, a [`@deprecated` tag](https://docs.scala-lang.org/overviews/scaladoc/for-library-authors.html#other-tags) is used in the Scaladoc comment. This only affects rendering of API docs.

**The compiler does not read Scaladoc comments, and therefore this cannot "junk" anyone's build.** This addresses the concern from https://github.com/typelevel/cats/pull/4182#issuecomment-1099647958.

Odds are, nobody will ever see these, because these are implicit instances that don't need to be imported or directly referenced in modern Cats. But it's better than nothing. I hope this is a reasonable compromise for everyone.

The language is taken verbatim from https://github.com/typelevel/cats/pull/4182#issuecomment-1099627292. It also clarifies that these instances will not be removed from Cats and references the issue about the behavior change in `traverse`.

In addition, I propose we repeat this message in the Cats v2.8.0 release notes. Finally, we can also publish a scalafix lint via https://github.com/typelevel/typelevel-scalafix/issues/2 as proposed in https://github.com/typelevel/cats/pull/4182#issuecomment-1096921448.

Politely requesting reviews from Oscar and Ross since they were 👎  on hard-deprecation in https://github.com/typelevel/cats/pull/4182; thank you!

<img width="883" alt="Screen Shot 2022-06-09 at 12 00 16" src="https://user-images.githubusercontent.com/3119428/172924904-9255b17d-e3b7-4818-98c8-41f24a02e1e7.png">

<img width="907" alt="Screen Shot 2022-06-09 at 12 06 44" src="https://user-images.githubusercontent.com/3119428/172924966-60a7080d-df3a-421f-a89b-e73857706ff3.png">

<img width="937" alt="Screen Shot 2022-06-09 at 12 07 20" src="https://user-images.githubusercontent.com/3119428/172925068-fccd2db8-8b88-4144-be48-bc259b2c3934.png">

