### PR TITLE
Bump base version to 2.9

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "2.8"
+ThisBuild / tlBaseVersion := "2.9"
 
 val scalaCheckVersion = "1.16.0"
 
@@ -296,7 +296,6 @@ lazy val docs = project
   .settings(
     tlFatalWarnings := false,
     laikaConfig ~= { _.withRawContent },
-    tlSiteApiUrl := Some(url("https://typelevel.org/cats/api/")),
     tlSiteRelatedProjects := Seq(
       TypelevelProject.CatsEffect,
       "Mouse" -> url("https://typelevel.org/mouse"),


### PR DESCRIPTION
Cats rarely release patches and we have a number of open PRs that would require a bump anyway. So bumping this pro-actively, and we can start a series/2.8 branch if anything crops up.