### PR TITLE
Add `ApplicativeError` helpers for `scala.Predef` assertions

### DIFF
--- a/core/src/main/scala/cats/ApplicativeError.scala
+++ b/core/src/main/scala/cats/ApplicativeError.scala
@@ -338,6 +338,130 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
       case Invalid(e) => raiseError(e)
       case Valid(a)   => pure(a)
     }
+
+  /**
+   * Equivalent of a [[scala.Predef#assert(assertion:Boolean,message:=>Any)*]] assertion in `F[_]`.
+   *
+   * Tests an expression, sequencing an exception of type [[java.lang.AssertionError]] if false.
+   *
+   * Assertions can be disabled by using the scalac option `-Xdisable-assertions`, or by
+   * configuring the scalac option `-Xelide-below` with a value greater than
+   * [[scala.annotation.elidable.ASSERTION ASSERTION]].
+   *
+   * When assertions are disabled exceptions are not sequenced, and this method is equivalent to
+   * [[cats.InvariantMonoidal#unit]]
+   *
+   * @param assertion
+   *   the expression to test
+   * @param message
+   *   a String to include in the failure message
+   */
+  def assert(assertion: Boolean, message: => String)(implicit ev: Throwable <:< E): F[Unit] =
+    catchOnly[AssertionError](Predef.assert(assertion, message))
+
+  /**
+   * Equivalent of a [[scala.Predef#assert(assertion:Boolean)*]] assertion in `F[_]`.
+   *
+   * Tests an expression, sequencing an exception of type [[java.lang.AssertionError]] if false.
+   *
+   * Assertions can be disabled by using the scalac option `-Xdisable-assertions`, or by
+   * configuring the scalac option `-Xelide-below` with a value greater than
+   * [[scala.annotation.elidable.ASSERTION ASSERTION]].
+   *
+   * When assertions are disabled exceptions are not sequenced, and this method is equivalent to
+   * [[cats.InvariantMonoidal#unit]]
+   *
+   * @param assertion
+   *   the expression to test
+   */
+  def assert(assertion: Boolean)(implicit ev: Throwable <:< E): F[Unit] =
+    catchOnly[AssertionError](Predef.assert(assertion))
+
+  /**
+   * Equivalent of a [[scala.Predef#assume(assumption:Boolean,message:=>Any)*]] assumption in `F[_]`.
+   *
+   * Tests an expression, sequencing an exception of type [[java.lang.AssertionError]] if false.
+   *
+   * This method differs from
+   * [[cats.ApplicativeError#assert(assertion:Boolean,message:=>String)* assert]] only in the
+   * intent expressed: `assert` contains a predicate which needs to be proven, while `assume`
+   * contains an axiom for a static checker.
+   *
+   * Assertions can be disabled by using the scalac option `-Xdisable-assertions`, or by
+   * configuring the scalac option `-Xelide-below` with a value greater than
+   * [[scala.annotation.elidable.ASSERTION ASSERTION]].
+   *
+   * When assertions are disabled exceptions are not sequenced, and this method is equivalent to
+   * [[cats.InvariantMonoidal#unit]]
+   *
+   * @param assumption
+   *   the expression to test
+   * @param message
+   *   a String to include in the failure message
+   */
+  def assume(assumption: Boolean, message: => String)(implicit ev: Throwable <:< E): F[Unit] =
+    catchOnly[AssertionError](Predef.assume(assumption, message))
+
+  /**
+   * Equivalent of a [[scala.Predef#assume(assumption:Boolean)*]] assumption in `F[_]`.
+   *
+   * Tests an expression, sequencing an exception of type [[java.lang.AssertionError]] if false.
+   *
+   * This method differs from [[cats.ApplicativeError#assert(assertion:Boolean)* assert]] only
+   * in the intent expressed: `assert` contains a predicate which needs to be proven, while
+   * `assume` contains an axiom for a static checker.
+   *
+   * Assertions can be disabled by using the scalac option `-Xdisable-assertions`, or by
+   * configuring the scalac option `-Xelide-below` with a value greater than
+   * [[scala.annotation.elidable.ASSERTION ASSERTION]].
+   *
+   * When assertions are disabled exceptions are not sequenced, and this method is equivalent to
+   * [[cats.InvariantMonoidal#unit]]
+   *
+   * @param assumption
+   *   the expression to test
+   */
+  def assume(assumption: Boolean)(implicit ev: Throwable <:< E): F[Unit] =
+    catchOnly[AssertionError](Predef.assume(assumption))
+
+  /**
+   * Equivalent of a [[scala.Predef#require(requirement:Boolean,message:=>Any)*]] requirement in  `F[_]`.
+   *
+   * Tests an expression, sequencing an exception of type [[java.lang.IllegalArgumentException]]
+   * if false.
+   *
+   * This method is similar to
+   * [[cats.ApplicativeError#assert(assertion:Boolean,message:=>String)* assert]], but blames
+   * the caller of the method for violating the condition.
+   *
+   * Since requirements express a precondition that must be met by the caller, they cannot be
+   * disabled using `-Xdisable-assertions`.
+   *
+   * @param requirement
+   *   the expression to test
+   * @param message
+   *   a String to include in the failure message
+   */
+  def require(requirement: Boolean, message: => String)(implicit ev: Throwable <:< E): F[Unit] =
+    catchOnly[IllegalArgumentException](Predef.require(requirement, message))
+
+  /**
+   * Equivalent of a [[scala.Predef#require(requirement:Boolean)*]] requirement in `F[_]`.
+   *
+   * Tests an expression, sequencing an exception of type [[java.lang.IllegalArgumentException]]
+   * if false.
+   *
+   * This method is similar to [[cats.ApplicativeError#assert(assertion:Boolean)* assert]],
+   * but blames the caller of the method for violating the condition.
+   *
+   * Since requirements express a precondition that must be met by the caller, they cannot be
+   * disabled using `-Xdisable-assertions`.
+   *
+   * @param requirement
+   *   the expression to test
+   */
+  def require(requirement: Boolean)(implicit ev: Throwable <:< E): F[Unit] =
+    catchOnly[IllegalArgumentException](Predef.require(requirement))
 }
 
 object ApplicativeError {

--- a/core/src/main/scala/cats/ApplicativeError.scala
+++ b/core/src/main/scala/cats/ApplicativeError.scala
@@ -356,7 +356,7 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
    * @param message
    *   a String to include in the failure message
    */
-  def assert(assertion: Boolean, message: => String)(implicit ev: Throwable <:< E): F[Unit] =
+  final def assert(assertion: Boolean, message: => String)(implicit ev: Throwable <:< E): F[Unit] =
     catchOnly[AssertionError](Predef.assert(assertion, message))
 
   /**
@@ -374,7 +374,7 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
    * @param assertion
    *   the expression to test
    */
-  def assert(assertion: Boolean)(implicit ev: Throwable <:< E): F[Unit] =
+  final def assert(assertion: Boolean)(implicit ev: Throwable <:< E): F[Unit] =
     catchOnly[AssertionError](Predef.assert(assertion))
 
   /**
@@ -399,7 +399,7 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
    * @param message
    *   a String to include in the failure message
    */
-  def assume(assumption: Boolean, message: => String)(implicit ev: Throwable <:< E): F[Unit] =
+  final def assume(assumption: Boolean, message: => String)(implicit ev: Throwable <:< E): F[Unit] =
     catchOnly[AssertionError](Predef.assume(assumption, message))
 
   /**
@@ -421,7 +421,7 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
    * @param assumption
    *   the expression to test
    */
-  def assume(assumption: Boolean)(implicit ev: Throwable <:< E): F[Unit] =
+  final def assume(assumption: Boolean)(implicit ev: Throwable <:< E): F[Unit] =
     catchOnly[AssertionError](Predef.assume(assumption))
 
   /**
@@ -442,7 +442,7 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
    * @param message
    *   a String to include in the failure message
    */
-  def require(requirement: Boolean, message: => String)(implicit ev: Throwable <:< E): F[Unit] =
+  final def require(requirement: Boolean, message: => String)(implicit ev: Throwable <:< E): F[Unit] =
     catchOnly[IllegalArgumentException](Predef.require(requirement, message))
 
   /**
@@ -460,7 +460,7 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
    * @param requirement
    *   the expression to test
    */
-  def require(requirement: Boolean)(implicit ev: Throwable <:< E): F[Unit] =
+  final def require(requirement: Boolean)(implicit ev: Throwable <:< E): F[Unit] =
     catchOnly[IllegalArgumentException](Predef.require(requirement))
 }
 

--- a/tests/shared/src/test/scala/cats/tests/ApplicativeErrorSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/ApplicativeErrorSuite.scala
@@ -85,6 +85,54 @@ class ApplicativeErrorSuite extends CatsSuite {
     // assertEquals(compileErrors("e3.attemptNarrow[List[Str.type]]"), "")
   }
 
+  test("assert is equivalent to Predef.assert") {
+    val A = ApplicativeError[Either[Throwable, *], Throwable]
+    assertEquals(A.assert(true), A.unit)
+    assertEquals(A.assert(true, "foo"), A.unit)
+    val catsAssert = A.assert(false)
+    val predefAssert = intercept[AssertionError] { Predef.assert(false) }
+    assert(catsAssert.isLeft)
+    assert(catsAssert.left.get.isInstanceOf[AssertionError])
+    assertEquals(catsAssert.left.get.getMessage, predefAssert.getMessage)
+    val catsAssertWithMsg = A.assert(false, "foo")
+    val predefAssertWithMsg = intercept[AssertionError] { Predef.assert(false, "foo") }
+    assert(catsAssertWithMsg.isLeft)
+    assert(catsAssertWithMsg.left.get.isInstanceOf[AssertionError])
+    assertEquals(catsAssertWithMsg.left.get.getMessage, predefAssertWithMsg.getMessage)
+  }
+
+  test("assume is equivalent to Predef.assume") {
+    val A = ApplicativeError[Either[Throwable, *], Throwable]
+    assertEquals(A.assume(true), A.unit)
+    assertEquals(A.assume(true, "foo"), A.unit)
+    val catsAssume = A.assume(false)
+    val predefAssume = intercept[AssertionError] { Predef.assume(false) }
+    assert(catsAssume.isLeft)
+    assert(catsAssume.left.get.isInstanceOf[AssertionError])
+    assertEquals(catsAssume.left.get.getMessage, predefAssume.getMessage)
+    val catsAssumeWithMsg = A.assume(false, "foo")
+    val predefAssumeWithMsg = intercept[AssertionError] { Predef.assume(false, "foo") }
+    assert(catsAssumeWithMsg.isLeft)
+    assert(catsAssumeWithMsg.left.get.isInstanceOf[AssertionError])
+    assertEquals(catsAssumeWithMsg.left.get.getMessage, predefAssumeWithMsg.getMessage)
+  }
+
+  test("require is equivalent to Predef.require") {
+    val A = ApplicativeError[Either[Throwable, *], Throwable]
+    assertEquals(A.require(true), A.unit)
+    assertEquals(A.require(true, "foo"), A.unit)
+    val catsRequire = A.require(false)
+    val predefRequire = intercept[IllegalArgumentException] { Predef.require(false) }
+    assert(catsRequire.isLeft)
+    assert(catsRequire.left.get.isInstanceOf[IllegalArgumentException])
+    assertEquals(catsRequire.left.get.getMessage, predefRequire.getMessage)
+    val catsRequireWithMsg = A.require(false, "foo")
+    val predefRequireWithMsg = intercept[IllegalArgumentException] { Predef.require(false, "foo") }
+    assert(catsRequireWithMsg.isLeft)
+    assert(catsRequireWithMsg.left.get.isInstanceOf[IllegalArgumentException])
+    assertEquals(catsRequireWithMsg.left.get.getMessage, predefRequireWithMsg.getMessage)
+  }
+
   test("attemptT syntax creates an EitherT") {
     assert(failed.attemptT === (EitherT[Option, Unit, Int](Option(Left(())))))
   }


### PR DESCRIPTION
As discussed on typelevel/cats-effect#3044.