### PR TITLE
Change the ordering of invocations in `Defer#fix`

### DIFF
--- a/core/src/main/scala/cats/Defer.scala
+++ b/core/src/main/scala/cats/Defer.scala
@@ -69,7 +69,7 @@ trait Defer[F[_]] extends Serializable {
    * of the above F[A] run forever.
    */
   def fix[A](fn: F[A] => F[A]): F[A] = {
-    lazy val res: F[A] = defer(fn(res))
+    lazy val res: F[A] = fn(defer(res))
     res
   }
 }


### PR DESCRIPTION
What we want is to evaluate `fn` and pass the recursive value lazily in case `fn` doesn't need to evaluate it ie `fn(defer(res))`.

`defer(fn(res))` also works but it suspends the initial `fn` invocation, which is pointless as we must always evaluate `fn` at least once to produce a result

