### PR TITLE
Documentation: update freemonad.md

### DIFF
--- a/docs/datatypes/freemonad.md
+++ b/docs/datatypes/freemonad.md
@@ -185,7 +185,7 @@ def impureCompiler: KVStoreA ~> Id  =
           ()
         case Get(key) =>
           println(s"get($key)")
-          kvs.get(key).map(_.asInstanceOf[A])
+          kvs.get(key).asInstanceOf[A]
         case Delete(key) =>
           println(s"delete($key)")
           kvs.remove(key)
@@ -273,7 +273,7 @@ val pureCompiler: KVStoreA ~> KVStoreState = new (KVStoreA ~> KVStoreState) {
     fa match {
       case Put(key, value) => State.modify(_.updated(key, value))
       case Get(key) =>
-        State.inspect(_.get(key).map(_.asInstanceOf[A]))
+        State.inspect(_.get(key).asInstanceOf[A])
       case Delete(key) => State.modify(_ - key)
     }
 }


### PR DESCRIPTION
`Type Mismatch Error` occurred `impureCompiler` and `pureCompiler` in scalaVersion 3.1.3
```scala
kvs.get(key).map(_.asInstanceOf[A])
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Found:    Option[A]
Required: cats.Id[A]

State.inspect(_.get(key).map(_.asInstanceOf[A]))
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Found:    Option[A]
Required: A
```