### PR TITLE
Add `NonEmptyList#prependAll`

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -181,6 +181,19 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
     NonEmptyList(head, tail :+ a)
 
   /**
+   * Alias for [[concat]]
+   *
+   * {{{
+   * scala> import cats.data.NonEmptyList
+   * scala> val nel = NonEmptyList.of(1, 2, 3)
+   * scala> nel.appendList(List(4, 5))
+   * res0: cats.data.NonEmptyList[Int] = NonEmptyList(1, 2, 3, 4, 5)
+   * }}}
+   */
+  def appendList[AA >: A](other: List[AA]): NonEmptyList[AA] =
+    concat(other)
+
+  /**
    * Alias for concatNel
    *
    * {{{

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -111,8 +111,14 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
   def ++[AA >: A](l: List[AA]): NonEmptyList[AA] =
     concat(l)
 
+  def ++[AA >: A](other: Option[AA]): NonEmptyList[AA] =
+    concat(other)
+
   def concat[AA >: A](other: List[AA]): NonEmptyList[AA] =
     NonEmptyList(head, tail ::: other)
+
+  def concat[AA >: A](other: Option[AA]): NonEmptyList[AA] =
+    concat(other.toList)
 
   @deprecated("Use concatNel", since = "1.0.0-RC1")
   private[data] def concat[AA >: A](other: NonEmptyList[AA]): NonEmptyList[AA] =
@@ -132,6 +138,37 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
 
   def prepend[AA >: A](a: AA): NonEmptyList[AA] =
     NonEmptyList(a, head :: tail)
+
+  /**
+   * Alias for prependAll
+   * 
+   * {{{
+   * scala> import cats.data.NonEmptyList
+   * scala> val nel = NonEmptyList.of(1, 2, 3)
+   * scala> val list = List(-1, 0)
+   * scala> list ++: nel
+   * res0: cats.data.NonEmptyList[Int] = NonEmptyList(-1, 0, 1, 2, 3)
+   * }}}
+   */
+  def ++:[AA >: A](other: List[AA]): NonEmptyList[AA] =
+    prependAll(other)
+
+  /** 
+   * Prepend another List
+   *
+   * {{{
+   * scala> import cats.data.NonEmptyList
+   * scala> val nel = NonEmptyList.of(1, 2, 3)
+   * scala> val list = List(-1, 0)
+   * scala> list ++: nel
+   * res0: cats.data.NonEmptyList[Int] = NonEmptyList(-1, 0, 1, 2, 3)
+   * }}}
+   */
+  def prependAll[AA >: A](other: List[AA]): NonEmptyList[AA] =
+    other match {
+      case Nil          => this
+      case head :: tail => head :: prependAll[AA](tail)
+    }
 
   /**
    * Alias for append

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -161,7 +161,7 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
   def prependList[AA >: A](other: List[AA]): NonEmptyList[AA] =
     other match {
       case Nil          => this
-      case head :: tail => head :: prependAll[AA](tail)
+      case head :: tail => NonEmptyList(head, tail ::: toList)
     }
 
   /**

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -111,14 +111,8 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
   def ++[AA >: A](l: List[AA]): NonEmptyList[AA] =
     concat(l)
 
-  def ++[AA >: A](other: Option[AA]): NonEmptyList[AA] =
-    concat(other)
-
   def concat[AA >: A](other: List[AA]): NonEmptyList[AA] =
     NonEmptyList(head, tail ::: other)
-
-  def concat[AA >: A](other: Option[AA]): NonEmptyList[AA] =
-    concat(other.toList)
 
   @deprecated("Use concatNel", since = "1.0.0-RC1")
   private[data] def concat[AA >: A](other: NonEmptyList[AA]): NonEmptyList[AA] =

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -134,7 +134,7 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
     NonEmptyList(a, head :: tail)
 
   /**
-   * Alias for prependAll
+   * Alias for [[prependList]]
    * 
    * {{{
    * scala> import cats.data.NonEmptyList
@@ -145,20 +145,20 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
    * }}}
    */
   def ++:[AA >: A](other: List[AA]): NonEmptyList[AA] =
-    prependAll(other)
+    prependList(other)
 
-  /** 
-   * Prepend another List
+  /**
+   * Prepend another `List`
    *
    * {{{
    * scala> import cats.data.NonEmptyList
    * scala> val nel = NonEmptyList.of(1, 2, 3)
    * scala> val list = List(-1, 0)
-   * scala> list ++: nel
+   * scala> nel.prependList(list)
    * res0: cats.data.NonEmptyList[Int] = NonEmptyList(-1, 0, 1, 2, 3)
    * }}}
    */
-  def prependAll[AA >: A](other: List[AA]): NonEmptyList[AA] =
+  def prependList[AA >: A](other: List[AA]): NonEmptyList[AA] =
     other match {
       case Nil          => this
       case head :: tail => head :: prependAll[AA](tail)

--- a/core/src/main/scala/cats/data/NonEmptySeq.scala
+++ b/core/src/main/scala/cats/data/NonEmptySeq.scala
@@ -120,6 +120,18 @@ final class NonEmptySeq[+A] private (val toSeq: Seq[A]) extends AnyVal with NonE
   def concat[AA >: A](other: Seq[AA]): NonEmptySeq[AA] = new NonEmptySeq(toSeq ++ other)
 
   /**
+   * Append another `Seq` to this, producing a new `NonEmptySeq`.
+   * 
+   * {{{
+   * scala> import cats.data.NonEmptySeq
+   * scala> val neSeq = NonEmptySeq.of(1, 2, 3)
+   * scala> neSeq.appendSeq(Seq(4, 5))
+   * res0: cats.data.NonEmptySeq[Int] = NonEmptySeq(1, 2, 3, 4, 5)
+   * }}}
+   */
+   def appendSeq[AA >: A](other: Seq[AA]): NonEmptySeq[AA] = concat(other)
+
+  /**
    * Append another `NonEmptySeq` to this, producing a new `NonEmptySeq`.
    */
   def concatNeSeq[AA >: A](other: NonEmptySeq[AA]): NonEmptySeq[AA] = new NonEmptySeq(toSeq ++ other.toSeq)
@@ -149,6 +161,19 @@ final class NonEmptySeq[+A] private (val toSeq: Seq[A]) extends AnyVal with NonE
    * Alias for [[prepend]]
    */
   def +:[AA >: A](a: AA): NonEmptySeq[AA] = prepend(a)
+
+  /**
+   * Alias for [[prependSeq]]
+   * 
+   * {{{
+   * scala> import cats.data.NonEmptySeq
+   * scala> val neSeq = NonEmptySeq.of(4, 5, 6)
+   * scala> Seq(1, 2, 3) ++: neSeq
+   * res0: cats.data.NonEmptySeq[Int] = NonEmptySeq(1, 2, 3, 4, 5, 6)
+   * }}}
+   */
+  def ++:[AA >: A](seq: Seq[AA]): NonEmptySeq[AA] =
+    prependSeq(seq)
 
   /**
    * Find the first element matching the predicate, if one exists

--- a/core/src/main/scala/cats/data/NonEmptySeq.scala
+++ b/core/src/main/scala/cats/data/NonEmptySeq.scala
@@ -129,7 +129,7 @@ final class NonEmptySeq[+A] private (val toSeq: Seq[A]) extends AnyVal with NonE
    * res0: cats.data.NonEmptySeq[Int] = NonEmptySeq(1, 2, 3, 4, 5)
    * }}}
    */
-   def appendSeq[AA >: A](other: Seq[AA]): NonEmptySeq[AA] = concat(other)
+  def appendSeq[AA >: A](other: Seq[AA]): NonEmptySeq[AA] = concat(other)
 
   /**
    * Append another `NonEmptySeq` to this, producing a new `NonEmptySeq`.

--- a/core/src/main/scala/cats/data/NonEmptySeq.scala
+++ b/core/src/main/scala/cats/data/NonEmptySeq.scala
@@ -121,13 +121,6 @@ final class NonEmptySeq[+A] private (val toSeq: Seq[A]) extends AnyVal with NonE
 
   /**
    * Append another `Seq` to this, producing a new `NonEmptySeq`.
-   * 
-   * {{{
-   * scala> import cats.data.NonEmptySeq
-   * scala> val neSeq = NonEmptySeq.of(1, 2, 3)
-   * scala> neSeq.appendSeq(Seq(4, 5))
-   * res0: cats.data.NonEmptySeq[Int] = NonEmptySeq(1, 2, 3, 4, 5)
-   * }}}
    */
   def appendSeq[AA >: A](other: Seq[AA]): NonEmptySeq[AA] = concat(other)
 

--- a/core/src/main/scala/cats/data/NonEmptySeq.scala
+++ b/core/src/main/scala/cats/data/NonEmptySeq.scala
@@ -163,19 +163,6 @@ final class NonEmptySeq[+A] private (val toSeq: Seq[A]) extends AnyVal with NonE
   def +:[AA >: A](a: AA): NonEmptySeq[AA] = prepend(a)
 
   /**
-   * Alias for [[prependSeq]]
-   * 
-   * {{{
-   * scala> import cats.data.NonEmptySeq
-   * scala> val neSeq = NonEmptySeq.of(4, 5, 6)
-   * scala> Seq(1, 2, 3) ++: neSeq
-   * res0: cats.data.NonEmptySeq[Int] = NonEmptySeq(1, 2, 3, 4, 5, 6)
-   * }}}
-   */
-  def ++:[AA >: A](seq: Seq[AA]): NonEmptySeq[AA] =
-    prependSeq(seq)
-
-  /**
    * Find the first element matching the predicate, if one exists
    */
   def find(f: A => Boolean): Option[A] = toSeq.find(f)

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -123,6 +123,18 @@ final class NonEmptyVector[+A] private (val toVector: Vector[A])
   def concat[AA >: A](other: Vector[AA]): NonEmptyVector[AA] = new NonEmptyVector(toVector ++ other)
 
   /**
+   * Append another `Vector` to this, producing a new `NonEmptyVector`
+   * 
+   * {{{
+   * scala> import cats.data.NonEmptyVector
+   * scala> val nev = NonEmptyVector.of(1, 2, 3)
+   * scala> nev.appendVector(Vector(4, 5))
+   * res0: cats.data.NonEmptyVector[Int] = NonEmptyVector(1, 2, 3, 4, 5)
+   * }}}
+   */
+  def appendVector[AA >: A](other: Vector[AA]): NonEmptyVector[AA] = concat(other)
+
+  /**
    * Append another `NonEmptyVector` to this, producing a new `NonEmptyVector`.
    */
   def concatNev[AA >: A](other: NonEmptyVector[AA]): NonEmptyVector[AA] = new NonEmptyVector(toVector ++ other.toVector)

--- a/tests/shared/src/test/scala/cats/tests/NonEmptyListSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NonEmptyListSuite.scala
@@ -385,6 +385,7 @@ class NonEmptyListSuite extends NonEmptyCollectionSuite[List, NonEmptyList, NonE
     forAll { (nel: NonEmptyList[Int], l: List[Int], n: Int) =>
       assert((nel ++ l).toList === (nel.toList ::: l))
       assert(nel.concat(l).toList === (nel.toList ::: l))
+      assert(nel.appendList(l).toList === (nel.toList ::: l))
       assert(nel.concatNel(NonEmptyList(n, l)).toList === (nel.toList ::: (n :: l)))
     }
   }

--- a/tests/shared/src/test/scala/cats/tests/NonEmptyListSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NonEmptyListSuite.scala
@@ -285,6 +285,13 @@ class NonEmptyListSuite extends NonEmptyCollectionSuite[List, NonEmptyList, NonE
     }
   }
 
+  test("++: consistent with List#:::") {
+    forAll { (nel: NonEmptyList[Int], i: List[Int]) =>
+      assert((i ++: nel).toList === (i ::: nel.toList))
+      assert(nel.prependAll(i).toList === (i ::: nel.toList))
+    }
+  }
+
   test("NonEmptyList#distinct is consistent with List#distinct") {
     forAll { (nel: NonEmptyList[Int]) =>
       assert(nel.distinct.toList === (nel.toList.distinct))
@@ -379,6 +386,13 @@ class NonEmptyListSuite extends NonEmptyCollectionSuite[List, NonEmptyList, NonE
       assert((nel ++ l).toList === (nel.toList ::: l))
       assert(nel.concat(l).toList === (nel.toList ::: l))
       assert(nel.concatNel(NonEmptyList(n, l)).toList === (nel.toList ::: (n :: l)))
+    }
+  }
+
+  test("NonEmptyList#concat(Option) is consistent with List#++") {
+    forAll { (nel: NonEmptyList[Int], l: Option[Int], n: Int) =>
+      assert((nel ++ l).toList === (nel.toList ++ l))
+      assert(nel.concat(l).toList === (nel.toList ++ l))
     }
   }
 

--- a/tests/shared/src/test/scala/cats/tests/NonEmptyListSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NonEmptyListSuite.scala
@@ -288,7 +288,7 @@ class NonEmptyListSuite extends NonEmptyCollectionSuite[List, NonEmptyList, NonE
   test("++: consistent with List#:::") {
     forAll { (nel: NonEmptyList[Int], i: List[Int]) =>
       assert((i ++: nel).toList === (i ::: nel.toList))
-      assert(nel.prependAll(i).toList === (i ::: nel.toList))
+      assert(nel.prependList(i).toList === (i ::: nel.toList))
     }
   }
 

--- a/tests/shared/src/test/scala/cats/tests/NonEmptyListSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NonEmptyListSuite.scala
@@ -389,13 +389,6 @@ class NonEmptyListSuite extends NonEmptyCollectionSuite[List, NonEmptyList, NonE
     }
   }
 
-  test("NonEmptyList#concat(Option) is consistent with List#++") {
-    forAll { (nel: NonEmptyList[Int], l: Option[Int], n: Int) =>
-      assert((nel ++ l).toList === (nel.toList ++ l))
-      assert(nel.concat(l).toList === (nel.toList ++ l))
-    }
-  }
-
   test("NonEmptyList#fromFoldabale is consistent with NonEmptyList#fromList") {
     forAll { (xs: List[Int]) =>
       assert(NonEmptyList.fromList(xs) === (NonEmptyList.fromFoldable(xs)))

--- a/tests/shared/src/test/scala/cats/tests/NonEmptySeqSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NonEmptySeqSuite.scala
@@ -39,12 +39,17 @@ class NonEmptySeqSuite extends NonEmptyCollectionSuite[Seq, NonEmptySeq, NonEmpt
     }
   )
 
-  test("NonEmptySeq#concat/concatNeSeq/appendSeq is consistent with Seq#++")(
-    forAll { (fa: NonEmptySeq[Int], fb: Seq[Int], n: Int) =>
+  test("NonEmptySeq#concat/appendSeq is consistent with Seq#++")(
+    forAll { (fa: NonEmptySeq[Int], fb: Seq[Int]) =>
       assert((fa ++ fb).toSeq == fa.toSeq ++ fb)
       assert(fa.concat(fb).toSeq == fa.toSeq ++ fb)
       assert(fa.appendSeq(fb).toSeq == fa.toSeq ++ fb)
-      assert(fa.concatNeSeq(NonEmptySeq(n, fb)).toSeq == fa.toSeq :+ n ++: fb)
+    }
+  )
+
+  test("NonEmptySeq#concatNeSeq is consistent with concat")(
+    forAll { (fa: NonEmptySeq[Int], fb: NonEmptySeq[Int]) =>
+      assert(fa.concatNeSeq(fb).toSeq == fa.concat(fb.toSeq).toSeq)
     }
   )
 

--- a/tests/shared/src/test/scala/cats/tests/NonEmptySeqSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NonEmptySeqSuite.scala
@@ -28,7 +28,7 @@ import org.scalacheck.Prop._
 
 import scala.collection.immutable.Seq
 
-class NonEmtpySeqSuite extends NonEmptyCollectionSuite[Seq, NonEmptySeq, NonEmptySeq]{
+class NonEmptySeqSuite extends NonEmptyCollectionSuite[Seq, NonEmptySeq, NonEmptySeq] {
   protected def toList[A](value: NonEmptySeq[A]): List[A] = value.toSeq.toList
   protected def underlyingToList[A](underlying: Seq[A]): List[A] = underlying.toList
   protected def toNonEmptyCollection[A](value: NonEmptySeq[A]): NonEmptySeq[A] = value

--- a/tests/shared/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
@@ -256,6 +256,12 @@ class NonEmptyVectorSuite extends NonEmptyCollectionSuite[Vector, NonEmptyVector
     }
   }
 
+  test("appendVector is consistent with concat") {
+    forAll { (nonEmptyVector: NonEmptyVector[Int], vector: Vector[Int]) =>
+      assert(nonEmptyVector.appendVector(vector) === nonEmptyVector.concat(vector))
+    }
+  }
+
   test(":+ is consistent with concat") {
     forAll { (nonEmptyVector: NonEmptyVector[Int], i: Int) =>
       assert(nonEmptyVector :+ i === (nonEmptyVector.concat(Vector(i))))

--- a/tests/shared/src/test/scala/cats/tests/NonEmtpySeqSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NonEmtpySeqSuite.scala
@@ -1,3 +1,24 @@
+/*
+ * Copyright (c) 2015 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
 package cats.tests
 
 import cats.data.NonEmptySeq

--- a/tests/shared/src/test/scala/cats/tests/NonEmtpySeqSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NonEmtpySeqSuite.scala
@@ -1,0 +1,33 @@
+package cats.tests
+
+import cats.data.NonEmptySeq
+import cats.laws.discipline.arbitrary._
+import cats.syntax.seq._
+import org.scalacheck.Prop._
+
+import scala.collection.immutable.Seq
+
+class NonEmtpySeqSuite extends NonEmptyCollectionSuite[Seq, NonEmptySeq, NonEmptySeq]{
+  protected def toList[A](value: NonEmptySeq[A]): List[A] = value.toSeq.toList
+  protected def underlyingToList[A](underlying: Seq[A]): List[A] = underlying.toList
+  protected def toNonEmptyCollection[A](value: NonEmptySeq[A]): NonEmptySeq[A] = value
+
+  test("neSeq => Seq => neSeq returns original neSeq")(
+    forAll { (fa: NonEmptySeq[Int]) =>
+      assert(fa.toSeq.toNeSeq == Some(fa))
+    }
+  )
+
+  test("NonEmptySeq#concat/concatNeSeq/appendSeq is consistent with Seq#++")(
+    forAll { (fa: NonEmptySeq[Int], fb: Seq[Int], n: Int) =>
+      assert((fa ++ fb).toSeq == fa.toSeq ++ fb)
+      assert(fa.concat(fb).toSeq == fa.toSeq ++ fb)
+      assert(fa.appendSeq(fb).toSeq == fa.toSeq ++ fb)
+      assert(fa.concatNeSeq(NonEmptySeq(n, fb)).toSeq == fa.toSeq :+ n ++: fb)
+    }
+  )
+
+  test("toNeSeq on empty Seq returns None") {
+    assert(Seq.empty[Int].toNeSeq == None)
+  }
+}

--- a/tests/shared/src/test/scala/cats/tests/SeqSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/SeqSuite.scala
@@ -22,7 +22,7 @@
 package cats.tests
 
 import cats.{Align, Alternative, CoflatMap, Monad, Semigroupal, Traverse, TraverseFilter}
-import cats.data.{NonEmptySeq, ZipSeq}
+import cats.data.ZipSeq
 import cats.laws.discipline.{
   AlignTests,
   AlternativeTests,
@@ -37,7 +37,6 @@ import cats.laws.discipline.{
 }
 import cats.laws.discipline.arbitrary._
 import cats.syntax.show._
-import cats.syntax.seq._
 import cats.syntax.eq._
 import org.scalacheck.Prop._
 import scala.collection.immutable.Seq

--- a/tests/shared/src/test/scala/cats/tests/SeqSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/SeqSuite.scala
@@ -75,16 +75,6 @@ class SeqSuite extends CatsSuite {
     }
   }
 
-  test("neSeq => Seq => neSeq returns original neSeq")(
-    forAll { (fa: NonEmptySeq[Int]) =>
-      assert(fa.toSeq.toNeSeq == Some(fa))
-    }
-  )
-
-  test("toNeSeq on empty Seq returns None") {
-    assert(Seq.empty[Int].toNeSeq == None)
-  }
-
   test("traverse is stack-safe") {
     val seq = (0 until 100000).toSeq
     val sumAll = Traverse[Seq]


### PR DESCRIPTION
`NonEmptyList` was missing a `prependAll`/`++:`. This adds the method and the alias and tests. The implementation may not be most efficient.

I also added an override for `concat` to append an `Option` to a `NonEmptyList`. I would have used `IterableOnce` as in the standard library for Scala 2.13 with `Seq`. But I didn't know how to do that cross-version with Scala 2.12 and `TraversableOnce`. Maybe I could use `Foldable`? Any help appreciated.


