### PR TITLE
Mention `tupled` syntax, a Cats workhorse that deserves to be more well known

### DIFF
--- a/docs/typeclasses/applicative.md
+++ b/docs/typeclasses/applicative.md
@@ -262,6 +262,16 @@ import cats.implicits._
 We don't have to mention the type or specify the number of values we're composing
 together, so there's a little less boilerplate here.
 
+Another very useful `Apply` syntax is `tupled`, which allows a tuple of effectful values to be composed into a single effectful value containing a tuple. 
+
+```scala mdoc
+import cats.implicits._
+
+val optPair: Option[(String, String)] = (username, password).tupled
+```
+
+(See also: variant `parTupled`, useful for composing tuples of executable tasks (eg `IO` from [Cats Effect](https://typelevel.org/cats-effect/docs/concepts#concurrent)) into a single task to run in [parallel](parallel.md))
+
 ## Further Reading
 
 * [Applicative Programming with Effects][applicativePaper] - McBride, Patterson. JFP 2008.

--- a/docs/typeclasses/applicative.md
+++ b/docs/typeclasses/applicative.md
@@ -270,7 +270,11 @@ import cats.implicits._
 val optPair: Option[(String, String)] = (username, password).tupled
 ```
 
-(See also: variant `parTupled`, useful for composing tuples of executable tasks (eg `IO` from [Cats Effect](https://typelevel.org/cats-effect/docs/concepts#concurrent)) into a single task to run in [parallel](parallel.md))
+### See also Parallel variants
+
+Both `tupled` and `mapN` have [parallel](parallel.md) variant operations, named `parTupled` and `parMapN` respectively. Regular `tupled`/`mapN` evaluate their effects from left to right ("sequentially"), while `parTupled`/`parMapN` evaluate in an indeterminate order, or in parallel.
+
+The difference can be understood intuitively when the effect is an executable task, such as `IO` from [Cats Effect](https://typelevel.org/cats-effect/docs/concepts#concurrent). In this case, the parallel forms support composing tuples of tasks into a single task that will run its components in parallel.
 
 ## Further Reading
 

--- a/docs/typeclasses/applicative.md
+++ b/docs/typeclasses/applicative.md
@@ -274,7 +274,7 @@ val optPair: Option[(String, String)] = (username, password).tupled
 
 Both `tupled` and `mapN` have [parallel](parallel.md) variant operations, named `parTupled` and `parMapN` respectively. Regular `tupled`/`mapN` evaluate their effects from left to right ("sequentially"), while `parTupled`/`parMapN` evaluate in an indeterminate order, or in parallel.
 
-The difference can be understood intuitively when the effect is an executable task, such as `IO` from [Cats Effect](https://typelevel.org/cats-effect/docs/concepts#concurrent). In this case, the parallel forms support composing tuples of tasks into a single task that will run its components in parallel.
+The difference can be understood intuitively when the effect is an executable task, such as `IO` from [Cats Effect](https://typelevel.org/cats-effect/docs/concepts#concurrent). In this case, the parallel variants enable you to compose tuples of tasks into a single task that will run its sub-tasks concurrently.
 
 ## Further Reading
 


### PR DESCRIPTION
In my experiences working with Cats users, awareness of `tupled` and `parTupled` is not high, considering how fundamental and useful these operations are. Attempt to raise the exposure plus a bit of relevant cross-linking in the docs.


Thank you for contributing to Cats!

This is a kind reminder to run `sbt +prePR` and commit the changed files, if any, before submitting.


