### PR TITLE
Add `collectFirst` to the `NonEmptyCollection` interface

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyCollection.scala
+++ b/core/src/main/scala/cats/data/NonEmptyCollection.scala
@@ -40,6 +40,7 @@ private[cats] trait NonEmptyCollection[+A, U[+_], NE[+_]] extends Any {
   def filter(f: A => Boolean): U[A]
   def filterNot(p: A => Boolean): U[A]
   def collect[B](pf: PartialFunction[A, B]): U[B]
+  def collectFirst[B](pf: PartialFunction[A, B]): Option[B]
   def find(p: A => Boolean): Option[A]
   def exists(p: A => Boolean): Boolean
   def forall(p: A => Boolean): Boolean

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -218,6 +218,16 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
     }
 
   /**
+   * Find the first element matching the partial function, if one exists
+   */
+  def collectFirst[B](pf: PartialFunction[A, B]): Option[B] =
+    if (pf.isDefinedAt(head)) {
+      Some(pf.apply(head))
+    } else {
+      tail.collectFirst(pf)
+    }
+
+  /**
    * Find the first element matching the predicate, if one exists
    */
   def find(p: A => Boolean): Option[A] =

--- a/core/src/main/scala/cats/data/NonEmptySeq.scala
+++ b/core/src/main/scala/cats/data/NonEmptySeq.scala
@@ -97,6 +97,8 @@ final class NonEmptySeq[+A] private (val toSeq: Seq[A]) extends AnyVal with NonE
 
   def collect[B](pf: PartialFunction[A, B]): Seq[B] = toSeq.collect(pf)
 
+  def collectFirst[B](pf: PartialFunction[A, B]): Option[B] = toSeq.collectFirst(pf)
+
   /**
    * Alias for [[concat]]
    */

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -100,6 +100,8 @@ final class NonEmptyVector[+A] private (val toVector: Vector[A])
 
   def collect[B](pf: PartialFunction[A, B]): Vector[B] = toVector.collect(pf)
 
+  def collectFirst[B](pf: PartialFunction[A, B]): Option[B] = toVector.collectFirst(pf)
+
   /**
    * Alias for [[concat]]
    */

--- a/tests/shared/src/test/scala/cats/tests/NonEmptyCollectionSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NonEmptyCollectionSuite.scala
@@ -103,6 +103,12 @@ abstract class NonEmptyCollectionSuite[U[+_], NE[+_], NEC[x] <: NonEmptyCollecti
     }
   }
 
+  test("collectFirst is consistent with iterator.toList.collectFirst") {
+    forAll { (is: NE[Int], pf: PartialFunction[Int, String]) =>
+      assert(is.collectFirst(pf) === is.iterator.toList.collectFirst(pf))
+    }
+  }
+
   test("find is consistent with iterator.toList.find") {
     forAll { (is: NE[Int], pred: Int => Boolean) =>
       assert(is.find(pred) === (is.iterator.toList.find(pred)))


### PR DESCRIPTION
This work was initially done on PR #4193 to support the `cats.data.HashMap` implementation, but now that that PR is being retargeted onto cats-collections I'd like to make sure this change isn't lost.