### PR TITLE
Use SAM syntax for typeclass instances where possible

### DIFF
--- a/algebra-core/src/main/scala/algebra/lattice/BoundedJoinSemilattice.scala
+++ b/algebra-core/src/main/scala/algebra/lattice/BoundedJoinSemilattice.scala
@@ -29,7 +29,10 @@ trait BoundedJoinSemilattice[@sp(Int, Long, Float, Double) A] extends Any with J
   def isZero(a: A)(implicit ev: Eq[A]): Boolean = ev.eqv(a, zero)
 
   override def joinSemilattice: BoundedSemilattice[A] =
-    BoundedSemilattice.instance(zero, join)
+    new BoundedSemilattice[A] {
+      def empty: A = zero
+      def combine(x: A, y: A): A = join(x, y)
+    }
 }
 
 trait BoundedJoinSemilatticeFunctions[B[A] <: BoundedJoinSemilattice[A]] extends JoinSemilatticeFunctions[B] {

--- a/algebra-core/src/main/scala/algebra/lattice/BoundedJoinSemilattice.scala
+++ b/algebra-core/src/main/scala/algebra/lattice/BoundedJoinSemilattice.scala
@@ -24,15 +24,12 @@ package lattice
 
 import scala.{specialized => sp}
 
-trait BoundedJoinSemilattice[@sp(Int, Long, Float, Double) A] extends Any with JoinSemilattice[A] { self =>
+trait BoundedJoinSemilattice[@sp(Int, Long, Float, Double) A] extends Any with JoinSemilattice[A] {
   def zero: A
   def isZero(a: A)(implicit ev: Eq[A]): Boolean = ev.eqv(a, zero)
 
   override def joinSemilattice: BoundedSemilattice[A] =
-    new BoundedSemilattice[A] {
-      def empty: A = self.zero
-      def combine(x: A, y: A): A = join(x, y)
-    }
+    BoundedSemilattice.instance(zero, join)
 }
 
 trait BoundedJoinSemilatticeFunctions[B[A] <: BoundedJoinSemilattice[A]] extends JoinSemilatticeFunctions[B] {

--- a/algebra-core/src/main/scala/algebra/lattice/BoundedMeetSemilattice.scala
+++ b/algebra-core/src/main/scala/algebra/lattice/BoundedMeetSemilattice.scala
@@ -29,7 +29,10 @@ trait BoundedMeetSemilattice[@sp(Int, Long, Float, Double) A] extends Any with M
   def isOne(a: A)(implicit ev: Eq[A]): Boolean = ev.eqv(a, one)
 
   override def meetSemilattice: BoundedSemilattice[A] =
-    BoundedSemilattice.instance(one, meet)
+    new BoundedSemilattice[A] {
+      def empty: A = one
+      def combine(x: A, y: A): A = meet(x, y)
+    }
 }
 
 trait BoundedMeetSemilatticeFunctions[B[A] <: BoundedMeetSemilattice[A]] extends MeetSemilatticeFunctions[B] {

--- a/algebra-core/src/main/scala/algebra/lattice/BoundedMeetSemilattice.scala
+++ b/algebra-core/src/main/scala/algebra/lattice/BoundedMeetSemilattice.scala
@@ -24,15 +24,12 @@ package lattice
 
 import scala.{specialized => sp}
 
-trait BoundedMeetSemilattice[@sp(Int, Long, Float, Double) A] extends Any with MeetSemilattice[A] { self =>
+trait BoundedMeetSemilattice[@sp(Int, Long, Float, Double) A] extends Any with MeetSemilattice[A] {
   def one: A
   def isOne(a: A)(implicit ev: Eq[A]): Boolean = ev.eqv(a, one)
 
   override def meetSemilattice: BoundedSemilattice[A] =
-    new BoundedSemilattice[A] {
-      def empty: A = self.one
-      def combine(x: A, y: A): A = meet(x, y)
-    }
+    BoundedSemilattice.instance(one, meet)
 }
 
 trait BoundedMeetSemilatticeFunctions[B[A] <: BoundedMeetSemilattice[A]] extends MeetSemilatticeFunctions[B] {

--- a/algebra-core/src/main/scala/algebra/lattice/JoinSemilattice.scala
+++ b/algebra-core/src/main/scala/algebra/lattice/JoinSemilattice.scala
@@ -29,13 +29,11 @@ import scala.{specialized => sp}
  * operation is called "join", and which can be thought of as a least
  * upper bound.
  */
-trait JoinSemilattice[@sp(Int, Long, Float, Double) A] extends Any with Serializable { self =>
+trait JoinSemilattice[@sp(Int, Long, Float, Double) A] extends Any with Serializable {
   def join(lhs: A, rhs: A): A
 
   def joinSemilattice: Semilattice[A] =
-    new Semilattice[A] {
-      def combine(x: A, y: A): A = self.join(x, y)
-    }
+    Semilattice.instance(join)
 
   def joinPartialOrder(implicit ev: Eq[A]): PartialOrder[A] =
     joinSemilattice.asJoinPartialOrder

--- a/algebra-core/src/main/scala/algebra/lattice/JoinSemilattice.scala
+++ b/algebra-core/src/main/scala/algebra/lattice/JoinSemilattice.scala
@@ -32,8 +32,7 @@ import scala.{specialized => sp}
 trait JoinSemilattice[@sp(Int, Long, Float, Double) A] extends Any with Serializable {
   def join(lhs: A, rhs: A): A
 
-  def joinSemilattice: Semilattice[A] =
-    Semilattice.instance(join)
+  def joinSemilattice: Semilattice[A] = join(_, _)
 
   def joinPartialOrder(implicit ev: Eq[A]): PartialOrder[A] =
     joinSemilattice.asJoinPartialOrder

--- a/algebra-core/src/main/scala/algebra/lattice/MeetSemilattice.scala
+++ b/algebra-core/src/main/scala/algebra/lattice/MeetSemilattice.scala
@@ -32,8 +32,7 @@ import scala.{specialized => sp}
 trait MeetSemilattice[@sp(Int, Long, Float, Double) A] extends Any with Serializable {
   def meet(lhs: A, rhs: A): A
 
-  def meetSemilattice: Semilattice[A] =
-    Semilattice.instance(meet)
+  def meetSemilattice: Semilattice[A] = meet(_, _)
 
   def meetPartialOrder(implicit ev: Eq[A]): PartialOrder[A] =
     meetSemilattice.asMeetPartialOrder

--- a/algebra-core/src/main/scala/algebra/lattice/MeetSemilattice.scala
+++ b/algebra-core/src/main/scala/algebra/lattice/MeetSemilattice.scala
@@ -29,13 +29,11 @@ import scala.{specialized => sp}
  * operation is called "meet", and which can be thought of as a
  * greatest lower bound.
  */
-trait MeetSemilattice[@sp(Int, Long, Float, Double) A] extends Any with Serializable { self =>
+trait MeetSemilattice[@sp(Int, Long, Float, Double) A] extends Any with Serializable {
   def meet(lhs: A, rhs: A): A
 
   def meetSemilattice: Semilattice[A] =
-    new Semilattice[A] {
-      def combine(x: A, y: A): A = self.meet(x, y)
-    }
+    Semilattice.instance(meet)
 
   def meetPartialOrder(implicit ev: Eq[A]): PartialOrder[A] =
     meetSemilattice.asMeetPartialOrder

--- a/algebra-core/src/main/scala/algebra/ring/Multiplicative.scala
+++ b/algebra-core/src/main/scala/algebra/ring/Multiplicative.scala
@@ -27,9 +27,7 @@ import scala.annotation.{nowarn, tailrec}
 
 trait MultiplicativeSemigroup[@sp(Int, Long, Float, Double) A] extends Any with Serializable {
   def multiplicative: Semigroup[A] =
-    new Semigroup[A] {
-      def combine(x: A, y: A): A = times(x, y)
-    }
+    Semigroup.instance(times)
 
   def times(x: A, y: A): A
 
@@ -58,9 +56,8 @@ trait MultiplicativeSemigroup[@sp(Int, Long, Float, Double) A] extends Any with 
 }
 
 trait MultiplicativeCommutativeSemigroup[@sp(Int, Long, Float, Double) A] extends Any with MultiplicativeSemigroup[A] {
-  override def multiplicative: CommutativeSemigroup[A] = new CommutativeSemigroup[A] {
-    def combine(x: A, y: A): A = times(x, y)
-  }
+  override def multiplicative: CommutativeSemigroup[A] =
+    CommutativeSemigroup.instance(times)
 }
 
 trait MultiplicativeMonoid[@sp(Int, Long, Float, Double) A] extends Any with MultiplicativeSemigroup[A] {

--- a/algebra-core/src/main/scala/algebra/ring/Multiplicative.scala
+++ b/algebra-core/src/main/scala/algebra/ring/Multiplicative.scala
@@ -26,8 +26,7 @@ import scala.{specialized => sp}
 import scala.annotation.{nowarn, tailrec}
 
 trait MultiplicativeSemigroup[@sp(Int, Long, Float, Double) A] extends Any with Serializable {
-  def multiplicative: Semigroup[A] =
-    Semigroup.instance(times)
+  def multiplicative: Semigroup[A] = times(_, _)
 
   def times(x: A, y: A): A
 
@@ -56,8 +55,7 @@ trait MultiplicativeSemigroup[@sp(Int, Long, Float, Double) A] extends Any with 
 }
 
 trait MultiplicativeCommutativeSemigroup[@sp(Int, Long, Float, Double) A] extends Any with MultiplicativeSemigroup[A] {
-  override def multiplicative: CommutativeSemigroup[A] =
-    CommutativeSemigroup.instance(times)
+  override def multiplicative: CommutativeSemigroup[A] = times(_, _)
 }
 
 trait MultiplicativeMonoid[@sp(Int, Long, Float, Double) A] extends Any with MultiplicativeSemigroup[A] {

--- a/algebra-core/src/test/scala/algebra/Instances.scala
+++ b/algebra-core/src/test/scala/algebra/Instances.scala
@@ -23,12 +23,6 @@ package algebra
 
 object Instances {
 
-  def t2HasSemigroup[A, B](implicit eva: Semigroup[A], evb: Semigroup[B]) =
-    new Semigroup[(A, B)] {
-      def combine(x: (A, B), y: (A, B)): (A, B) =
-        (eva.combine(x._1, y._1), evb.combine(x._2, y._2))
-    }
-
   val stringHasMonoid =
     new Monoid[String] {
       def empty: String = ""

--- a/algebra-laws/shared/src/test/scala/algebra/laws/FPApprox.scala
+++ b/algebra-laws/shared/src/test/scala/algebra/laws/FPApprox.scala
@@ -125,20 +125,18 @@ object FPApprox {
 
   // An Eq instance that returns true if 2 values *could* be equal.
   implicit def fpApproxEq[A: Field: Order: Epsilon]: Eq[FPApprox[A]] =
-    new Eq[FPApprox[A]] {
-      def eqv(x: FPApprox[A], y: FPApprox[A]): Boolean = {
-        // We want to check if z +/- error contains 0
-        if (x.approx == y.approx) {
-          true
+    Eq.instance { (x, y) =>
+      // We want to check if z +/- error contains 0
+      if (x.approx == y.approx) {
+        true
+      } else {
+        val z = x - y
+        val err = z.error
+        if (Epsilon.isFinite(err)) {
+          Order.lteqv(Ring[A].minus(z.approx, err), Ring[A].zero) &&
+          Order.gteqv(Ring[A].plus(z.approx, err), Ring[A].zero)
         } else {
-          val z = x - y
-          val err = z.error
-          if (Epsilon.isFinite(err)) {
-            Order.lteqv(Ring[A].minus(z.approx, err), Ring[A].zero) &&
-            Order.gteqv(Ring[A].plus(z.approx, err), Ring[A].zero)
-          } else {
-            true
-          }
+          true
         }
       }
     }

--- a/algebra-laws/shared/src/test/scala/algebra/laws/FPApprox.scala
+++ b/algebra-laws/shared/src/test/scala/algebra/laws/FPApprox.scala
@@ -124,21 +124,14 @@ object FPApprox {
   implicit def fpApproxAlgebra[A: Field: Order: Epsilon]: FPApproxAlgebra[A] = new FPApproxAlgebra[A]
 
   // An Eq instance that returns true if 2 values *could* be equal.
-  implicit def fpApproxEq[A: Field: Order: Epsilon]: Eq[FPApprox[A]] =
-    Eq.instance { (x, y) =>
-      // We want to check if z +/- error contains 0
-      if (x.approx == y.approx) {
-        true
-      } else {
-        val z = x - y
-        val err = z.error
-        if (Epsilon.isFinite(err)) {
-          Order.lteqv(Ring[A].minus(z.approx, err), Ring[A].zero) &&
-          Order.gteqv(Ring[A].plus(z.approx, err), Ring[A].zero)
-        } else {
-          true
-        }
-      }
+  implicit def fpApproxEq[A: Field: Order: Epsilon]: Eq[FPApprox[A]] = (x, y) =>
+    // We want to check if z +/- error contains 0
+    x.approx == y.approx || {
+      val z = x - y
+      val err = z.error
+      !Epsilon.isFinite(err) ||
+      Order.lteqv(Ring[A].minus(z.approx, err), Ring[A].zero) &&
+      Order.gteqv(Ring[A].plus(z.approx, err), Ring[A].zero)
     }
 
   implicit def arbFPApprox[A: Rng: Order: Arbitrary]: Arbitrary[FPApprox[A]] =

--- a/algebra-laws/shared/src/test/scala/algebra/laws/LawTests.scala
+++ b/algebra-laws/shared/src/test/scala/algebra/laws/LawTests.scala
@@ -177,12 +177,11 @@ class LawTests extends munit.DisciplineSuite {
     implicit val NOrderEq: Eq[Order[N]] = Eq.by { (order: Order[N]) =>
       Vector.tabulate(nMax)(N).sorted(order.toOrdering)
     }
-    implicit val NEqEq: Eq[Eq[N]] = new Eq[Eq[N]] {
-      def eqv(a: Eq[N], b: Eq[N]) =
-        Iterator
-          .tabulate(nMax)(N)
-          .flatMap { x => Iterator.tabulate(nMax)(N).map((x, _)) }
-          .forall { case (x, y) => a.eqv(x, y) == b.eqv(x, y) }
+    implicit val NEqEq: Eq[Eq[N]] = Eq.instance { (a, b) =>
+      Iterator
+        .tabulate(nMax)(N)
+        .flatMap { x => Iterator.tabulate(nMax)(N).map((x, _)) }
+        .forall { case (x, y) => a.eqv(x, y) == b.eqv(x, y) }
     }
 
     implicit val monoidOrderN: Monoid[Order[N]] = Order.whenEqualMonoid[N]

--- a/algebra-laws/shared/src/test/scala/algebra/laws/LawTests.scala
+++ b/algebra-laws/shared/src/test/scala/algebra/laws/LawTests.scala
@@ -177,12 +177,11 @@ class LawTests extends munit.DisciplineSuite {
     implicit val NOrderEq: Eq[Order[N]] = Eq.by { (order: Order[N]) =>
       Vector.tabulate(nMax)(N).sorted(order.toOrdering)
     }
-    implicit val NEqEq: Eq[Eq[N]] = Eq.instance { (a, b) =>
+    implicit val NEqEq: Eq[Eq[N]] = (a, b) =>
       Iterator
         .tabulate(nMax)(N)
         .flatMap { x => Iterator.tabulate(nMax)(N).map((x, _)) }
         .forall { case (x, y) => a.eqv(x, y) == b.eqv(x, y) }
-    }
 
     implicit val monoidOrderN: Monoid[Order[N]] = Order.whenEqualMonoid[N]
     checkAll("Order[N]", GroupLaws[Order[N]].monoid)

--- a/algebra-laws/shared/src/test/scala/algebra/laws/SimpleDeMorgan.scala
+++ b/algebra-laws/shared/src/test/scala/algebra/laws/SimpleDeMorgan.scala
@@ -68,7 +68,6 @@ object SimpleDeMorgan {
 
   implicit val arbitrary: Arbitrary[SimpleDeMorgan] = Arbitrary(oneOf(False, Unknown, True))
 
-  implicit val eq: Eq[SimpleDeMorgan] = new Eq[SimpleDeMorgan] {
-    def eqv(x: SimpleDeMorgan, y: SimpleDeMorgan): Boolean = x == y
-  }
+  implicit val eq: Eq[SimpleDeMorgan] =
+    Eq.fromUniversalEquals
 }

--- a/algebra-laws/shared/src/test/scala/algebra/laws/SimpleHeyting.scala
+++ b/algebra-laws/shared/src/test/scala/algebra/laws/SimpleHeyting.scala
@@ -74,7 +74,6 @@ object SimpleHeyting {
 
   implicit val arbitrary: Arbitrary[SimpleHeyting] = Arbitrary(oneOf(Zero, Half, One))
 
-  implicit val eq: Eq[SimpleHeyting] = new Eq[SimpleHeyting] {
-    def eqv(x: SimpleHeyting, y: SimpleHeyting): Boolean = x == y
-  }
+  implicit val eq: Eq[SimpleHeyting] =
+    Eq.fromUniversalEquals
 }

--- a/core/src/main/scala-2.12/cats/instances/stream.scala
+++ b/core/src/main/scala-2.12/cats/instances/stream.scala
@@ -194,9 +194,7 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
     }
 
   implicit def catsStdShowForStream[A: Show]: Show[Stream[A]] =
-    new Show[Stream[A]] {
-      def show(fa: Stream[A]): String = if (fa.isEmpty) "Stream()" else s"Stream(${fa.head.show}, ?)"
-    }
+    Show.show(stream => if (stream.isEmpty) "Stream()" else s"Stream(${stream.head.show}, ?)")
 
   implicit def catsStdParallelForStreamZipStream: Parallel.Aux[Stream, ZipStream] =
     new Parallel[Stream] {

--- a/core/src/main/scala-2.12/cats/instances/stream.scala
+++ b/core/src/main/scala-2.12/cats/instances/stream.scala
@@ -194,7 +194,7 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
     }
 
   implicit def catsStdShowForStream[A: Show]: Show[Stream[A]] =
-    Show.show(stream => if (stream.isEmpty) "Stream()" else s"Stream(${stream.head.show}, ?)")
+    stream => if (stream.isEmpty) "Stream()" else s"Stream(${stream.head.show}, ?)"
 
   implicit def catsStdParallelForStreamZipStream: Parallel.Aux[Stream, ZipStream] =
     new Parallel[Stream] {

--- a/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
+++ b/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
@@ -553,8 +553,7 @@ sealed abstract private[data] class NonEmptyLazyListInstances extends NonEmptyLa
   implicit def catsDataSemigroupForNonEmptyLazyList[A]: Semigroup[NonEmptyLazyList[A]] =
     Semigroup[LazyList[A]].asInstanceOf[Semigroup[NonEmptyLazyList[A]]]
 
-  implicit def catsDataShowForNonEmptyLazyList[A](implicit A: Show[A]): Show[NonEmptyLazyList[A]] =
-    Show.show[NonEmptyLazyList[A]](_.show)
+  implicit def catsDataShowForNonEmptyLazyList[A: Show]: Show[NonEmptyLazyList[A]] = _.show
 
   implicit def catsDataParallelForNonEmptyLazyList: Parallel.Aux[NonEmptyLazyList, OneAnd[ZipLazyList, *]] =
     new Parallel[NonEmptyLazyList] {

--- a/core/src/main/scala-2.13+/cats/instances/arraySeq.scala
+++ b/core/src/main/scala-2.13+/cats/instances/arraySeq.scala
@@ -36,9 +36,7 @@ trait ArraySeqInstances extends cats.kernel.instances.ArraySeqInstances {
     ArraySeqInstances.stdTraverseFilterInstance
 
   implicit def catsStdShowForArraySeq[A](implicit ev: Show[A]): Show[ArraySeq[A]] =
-    Show.show { arraySeq =>
-      arraySeq.iterator.map(ev.show).mkString("ArraySeq(", ", ", ")")
-    }
+    _.iterator.map(ev.show).mkString("ArraySeq(", ", ", ")")
 }
 
 private[cats] object ArraySeqInstances {

--- a/core/src/main/scala-2.13+/cats/instances/lazyList.scala
+++ b/core/src/main/scala-2.13+/cats/instances/lazyList.scala
@@ -176,7 +176,7 @@ trait LazyListInstances extends cats.kernel.instances.LazyListInstances {
     }
 
   implicit def catsStdShowForLazyList[A: Show]: Show[LazyList[A]] =
-    Show.show(list => if (list.isEmpty) "LazyList()" else s"LazyList(${list.head.show}, ?)")
+    list => if (list.isEmpty) "LazyList()" else s"LazyList(${list.head.show}, ?)"
 
   implicit val catsStdTraverseFilterForLazyList: TraverseFilter[LazyList] = new TraverseFilter[LazyList] {
     val traverse: Traverse[LazyList] = catsStdInstancesForLazyList

--- a/core/src/main/scala-2.13+/cats/instances/lazyList.scala
+++ b/core/src/main/scala-2.13+/cats/instances/lazyList.scala
@@ -176,9 +176,7 @@ trait LazyListInstances extends cats.kernel.instances.LazyListInstances {
     }
 
   implicit def catsStdShowForLazyList[A: Show]: Show[LazyList[A]] =
-    new Show[LazyList[A]] {
-      def show(fa: LazyList[A]): String = if (fa.isEmpty) "LazyList()" else s"LazyList(${fa.head.show}, ?)"
-    }
+    Show.show(list => if (list.isEmpty) "LazyList()" else s"LazyList(${list.head.show}, ?)")
 
   implicit val catsStdTraverseFilterForLazyList: TraverseFilter[LazyList] = new TraverseFilter[LazyList] {
     val traverse: Traverse[LazyList] = catsStdInstancesForLazyList

--- a/core/src/main/scala-2.13+/cats/instances/stream.scala
+++ b/core/src/main/scala-2.13+/cats/instances/stream.scala
@@ -196,9 +196,7 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
 
   @deprecated("Use cats.instances.lazyList", "2.0.0-RC2")
   implicit def catsStdShowForStream[A: Show]: Show[Stream[A]] =
-    new Show[Stream[A]] {
-      def show(fa: Stream[A]): String = if (fa.isEmpty) "Stream()" else s"Stream(${fa.head.show}, ?)"
-    }
+    Show.show(stream => if (stream.isEmpty) "Stream()" else s"Stream(${stream.head.show}, ?)")
 
   @deprecated("Use catsStdParallelForZipLazyList", "2.0.0-RC2")
   implicit def catsStdParallelForStreamZipStream: Parallel.Aux[Stream, ZipStream] =

--- a/core/src/main/scala-2.13+/cats/instances/stream.scala
+++ b/core/src/main/scala-2.13+/cats/instances/stream.scala
@@ -196,7 +196,7 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
 
   @deprecated("Use cats.instances.lazyList", "2.0.0-RC2")
   implicit def catsStdShowForStream[A: Show]: Show[Stream[A]] =
-    Show.show(stream => if (stream.isEmpty) "Stream()" else s"Stream(${stream.head.show}, ?)")
+    stream => if (stream.isEmpty) "Stream()" else s"Stream(${stream.head.show}, ?)"
 
   @deprecated("Use catsStdParallelForZipLazyList", "2.0.0-RC2")
   implicit def catsStdParallelForStreamZipStream: Parallel.Aux[Stream, ZipStream] =

--- a/core/src/main/scala/cats/Align.scala
+++ b/core/src/main/scala/cats/Align.scala
@@ -135,7 +135,7 @@ trait Align[F[_]] extends Serializable {
 
 object Align extends ScalaVersionSpecificAlignInstances {
   def semigroup[F[_], A](implicit F: Align[F], A: Semigroup[A]): Semigroup[F[A]] =
-    Semigroup.instance(F.alignCombine[A])
+    F.alignCombine(_, _)
 
   implicit def catsAlignForList: Align[List] = cats.instances.list.catsStdInstancesForList
   implicit def catsAlignForOption: Align[Option] = cats.instances.option.catsStdInstancesForOption

--- a/core/src/main/scala/cats/Align.scala
+++ b/core/src/main/scala/cats/Align.scala
@@ -135,9 +135,7 @@ trait Align[F[_]] extends Serializable {
 
 object Align extends ScalaVersionSpecificAlignInstances {
   def semigroup[F[_], A](implicit F: Align[F], A: Semigroup[A]): Semigroup[F[A]] =
-    new Semigroup[F[A]] {
-      def combine(x: F[A], y: F[A]): F[A] = Align[F].alignCombine(x, y)
-    }
+    Semigroup.instance(F.alignCombine[A])
 
   implicit def catsAlignForList: Align[List] = cats.instances.list.catsStdInstancesForList
   implicit def catsAlignForOption: Align[Option] = cats.instances.option.catsStdInstancesForOption

--- a/core/src/main/scala/cats/CommutativeApply.scala
+++ b/core/src/main/scala/cats/CommutativeApply.scala
@@ -36,7 +36,7 @@ trait CommutativeApply[F[_]] extends Apply[F]
 
 object CommutativeApply {
   def commutativeSemigroupFor[F[_]: CommutativeApply, A: CommutativeSemigroup]: CommutativeSemigroup[F[A]] =
-    CommutativeSemigroup.instance(CommutativeApply[F].map2(_, _)(CommutativeSemigroup[A].combine))
+    CommutativeApply[F].map2(_, _)(CommutativeSemigroup[A].combine)
 
   /**
    * Summon an instance of [[CommutativeApply]] for `F`.

--- a/core/src/main/scala/cats/CommutativeApply.scala
+++ b/core/src/main/scala/cats/CommutativeApply.scala
@@ -36,11 +36,7 @@ trait CommutativeApply[F[_]] extends Apply[F]
 
 object CommutativeApply {
   def commutativeSemigroupFor[F[_]: CommutativeApply, A: CommutativeSemigroup]: CommutativeSemigroup[F[A]] =
-    new CommutativeSemigroup[F[A]] {
-      override def combine(x: F[A], y: F[A]): F[A] =
-        CommutativeApply[F]
-          .map2(x, y)(CommutativeSemigroup[A].combine)
-    }
+    CommutativeSemigroup.instance(CommutativeApply[F].map2(_, _)(CommutativeSemigroup[A].combine))
 
   /**
    * Summon an instance of [[CommutativeApply]] for `F`.

--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -431,10 +431,7 @@ sealed abstract private[cats] class EvalInstances extends EvalInstances0 {
     }
 
   implicit def catsOrderForEval[A: Order]: Order[Eval[A]] =
-    new Order[Eval[A]] {
-      def compare(lx: Eval[A], ly: Eval[A]): Int =
-        Order[A].compare(lx.value, ly.value)
-    }
+    Order.by(_.value)
 
   implicit def catsGroupForEval[A: Group]: Group[Eval[A]] =
     new EvalGroup[A] { val algebra: Group[A] = Group[A] }

--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -463,10 +463,7 @@ sealed abstract private[cats] class EvalInstances0 extends EvalInstances1 {
 
 sealed abstract private[cats] class EvalInstances1 {
   implicit def catsEqForEval[A: Eq]: Eq[Eval[A]] =
-    new Eq[Eval[A]] {
-      def eqv(lx: Eval[A], ly: Eval[A]): Boolean =
-        Eq[A].eqv(lx.value, ly.value)
-    }
+    Eq.by(_.value)
 
   implicit def catsSemigroupForEval[A: Semigroup]: Semigroup[Eval[A]] =
     new EvalSemigroup[A] { val algebra = Semigroup[A] }

--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -455,10 +455,7 @@ sealed abstract private[cats] class EvalInstances extends EvalInstances0 {
 
 sealed abstract private[cats] class EvalInstances0 extends EvalInstances1 {
   implicit def catsPartialOrderForEval[A: PartialOrder]: PartialOrder[Eval[A]] =
-    new PartialOrder[Eval[A]] {
-      def partialCompare(lx: Eval[A], ly: Eval[A]): Double =
-        PartialOrder[A].partialCompare(lx.value, ly.value)
-    }
+    PartialOrder.by(_.value)
 
   implicit def catsMonoidForEval[A: Monoid]: Monoid[Eval[A]] =
     new EvalMonoid[A] { val algebra = Monoid[A] }

--- a/core/src/main/scala/cats/SemigroupK.scala
+++ b/core/src/main/scala/cats/SemigroupK.scala
@@ -95,9 +95,7 @@ trait SemigroupK[F[_]] extends Serializable { self =>
    * }}}
    */
   def algebra[A]: Semigroup[F[A]] =
-    new Semigroup[F[A]] {
-      def combine(x: F[A], y: F[A]): F[A] = self.combineK(x, y)
-    }
+    Semigroup.instance(combineK)
 
   /**
    * "Compose" with a `G[_]` type to form a `SemigroupK` for `λ[α => F[G[α]]]`.

--- a/core/src/main/scala/cats/SemigroupK.scala
+++ b/core/src/main/scala/cats/SemigroupK.scala
@@ -86,7 +86,7 @@ trait SemigroupK[F[_]] extends Serializable { self =>
     y.map(yy => combineK(x, yy))
 
   /**
-   * Given a type A, create a concrete Semigroup[F[A]].
+   * Given a type A, create a concrete `Semigroup[F[A]]`.
    *
    * Example:
    * {{{
@@ -94,8 +94,7 @@ trait SemigroupK[F[_]] extends Serializable { self =>
    * scala> val s: Semigroup[List[Int]] = SemigroupK[List].algebra[Int]
    * }}}
    */
-  def algebra[A]: Semigroup[F[A]] =
-    Semigroup.instance(combineK)
+  def algebra[A]: Semigroup[F[A]] = combineK(_, _)
 
   /**
    * "Compose" with a `G[_]` type to form a `SemigroupK` for `λ[α => F[G[α]]]`.

--- a/core/src/main/scala/cats/Show.scala
+++ b/core/src/main/scala/cats/Show.scala
@@ -80,8 +80,7 @@ object Show extends ScalaVersionSpecificShowInstances with ShowInstances {
   }
 
   implicit val catsContravariantForShow: Contravariant[Show] = new Contravariant[Show] {
-    def contramap[A, B](fa: Show[A])(f: B => A): Show[B] =
-      show[B]((fa.show _).compose(f))
+    def contramap[A, B](fa: Show[A])(f: B => A): Show[B] = b => fa.show(f(b))
   }
 
   implicit def catsShowForUnit: Show[Unit] = cats.instances.unit.catsStdShowForUnit

--- a/core/src/main/scala/cats/arrow/Compose.scala
+++ b/core/src/main/scala/cats/arrow/Compose.scala
@@ -49,8 +49,7 @@ trait Compose[F[_, _]] extends Serializable { self =>
       def combineK[A](f1: F[A, A], f2: F[A, A]): F[A, A] = self.compose(f1, f2)
     }
 
-  def algebra[A]: Semigroup[F[A, A]] =
-    Semigroup.instance(compose)
+  def algebra[A]: Semigroup[F[A, A]] = compose(_, _)
 }
 
 object Compose {

--- a/core/src/main/scala/cats/arrow/Compose.scala
+++ b/core/src/main/scala/cats/arrow/Compose.scala
@@ -50,9 +50,7 @@ trait Compose[F[_, _]] extends Serializable { self =>
     }
 
   def algebra[A]: Semigroup[F[A, A]] =
-    new Semigroup[F[A, A]] {
-      def combine(f1: F[A, A], f2: F[A, A]): F[A, A] = self.compose(f1, f2)
-    }
+    Semigroup.instance(compose)
 }
 
 object Compose {

--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -858,7 +858,8 @@ sealed abstract class Chain[+A] extends ChainCompat[A] {
   def hash[AA >: A](implicit hashA: Hash[AA]): Int =
     KernelStaticMethods.orderedHash((this: Chain[AA]).iterator)
 
-  override def toString: String = show(Show.show[A](_.toString))
+  override def toString: String =
+    show(Show.fromToString)
 
   override def equals(o: Any): Boolean =
     o match {
@@ -1320,8 +1321,7 @@ sealed abstract private[data] class ChainInstances extends ChainInstances1 {
       }
     }
 
-  implicit def catsDataShowForChain[A](implicit A: Show[A]): Show[Chain[A]] =
-    Show.show[Chain[A]](_.show)
+  implicit def catsDataShowForChain[A: Show]: Show[Chain[A]] = _.show
 
   implicit def catsDataOrderForChain[A](implicit A0: Order[A]): Order[Chain[A]] =
     new Order[Chain[A]] with ChainPartialOrder[A] {

--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -1391,7 +1391,9 @@ sealed abstract private[data] class ChainInstances2 extends ChainInstances3 {
 
 sealed abstract private[data] class ChainInstances3 {
   implicit def catsDataEqForChain[A](implicit A: Eq[A]): Eq[Chain[A]] =
-    Eq.instance(_ === _)
+    new Eq[Chain[A]] {
+      def eqv(x: Chain[A], y: Chain[A]): Boolean = x === y
+    }
 }
 
 private[data] trait ChainPartialOrder[A] extends PartialOrder[Chain[A]] {

--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -1391,9 +1391,7 @@ sealed abstract private[data] class ChainInstances2 extends ChainInstances3 {
 
 sealed abstract private[data] class ChainInstances3 {
   implicit def catsDataEqForChain[A](implicit A: Eq[A]): Eq[Chain[A]] =
-    new Eq[Chain[A]] {
-      def eqv(x: Chain[A], y: Chain[A]): Boolean = x === y
-    }
+    Eq.instance(_ === _)
 }
 
 private[data] trait ChainPartialOrder[A] extends PartialOrder[Chain[A]] {

--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -104,9 +104,7 @@ sealed abstract private[data] class ConstInstances extends ConstInstances0 {
     }
 
   implicit def catsDataShowForConst[A: Show, B]: Show[Const[A, B]] =
-    new Show[Const[A, B]] {
-      def show(f: Const[A, B]): String = f.show
-    }
+    Show.show(_.show)
 
   implicit def catsDataTraverseForConst[C]: Traverse[Const[C, *]] =
     new Traverse[Const[C, *]] {

--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -91,10 +91,7 @@ sealed abstract private[data] class ConstInstances extends ConstInstances0 {
     }
 
   implicit def catsDataOrderForConst[A: Order, B]: Order[Const[A, B]] =
-    new Order[Const[A, B]] {
-      def compare(x: Const[A, B], y: Const[A, B]): Int =
-        x.compare(y)
-    }
+    Order.from(_ compare _)
 
   implicit def catsDataAlignForConst[A: Semigroup]: Align[Const[A, *]] =
     new Align[Const[A, *]] {

--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -188,8 +188,7 @@ sealed abstract private[data] class ConstInstances1 extends ConstInstances2 {
 
 sealed abstract private[data] class ConstInstances2 extends ConstInstances3 {
 
-  implicit def catsDataSemigroupForConst[A: Semigroup, B]: Semigroup[Const[A, B]] =
-    Semigroup.instance(_ combine _)
+  implicit def catsDataSemigroupForConst[A: Semigroup, B]: Semigroup[Const[A, B]] = _ combine _
 
   implicit def catsDataPartialOrderForConst[A: PartialOrder, B]: PartialOrder[Const[A, B]] = _ partialCompare _
 

--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -90,8 +90,7 @@ sealed abstract private[data] class ConstInstances extends ConstInstances0 {
       override def minBound: Const[A, B] = Const(A.minBound)
     }
 
-  implicit def catsDataOrderForConst[A: Order, B]: Order[Const[A, B]] =
-    Order.from(_ compare _)
+  implicit def catsDataOrderForConst[A: Order, B]: Order[Const[A, B]] = _ compare _
 
   implicit def catsDataAlignForConst[A: Semigroup]: Align[Const[A, *]] =
     new Align[Const[A, *]] {
@@ -192,8 +191,7 @@ sealed abstract private[data] class ConstInstances2 extends ConstInstances3 {
   implicit def catsDataSemigroupForConst[A: Semigroup, B]: Semigroup[Const[A, B]] =
     Semigroup.instance(_ combine _)
 
-  implicit def catsDataPartialOrderForConst[A: PartialOrder, B]: PartialOrder[Const[A, B]] =
-    PartialOrder.from(_ partialCompare _)
+  implicit def catsDataPartialOrderForConst[A: PartialOrder, B]: PartialOrder[Const[A, B]] = _ partialCompare _
 
   implicit def catsDataApplicativeForConst[C](implicit C: Monoid[C]): Applicative[Const[C, *]] =
     new ConstApplicative[C] { val C0: Monoid[C] = C }

--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -100,8 +100,7 @@ sealed abstract private[data] class ConstInstances extends ConstInstances0 {
       def functor: Functor[Const[A, *]] = catsDataFunctorForConst
     }
 
-  implicit def catsDataShowForConst[A: Show, B]: Show[Const[A, B]] =
-    Show.show(_.show)
+  implicit def catsDataShowForConst[A: Show, B]: Show[Const[A, B]] = _.show
 
   implicit def catsDataTraverseForConst[C]: Traverse[Const[C, *]] =
     new Traverse[Const[C, *]] {

--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -205,10 +205,7 @@ sealed abstract private[data] class ConstInstances2 extends ConstInstances3 {
 sealed abstract private[data] class ConstInstances3 extends ConstInstances4 {
 
   implicit def catsDataEqForConst[A: Eq, B]: Eq[Const[A, B]] =
-    new Eq[Const[A, B]] {
-      def eqv(x: Const[A, B], y: Const[A, B]): Boolean =
-        x === y
-    }
+    Eq.instance(_ === _)
 
   implicit def catsDataApplyForConst[C](implicit C: Semigroup[C]): Apply[Const[C, *]] =
     new ConstApply[C] { val C0: Semigroup[C] = C }

--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -196,10 +196,7 @@ sealed abstract private[data] class ConstInstances2 extends ConstInstances3 {
     }
 
   implicit def catsDataPartialOrderForConst[A: PartialOrder, B]: PartialOrder[Const[A, B]] =
-    new PartialOrder[Const[A, B]] {
-      def partialCompare(x: Const[A, B], y: Const[A, B]): Double =
-        x.partialCompare(y)
-    }
+    PartialOrder.from(_ partialCompare _)
 
   implicit def catsDataApplicativeForConst[C](implicit C: Monoid[C]): Applicative[Const[C, *]] =
     new ConstApplicative[C] { val C0: Monoid[C] = C }

--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -191,9 +191,7 @@ sealed abstract private[data] class ConstInstances1 extends ConstInstances2 {
 sealed abstract private[data] class ConstInstances2 extends ConstInstances3 {
 
   implicit def catsDataSemigroupForConst[A: Semigroup, B]: Semigroup[Const[A, B]] =
-    new Semigroup[Const[A, B]] {
-      def combine(x: Const[A, B], y: Const[A, B]): Const[A, B] = x.combine(y)
-    }
+    Semigroup.instance(_ combine _)
 
   implicit def catsDataPartialOrderForConst[A: PartialOrder, B]: PartialOrder[Const[A, B]] =
     PartialOrder.from(_ partialCompare _)

--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -201,9 +201,7 @@ sealed abstract private[data] class ConstInstances2 extends ConstInstances3 {
 }
 
 sealed abstract private[data] class ConstInstances3 extends ConstInstances4 {
-
-  implicit def catsDataEqForConst[A: Eq, B]: Eq[Const[A, B]] =
-    Eq.instance(_ === _)
+  implicit def catsDataEqForConst[A: Eq, B]: Eq[Const[A, B]] = _ === _
 
   implicit def catsDataApplyForConst[C](implicit C: Semigroup[C]): Apply[Const[C, *]] =
     new ConstApply[C] { val C0: Semigroup[C] = C }

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -861,8 +861,7 @@ sealed abstract private[data] class IorInstances extends IorInstances0 {
 
   implicit def catsDataShowForIor[A: Show, B: Show]: Show[A Ior B] = _.show
 
-  implicit def catsDataSemigroupForIor[A: Semigroup, B: Semigroup]: Semigroup[Ior[A, B]] =
-    Semigroup.instance(_ combine _)
+  implicit def catsDataSemigroupForIor[A: Semigroup, B: Semigroup]: Semigroup[Ior[A, B]] = _ combine _
 
   implicit def catsDataMonadErrorForIor[A: Semigroup]: MonadError[Ior[A, *], A] =
     new MonadError[Ior[A, *], A] {

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -864,9 +864,7 @@ sealed abstract private[data] class IorInstances extends IorInstances0 {
     }
 
   implicit def catsDataShowForIor[A: Show, B: Show]: Show[A Ior B] =
-    new Show[A Ior B] {
-      def show(f: A Ior B): String = f.show
-    }
+    Show.show(_.show)
 
   implicit def catsDataSemigroupForIor[A: Semigroup, B: Semigroup]: Semigroup[Ior[A, B]] =
     new Semigroup[Ior[A, B]] {

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -860,8 +860,7 @@ sealed abstract private[data] class IorInstances extends IorInstances0 {
   implicit def catsDataOrderForIor[A: Order, B: Order]: Order[A Ior B] =
     Order.from(_ compare _)
 
-  implicit def catsDataShowForIor[A: Show, B: Show]: Show[A Ior B] =
-    Show.show(_.show)
+  implicit def catsDataShowForIor[A: Show, B: Show]: Show[A Ior B] = _.show
 
   implicit def catsDataSemigroupForIor[A: Semigroup, B: Semigroup]: Semigroup[Ior[A, B]] =
     Semigroup.instance(_ combine _)

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -858,10 +858,7 @@ sealed abstract private[data] class IorInstances extends IorInstances0 {
   }
 
   implicit def catsDataOrderForIor[A: Order, B: Order]: Order[A Ior B] =
-    new Order[A Ior B] {
-
-      def compare(x: Ior[A, B], y: Ior[A, B]): Int = x.compare(y)
-    }
+    Order.from(_ compare _)
 
   implicit def catsDataShowForIor[A: Show, B: Show]: Show[A Ior B] =
     Show.show(_.show)

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -989,8 +989,7 @@ sealed abstract private[data] class IorInstances0 {
         fa.map(f)
     }
 
-  implicit def catsDataEqForIor[A: Eq, B: Eq]: Eq[A Ior B] =
-    Eq.instance(_ === _)
+  implicit def catsDataEqForIor[A: Eq, B: Eq]: Eq[A Ior B] = _ === _
 }
 
 sealed private[data] trait IorFunctions {

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -992,10 +992,7 @@ sealed abstract private[data] class IorInstances0 {
     }
 
   implicit def catsDataEqForIor[A: Eq, B: Eq]: Eq[A Ior B] =
-    new Eq[A Ior B] {
-
-      def eqv(x: A Ior B, y: A Ior B): Boolean = x === y
-    }
+    Eq.instance(_ === _)
 }
 
 sealed private[data] trait IorFunctions {

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -857,8 +857,7 @@ sealed abstract private[data] class IorInstances extends IorInstances0 {
       }
   }
 
-  implicit def catsDataOrderForIor[A: Order, B: Order]: Order[A Ior B] =
-    Order.from(_ compare _)
+  implicit def catsDataOrderForIor[A: Order, B: Order]: Order[A Ior B] = _ compare _
 
   implicit def catsDataShowForIor[A: Show, B: Show]: Show[A Ior B] = _.show
 

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -864,9 +864,7 @@ sealed abstract private[data] class IorInstances extends IorInstances0 {
     Show.show(_.show)
 
   implicit def catsDataSemigroupForIor[A: Semigroup, B: Semigroup]: Semigroup[Ior[A, B]] =
-    new Semigroup[Ior[A, B]] {
-      def combine(x: Ior[A, B], y: Ior[A, B]) = x.combine(y)
-    }
+    Semigroup.instance(_ combine _)
 
   implicit def catsDataMonadErrorForIor[A: Semigroup]: MonadError[Ior[A, *], A] =
     new MonadError[Ior[A, *], A] {

--- a/core/src/main/scala/cats/data/NonEmptyChain.scala
+++ b/core/src/main/scala/cats/data/NonEmptyChain.scala
@@ -682,9 +682,7 @@ sealed abstract private[data] class NonEmptyChainInstances extends NonEmptyChain
   implicit def catsDataSemigroupForNonEmptyChain[A]: Semigroup[NonEmptyChain[A]] =
     Semigroup[Chain[A]].asInstanceOf[Semigroup[NonEmptyChain[A]]]
 
-  implicit def catsDataShowForNonEmptyChain[A](implicit A: Show[A]): Show[NonEmptyChain[A]] =
-    Show.show[NonEmptyChain[A]](_.show)
-
+  implicit def catsDataShowForNonEmptyChain[A: Show]: Show[NonEmptyChain[A]] = _.show
 }
 
 sealed abstract private[data] class NonEmptyChainInstances1 extends NonEmptyChainInstances2 {

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -897,8 +897,7 @@ sealed abstract private[data] class NonEmptyListInstances extends NonEmptyListIn
 
     }
 
-  implicit def catsDataShowForNonEmptyList[A](implicit A: Show[A]): Show[NonEmptyList[A]] =
-    Show.show[NonEmptyList[A]](_.show)
+  implicit def catsDataShowForNonEmptyList[A: Show]: Show[NonEmptyList[A]] = _.show
 
   implicit def catsDataSemigroupForNonEmptyList[A]: Semigroup[NonEmptyList[A]] =
     SemigroupK[NonEmptyList].algebra[A]

--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -374,11 +374,8 @@ sealed abstract private[data] class NonEmptyMapInstances extends NonEmptyMapInst
     }
 
   implicit def catsDataSemigroupForNonEmptyMap[K, A: Semigroup]: Semigroup[NonEmptyMap[K, A]] =
-    new Semigroup[NonEmptyMap[K, A]] {
-      def combine(x: NonEmptyMap[K, A], y: NonEmptyMap[K, A]): NonEmptyMap[K, A] =
-        NonEmptyMap.fromMapUnsafe(
-          Semigroup[SortedMap[K, A]].combine(x.toSortedMap, y.toSortedMap)
-        )
+    Semigroup.instance { (x, y) =>
+      NonEmptyMap.fromMapUnsafe(Semigroup[SortedMap[K, A]].combine(x.toSortedMap, y.toSortedMap))
     }
 }
 

--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -371,9 +371,7 @@ sealed abstract private[data] class NonEmptyMapInstances extends NonEmptyMapInst
     Band.instance(_ ++ _)
 
   implicit def catsDataSemigroupForNonEmptyMap[K, A: Semigroup]: Semigroup[NonEmptyMap[K, A]] =
-    Semigroup.instance { (x, y) =>
-      NonEmptyMap.fromMapUnsafe(Semigroup[SortedMap[K, A]].combine(x.toSortedMap, y.toSortedMap))
-    }
+    (x, y) => NonEmptyMap.fromMapUnsafe(Semigroup[SortedMap[K, A]].combine(x.toSortedMap, y.toSortedMap))
 }
 
 sealed abstract private[data] class NonEmptyMapInstances0 {

--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -364,8 +364,7 @@ sealed abstract private[data] class NonEmptyMapInstances extends NonEmptyMapInst
   def catsDataHashForNonEmptyMap[K, A](hashK: Hash[K], orderK: Order[K], hashA: Hash[A]): Hash[NonEmptyMap[K, A]] =
     catsDataHashForNonEmptyMap(hashK, hashA)
 
-  implicit def catsDataShowForNonEmptyMap[K: Show, A: Show]: Show[NonEmptyMap[K, A]] =
-    Show.show[NonEmptyMap[K, A]](_.show)
+  implicit def catsDataShowForNonEmptyMap[K: Show, A: Show]: Show[NonEmptyMap[K, A]] = _.show
 
   @deprecated("Use catsDataSemigroupForNonEmptyMap", "2.5.0")
   def catsDataBandForNonEmptyMap[K, A]: Band[NonEmptyMap[K, A]] =

--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -367,8 +367,7 @@ sealed abstract private[data] class NonEmptyMapInstances extends NonEmptyMapInst
   implicit def catsDataShowForNonEmptyMap[K: Show, A: Show]: Show[NonEmptyMap[K, A]] = _.show
 
   @deprecated("Use catsDataSemigroupForNonEmptyMap", "2.5.0")
-  def catsDataBandForNonEmptyMap[K, A]: Band[NonEmptyMap[K, A]] =
-    Band.instance(_ ++ _)
+  def catsDataBandForNonEmptyMap[K, A]: Band[NonEmptyMap[K, A]] = _ ++ _
 
   implicit def catsDataSemigroupForNonEmptyMap[K, A: Semigroup]: Semigroup[NonEmptyMap[K, A]] =
     (x, y) => NonEmptyMap.fromMapUnsafe(Semigroup[SortedMap[K, A]].combine(x.toSortedMap, y.toSortedMap))

--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -369,9 +369,7 @@ sealed abstract private[data] class NonEmptyMapInstances extends NonEmptyMapInst
 
   @deprecated("Use catsDataSemigroupForNonEmptyMap", "2.5.0")
   def catsDataBandForNonEmptyMap[K, A]: Band[NonEmptyMap[K, A]] =
-    new Band[NonEmptyMap[K, A]] {
-      def combine(x: NonEmptyMap[K, A], y: NonEmptyMap[K, A]): NonEmptyMap[K, A] = x ++ y
-    }
+    Band.instance(_ ++ _)
 
   implicit def catsDataSemigroupForNonEmptyMap[K, A: Semigroup]: Semigroup[NonEmptyMap[K, A]] =
     Semigroup.instance { (x, y) =>

--- a/core/src/main/scala/cats/data/NonEmptySeq.scala
+++ b/core/src/main/scala/cats/data/NonEmptySeq.scala
@@ -524,8 +524,7 @@ sealed abstract private[data] class NonEmptySeqInstances {
 
   implicit def catsDataEqForNonEmptySeq[A: Eq]: Eq[NonEmptySeq[A]] = _ === _
 
-  implicit def catsDataShowForNonEmptySeq[A](implicit A: Show[A]): Show[NonEmptySeq[A]] =
-    Show.show[NonEmptySeq[A]](_.show)
+  implicit def catsDataShowForNonEmptySeq[A: Show]: Show[NonEmptySeq[A]] = _.show
 
   implicit def catsDataSemigroupForNonEmptySeq[A]: Semigroup[NonEmptySeq[A]] =
     catsDataInstancesForNonEmptySeq.algebra

--- a/core/src/main/scala/cats/data/NonEmptySeq.scala
+++ b/core/src/main/scala/cats/data/NonEmptySeq.scala
@@ -523,9 +523,7 @@ sealed abstract private[data] class NonEmptySeqInstances {
     }
 
   implicit def catsDataEqForNonEmptySeq[A](implicit A: Eq[A]): Eq[NonEmptySeq[A]] =
-    new Eq[NonEmptySeq[A]] {
-      def eqv(x: NonEmptySeq[A], y: NonEmptySeq[A]): Boolean = x === y
-    }
+    Eq.instance(_ === _)
 
   implicit def catsDataShowForNonEmptySeq[A](implicit A: Show[A]): Show[NonEmptySeq[A]] =
     Show.show[NonEmptySeq[A]](_.show)

--- a/core/src/main/scala/cats/data/NonEmptySeq.scala
+++ b/core/src/main/scala/cats/data/NonEmptySeq.scala
@@ -522,8 +522,7 @@ sealed abstract private[data] class NonEmptySeqInstances {
         NonEmptySeq.fromSeqUnsafe(Align[Seq].alignWith(fa.toSeq, fb.toSeq)(f))
     }
 
-  implicit def catsDataEqForNonEmptySeq[A](implicit A: Eq[A]): Eq[NonEmptySeq[A]] =
-    Eq.instance(_ === _)
+  implicit def catsDataEqForNonEmptySeq[A: Eq]: Eq[NonEmptySeq[A]] = _ === _
 
   implicit def catsDataShowForNonEmptySeq[A](implicit A: Show[A]): Show[NonEmptySeq[A]] =
     Show.show[NonEmptySeq[A]](_.show)

--- a/core/src/main/scala/cats/data/NonEmptySet.scala
+++ b/core/src/main/scala/cats/data/NonEmptySet.scala
@@ -430,9 +430,7 @@ sealed abstract private[data] class NonEmptySetInstances extends NonEmptySetInst
     Show.show[NonEmptySet[A]](_.show)
 
   implicit def catsDataSemilatticeForNonEmptySet[A]: Semilattice[NonEmptySet[A]] =
-    new Semilattice[NonEmptySet[A]] {
-      def combine(x: NonEmptySet[A], y: NonEmptySet[A]): NonEmptySet[A] = x | y
-    }
+    Semilattice.instance(_ | _)
 }
 
 sealed abstract private[data] class NonEmptySetInstances0 extends NonEmptySetInstances1 {

--- a/core/src/main/scala/cats/data/NonEmptySet.scala
+++ b/core/src/main/scala/cats/data/NonEmptySet.scala
@@ -426,8 +426,7 @@ sealed abstract private[data] class NonEmptySetInstances extends NonEmptySetInst
       implicit override def A0: Order[A] = A
     }
 
-  implicit def catsDataShowForNonEmptySet[A](implicit A: Show[A]): Show[NonEmptySet[A]] =
-    Show.show[NonEmptySet[A]](_.show)
+  implicit def catsDataShowForNonEmptySet[A: Show]: Show[NonEmptySet[A]] = _.show
 
   implicit def catsDataSemilatticeForNonEmptySet[A]: Semilattice[NonEmptySet[A]] =
     Semilattice.instance(_ | _)

--- a/core/src/main/scala/cats/data/NonEmptySet.scala
+++ b/core/src/main/scala/cats/data/NonEmptySet.scala
@@ -429,7 +429,9 @@ sealed abstract private[data] class NonEmptySetInstances extends NonEmptySetInst
   implicit def catsDataShowForNonEmptySet[A: Show]: Show[NonEmptySet[A]] = _.show
 
   implicit def catsDataSemilatticeForNonEmptySet[A]: Semilattice[NonEmptySet[A]] =
-    Semilattice.instance(_ | _)
+    new Semilattice[NonEmptySet[A]] {
+      def combine(x: NonEmptySet[A], y: NonEmptySet[A]): NonEmptySet[A] = x | y
+    }
 }
 
 sealed abstract private[data] class NonEmptySetInstances0 extends NonEmptySetInstances1 {

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -534,9 +534,7 @@ sealed abstract private[data] class NonEmptyVectorInstances {
     }
 
   implicit def catsDataEqForNonEmptyVector[A](implicit A: Eq[A]): Eq[NonEmptyVector[A]] =
-    new Eq[NonEmptyVector[A]] {
-      def eqv(x: NonEmptyVector[A], y: NonEmptyVector[A]): Boolean = x === y
-    }
+    Eq.instance(_ === _)
 
   implicit def catsDataShowForNonEmptyVector[A](implicit A: Show[A]): Show[NonEmptyVector[A]] =
     Show.show[NonEmptyVector[A]](_.show)

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -535,8 +535,7 @@ sealed abstract private[data] class NonEmptyVectorInstances {
 
   implicit def catsDataEqForNonEmptyVector[A: Eq]: Eq[NonEmptyVector[A]] = _ === _
 
-  implicit def catsDataShowForNonEmptyVector[A](implicit A: Show[A]): Show[NonEmptyVector[A]] =
-    Show.show[NonEmptyVector[A]](_.show)
+  implicit def catsDataShowForNonEmptyVector[A: Show]: Show[NonEmptyVector[A]] = _.show
 
   implicit def catsDataSemigroupForNonEmptyVector[A]: Semigroup[NonEmptyVector[A]] =
     catsDataInstancesForNonEmptyVector.algebra

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -533,8 +533,7 @@ sealed abstract private[data] class NonEmptyVectorInstances {
         NonEmptyVector.fromVectorUnsafe(Align[Vector].alignWith(fa.toVector, fb.toVector)(f))
     }
 
-  implicit def catsDataEqForNonEmptyVector[A](implicit A: Eq[A]): Eq[NonEmptyVector[A]] =
-    Eq.instance(_ === _)
+  implicit def catsDataEqForNonEmptyVector[A: Eq]: Eq[NonEmptyVector[A]] = _ === _
 
   implicit def catsDataShowForNonEmptyVector[A](implicit A: Show[A]): Show[NonEmptyVector[A]] =
     Show.show[NonEmptyVector[A]](_.show)

--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -148,9 +148,7 @@ sealed abstract private[data] class OneAndInstances extends OneAndLowPriority0 {
     }
 
   implicit def catsDataEqForOneAnd[A, F[_]](implicit A: Eq[A], FA: Eq[F[A]]): Eq[OneAnd[F, A]] =
-    new Eq[OneAnd[F, A]] {
-      def eqv(x: OneAnd[F, A], y: OneAnd[F, A]): Boolean = x === y
-    }
+    Eq.instance(_ === _)
 
   implicit def catsDataShowForOneAnd[A, F[_]](implicit A: Show[A], FA: Show[F[A]]): Show[OneAnd[F, A]] =
     Show.show[OneAnd[F, A]](_.show)

--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -149,8 +149,7 @@ sealed abstract private[data] class OneAndInstances extends OneAndLowPriority0 {
 
   implicit def catsDataEqForOneAnd[A, F[_]](implicit A: Eq[A], FA: Eq[F[A]]): Eq[OneAnd[F, A]] = _ === _
 
-  implicit def catsDataShowForOneAnd[A, F[_]](implicit A: Show[A], FA: Show[F[A]]): Show[OneAnd[F, A]] =
-    Show.show[OneAnd[F, A]](_.show)
+  implicit def catsDataShowForOneAnd[A, F[_]](implicit A: Show[A], FA: Show[F[A]]): Show[OneAnd[F, A]] = _.show
 
   implicit def catsDataSemigroupKForOneAnd[F[_]: Alternative]: SemigroupK[OneAnd[F, *]] =
     new SemigroupK[OneAnd[F, *]] {

--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -147,8 +147,7 @@ sealed abstract private[data] class OneAndInstances extends OneAndLowPriority0 {
 
     }
 
-  implicit def catsDataEqForOneAnd[A, F[_]](implicit A: Eq[A], FA: Eq[F[A]]): Eq[OneAnd[F, A]] =
-    Eq.instance(_ === _)
+  implicit def catsDataEqForOneAnd[A, F[_]](implicit A: Eq[A], FA: Eq[F[A]]): Eq[OneAnd[F, A]] = _ === _
 
   implicit def catsDataShowForOneAnd[A, F[_]](implicit A: Show[A], FA: Show[F[A]]): Show[OneAnd[F, A]] =
     Show.show[OneAnd[F, A]](_.show)

--- a/core/src/main/scala/cats/data/Tuple2K.scala
+++ b/core/src/main/scala/cats/data/Tuple2K.scala
@@ -114,10 +114,7 @@ sealed abstract private[data] class Tuple2KInstances0 extends Tuple2KInstances1 
       def G: Contravariant[G] = GC
     }
   implicit def catsDataEqForTuple2K[F[_], G[_], A](implicit FF: Eq[F[A]], GG: Eq[G[A]]): Eq[Tuple2K[F, G, A]] =
-    new Eq[Tuple2K[F, G, A]] {
-      def eqv(x: Tuple2K[F, G, A], y: Tuple2K[F, G, A]): Boolean =
-        FF.eqv(x.first, y.first) && GG.eqv(x.second, y.second)
-    }
+    Eq.instance((x, y) => FF.eqv(x.first, y.first) && GG.eqv(x.second, y.second))
 }
 
 sealed abstract private[data] class Tuple2KInstances1 extends Tuple2KInstances2 {

--- a/core/src/main/scala/cats/data/Tuple2K.scala
+++ b/core/src/main/scala/cats/data/Tuple2K.scala
@@ -114,7 +114,7 @@ sealed abstract private[data] class Tuple2KInstances0 extends Tuple2KInstances1 
       def G: Contravariant[G] = GC
     }
   implicit def catsDataEqForTuple2K[F[_], G[_], A](implicit FF: Eq[F[A]], GG: Eq[G[A]]): Eq[Tuple2K[F, G, A]] =
-    Eq.instance((x, y) => FF.eqv(x.first, y.first) && GG.eqv(x.second, y.second))
+    (x, y) => FF.eqv(x.first, y.first) && GG.eqv(x.second, y.second)
 }
 
 sealed abstract private[data] class Tuple2KInstances1 extends Tuple2KInstances2 {

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -927,8 +927,7 @@ sealed abstract private[data] class ValidatedInstances extends ValidatedInstance
       override def eqv(x: Validated[A, B], y: Validated[A, B]): Boolean = x === y
     }
 
-  implicit def catsDataShowForValidated[A, B](implicit A: Show[A], B: Show[B]): Show[Validated[A, B]] =
-    Show.show(_.show)
+  implicit def catsDataShowForValidated[A: Show, B: Show]: Show[Validated[A, B]] = _.show
 
   implicit val catsDataBitraverseForValidated: Bitraverse[Validated] =
     new Bitraverse[Validated] {

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -996,9 +996,7 @@ sealed abstract private[data] class ValidatedInstances1 extends ValidatedInstanc
 
 sealed abstract private[data] class ValidatedInstances2 {
   implicit def catsDataEqForValidated[A: Eq, B: Eq]: Eq[Validated[A, B]] =
-    new Eq[Validated[A, B]] {
-      def eqv(x: Validated[A, B], y: Validated[A, B]): Boolean = x === y
-    }
+    Eq.instance(_ === _)
 
   implicit def catsDataTraverseFunctorForValidated[E]: Traverse[Validated[E, *]] =
     new Traverse[Validated[E, *]] {

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -974,11 +974,7 @@ sealed abstract private[data] class ValidatedInstances extends ValidatedInstance
 
 sealed abstract private[data] class ValidatedInstances1 extends ValidatedInstances2 {
 
-  implicit def catsDataSemigroupForValidated[A, B](implicit
-    A: Semigroup[A],
-    B: Semigroup[B]
-  ): Semigroup[Validated[A, B]] =
-    Semigroup.instance(_ combine _)
+  implicit def catsDataSemigroupForValidated[A: Semigroup, B: Semigroup]: Semigroup[Validated[A, B]] = _ combine _
 
   implicit def catsDataCommutativeApplicativeForValidated[E: CommutativeSemigroup]
     : CommutativeApplicative[Validated[E, *]] =

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -993,8 +993,7 @@ sealed abstract private[data] class ValidatedInstances1 extends ValidatedInstanc
 }
 
 sealed abstract private[data] class ValidatedInstances2 {
-  implicit def catsDataEqForValidated[A: Eq, B: Eq]: Eq[Validated[A, B]] =
-    Eq.instance(_ === _)
+  implicit def catsDataEqForValidated[A: Eq, B: Eq]: Eq[Validated[A, B]] = _ === _
 
   implicit def catsDataTraverseFunctorForValidated[E]: Traverse[Validated[E, *]] =
     new Traverse[Validated[E, *]] {

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -928,9 +928,7 @@ sealed abstract private[data] class ValidatedInstances extends ValidatedInstance
     }
 
   implicit def catsDataShowForValidated[A, B](implicit A: Show[A], B: Show[B]): Show[Validated[A, B]] =
-    new Show[Validated[A, B]] {
-      def show(f: Validated[A, B]): String = f.show
-    }
+    Show.show(_.show)
 
   implicit val catsDataBitraverseForValidated: Bitraverse[Validated] =
     new Bitraverse[Validated] {

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -979,9 +979,7 @@ sealed abstract private[data] class ValidatedInstances1 extends ValidatedInstanc
     A: Semigroup[A],
     B: Semigroup[B]
   ): Semigroup[Validated[A, B]] =
-    new Semigroup[Validated[A, B]] {
-      def combine(x: Validated[A, B], y: Validated[A, B]): Validated[A, B] = x.combine(y)
-    }
+    Semigroup.instance(_ combine _)
 
   implicit def catsDataCommutativeApplicativeForValidated[E: CommutativeSemigroup]
     : CommutativeApplicative[Validated[E, *]] =

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -403,7 +403,7 @@ sealed abstract private[data] class WriterTInstances1 extends WriterTInstances2 
     catsDataFoldableForWriterT[Id, L](F)
 
   implicit def catsDataOrderForWriterT[F[_], L, V](implicit Ord: Order[F[(L, V)]]): Order[WriterT[F, L, V]] =
-    Order.from(_ compare _)
+    _ compare _
 }
 
 sealed abstract private[data] class WriterTInstances2 extends WriterTInstances3 {

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -403,9 +403,7 @@ sealed abstract private[data] class WriterTInstances1 extends WriterTInstances2 
     catsDataFoldableForWriterT[Id, L](F)
 
   implicit def catsDataOrderForWriterT[F[_], L, V](implicit Ord: Order[F[(L, V)]]): Order[WriterT[F, L, V]] =
-    new Order[WriterT[F, L, V]] {
-      def compare(x: WriterT[F, L, V], y: WriterT[F, L, V]): Int = x.compare(y)
-    }
+    Order.from(_ compare _)
 }
 
 sealed abstract private[data] class WriterTInstances2 extends WriterTInstances3 {

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -446,8 +446,7 @@ sealed abstract private[data] class WriterTInstances2 extends WriterTInstances3 
         fab.bimap(f, g)
     }
 
-  implicit def catsDataShowForWriterT[F[_], L, V](implicit F: Show[F[(L, V)]]): Show[WriterT[F, L, V]] =
-    Show.show(_.show)
+  implicit def catsDataShowForWriterT[F[_], L, V](implicit F: Show[F[(L, V)]]): Show[WriterT[F, L, V]] = _.show
 
   implicit def catsDataMonoidForWriterTId[L: Monoid, V: Monoid]: Monoid[WriterT[Id, L, V]] =
     catsDataMonoidForWriterT[Id, L, V]

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -449,9 +449,7 @@ sealed abstract private[data] class WriterTInstances2 extends WriterTInstances3 
     }
 
   implicit def catsDataShowForWriterT[F[_], L, V](implicit F: Show[F[(L, V)]]): Show[WriterT[F, L, V]] =
-    new Show[WriterT[F, L, V]] {
-      override def show(f: WriterT[F, L, V]): String = f.show
-    }
+    Show.show(_.show)
 
   implicit def catsDataMonoidForWriterTId[L: Monoid, V: Monoid]: Monoid[WriterT[Id, L, V]] =
     catsDataMonoidForWriterT[Id, L, V]

--- a/core/src/main/scala/cats/instances/either.scala
+++ b/core/src/main/scala/cats/instances/either.scala
@@ -232,12 +232,9 @@ trait EitherInstances extends cats.kernel.instances.EitherInstances {
     }
 
   implicit def catsStdShowForEither[A, B](implicit A: Show[A], B: Show[B]): Show[Either[A, B]] =
-    new Show[Either[A, B]] {
-      def show(x: Either[A, B]): String =
-        x match {
-          case Left(a)  => "Left(" + A.show(a) + ")"
-          case Right(b) => "Right(" + B.show(b) + ")"
-        }
+    Show.show {
+      case Left(a)  => "Left(" + A.show(a) + ")"
+      case Right(b) => "Right(" + B.show(b) + ")"
     }
 
   implicit def catsParallelForEitherAndValidated[E: Semigroup]: Parallel.Aux[Either[E, *], Validated[E, *]] =

--- a/core/src/main/scala/cats/instances/either.scala
+++ b/core/src/main/scala/cats/instances/either.scala
@@ -231,11 +231,10 @@ trait EitherInstances extends cats.kernel.instances.EitherInstances {
         }
     }
 
-  implicit def catsStdShowForEither[A, B](implicit A: Show[A], B: Show[B]): Show[Either[A, B]] =
-    Show.show {
-      case Left(a)  => "Left(" + A.show(a) + ")"
-      case Right(b) => "Right(" + B.show(b) + ")"
-    }
+  implicit def catsStdShowForEither[A, B](implicit A: Show[A], B: Show[B]): Show[Either[A, B]] = {
+    case Left(a)  => "Left(" + A.show(a) + ")"
+    case Right(b) => "Right(" + B.show(b) + ")"
+  }
 
   implicit def catsParallelForEitherAndValidated[E: Semigroup]: Parallel.Aux[Either[E, *], Validated[E, *]] =
     new Parallel[Either[E, *]] {

--- a/core/src/main/scala/cats/instances/eq.scala
+++ b/core/src/main/scala/cats/instances/eq.scala
@@ -41,8 +41,6 @@ trait EqInstances extends kernel.instances.EqInstances {
         Eq.by(f)(fa)
 
       def product[A, B](fa: Eq[A], fb: Eq[B]): Eq[(A, B)] =
-        Eq.instance { (left, right) =>
-          fa.eqv(left._1, right._1) && fb.eqv(left._2, right._2)
-        }
+        (left, right) => fa.eqv(left._1, right._1) && fb.eqv(left._2, right._2)
     }
 }

--- a/core/src/main/scala/cats/instances/invariant.scala
+++ b/core/src/main/scala/cats/instances/invariant.scala
@@ -45,10 +45,10 @@ trait InvariantMonoidalInstances {
 
   implicit val catsInvariantMonoidalSemigroup: InvariantMonoidal[Semigroup] = new InvariantMonoidal[Semigroup] {
     def product[A, B](fa: Semigroup[A], fb: Semigroup[B]): Semigroup[(A, B)] =
-      Semigroup.instance((x, y) => fa.combine(x._1, y._1) -> fb.combine(x._2, y._2))
+      (x, y) => fa.combine(x._1, y._1) -> fb.combine(x._2, y._2)
 
     def imap[A, B](fa: Semigroup[A])(f: A => B)(g: B => A): Semigroup[B] =
-      Semigroup.instance((x, y) => f(fa.combine(g(x), g(y))))
+      (x, y) => f(fa.combine(g(x), g(y)))
 
     def unit: Semigroup[Unit] = implicitly
   }
@@ -56,10 +56,10 @@ trait InvariantMonoidalInstances {
   implicit val catsInvariantMonoidalCommutativeSemigroup: InvariantMonoidal[CommutativeSemigroup] =
     new InvariantMonoidal[CommutativeSemigroup] {
       def product[A, B](fa: CommutativeSemigroup[A], fb: CommutativeSemigroup[B]): CommutativeSemigroup[(A, B)] =
-        CommutativeSemigroup.instance((x, y) => fa.combine(x._1, y._1) -> fb.combine(x._2, y._2))
+        (x, y) => fa.combine(x._1, y._1) -> fb.combine(x._2, y._2)
 
       def imap[A, B](fa: CommutativeSemigroup[A])(f: A => B)(g: B => A): CommutativeSemigroup[B] =
-        CommutativeSemigroup.instance((x, y) => f(fa.combine(g(x), g(y))))
+        (x, y) => f(fa.combine(g(x), g(y)))
 
       def unit: CommutativeSemigroup[Unit] = implicitly
     }

--- a/core/src/main/scala/cats/instances/invariant.scala
+++ b/core/src/main/scala/cats/instances/invariant.scala
@@ -45,14 +45,10 @@ trait InvariantMonoidalInstances {
 
   implicit val catsInvariantMonoidalSemigroup: InvariantMonoidal[Semigroup] = new InvariantMonoidal[Semigroup] {
     def product[A, B](fa: Semigroup[A], fb: Semigroup[B]): Semigroup[(A, B)] =
-      new Semigroup[(A, B)] {
-        def combine(x: (A, B), y: (A, B)): (A, B) = fa.combine(x._1, y._1) -> fb.combine(x._2, y._2)
-      }
+      Semigroup.instance((x, y) => fa.combine(x._1, y._1) -> fb.combine(x._2, y._2))
 
     def imap[A, B](fa: Semigroup[A])(f: A => B)(g: B => A): Semigroup[B] =
-      new Semigroup[B] {
-        def combine(x: B, y: B): B = f(fa.combine(g(x), g(y)))
-      }
+      Semigroup.instance((x, y) => f(fa.combine(g(x), g(y))))
 
     def unit: Semigroup[Unit] = implicitly
   }
@@ -60,14 +56,10 @@ trait InvariantMonoidalInstances {
   implicit val catsInvariantMonoidalCommutativeSemigroup: InvariantMonoidal[CommutativeSemigroup] =
     new InvariantMonoidal[CommutativeSemigroup] {
       def product[A, B](fa: CommutativeSemigroup[A], fb: CommutativeSemigroup[B]): CommutativeSemigroup[(A, B)] =
-        new CommutativeSemigroup[(A, B)] {
-          def combine(x: (A, B), y: (A, B)): (A, B) = fa.combine(x._1, y._1) -> fb.combine(x._2, y._2)
-        }
+        CommutativeSemigroup.instance((x, y) => fa.combine(x._1, y._1) -> fb.combine(x._2, y._2))
 
       def imap[A, B](fa: CommutativeSemigroup[A])(f: A => B)(g: B => A): CommutativeSemigroup[B] =
-        new CommutativeSemigroup[B] {
-          def combine(x: B, y: B): B = f(fa.combine(g(x), g(y)))
-        }
+        CommutativeSemigroup.instance((x, y) => f(fa.combine(g(x), g(y))))
 
       def unit: CommutativeSemigroup[Unit] = implicitly
     }

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -275,7 +275,7 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
     }
 
   implicit def catsStdShowForList[A: Show]: Show[List[A]] =
-    Show.show(_.iterator.map(Show[A].show).mkString("List(", ", ", ")"))
+    _.iterator.map(Show[A].show).mkString("List(", ", ", ")")
 
   implicit def catsStdNonEmptyParallelForListZipList: NonEmptyParallel.Aux[List, ZipList] =
     new NonEmptyParallel[List] {

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -22,16 +22,13 @@
 package cats
 package instances
 
-import cats.data.{Chain, ZipList}
+import cats.data.{Chain, Ior, ZipList}
 import cats.instances.StaticMethods.appendAll
 import cats.kernel.compat.scalaVersionSpecific._
 import cats.kernel.instances.StaticMethods.wrapMutableIndexedSeq
-import cats.syntax.show._
 
 import scala.annotation.tailrec
 import scala.collection.mutable.ListBuffer
-
-import cats.data.Ior
 
 trait ListInstances extends cats.kernel.instances.ListInstances {
 
@@ -278,10 +275,7 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
     }
 
   implicit def catsStdShowForList[A: Show]: Show[List[A]] =
-    new Show[List[A]] {
-      def show(fa: List[A]): String =
-        fa.iterator.map(_.show).mkString("List(", ", ", ")")
-    }
+    Show.show(_.iterator.map(Show[A].show).mkString("List(", ", ", ")"))
 
   implicit def catsStdNonEmptyParallelForListZipList: NonEmptyParallel.Aux[List, ZipList] =
     new NonEmptyParallel[List] {

--- a/core/src/main/scala/cats/instances/map.scala
+++ b/core/src/main/scala/cats/instances/map.scala
@@ -32,12 +32,11 @@ import cats.data.Ior
 trait MapInstances extends cats.kernel.instances.MapInstances {
 
   implicit def catsStdShowForMap[A, B](implicit showA: Show[A], showB: Show[B]): Show[Map[A, B]] =
-    new Show[Map[A, B]] {
-      def show(m: Map[A, B]): String =
-        m.iterator
-          .map { case (a, b) => showA.show(a) + " -> " + showB.show(b) }
-          .mkString("Map(", ", ", ")")
-    }
+    Show.show(
+      _.iterator
+        .map { case (a, b) => showA.show(a) + " -> " + showB.show(b) }
+        .mkString("Map(", ", ", ")")
+    )
 
   implicit def catsStdInstancesForMap[K]: UnorderedTraverse[Map[K, *]] with FlatMap[Map[K, *]] with Align[Map[K, *]] =
     new UnorderedTraverse[Map[K, *]] with FlatMap[Map[K, *]] with Align[Map[K, *]] {

--- a/core/src/main/scala/cats/instances/map.scala
+++ b/core/src/main/scala/cats/instances/map.scala
@@ -32,11 +32,9 @@ import cats.data.Ior
 trait MapInstances extends cats.kernel.instances.MapInstances {
 
   implicit def catsStdShowForMap[A, B](implicit showA: Show[A], showB: Show[B]): Show[Map[A, B]] =
-    Show.show(
-      _.iterator
-        .map { case (a, b) => showA.show(a) + " -> " + showB.show(b) }
-        .mkString("Map(", ", ", ")")
-    )
+    _.iterator
+      .map { case (a, b) => showA.show(a) + " -> " + showB.show(b) }
+      .mkString("Map(", ", ", ")")
 
   implicit def catsStdInstancesForMap[K]: UnorderedTraverse[Map[K, *]] with FlatMap[Map[K, *]] with Align[Map[K, *]] =
     new UnorderedTraverse[Map[K, *]] with FlatMap[Map[K, *]] with Align[Map[K, *]] {

--- a/core/src/main/scala/cats/instances/option.scala
+++ b/core/src/main/scala/cats/instances/option.scala
@@ -252,11 +252,10 @@ trait OptionInstances extends cats.kernel.instances.OptionInstances {
         if (oa.isDefined) someUnit else None
     }
 
-  implicit def catsStdShowForOption[A](implicit A: Show[A]): Show[Option[A]] =
-    Show.show {
-      case Some(a) => s"Some(${A.show(a)})"
-      case None    => "None"
-    }
+  implicit def catsStdShowForOption[A](implicit A: Show[A]): Show[Option[A]] = {
+    case Some(a) => s"Some(${A.show(a)})"
+    case None    => "None"
+  }
 }
 
 @suppressUnusedImportWarningForScalaVersionSpecific

--- a/core/src/main/scala/cats/instances/option.scala
+++ b/core/src/main/scala/cats/instances/option.scala
@@ -253,12 +253,9 @@ trait OptionInstances extends cats.kernel.instances.OptionInstances {
     }
 
   implicit def catsStdShowForOption[A](implicit A: Show[A]): Show[Option[A]] =
-    new Show[Option[A]] {
-      def show(fa: Option[A]): String =
-        fa match {
-          case Some(a) => s"Some(${A.show(a)})"
-          case None    => "None"
-        }
+    Show.show {
+      case Some(a) => s"Some(${A.show(a)})"
+      case None    => "None"
     }
 }
 

--- a/core/src/main/scala/cats/instances/order.scala
+++ b/core/src/main/scala/cats/instances/order.scala
@@ -43,11 +43,9 @@ trait OrderInstances extends kernel.instances.OrderInstances {
         Order.by(f)(fa)
 
       def product[A, B](fa: Order[A], fb: Order[B]): Order[(A, B)] =
-        new Order[(A, B)] {
-          def compare(x: (A, B), y: (A, B)): Int = {
-            val z = fa.compare(x._1, y._1)
-            if (z == 0) fb.compare(x._2, y._2) else z
-          }
+        Order.from { (x, y) =>
+          val z = fa.compare(x._1, y._1)
+          if (z == 0) fb.compare(x._2, y._2) else z
         }
     }
 }

--- a/core/src/main/scala/cats/instances/order.scala
+++ b/core/src/main/scala/cats/instances/order.scala
@@ -42,10 +42,9 @@ trait OrderInstances extends kernel.instances.OrderInstances {
       def contramap[A, B](fa: Order[A])(f: B => A): Order[B] =
         Order.by(f)(fa)
 
-      def product[A, B](fa: Order[A], fb: Order[B]): Order[(A, B)] =
-        Order.from { (x, y) =>
-          val z = fa.compare(x._1, y._1)
-          if (z == 0) fb.compare(x._2, y._2) else z
-        }
+      def product[A, B](fa: Order[A], fb: Order[B]): Order[(A, B)] = { (x, y) =>
+        val z = fa.compare(x._1, y._1)
+        if (z == 0) fb.compare(x._2, y._2) else z
+      }
     }
 }

--- a/core/src/main/scala/cats/instances/partialOrder.scala
+++ b/core/src/main/scala/cats/instances/partialOrder.scala
@@ -35,11 +35,9 @@ trait PartialOrderInstances extends kernel.instances.PartialOrderInstances {
       def contramap[A, B](fa: PartialOrder[A])(f: B => A): PartialOrder[B] = PartialOrder.by[B, A](f)(fa)
 
       def product[A, B](fa: PartialOrder[A], fb: PartialOrder[B]): PartialOrder[(A, B)] =
-        new PartialOrder[(A, B)] {
-          def partialCompare(x: (A, B), y: (A, B)): Double = {
-            val z = fa.partialCompare(x._1, y._1)
-            if (z == 0.0) fb.partialCompare(x._2, y._2) else z
-          }
+        PartialOrder.from { (x, y) =>
+          val z = fa.partialCompare(x._1, y._1)
+          if (z == 0.0) fb.partialCompare(x._2, y._2) else z
         }
 
       def unit: PartialOrder[Unit] = Order[Unit]

--- a/core/src/main/scala/cats/instances/partialOrder.scala
+++ b/core/src/main/scala/cats/instances/partialOrder.scala
@@ -34,11 +34,10 @@ trait PartialOrderInstances extends kernel.instances.PartialOrderInstances {
        */
       def contramap[A, B](fa: PartialOrder[A])(f: B => A): PartialOrder[B] = PartialOrder.by[B, A](f)(fa)
 
-      def product[A, B](fa: PartialOrder[A], fb: PartialOrder[B]): PartialOrder[(A, B)] =
-        PartialOrder.from { (x, y) =>
-          val z = fa.partialCompare(x._1, y._1)
-          if (z == 0.0) fb.partialCompare(x._2, y._2) else z
-        }
+      def product[A, B](fa: PartialOrder[A], fb: PartialOrder[B]): PartialOrder[(A, B)] = { (x, y) =>
+        val z = fa.partialCompare(x._1, y._1)
+        if (z == 0.0) fb.partialCompare(x._2, y._2) else z
+      }
 
       def unit: PartialOrder[Unit] = Order[Unit]
     }

--- a/core/src/main/scala/cats/instances/queue.scala
+++ b/core/src/main/scala/cats/instances/queue.scala
@@ -26,7 +26,7 @@ import cats.data.Chain
 import cats.instances.StaticMethods.appendAll
 import cats.kernel.compat.scalaVersionSpecific._
 import cats.kernel.instances.StaticMethods.wrapMutableIndexedSeq
-import cats.syntax.show._
+
 import scala.annotation.tailrec
 import scala.collection.immutable.Queue
 import scala.util.Try
@@ -199,10 +199,7 @@ trait QueueInstances extends cats.kernel.instances.QueueInstances {
     }
 
   implicit def catsStdShowForQueue[A: Show]: Show[Queue[A]] =
-    new Show[Queue[A]] {
-      def show(fa: Queue[A]): String =
-        fa.iterator.map(_.show).mkString("Queue(", ", ", ")")
-    }
+    Show.show(_.iterator.map(Show[A].show).mkString("Queue(", ", ", ")"))
 
   implicit def catsStdTraverseFilterForQueue: TraverseFilter[Queue] = QueueInstances.catsStdTraverseFilterForQueue
 }

--- a/core/src/main/scala/cats/instances/queue.scala
+++ b/core/src/main/scala/cats/instances/queue.scala
@@ -199,7 +199,7 @@ trait QueueInstances extends cats.kernel.instances.QueueInstances {
     }
 
   implicit def catsStdShowForQueue[A: Show]: Show[Queue[A]] =
-    Show.show(_.iterator.map(Show[A].show).mkString("Queue(", ", ", ")"))
+    _.iterator.map(Show[A].show).mkString("Queue(", ", ", ")")
 
   implicit def catsStdTraverseFilterForQueue: TraverseFilter[Queue] = QueueInstances.catsStdTraverseFilterForQueue
 }

--- a/core/src/main/scala/cats/instances/seq.scala
+++ b/core/src/main/scala/cats/instances/seq.scala
@@ -207,7 +207,7 @@ trait SeqInstances extends cats.kernel.instances.SeqInstances {
   }
 
   implicit def catsStdShowForSeq[A: Show]: Show[Seq[A]] =
-    Show.show(_.map(Show[A].show).toString)
+    _.map(Show[A].show).toString
 
   implicit def catsStdNonEmptyParallelForSeqZipSeq: NonEmptyParallel.Aux[Seq, ZipSeq] =
     new NonEmptyParallel[Seq] {

--- a/core/src/main/scala/cats/instances/seq.scala
+++ b/core/src/main/scala/cats/instances/seq.scala
@@ -27,7 +27,7 @@ import cats.instances.StaticMethods.appendAll
 import cats.kernel.compat.scalaVersionSpecific._
 
 import scala.annotation.tailrec
-import scala.collection.{+:, mutable}
+import scala.collection.mutable
 import scala.collection.immutable.Seq
 
 @suppressUnusedImportWarningForScalaVersionSpecific
@@ -207,10 +207,7 @@ trait SeqInstances extends cats.kernel.instances.SeqInstances {
   }
 
   implicit def catsStdShowForSeq[A: Show]: Show[Seq[A]] =
-    new Show[Seq[A]] {
-      def show(fa: Seq[A]): String =
-        fa.toString()
-    }
+    Show.show(_.iterator.map(Show[A].show).mkString("Seq(", ", ", ")"))
 
   implicit def catsStdNonEmptyParallelForSeqZipSeq: NonEmptyParallel.Aux[Seq, ZipSeq] =
     new NonEmptyParallel[Seq] {

--- a/core/src/main/scala/cats/instances/seq.scala
+++ b/core/src/main/scala/cats/instances/seq.scala
@@ -207,7 +207,7 @@ trait SeqInstances extends cats.kernel.instances.SeqInstances {
   }
 
   implicit def catsStdShowForSeq[A: Show]: Show[Seq[A]] =
-    Show.show(_.iterator.map(Show[A].show).mkString("Seq(", ", ", ")"))
+    Show.show(_.map(Show[A].show).toString)
 
   implicit def catsStdNonEmptyParallelForSeqZipSeq: NonEmptyParallel.Aux[Seq, ZipSeq] =
     new NonEmptyParallel[Seq] {

--- a/core/src/main/scala/cats/instances/set.scala
+++ b/core/src/main/scala/cats/instances/set.scala
@@ -24,8 +24,6 @@ package instances
 
 import cats.kernel.CommutativeMonoid
 
-import cats.syntax.show._
-
 trait SetInstances extends cats.kernel.instances.SetInstances {
 
   implicit val catsStdInstancesForSet: UnorderedTraverse[Set] with MonoidK[Set] =
@@ -61,8 +59,5 @@ trait SetInstances extends cats.kernel.instances.SetInstances {
     }
 
   implicit def catsStdShowForSet[A: Show]: Show[Set[A]] =
-    new Show[Set[A]] {
-      def show(fa: Set[A]): String =
-        fa.iterator.map(_.show).mkString("Set(", ", ", ")")
-    }
+    Show.show(_.iterator.map(Show[A].show).mkString("Set(", ", ", ")"))
 }

--- a/core/src/main/scala/cats/instances/set.scala
+++ b/core/src/main/scala/cats/instances/set.scala
@@ -59,5 +59,5 @@ trait SetInstances extends cats.kernel.instances.SetInstances {
     }
 
   implicit def catsStdShowForSet[A: Show]: Show[Set[A]] =
-    Show.show(_.iterator.map(Show[A].show).mkString("Set(", ", ", ")"))
+    _.iterator.map(Show[A].show).mkString("Set(", ", ", ")")
 }

--- a/core/src/main/scala/cats/instances/sortedSet.scala
+++ b/core/src/main/scala/cats/instances/sortedSet.scala
@@ -84,7 +84,7 @@ trait SortedSetInstances extends SortedSetInstances1 {
     }
 
   implicit def catsStdShowForSortedSet[A: Show]: Show[SortedSet[A]] =
-    Show.show(_.iterator.map(Show[A].show).mkString("SortedSet(", ", ", ")"))
+    _.iterator.map(Show[A].show).mkString("SortedSet(", ", ", ")")
 
   @deprecated("Use cats.kernel.instances.sortedSet.catsKernelStdOrderForSortedSet", "2.0.0-RC2")
   private[instances] def catsKernelStdOrderForSortedSet[A: Order]: Order[SortedSet[A]] =

--- a/core/src/main/scala/cats/instances/sortedSet.scala
+++ b/core/src/main/scala/cats/instances/sortedSet.scala
@@ -84,10 +84,7 @@ trait SortedSetInstances extends SortedSetInstances1 {
     }
 
   implicit def catsStdShowForSortedSet[A: Show]: Show[SortedSet[A]] =
-    new Show[SortedSet[A]] {
-      def show(fa: SortedSet[A]): String =
-        fa.iterator.map(Show[A].show).mkString("SortedSet(", ", ", ")")
-    }
+    Show.show(_.iterator.map(Show[A].show).mkString("SortedSet(", ", ", ")"))
 
   @deprecated("Use cats.kernel.instances.sortedSet.catsKernelStdOrderForSortedSet", "2.0.0-RC2")
   private[instances] def catsKernelStdOrderForSortedSet[A: Order]: Order[SortedSet[A]] =

--- a/core/src/main/scala/cats/instances/try.scala
+++ b/core/src/main/scala/cats/instances/try.scala
@@ -191,15 +191,8 @@ trait TryInstances extends TryInstances1 {
    * doing a fine grained equality on Throwable can make the code very execution
    * order dependent
    */
-  implicit def catsStdEqForTry[A, T](implicit A: Eq[A], T: Eq[Throwable]): Eq[Try[A]] =
-    new Eq[Try[A]] {
-      def eqv(x: Try[A], y: Try[A]): Boolean =
-        (x, y) match {
-          case (Success(a), Success(b)) => A.eqv(a, b)
-          case (Failure(a), Failure(b)) => T.eqv(a, b)
-          case _                        => false
-        }
-    }
+  implicit def catsStdEqForTry[A](implicit A: Eq[A], T: Eq[Throwable]): Eq[Try[A]] =
+    Eq.catsStdEqForTry
 }
 
 private[instances] object TryInstances {

--- a/core/src/main/scala/cats/instances/try.scala
+++ b/core/src/main/scala/cats/instances/try.scala
@@ -181,12 +181,9 @@ trait TryInstances extends TryInstances1 {
     }
 
   implicit def catsStdShowForTry[A](implicit A: Show[A]): Show[Try[A]] =
-    new Show[Try[A]] {
-      def show(fa: Try[A]): String =
-        fa match {
-          case Success(a) => s"Success(${A.show(a)})"
-          case Failure(e) => s"Failure($e)"
-        }
+    Show.show {
+      case Success(a) => s"Success(${A.show(a)})"
+      case Failure(e) => s"Failure($e)"
     }
 
   /**

--- a/core/src/main/scala/cats/instances/try.scala
+++ b/core/src/main/scala/cats/instances/try.scala
@@ -180,11 +180,10 @@ trait TryInstances extends TryInstances1 {
       override def unit: Try[Unit] = successUnit
     }
 
-  implicit def catsStdShowForTry[A](implicit A: Show[A]): Show[Try[A]] =
-    Show.show {
-      case Success(a) => s"Success(${A.show(a)})"
-      case Failure(e) => s"Failure($e)"
-    }
+  implicit def catsStdShowForTry[A](implicit A: Show[A]): Show[Try[A]] = {
+    case Success(a) => s"Success(${A.show(a)})"
+    case Failure(e) => s"Failure($e)"
+  }
 
   /**
    * you may wish to do equality by making `implicit val eqT: Eq[Throwable] = Eq.allEqual`

--- a/core/src/main/scala/cats/instances/tuple.scala
+++ b/core/src/main/scala/cats/instances/tuple.scala
@@ -70,8 +70,9 @@ sealed private[instances] trait Tuple2Instances extends Tuple2Instances1 {
     }
 
   @deprecated("Use catsStdShowForTuple2 in cats.instances.NTupleShowInstances", "2.4.0")
-  def catsStdShowForTuple2[A, B](implicit aShow: Show[A], bShow: Show[B]): Show[(A, B)] =
-    Show.show { case (a, b) => s"(${aShow.show(a)},${bShow.show(b)})" }
+  def catsStdShowForTuple2[A, B](implicit aShow: Show[A], bShow: Show[B]): Show[(A, B)] = { case (a, b) =>
+    s"(${aShow.show(a)},${bShow.show(b)})"
+  }
 
   @deprecated("Use catsStdInstancesForTuple2 in cats.instances.NTupleMonadInstances", "2.4.0")
   def catsStdInstancesForTuple2[X]: Traverse[(X, *)] with Comonad[(X, *)] with Reducible[(X, *)] =

--- a/core/src/main/scala/cats/instances/tuple.scala
+++ b/core/src/main/scala/cats/instances/tuple.scala
@@ -71,10 +71,7 @@ sealed private[instances] trait Tuple2Instances extends Tuple2Instances1 {
 
   @deprecated("Use catsStdShowForTuple2 in cats.instances.NTupleShowInstances", "2.4.0")
   def catsStdShowForTuple2[A, B](implicit aShow: Show[A], bShow: Show[B]): Show[(A, B)] =
-    new Show[(A, B)] {
-      override def show(f: (A, B)): String =
-        s"(${aShow.show(f._1)},${bShow.show(f._2)})"
-    }
+    Show.show { case (a, b) => s"(${aShow.show(a)},${bShow.show(b)})" }
 
   @deprecated("Use catsStdInstancesForTuple2 in cats.instances.NTupleMonadInstances", "2.4.0")
   def catsStdInstancesForTuple2[X]: Traverse[(X, *)] with Comonad[(X, *)] with Reducible[(X, *)] =

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -22,15 +22,12 @@
 package cats
 package instances
 
-import cats.data.{Chain, ZipVector}
+import cats.data.{Chain, Ior, ZipVector}
 import cats.instances.StaticMethods.appendAll
 import cats.kernel.compat.scalaVersionSpecific._
-import cats.syntax.show._
 
 import scala.annotation.tailrec
-import scala.collection.+:
 import scala.collection.immutable.VectorBuilder
-import cats.data.Ior
 
 trait VectorInstances extends cats.kernel.instances.VectorInstances {
   implicit val catsStdInstancesForVector
@@ -232,10 +229,7 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
     }
 
   implicit def catsStdShowForVector[A: Show]: Show[Vector[A]] =
-    new Show[Vector[A]] {
-      def show(fa: Vector[A]): String =
-        fa.iterator.map(_.show).mkString("Vector(", ", ", ")")
-    }
+    Show.show(_.iterator.map(Show[A].show).mkString("Vector(", ", ", ")"))
 
   implicit def catsStdNonEmptyParallelForVectorZipVector: NonEmptyParallel.Aux[Vector, ZipVector] =
     new NonEmptyParallel[Vector] {

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -229,7 +229,7 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
     }
 
   implicit def catsStdShowForVector[A: Show]: Show[Vector[A]] =
-    Show.show(_.iterator.map(Show[A].show).mkString("Vector(", ", ", ")"))
+    _.iterator.map(Show[A].show).mkString("Vector(", ", ", ")")
 
   implicit def catsStdNonEmptyParallelForVectorZipVector: NonEmptyParallel.Aux[Vector, ZipVector] =
     new NonEmptyParallel[Vector] {

--- a/docs/typeclasses/invariantmonoidal.md
+++ b/docs/typeclasses/invariantmonoidal.md
@@ -24,15 +24,11 @@ To construct a `Semigroup` from a single value, we can define a trivial `Semigro
 import cats.Semigroup
 
 def unit: Semigroup[Unit] =
-  new Semigroup[Unit] {
-    def combine(x: Unit, y: Unit): Unit = ()
-  }
+  Semigroup.instance((_, _) => ())
 
 def product[A, B](fa: Semigroup[A], fb: Semigroup[B]): Semigroup[(A, B)] =
-  new Semigroup[(A, B)] {
-    def combine(x: (A, B), y: (A, B)): (A, B) = (x, y) match {
-      case ((xa, xb), (ya, yb)) => fa.combine(xa, ya) -> fb.combine(xb, yb)
-    }
+  Semigroup.instances { case ((xa, xb), (ya, yb)) =>
+    fa.combine(xa, ya) -> fb.combine(xb, yb)
   }
 ```
 

--- a/docs/typeclasses/invariantmonoidal.md
+++ b/docs/typeclasses/invariantmonoidal.md
@@ -27,7 +27,7 @@ def unit: Semigroup[Unit] =
   Semigroup.instance((_, _) => ())
 
 def product[A, B](fa: Semigroup[A], fb: Semigroup[B]): Semigroup[(A, B)] =
-  Semigroup.instances { case ((xa, xb), (ya, yb)) =>
+  Semigroup.instance { case ((xa, xb), (ya, yb)) =>
     fa.combine(xa, ya) -> fb.combine(xb, yb)
   }
 ```

--- a/docs/typeclasses/invariantmonoidal.md
+++ b/docs/typeclasses/invariantmonoidal.md
@@ -23,13 +23,11 @@ To construct a `Semigroup` from a single value, we can define a trivial `Semigro
 ```scala mdoc:silent
 import cats.Semigroup
 
-def unit: Semigroup[Unit] =
-  Semigroup.instance((_, _) => ())
+def unit: Semigroup[Unit] = (_, _) => ()
 
-def product[A, B](fa: Semigroup[A], fb: Semigroup[B]): Semigroup[(A, B)] =
-  Semigroup.instance { case ((xa, xb), (ya, yb)) =>
-    fa.combine(xa, ya) -> fb.combine(xb, yb)
-  }
+def product[A, B](fa: Semigroup[A], fb: Semigroup[B]): Semigroup[(A, B)] = {
+  case ((xa, xb), (ya, yb)) => fa.combine(xa, ya) -> fb.combine(xb, yb)
+}
 ```
 
 Given an instance of `InvariantMonoidal` for `Semigroup`, we are able to combine existing `Semigroup` instances to form a new `Semigroup` by using the `Semigroupal` syntax:

--- a/docs/typeclasses/lawtesting.md
+++ b/docs/typeclasses/lawtesting.md
@@ -135,7 +135,7 @@ implicit def semigroupTree[A: Semigroup]: Semigroup[Tree[A]] = new Semigroup[Tre
     case (Leaf, _) => Leaf
     case (_, Leaf) => Leaf
     case (Node(xp, xLeft, xRight), Node(yp, yLeft, yRight)) =>
-      Node(xp |+| yp, xLeft |+| yLeft, xRight |+| yRight)
+      Node(xp |+| yp, combine(xLeft, yLeft), combine(xRight, yRight))
   }
 }
 ```

--- a/docs/typeclasses/monoid.md
+++ b/docs/typeclasses/monoid.md
@@ -83,9 +83,7 @@ final case class NonEmptyList[A](head: A, tail: List[A]) {
 
 object NonEmptyList {
   implicit def nonEmptyListSemigroup[A]: Semigroup[NonEmptyList[A]] =
-    new Semigroup[NonEmptyList[A]] {
-      def combine(x: NonEmptyList[A], y: NonEmptyList[A]): NonEmptyList[A] = x ++ y
-    }
+    Semigroup.instance(_ ++ _)
 }
 ```
 

--- a/docs/typeclasses/monoid.md
+++ b/docs/typeclasses/monoid.md
@@ -82,8 +82,7 @@ final case class NonEmptyList[A](head: A, tail: List[A]) {
 }
 
 object NonEmptyList {
-  implicit def nonEmptyListSemigroup[A]: Semigroup[NonEmptyList[A]] =
-    Semigroup.instance(_ ++ _)
+  implicit def nonEmptyListSemigroup[A]: Semigroup[NonEmptyList[A]] = _ ++ _
 }
 ```
 

--- a/docs/typeclasses/semigroup.md
+++ b/docs/typeclasses/semigroup.md
@@ -20,9 +20,8 @@ A common example of a semigroup is the type `Int` with the operation `+`.
 ```scala mdoc:reset:silent
 import cats.Semigroup
 
-implicit val intAdditionSemigroup: Semigroup[Int] = new Semigroup[Int] {
-  def combine(x: Int, y: Int): Int = x + y
-}
+implicit val intAdditionSemigroup: Semigroup[Int] =
+  Semigroup.instance(_ + _)
 
 val x = 1
 val y = 2

--- a/docs/typeclasses/semigroup.md
+++ b/docs/typeclasses/semigroup.md
@@ -20,8 +20,7 @@ A common example of a semigroup is the type `Int` with the operation `+`.
 ```scala mdoc:reset:silent
 import cats.Semigroup
 
-implicit val intAdditionSemigroup: Semigroup[Int] =
-  Semigroup.instance(_ + _)
+implicit val intAdditionSemigroup: Semigroup[Int] = _ + _
 
 val x = 1
 val y = 2

--- a/free/src/main/scala-2.13+/cats/free/FreeStructuralInstances.scala
+++ b/free/src/main/scala-2.13+/cats/free/FreeStructuralInstances.scala
@@ -54,13 +54,10 @@ private trait FreeStructuralInstances0 extends FreeStructuralInstances1 {
     SF: Functor[S],
     S: => Show[S[Free[S, A]]],
     A: Show[A]
-  ): Show[Free[S, A]] =
-    Show.show { fsa =>
-      fsa.resume match {
-        case Right(a)  => A.show(a)
-        case Left(sfa) => S.show(sfa)
-      }
-    }
+  ): Show[Free[S, A]] = _.resume match {
+    case Right(a)  => A.show(a)
+    case Left(sfa) => S.show(sfa)
+  }
 
   implicit def catsFreeHashForFree[S[_], A](implicit
     SF: Functor[S],

--- a/free/src/test/scala-2.13+/cats/free/FreeStructuralSuite.scala
+++ b/free/src/test/scala-2.13+/cats/free/FreeStructuralSuite.scala
@@ -59,21 +59,16 @@ object FreeStructuralSuite {
   sealed trait ExprF[A] extends Product with Serializable
 
   object ExprF {
-
-    implicit def eq[A: Eq]: Eq[ExprF[A]] =
-      Eq.instance {
-        case (Add(left1, right1), Add(left2, right2)) =>
-          left1 === left2 && right1 === right2
-
-        case (Neg(inner1), Neg(inner2)) =>
-          inner1 === inner2
-
-        case (Num(value1), Num(value2)) =>
-          value1 === value2
-
-        case (_, _) =>
-          false
-      }
+    implicit def eq[A: Eq]: Eq[ExprF[A]] = {
+      case (Add(left1, right1), Add(left2, right2)) =>
+        left1 === left2 && right1 === right2
+      case (Neg(inner1), Neg(inner2)) =>
+        inner1 === inner2
+      case (Num(value1), Num(value2)) =>
+        value1 === value2
+      case (_, _) =>
+        false
+    }
 
     implicit def traverse: Traverse[ExprF] =
       new Traverse[ExprF] {

--- a/free/src/test/scala/cats/free/CofreeSuite.scala
+++ b/free/src/test/scala/cats/free/CofreeSuite.scala
@@ -178,16 +178,14 @@ sealed trait CofreeSuiteInstances {
   type CofreeNel[A] = Cofree[Option, A]
   type CofreeRoseTree[A] = Cofree[List, A]
 
-  implicit def cofNelEq[A](implicit e: Eq[A]): Eq[CofreeNel[A]] =
-    Eq.instance { (a, b) =>
-      @tailrec def tr(a: CofreeNel[A], b: CofreeNel[A]): Boolean =
-        (a.tailForced, b.tailForced) match {
-          case (Some(at), Some(bt)) if e.eqv(a.head, b.head) => tr(at, bt)
-          case (None, None) if e.eqv(a.head, b.head)         => true
-          case _                                             => false
-        }
-      tr(a, b)
-    }
+  implicit def cofNelEq[A](implicit e: Eq[A]): Eq[CofreeNel[A]] = new Eq[CofreeNel[A]] {
+    @tailrec def eqv(a: CofreeNel[A], b: CofreeNel[A]): Boolean =
+      (a.tailForced, b.tailForced) match {
+        case (Some(at), Some(bt)) if e.eqv(a.head, b.head) => eqv(at, bt)
+        case (None, None) if e.eqv(a.head, b.head)         => true
+        case _                                             => false
+      }
+  }
 
   implicit def CofreeOptionCogen[A: Cogen]: Cogen[CofreeNel[A]] =
     implicitly[Cogen[List[A]]].contramap[CofreeNel[A]](cofNelToNel(_).toList)

--- a/free/src/test/scala/cats/free/ContravariantCoyonedaSuite.scala
+++ b/free/src/test/scala/cats/free/ContravariantCoyonedaSuite.scala
@@ -41,11 +41,10 @@ class ContravariantCoyonedaSuite extends CatsSuite {
 
   // We can't really test that functions are equal but we can try it with a bunch of test data.
   implicit def contravariantCoyonedaEq[A: Arbitrary, T](implicit eqft: Eq[T]): Eq[ContravariantCoyoneda[* => T, A]] =
-    Eq.instance { (cca, ccb) =>
+    (cca, ccb) =>
       Arbitrary.arbitrary[List[A]].sample.get.forall { a =>
         eqft.eqv(cca.run.apply(a), ccb.run.apply(a))
       }
-    }
 
   // This instance cannot be summoned implicitly. This is not specific to contravariant coyoneda;
   // it doesn't work for Functor[Coyoneda[* => String, *]] either.

--- a/free/src/test/scala/cats/free/ContravariantCoyonedaSuite.scala
+++ b/free/src/test/scala/cats/free/ContravariantCoyonedaSuite.scala
@@ -41,11 +41,10 @@ class ContravariantCoyonedaSuite extends CatsSuite {
 
   // We can't really test that functions are equal but we can try it with a bunch of test data.
   implicit def contravariantCoyonedaEq[A: Arbitrary, T](implicit eqft: Eq[T]): Eq[ContravariantCoyoneda[* => T, A]] =
-    new Eq[ContravariantCoyoneda[* => T, A]] {
-      def eqv(cca: ContravariantCoyoneda[* => T, A], ccb: ContravariantCoyoneda[* => T, A]): Boolean =
-        Arbitrary.arbitrary[List[A]].sample.get.forall { a =>
-          eqft.eqv(cca.run.apply(a), ccb.run.apply(a))
-        }
+    Eq.instance { (cca, ccb) =>
+      Arbitrary.arbitrary[List[A]].sample.get.forall { a =>
+        eqft.eqv(cca.run.apply(a), ccb.run.apply(a))
+      }
     }
 
   // This instance cannot be summoned implicitly. This is not specific to contravariant coyoneda;

--- a/free/src/test/scala/cats/free/CoyonedaSuite.scala
+++ b/free/src/test/scala/cats/free/CoyonedaSuite.scala
@@ -36,9 +36,7 @@ class CoyonedaSuite extends CatsSuite {
     Arbitrary(F.arbitrary.map(Coyoneda.lift))
 
   implicit def coyonedaEq[F[_]: Functor, A](implicit FA: Eq[F[A]]): Eq[Coyoneda[F, A]] =
-    new Eq[Coyoneda[F, A]] {
-      def eqv(a: Coyoneda[F, A], b: Coyoneda[F, A]): Boolean = FA.eqv(a.run, b.run)
-    }
+    Eq.by(_.run)
 
   checkAll("Coyoneda[Option, *]", FunctorTests[Coyoneda[Option, *]].functor[Int, Int, Int])
   checkAll("Functor[Coyoneda[Option, *]]", SerializableTests.serializable(Functor[Coyoneda[Option, *]]))

--- a/free/src/test/scala/cats/free/FreeApplicativeSuite.scala
+++ b/free/src/test/scala/cats/free/FreeApplicativeSuite.scala
@@ -190,10 +190,7 @@ object FreeApplicativeSuite {
     Arbitrary(freeGen[F, A](4))
 
   implicit def freeApplicativeEq[S[_]: Applicative, A](implicit SA: Eq[S[A]]): Eq[FreeApplicative[S, A]] =
-    new Eq[FreeApplicative[S, A]] {
-      def eqv(a: FreeApplicative[S, A], b: FreeApplicative[S, A]): Boolean =
-        SA.eqv(a.fold, b.fold)
-    }
+    Eq.by(_.fold)
 
   implicit def catsLawsArbitraryForListNatTrans: Arbitrary[List ~> List] =
     Arbitrary(

--- a/free/src/test/scala/cats/free/FreeInvariantMonoidalSuite.scala
+++ b/free/src/test/scala/cats/free/FreeInvariantMonoidalSuite.scala
@@ -48,12 +48,7 @@ class FreeInvariantMonoidalSuite extends CatsSuite {
   implicit def freeInvariantMonoidalEq[S[_]: InvariantMonoidal, A](implicit
     SA: Eq[S[A]]
   ): Eq[FreeInvariantMonoidal[S, A]] =
-    new Eq[FreeInvariantMonoidal[S, A]] {
-      def eqv(a: FreeInvariantMonoidal[S, A], b: FreeInvariantMonoidal[S, A]): Boolean = {
-        val nt = FunctionK.id[S]
-        SA.eqv(a.foldMap(nt), b.foldMap(nt))
-      }
-    }
+    Eq.by(_.foldMap(FunctionK.id))
 
   implicit val isoFreeBinCodec: Isomorphisms[FreeInvariantMonoidal[BinCodec, *]] =
     Isomorphisms.invariant[FreeInvariantMonoidal[BinCodec, *]]

--- a/free/src/test/scala/cats/free/FreeSuite.scala
+++ b/free/src/test/scala/cats/free/FreeSuite.scala
@@ -285,8 +285,5 @@ sealed trait FreeSuiteInstances1 {
     Arbitrary(freeGen[F, A](4))
 
   implicit def freeEq[S[_]: Monad, A](implicit SA: Eq[S[A]]): Eq[Free[S, A]] =
-    new Eq[Free[S, A]] {
-      def eqv(a: Free[S, A], b: Free[S, A]): Boolean =
-        SA.eqv(a.runM(identity), b.runM(identity))
-    }
+    Eq.by(_.runM(identity))
 }

--- a/free/src/test/scala/cats/free/FreeTSuite.scala
+++ b/free/src/test/scala/cats/free/FreeTSuite.scala
@@ -302,9 +302,9 @@ trait FreeTSuiteInstances {
     override def map[A, B](fa: JustFunctor[A])(f: A => B): JustFunctor[B] = JustFunctor(f(fa.a))
   }
 
-  implicit def freeTOptionEq[A](implicit A: Eq[A], OM: Monad[Option]): Eq[FreeTOption[A]] =
+  implicit def freeTOptionEq[A](implicit A: Eq[A]): Eq[FreeTOption[A]] =
     Eq.by(_.runM(identity))
 
-  implicit def freeTStateEq[A](implicit A: Eq[A], SM: Monad[IntState]): Eq[FreeTState[A]] =
+  implicit def freeTStateEq[A](implicit A: Eq[A]): Eq[FreeTState[A]] =
     Eq.by(_.runM(identity))
 }

--- a/free/src/test/scala/cats/free/FreeTSuite.scala
+++ b/free/src/test/scala/cats/free/FreeTSuite.scala
@@ -303,13 +303,8 @@ trait FreeTSuiteInstances {
   }
 
   implicit def freeTOptionEq[A](implicit A: Eq[A], OM: Monad[Option]): Eq[FreeTOption[A]] =
-    new Eq[FreeTOption[A]] {
-      def eqv(a: FreeTOption[A], b: FreeTOption[A]) = Eq[Option[A]].eqv(a.runM(identity), b.runM(identity))
-    }
+    Eq.by(_.runM(identity))
 
   implicit def freeTStateEq[A](implicit A: Eq[A], SM: Monad[IntState]): Eq[FreeTState[A]] =
-    new Eq[FreeTState[A]] {
-      def eqv(a: FreeTState[A], b: FreeTState[A]) =
-        Eq[IntState[A]].eqv(a.runM(identity)(SM, SM), b.runM(identity)(SM, SM))
-    }
+    Eq.by(_.runM(identity))
 }

--- a/free/src/test/scala/cats/free/InvariantCoyonedaSuite.scala
+++ b/free/src/test/scala/cats/free/InvariantCoyonedaSuite.scala
@@ -50,11 +50,10 @@ class InvariantCoyonedaSuite extends CatsSuite {
 
   // We can't really test that magmas are equal but we can try it with a bunch of test data.
   implicit def invariantCoyonedaEq[A: Arbitrary: Eq]: Eq[InvariantCoyoneda[Magma, A]] =
-    new Eq[InvariantCoyoneda[Magma, A]] {
-      def eqv(cca: InvariantCoyoneda[Magma, A], ccb: InvariantCoyoneda[Magma, A]): Boolean =
-        Arbitrary.arbitrary[List[(A, A)]].sample.get.forall { case (x, y) =>
-          cca.run.apply(x, y) == ccb.run.apply(x, y)
-        }
+    Eq.instance { (cca, ccb) =>
+      Arbitrary.arbitrary[List[(A, A)]].sample.get.forall { case (x, y) =>
+        cca.run.apply(x, y) == ccb.run.apply(x, y)
+      }
     }
 
   // Needed to help implicit resolution?

--- a/free/src/test/scala/cats/free/InvariantCoyonedaSuite.scala
+++ b/free/src/test/scala/cats/free/InvariantCoyonedaSuite.scala
@@ -50,11 +50,10 @@ class InvariantCoyonedaSuite extends CatsSuite {
 
   // We can't really test that magmas are equal but we can try it with a bunch of test data.
   implicit def invariantCoyonedaEq[A: Arbitrary: Eq]: Eq[InvariantCoyoneda[Magma, A]] =
-    Eq.instance { (cca, ccb) =>
+    (cca, ccb) =>
       Arbitrary.arbitrary[List[(A, A)]].sample.get.forall { case (x, y) =>
         cca.run.apply(x, y) == ccb.run.apply(x, y)
       }
-    }
 
   // Needed to help implicit resolution?
   implicit val invariantCoyonedaMagma: Invariant[InvariantCoyoneda[Magma, *]] =

--- a/free/src/test/scala/cats/free/YonedaSuite.scala
+++ b/free/src/test/scala/cats/free/YonedaSuite.scala
@@ -35,9 +35,7 @@ class YonedaSuite extends CatsSuite {
     Arbitrary(F.arbitrary.map(Yoneda(_)))
 
   implicit def yonedaEq[F[_]: Functor, A](implicit FA: Eq[F[A]]): Eq[Yoneda[F, A]] =
-    new Eq[Yoneda[F, A]] {
-      def eqv(a: Yoneda[F, A], b: Yoneda[F, A]): Boolean = FA.eqv(a.run, b.run)
-    }
+    Eq.by(_.run)
 
   checkAll("Yoneda[Option, *]", FunctorTests[Yoneda[Option, *]].functor[Int, Int, Int])
   checkAll("Functor[Yoneda[Option, *]]", SerializableTests.serializable(Functor[Yoneda[Option, *]]))

--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -353,13 +353,11 @@ class Tests extends TestsConfig with DisciplineSuite {
   // Comparison related
 
   // Something that can give NaN for test
-  def subsetPartialOrder[A]: PartialOrder[Set[A]] =
-    PartialOrder.from { (x, y) =>
-      if (x == y) 0.0
-      else if (x.subsetOf(y)) -1.0
-      else if (y.subsetOf(x)) 1.0
-      else Double.NaN
-    }
+  def subsetPartialOrder[A]: PartialOrder[Set[A]] = (x, y) =>
+    if (x == y) 0.0
+    else if (x.subsetOf(y)) -1.0
+    else if (y.subsetOf(x)) 1.0
+    else Double.NaN
 
   checkAll("subsetPartialOrder[Int]", PartialOrderTests(subsetPartialOrder[Int]).partialOrder)
 

--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -424,9 +424,7 @@ class Tests extends TestsConfig with DisciplineSuite {
   // esoteric machinery follows...
 
   implicit lazy val band: Band[(Int, Int)] =
-    new Band[(Int, Int)] {
-      def combine(a: (Int, Int), b: (Int, Int)) = (a._1, b._2)
-    }
+    Band.instance((a, b) => (a._1, b._2))
 
   {
     // In order to check the monoid laws for `Order[N]`, we need

--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -460,12 +460,11 @@ class Tests extends TestsConfig with DisciplineSuite {
     implicit val NOrderEq: Eq[Order[N]] = Eq.by { (order: Order[N]) =>
       Vector.tabulate(nMax)(N).sorted(order.toOrdering)
     }
-    implicit val NEqEq: Eq[Eq[N]] = Eq.instance { (a, b) =>
+    implicit val NEqEq: Eq[Eq[N]] = (a, b) =>
       Iterator
         .tabulate(nMax)(N)
         .flatMap(x => Iterator.tabulate(nMax)(N).map((x, _)))
         .forall { case (x, y) => a.eqv(x, y) == b.eqv(x, y) }
-    }
 
     implicit val monoidOrderN: Monoid[Order[N]] with Band[Order[N]] = Order.whenEqualMonoid[N]
     checkAll("Monoid[Order[N]]", MonoidTests[Order[N]].monoid)

--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -462,14 +462,11 @@ class Tests extends TestsConfig with DisciplineSuite {
     implicit val NOrderEq: Eq[Order[N]] = Eq.by { (order: Order[N]) =>
       Vector.tabulate(nMax)(N).sorted(order.toOrdering)
     }
-    implicit val NEqEq: Eq[Eq[N]] = new Eq[Eq[N]] {
-      def eqv(a: Eq[N], b: Eq[N]) =
-        Iterator
-          .tabulate(nMax)(N)
-          .flatMap { x =>
-            Iterator.tabulate(nMax)(N).map((x, _))
-          }
-          .forall { case (x, y) => a.eqv(x, y) == b.eqv(x, y) }
+    implicit val NEqEq: Eq[Eq[N]] = Eq.instance { (a, b) =>
+      Iterator
+        .tabulate(nMax)(N)
+        .flatMap(x => Iterator.tabulate(nMax)(N).map((x, _)))
+        .forall { case (x, y) => a.eqv(x, y) == b.eqv(x, y) }
     }
 
     implicit val monoidOrderN: Monoid[Order[N]] with Band[Order[N]] = Order.whenEqualMonoid[N]

--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -354,12 +354,11 @@ class Tests extends TestsConfig with DisciplineSuite {
 
   // Something that can give NaN for test
   def subsetPartialOrder[A]: PartialOrder[Set[A]] =
-    new PartialOrder[Set[A]] {
-      def partialCompare(x: Set[A], y: Set[A]): Double =
-        if (x == y) 0.0
-        else if (x.subsetOf(y)) -1.0
-        else if (y.subsetOf(x)) 1.0
-        else Double.NaN
+    PartialOrder.from { (x, y) =>
+      if (x == y) 0.0
+      else if (x.subsetOf(y)) -1.0
+      else if (y.subsetOf(x)) 1.0
+      else Double.NaN
     }
 
   checkAll("subsetPartialOrder[Int]", PartialOrderTests(subsetPartialOrder[Int]).partialOrder)

--- a/kernel/src/main/scala/cats/kernel/Band.scala
+++ b/kernel/src/main/scala/cats/kernel/Band.scala
@@ -42,8 +42,6 @@ object Band extends SemigroupFunctions[Band] {
   /**
    * Create a `Band` instance from the given function.
    */
-  @inline def instance[A](cmb: (A, A) => A): Band[A] =
-    new Band[A] {
-      override def combine(x: A, y: A): A = cmb(x, y)
-    }
+  @inline def instance[@sp(Int, Long, Float, Double) A](cmb: (A, A) => A): Band[A] =
+    cmb(_, _)
 }

--- a/kernel/src/main/scala/cats/kernel/Band.scala
+++ b/kernel/src/main/scala/cats/kernel/Band.scala
@@ -42,6 +42,5 @@ object Band extends SemigroupFunctions[Band] {
   /**
    * Create a `Band` instance from the given function.
    */
-  @inline def instance[@sp(Int, Long, Float, Double) A](cmb: (A, A) => A): Band[A] =
-    cmb(_, _)
+  @inline def instance[A](cmb: (A, A) => A): Band[A] = cmb(_, _)
 }

--- a/kernel/src/main/scala/cats/kernel/BoundedSemilattice.scala
+++ b/kernel/src/main/scala/cats/kernel/BoundedSemilattice.scala
@@ -41,10 +41,9 @@ object BoundedSemilattice extends SemilatticeFunctions[BoundedSemilattice] {
   /**
    * Create a `BoundedSemilattice` instance from the given function and empty value.
    */
-  @inline def instance[A](emptyValue: A, cmb: (A, A) => A): BoundedSemilattice[A] =
+  @inline def instance[@sp(Int, Long, Float, Double) A](emptyValue: A, cmb: (A, A) => A): BoundedSemilattice[A] =
     new BoundedSemilattice[A] {
       override val empty: A = emptyValue
-
       override def combine(x: A, y: A): A = cmb(x, y)
     }
 }

--- a/kernel/src/main/scala/cats/kernel/BoundedSemilattice.scala
+++ b/kernel/src/main/scala/cats/kernel/BoundedSemilattice.scala
@@ -41,7 +41,7 @@ object BoundedSemilattice extends SemilatticeFunctions[BoundedSemilattice] {
   /**
    * Create a `BoundedSemilattice` instance from the given function and empty value.
    */
-  @inline def instance[@sp(Int, Long, Float, Double) A](emptyValue: A, cmb: (A, A) => A): BoundedSemilattice[A] =
+  @inline def instance[A](emptyValue: A, cmb: (A, A) => A): BoundedSemilattice[A] =
     new BoundedSemilattice[A] {
       override val empty: A = emptyValue
       override def combine(x: A, y: A): A = cmb(x, y)

--- a/kernel/src/main/scala/cats/kernel/CommutativeSemigroup.scala
+++ b/kernel/src/main/scala/cats/kernel/CommutativeSemigroup.scala
@@ -54,6 +54,5 @@ object CommutativeSemigroup extends SemigroupFunctions[CommutativeSemigroup] {
   /**
    * Create a `CommutativeSemigroup` instance from the given function.
    */
-  @inline def instance[@sp(Int, Long, Float, Double) A](cmb: (A, A) => A): CommutativeSemigroup[A] =
-    cmb(_, _)
+  @inline def instance[A](cmb: (A, A) => A): CommutativeSemigroup[A] = cmb(_, _)
 }

--- a/kernel/src/main/scala/cats/kernel/CommutativeSemigroup.scala
+++ b/kernel/src/main/scala/cats/kernel/CommutativeSemigroup.scala
@@ -54,8 +54,6 @@ object CommutativeSemigroup extends SemigroupFunctions[CommutativeSemigroup] {
   /**
    * Create a `CommutativeSemigroup` instance from the given function.
    */
-  @inline def instance[A](cmb: (A, A) => A): CommutativeSemigroup[A] =
-    new CommutativeSemigroup[A] {
-      override def combine(x: A, y: A): A = cmb(x, y)
-    }
+  @inline def instance[@sp(Int, Long, Float, Double) A](cmb: (A, A) => A): CommutativeSemigroup[A] =
+    cmb(_, _)
 }

--- a/kernel/src/main/scala/cats/kernel/Eq.scala
+++ b/kernel/src/main/scala/cats/kernel/Eq.scala
@@ -84,27 +84,26 @@ object Eq
    * function `f`.
    */
   def by[@sp A, @sp B](f: A => B)(implicit ev: Eq[B]): Eq[A] =
-    instance((x, y) => ev.eqv(f(x), f(y)))
+    (x, y) => ev.eqv(f(x), f(y))
 
   /**
    * Return an Eq that gives the result of the and of eq1 and eq2
    * note this is idempotent
    */
   def and[@sp A](eq1: Eq[A], eq2: Eq[A]): Eq[A] =
-    instance((x, y) => eq1.eqv(x, y) && eq2.eqv(x, y))
+    (x, y) => eq1.eqv(x, y) && eq2.eqv(x, y)
 
   /**
    * Return an Eq that gives the result of the or of this and that
    * Note this is idempotent
    */
   def or[@sp A](eq1: Eq[A], eq2: Eq[A]): Eq[A] =
-    instance((x, y) => eq1.eqv(x, y) || eq2.eqv(x, y))
+    (x, y) => eq1.eqv(x, y) || eq2.eqv(x, y)
 
   /**
    * Create an `Eq` instance from an `eqv` implementation.
    */
-  def instance[@sp A](f: (A, A) => Boolean): Eq[A] =
-    f(_, _)
+  def instance[A](f: (A, A) => Boolean): Eq[A] = f(_, _)
 
   /**
    * An `Eq[A]` that delegates to universal equality (`==`).
@@ -112,14 +111,12 @@ object Eq
    * This can be useful for case classes, which have reasonable `equals`
    * implementations
    */
-  def fromUniversalEquals[A]: Eq[A] =
-    instance(_ == _)
+  def fromUniversalEquals[A]: Eq[A] = _ == _
 
   /**
    * Everything is the same
    */
-  def allEqual[A]: Eq[A] =
-    instance((_, _) => true)
+  def allEqual[A]: Eq[A] = (_, _) => true
 
   /**
    * This is a monoid that creates an Eq that
@@ -133,7 +130,7 @@ object Eq
         if (es.iterator.isEmpty) None
         else {
           val materialized = es.iterator.toVector
-          Some(instance((x, y) => materialized.forall(_.eqv(x, y))))
+          Some((x, y) => materialized.forall(_.eqv(x, y)))
         }
     }
 
@@ -148,7 +145,7 @@ object Eq
         if (es.iterator.isEmpty) None
         else {
           val materialized = es.iterator.toVector
-          Some(instance((x, y) => materialized.exists(_.eqv(x, y))))
+          Some((x, y) => materialized.exists(_.eqv(x, y)))
         }
     }
 
@@ -209,12 +206,11 @@ object Eq
    * doing a fine grained equality on Throwable can make the code very execution
    * order dependent
    */
-  implicit def catsStdEqForTry[A](implicit A: Eq[A], T: Eq[Throwable]): Eq[Try[A]] =
-    instance {
-      case (Success(a), Success(b)) => A.eqv(a, b)
-      case (Failure(a), Failure(b)) => T.eqv(a, b)
-      case _                        => false
-    }
+  implicit def catsStdEqForTry[A](implicit A: Eq[A], T: Eq[Throwable]): Eq[Try[A]] = {
+    case (Success(a), Success(b)) => A.eqv(a, b)
+    case (Failure(a), Failure(b)) => T.eqv(a, b)
+    case _                        => false
+  }
 }
 
 private[kernel] trait OrderInstances0 extends PartialOrderInstances {

--- a/kernel/src/main/scala/cats/kernel/Eq.scala
+++ b/kernel/src/main/scala/cats/kernel/Eq.scala
@@ -21,13 +21,11 @@
 
 package cats.kernel
 
-import java.util.UUID
-
 import cats.kernel.compat.scalaVersionSpecific._
 
+import java.util.UUID
 import scala.collection.immutable.{BitSet, Queue, Seq, SortedMap, SortedSet}
 import scala.concurrent.duration.{Duration, FiniteDuration}
-import scala.math.Equiv
 import scala.util.{Failure, Success, Try}
 import scala.{specialized => sp}
 
@@ -65,9 +63,7 @@ trait EqToEquivConversion {
    * instance.
    */
   implicit def catsKernelEquivForEq[A](implicit ev: Eq[A]): Equiv[A] =
-    new Equiv[A] {
-      def equiv(a: A, b: A) = ev.eqv(a, b)
-    }
+    ev.eqv(_, _)
 }
 
 @suppressUnusedImportWarningForScalaVersionSpecific
@@ -88,35 +84,27 @@ object Eq
    * function `f`.
    */
   def by[@sp A, @sp B](f: A => B)(implicit ev: Eq[B]): Eq[A] =
-    new Eq[A] {
-      def eqv(x: A, y: A) = ev.eqv(f(x), f(y))
-    }
+    instance((x, y) => ev.eqv(f(x), f(y)))
 
   /**
    * Return an Eq that gives the result of the and of eq1 and eq2
    * note this is idempotent
    */
   def and[@sp A](eq1: Eq[A], eq2: Eq[A]): Eq[A] =
-    new Eq[A] {
-      def eqv(x: A, y: A) = eq1.eqv(x, y) && eq2.eqv(x, y)
-    }
+    instance((x, y) => eq1.eqv(x, y) && eq2.eqv(x, y))
 
   /**
    * Return an Eq that gives the result of the or of this and that
    * Note this is idempotent
    */
   def or[@sp A](eq1: Eq[A], eq2: Eq[A]): Eq[A] =
-    new Eq[A] {
-      def eqv(x: A, y: A) = eq1.eqv(x, y) || eq2.eqv(x, y)
-    }
+    instance((x, y) => eq1.eqv(x, y) || eq2.eqv(x, y))
 
   /**
    * Create an `Eq` instance from an `eqv` implementation.
    */
-  def instance[A](f: (A, A) => Boolean): Eq[A] =
-    new Eq[A] {
-      def eqv(x: A, y: A) = f(x, y)
-    }
+  def instance[@sp A](f: (A, A) => Boolean): Eq[A] =
+    f(_, _)
 
   /**
    * An `Eq[A]` that delegates to universal equality (`==`).
@@ -125,17 +113,13 @@ object Eq
    * implementations
    */
   def fromUniversalEquals[A]: Eq[A] =
-    new Eq[A] {
-      def eqv(x: A, y: A) = x == y
-    }
+    instance(_ == _)
 
   /**
    * Everything is the same
    */
   def allEqual[A]: Eq[A] =
-    new Eq[A] {
-      def eqv(x: A, y: A) = true
-    }
+    instance((_, _) => true)
 
   /**
    * This is a monoid that creates an Eq that
@@ -149,9 +133,7 @@ object Eq
         if (es.iterator.isEmpty) None
         else {
           val materialized = es.iterator.toVector
-          Some(new Eq[A] {
-            def eqv(x: A, y: A) = materialized.forall(_.eqv(x, y))
-          })
+          Some(instance((x, y) => materialized.forall(_.eqv(x, y))))
         }
     }
 
@@ -166,9 +148,7 @@ object Eq
         if (es.iterator.isEmpty) None
         else {
           val materialized = es.iterator.toVector
-          Some(new Eq[A] {
-            def eqv(x: A, y: A) = materialized.exists(_.eqv(x, y))
-          })
+          Some(instance((x, y) => materialized.exists(_.eqv(x, y))))
         }
     }
 
@@ -229,14 +209,11 @@ object Eq
    * doing a fine grained equality on Throwable can make the code very execution
    * order dependent
    */
-  implicit def catsStdEqForTry[A, T](implicit A: Eq[A], T: Eq[Throwable]): Eq[Try[A]] =
-    new Eq[Try[A]] {
-      def eqv(x: Try[A], y: Try[A]): Boolean =
-        (x, y) match {
-          case (Success(a), Success(b)) => A.eqv(a, b)
-          case (Failure(a), Failure(b)) => T.eqv(a, b)
-          case _                        => false
-        }
+  implicit def catsStdEqForTry[A](implicit A: Eq[A], T: Eq[Throwable]): Eq[Try[A]] =
+    instance {
+      case (Success(a), Success(b)) => A.eqv(a, b)
+      case (Failure(a), Failure(b)) => T.eqv(a, b)
+      case _                        => false
     }
 }
 

--- a/kernel/src/main/scala/cats/kernel/Order.scala
+++ b/kernel/src/main/scala/cats/kernel/Order.scala
@@ -156,13 +156,13 @@ object Order extends OrderFunctions[Order] with OrderToOrderingConversion {
    * function `f`.
    */
   def by[@sp A, @sp B](f: A => B)(implicit ev: Order[B]): Order[A] =
-    from((x, y) => ev.compare(f(x), f(y)))
+    (x, y) => ev.compare(f(x), f(y))
 
   /**
    * Defines an ordering on `A` from the given order such that all arrows switch direction.
    */
   def reverse[@sp A](order: Order[A]): Order[A] =
-    from((x, y) => order.compare(y, x))
+    (x, y) => order.compare(y, x)
 
   /**
    * Returns a new `Order[A]` instance that first compares by the first
@@ -171,18 +171,16 @@ object Order extends OrderFunctions[Order] with OrderToOrderingConversion {
    * That is, `Order.whenEqual(x, y)` creates an `Order` that first orders by `x` and
    * then (if two elements are equal) falls back to `y` for the comparison.
    */
-  def whenEqual[@sp A](first: Order[A], second: Order[A]): Order[A] =
-    from { (x, y) =>
-      val c = first.compare(x, y)
-      if (c == 0) second.compare(x, y)
-      else c
-    }
+  def whenEqual[@sp A](first: Order[A], second: Order[A]): Order[A] = { (x, y) =>
+    val c = first.compare(x, y)
+    if (c == 0) second.compare(x, y)
+    else c
+  }
 
   /**
    * Define an `Order[A]` using the given function `f`.
    */
-  def from[@sp A](f: (A, A) => Int): Order[A] =
-    f(_, _)
+  def from[@sp A](f: (A, A) => Int): Order[A] = f(_, _)
 
   /**
    * Define an `Order[A]` using the given 'less than' function `f`.
@@ -205,7 +203,7 @@ object Order extends OrderFunctions[Order] with OrderToOrderingConversion {
    * An `Order` instance that considers all `A` instances to be equal.
    */
   def allEqual[A]: Order[A] =
-    from((_, _) => 0)
+    (_, _) => 0
 
   /**
    * A `Monoid[Order[A]]` can be generated for all `A` with the following
@@ -231,10 +229,8 @@ object Order extends OrderFunctions[Order] with OrderToOrderingConversion {
   def fromOrdering[A](implicit ev: Ordering[A]): Order[A] =
     new Order[A] {
       def compare(x: A, y: A): Int = ev.compare(x, y)
-
       override def toOrdering: Ordering[A] = ev
     }
 
-  def fromComparable[A <: Comparable[A]]: Order[A] =
-    from(_ compareTo _)
+  def fromComparable[A <: Comparable[A]]: Order[A] = _ compareTo _
 }

--- a/kernel/src/main/scala/cats/kernel/Order.scala
+++ b/kernel/src/main/scala/cats/kernel/Order.scala
@@ -115,9 +115,7 @@ trait Order[@sp A] extends Any with PartialOrder[A] { self =>
    * instance.
    */
   def toOrdering: Ordering[A] =
-    new Ordering[A] {
-      def compare(x: A, y: A): Int = self.compare(x, y)
-    }
+    compare(_, _)
 }
 
 abstract class OrderFunctions[O[T] <: Order[T]] extends PartialOrderFunctions[O] {
@@ -158,17 +156,13 @@ object Order extends OrderFunctions[Order] with OrderToOrderingConversion {
    * function `f`.
    */
   def by[@sp A, @sp B](f: A => B)(implicit ev: Order[B]): Order[A] =
-    new Order[A] {
-      def compare(x: A, y: A): Int = ev.compare(f(x), f(y))
-    }
+    from((x, y) => ev.compare(f(x), f(y)))
 
   /**
    * Defines an ordering on `A` from the given order such that all arrows switch direction.
    */
   def reverse[@sp A](order: Order[A]): Order[A] =
-    new Order[A] {
-      def compare(x: A, y: A): Int = order.compare(y, x)
-    }
+    from((x, y) => order.compare(y, x))
 
   /**
    * Returns a new `Order[A]` instance that first compares by the first
@@ -178,21 +172,17 @@ object Order extends OrderFunctions[Order] with OrderToOrderingConversion {
    * then (if two elements are equal) falls back to `y` for the comparison.
    */
   def whenEqual[@sp A](first: Order[A], second: Order[A]): Order[A] =
-    new Order[A] {
-      def compare(x: A, y: A) = {
-        val c = first.compare(x, y)
-        if (c == 0) second.compare(x, y)
-        else c
-      }
+    from { (x, y) =>
+      val c = first.compare(x, y)
+      if (c == 0) second.compare(x, y)
+      else c
     }
 
   /**
    * Define an `Order[A]` using the given function `f`.
    */
   def from[@sp A](f: (A, A) => Int): Order[A] =
-    new Order[A] {
-      def compare(x: A, y: A) = f(x, y)
-    }
+    f(_, _)
 
   /**
    * Define an `Order[A]` using the given 'less than' function `f`.
@@ -215,9 +205,7 @@ object Order extends OrderFunctions[Order] with OrderToOrderingConversion {
    * An `Order` instance that considers all `A` instances to be equal.
    */
   def allEqual[A]: Order[A] =
-    new Order[A] {
-      def compare(x: A, y: A): Int = 0
-    }
+    from((_, _) => 0)
 
   /**
    * A `Monoid[Order[A]]` can be generated for all `A` with the following
@@ -248,8 +236,5 @@ object Order extends OrderFunctions[Order] with OrderToOrderingConversion {
     }
 
   def fromComparable[A <: Comparable[A]]: Order[A] =
-    new Order[A] {
-      override def compare(x: A, y: A): Int =
-        x.compareTo(y)
-    }
+    from(_ compareTo _)
 }

--- a/kernel/src/main/scala/cats/kernel/PartialOrder.scala
+++ b/kernel/src/main/scala/cats/kernel/PartialOrder.scala
@@ -162,22 +162,21 @@ object PartialOrder extends PartialOrderFunctions[PartialOrder] with PartialOrde
    * function `f`.
    */
   def by[@sp A, @sp B](f: A => B)(implicit ev: PartialOrder[B]): PartialOrder[A] =
-    from((x, y) => ev.partialCompare(f(x), f(y)))
+    (x, y) => ev.partialCompare(f(x), f(y))
 
   /**
    * Defines a partial order on `A` from p where all arrows switch direction.
    */
   def reverse[@sp A](p: PartialOrder[A]): PartialOrder[A] =
-    from((x, y) => p.partialCompare(y, x))
+    (x, y) => p.partialCompare(y, x)
 
   /**
    * Define a `PartialOrder[A]` using the given function `f`.
    */
-  def from[@sp A](f: (A, A) => Double): PartialOrder[A] =
-    f(_, _)
+  def from[@sp A](f: (A, A) => Double): PartialOrder[A] = f(_, _)
 
   def fromPartialOrdering[A](implicit ev: PartialOrdering[A]): PartialOrder[A] =
-    from((x, y) => ev.tryCompare(x, y).fold(Double.NaN)(_.toDouble))
+    ev.tryCompare(_, _).fold(Double.NaN)(_.toDouble)
 }
 
 trait PartialOrderToPartialOrderingConversion {

--- a/kernel/src/main/scala/cats/kernel/PartialOrder.scala
+++ b/kernel/src/main/scala/cats/kernel/PartialOrder.scala
@@ -162,31 +162,22 @@ object PartialOrder extends PartialOrderFunctions[PartialOrder] with PartialOrde
    * function `f`.
    */
   def by[@sp A, @sp B](f: A => B)(implicit ev: PartialOrder[B]): PartialOrder[A] =
-    new PartialOrder[A] {
-      def partialCompare(x: A, y: A): Double = ev.partialCompare(f(x), f(y))
-    }
+    from((x, y) => ev.partialCompare(f(x), f(y)))
 
   /**
    * Defines a partial order on `A` from p where all arrows switch direction.
    */
   def reverse[@sp A](p: PartialOrder[A]): PartialOrder[A] =
-    new PartialOrder[A] {
-      def partialCompare(x: A, y: A): Double = p.partialCompare(y, x)
-    }
+    from((x, y) => p.partialCompare(y, x))
 
   /**
    * Define a `PartialOrder[A]` using the given function `f`.
    */
   def from[@sp A](f: (A, A) => Double): PartialOrder[A] =
-    new PartialOrder[A] {
-      def partialCompare(x: A, y: A) = f(x, y)
-    }
+    f(_, _)
 
   def fromPartialOrdering[A](implicit ev: PartialOrdering[A]): PartialOrder[A] =
-    new PartialOrder[A] {
-      def partialCompare(x: A, y: A): Double =
-        ev.tryCompare(x, y).fold(Double.NaN)(_.toDouble)
-    }
+    from((x, y) => ev.tryCompare(x, y).fold(Double.NaN)(_.toDouble))
 }
 
 trait PartialOrderToPartialOrderingConversion {

--- a/kernel/src/main/scala/cats/kernel/Semigroup.scala
+++ b/kernel/src/main/scala/cats/kernel/Semigroup.scala
@@ -21,8 +21,6 @@
 
 package cats.kernel
 
-import cats.kernel.Semigroup.instance
-
 import scala.annotation.tailrec
 import scala.collection.immutable.{BitSet, Queue, Seq, SortedMap, SortedSet}
 import scala.concurrent.{ExecutionContext, Future}
@@ -122,7 +120,7 @@ trait Semigroup[@sp(Int, Long, Float, Double) A] extends Any with Serializable {
    * This name matches the term used in Foldable and Reducible and a similar Haskell function.
    */
   def intercalate(middle: A): Semigroup[A] =
-    instance((a, b) => self.combine(a, self.combine(middle, b)))
+    (a, b) => self.combine(a, self.combine(middle, b))
 }
 
 abstract class SemigroupFunctions[S[T] <: Semigroup[T]] {
@@ -168,20 +166,17 @@ object Semigroup
   /**
    * Create a `Semigroup` instance from the given function.
    */
-  @inline def instance[@sp(Int, Long, Float, Double) A](cmb: (A, A) => A): Semigroup[A] =
-    cmb(_, _)
+  @inline def instance[A](cmb: (A, A) => A): Semigroup[A] = cmb(_, _)
 
   /**
    * Create a `Semigroup` instance that always returns the lefthand side.
    */
-  @inline def first[A]: Semigroup[A] =
-    instance((x, _) => x)
+  @inline def first[A]: Semigroup[A] = (x, _) => x
 
   /**
    * Create a `Semigroup` instance that always returns the righthand side.
    */
-  @inline def last[A]: Semigroup[A] =
-    instance((_, y) => y)
+  @inline def last[A]: Semigroup[A] = (_, y) => y
 
   implicit def catsKernelBoundedSemilatticeForBitSet: BoundedSemilattice[BitSet] =
     cats.kernel.instances.bitSet.catsKernelStdSemilatticeForBitSet

--- a/kernel/src/main/scala/cats/kernel/Semilattice.scala
+++ b/kernel/src/main/scala/cats/kernel/Semilattice.scala
@@ -41,13 +41,11 @@ trait Semilattice[@sp(Int, Long, Float, Double) A] extends Any with Band[A] with
    *    1.0 if y = combine(x, y)
    *    NaN otherwise
    */
-  def asMeetPartialOrder(implicit ev: Eq[A]): PartialOrder[A] =
-    PartialOrder.from { (x, y) =>
-      if (ev.eqv(x, y)) 0.0
-      else {
-        val z = self.combine(x, y)
-        if (ev.eqv(x, z)) -1.0 else if (ev.eqv(y, z)) 1.0 else Double.NaN
-      }
+  def asMeetPartialOrder(implicit ev: Eq[A]): PartialOrder[A] = (x, y) =>
+    if (ev.eqv(x, y)) 0.0
+    else {
+      val z = self.combine(x, y)
+      if (ev.eqv(x, z)) -1.0 else if (ev.eqv(y, z)) 1.0 else Double.NaN
     }
 
   /**
@@ -62,13 +60,11 @@ trait Semilattice[@sp(Int, Long, Float, Double) A] extends Any with Band[A] with
    *    1.0 if x = combine(x, y)
    *    NaN otherwise
    */
-  def asJoinPartialOrder(implicit ev: Eq[A]): PartialOrder[A] =
-    PartialOrder.from { (x, y) =>
-      if (ev.eqv(x, y)) 0.0
-      else {
-        val z = self.combine(x, y)
-        if (ev.eqv(y, z)) -1.0 else if (ev.eqv(x, z)) 1.0 else Double.NaN
-      }
+  def asJoinPartialOrder(implicit ev: Eq[A]): PartialOrder[A] = (x, y) =>
+    if (ev.eqv(x, y)) 0.0
+    else {
+      val z = self.combine(x, y)
+      if (ev.eqv(y, z)) -1.0 else if (ev.eqv(x, z)) 1.0 else Double.NaN
     }
 }
 

--- a/kernel/src/main/scala/cats/kernel/Semilattice.scala
+++ b/kernel/src/main/scala/cats/kernel/Semilattice.scala
@@ -85,6 +85,5 @@ object Semilattice extends SemilatticeFunctions[Semilattice] {
   /**
    * Create a `Semilattice` instance from the given function.
    */
-  @inline def instance[@sp(Int, Long, Float, Double) A](cmb: (A, A) => A): Semilattice[A] =
-    cmb(_, _)
+  @inline def instance[A](cmb: (A, A) => A): Semilattice[A] = cmb(_, _)
 }

--- a/kernel/src/main/scala/cats/kernel/Semilattice.scala
+++ b/kernel/src/main/scala/cats/kernel/Semilattice.scala
@@ -89,8 +89,6 @@ object Semilattice extends SemilatticeFunctions[Semilattice] {
   /**
    * Create a `Semilattice` instance from the given function.
    */
-  @inline def instance[A](cmb: (A, A) => A): Semilattice[A] =
-    new Semilattice[A] {
-      override def combine(x: A, y: A): A = cmb(x, y)
-    }
+  @inline def instance[@sp(Int, Long, Float, Double) A](cmb: (A, A) => A): Semilattice[A] =
+    cmb(_, _)
 }

--- a/kernel/src/main/scala/cats/kernel/Semilattice.scala
+++ b/kernel/src/main/scala/cats/kernel/Semilattice.scala
@@ -42,13 +42,12 @@ trait Semilattice[@sp(Int, Long, Float, Double) A] extends Any with Band[A] with
    *    NaN otherwise
    */
   def asMeetPartialOrder(implicit ev: Eq[A]): PartialOrder[A] =
-    new PartialOrder[A] {
-      def partialCompare(x: A, y: A): Double =
-        if (ev.eqv(x, y)) 0.0
-        else {
-          val z = self.combine(x, y)
-          if (ev.eqv(x, z)) -1.0 else if (ev.eqv(y, z)) 1.0 else Double.NaN
-        }
+    PartialOrder.from { (x, y) =>
+      if (ev.eqv(x, y)) 0.0
+      else {
+        val z = self.combine(x, y)
+        if (ev.eqv(x, z)) -1.0 else if (ev.eqv(y, z)) 1.0 else Double.NaN
+      }
     }
 
   /**
@@ -64,13 +63,12 @@ trait Semilattice[@sp(Int, Long, Float, Double) A] extends Any with Band[A] with
    *    NaN otherwise
    */
   def asJoinPartialOrder(implicit ev: Eq[A]): PartialOrder[A] =
-    new PartialOrder[A] {
-      def partialCompare(x: A, y: A): Double =
-        if (ev.eqv(x, y)) 0.0
-        else {
-          val z = self.combine(x, y)
-          if (ev.eqv(y, z)) -1.0 else if (ev.eqv(x, z)) 1.0 else Double.NaN
-        }
+    PartialOrder.from { (x, y) =>
+      if (ev.eqv(x, y)) 0.0
+      else {
+        val z = self.combine(x, y)
+        if (ev.eqv(y, z)) -1.0 else if (ev.eqv(x, z)) 1.0 else Double.NaN
+      }
     }
 }
 

--- a/kernel/src/main/scala/cats/kernel/instances/EitherInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/EitherInstances.scala
@@ -59,16 +59,15 @@ trait EitherInstances extends EitherInstances0 {
 private[instances] trait EitherInstances0 extends EitherInstances1 {
 
   implicit def catsDataSemigroupForEither[A, B](implicit B: Semigroup[B]): Semigroup[Either[A, B]] =
-    new Semigroup[Either[A, B]] {
-      def combine(x: Either[A, B], y: Either[A, B]): Either[A, B] =
-        x match {
-          case left @ Left(_) => left
-          case Right(xx) =>
-            y match {
-              case left @ Left(_) => left
-              case Right(yy)      => Right(B.combine(xx, yy))
-            }
-        }
+    Semigroup.instance { (x, y) =>
+      x match {
+        case left @ Left(_) => left
+        case Right(xx) =>
+          y match {
+            case left @ Left(_) => left
+            case Right(yy)      => Right(B.combine(xx, yy))
+          }
+      }
     }
 
   implicit def catsStdPartialOrderForEither[A, B](implicit

--- a/kernel/src/main/scala/cats/kernel/instances/EitherInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/EitherInstances.scala
@@ -75,20 +75,19 @@ private[instances] trait EitherInstances0 extends EitherInstances1 {
     A: PartialOrder[A],
     B: PartialOrder[B]
   ): PartialOrder[Either[A, B]] =
-    new PartialOrder[Either[A, B]] {
-      def partialCompare(x: Either[A, B], y: Either[A, B]): Double =
-        x match {
-          case Left(xx) =>
-            y match {
-              case Left(yy) => A.partialCompare(xx, yy)
-              case Right(_) => -1.0
-            }
-          case Right(xx) =>
-            y match {
-              case Left(_)   => 1.0
-              case Right(yy) => B.partialCompare(xx, yy)
-            }
-        }
+    PartialOrder.from { (x, y) =>
+      x match {
+        case Left(xx) =>
+          y match {
+            case Left(yy) => A.partialCompare(xx, yy)
+            case Right(_) => -1.0
+          }
+        case Right(xx) =>
+          y match {
+            case Left(_)   => 1.0
+            case Right(yy) => B.partialCompare(xx, yy)
+          }
+      }
     }
 
   implicit def catsStdHashForEither[A, B](implicit A: Hash[A], B: Hash[B]): Hash[Either[A, B]] = new EitherHash[A, B]

--- a/kernel/src/main/scala/cats/kernel/instances/EitherInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/EitherInstances.scala
@@ -60,7 +60,7 @@ trait EitherInstances extends EitherInstances0 {
 private[instances] trait EitherInstances0 extends EitherInstances1 {
 
   implicit def catsDataSemigroupForEither[A, B](implicit B: Semigroup[B]): Semigroup[Either[A, B]] =
-    Semigroup.instance { (x, y) =>
+    (x, y) =>
       x match {
         case left @ Left(_) => left
         case Right(xx) =>
@@ -69,7 +69,6 @@ private[instances] trait EitherInstances0 extends EitherInstances1 {
             case Right(yy)      => Right(B.combine(xx, yy))
           }
       }
-    }
 
   implicit def catsStdPartialOrderForEither[A, B](implicit
     A: PartialOrder[A],

--- a/kernel/src/main/scala/cats/kernel/instances/EitherInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/EitherInstances.scala
@@ -25,20 +25,19 @@ package instances
 trait EitherInstances extends EitherInstances0 {
 
   implicit def catsStdOrderForEither[A, B](implicit A: Order[A], B: Order[B]): Order[Either[A, B]] =
-    new Order[Either[A, B]] {
-      def compare(x: Either[A, B], y: Either[A, B]): Int =
-        x match {
-          case Left(xx) =>
-            y match {
-              case Left(yy) => A.compare(xx, yy)
-              case Right(_) => -1
-            }
-          case Right(xx) =>
-            y match {
-              case Left(_)   => 1
-              case Right(yy) => B.compare(xx, yy)
-            }
-        }
+    Order.from { (x, y) =>
+      x match {
+        case Left(xx) =>
+          y match {
+            case Left(yy) => A.compare(xx, yy)
+            case Right(_) => -1
+          }
+        case Right(xx) =>
+          y match {
+            case Left(_)   => 1
+            case Right(yy) => B.compare(xx, yy)
+          }
+      }
     }
 
   implicit def catsDataMonoidForEither[A, B](implicit B: Monoid[B]): Monoid[Either[A, B]] =

--- a/kernel/src/main/scala/cats/kernel/instances/EitherInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/EitherInstances.scala
@@ -25,19 +25,20 @@ package instances
 trait EitherInstances extends EitherInstances0 {
 
   implicit def catsStdOrderForEither[A, B](implicit A: Order[A], B: Order[B]): Order[Either[A, B]] =
-    Order.from { (x, y) =>
-      x match {
-        case Left(xx) =>
-          y match {
-            case Left(yy) => A.compare(xx, yy)
-            case Right(_) => -1
-          }
-        case Right(xx) =>
-          y match {
-            case Left(_)   => 1
-            case Right(yy) => B.compare(xx, yy)
-          }
-      }
+    new Order[Either[A, B]] {
+      def compare(x: Either[A, B], y: Either[A, B]): Int =
+        x match {
+          case Left(xx) =>
+            y match {
+              case Left(yy) => A.compare(xx, yy)
+              case Right(_) => -1
+            }
+          case Right(xx) =>
+            y match {
+              case Left(_)   => 1
+              case Right(yy) => B.compare(xx, yy)
+            }
+        }
     }
 
   implicit def catsDataMonoidForEither[A, B](implicit B: Monoid[B]): Monoid[Either[A, B]] =
@@ -74,19 +75,20 @@ private[instances] trait EitherInstances0 extends EitherInstances1 {
     A: PartialOrder[A],
     B: PartialOrder[B]
   ): PartialOrder[Either[A, B]] =
-    PartialOrder.from { (x, y) =>
-      x match {
-        case Left(xx) =>
-          y match {
-            case Left(yy) => A.partialCompare(xx, yy)
-            case Right(_) => -1.0
-          }
-        case Right(xx) =>
-          y match {
-            case Left(_)   => 1.0
-            case Right(yy) => B.partialCompare(xx, yy)
-          }
-      }
+    new PartialOrder[Either[A, B]] {
+      def partialCompare(x: Either[A, B], y: Either[A, B]): Double =
+        x match {
+          case Left(xx) =>
+            y match {
+              case Left(yy) => A.partialCompare(xx, yy)
+              case Right(_) => -1.0
+            }
+          case Right(xx) =>
+            y match {
+              case Left(_)   => 1.0
+              case Right(yy) => B.partialCompare(xx, yy)
+            }
+        }
     }
 
   implicit def catsStdHashForEither[A, B](implicit A: Hash[A], B: Hash[B]): Hash[Either[A, B]] = new EitherHash[A, B]

--- a/kernel/src/main/scala/cats/kernel/instances/FunctionInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/FunctionInstances.scala
@@ -29,9 +29,7 @@ import scala.util.control.TailCalls.{done, tailcall, TailRec}
 trait FunctionInstances extends FunctionInstances0 {
 
   implicit def catsKernelOrderForFunction0[A](implicit ev: Order[A]): Order[() => A] =
-    new Order[() => A] {
-      def compare(x: () => A, y: () => A): Int = ev.compare(x(), y())
-    }
+    Order.by(_.apply())
 
   implicit def catsKernelCommutativeGroupForFunction0[A](implicit G: CommutativeGroup[A]): CommutativeGroup[() => A] =
     new Function0Group[A] with CommutativeGroup[() => A] { def A: Group[A] = G }

--- a/kernel/src/main/scala/cats/kernel/instances/FunctionInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/FunctionInstances.scala
@@ -69,9 +69,7 @@ private[instances] trait FunctionInstances0 extends FunctionInstances1 {
 private[instances] trait FunctionInstances1 extends FunctionInstances2 {
 
   implicit def catsKernelEqForFunction0[A](implicit ev: Eq[A]): Eq[() => A] =
-    new Eq[() => A] {
-      def eqv(x: () => A, y: () => A): Boolean = ev.eqv(x(), y())
-    }
+    Eq.by(_.apply())
 
   implicit def catsKernelCommutativeMonoidForFunction0[A](implicit
     M: CommutativeMonoid[A]

--- a/kernel/src/main/scala/cats/kernel/instances/FunctionInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/FunctionInstances.scala
@@ -47,9 +47,7 @@ private[instances] trait FunctionInstances0 extends FunctionInstances1 {
     }
 
   implicit def catsKernelPartialOrderForFunction0[A](implicit ev: PartialOrder[A]): PartialOrder[() => A] =
-    new PartialOrder[() => A] {
-      def partialCompare(x: () => A, y: () => A): Double = ev.partialCompare(x(), y())
-    }
+    PartialOrder.by(_.apply())
 
   implicit def catsKernelGroupForFunction0[A](implicit G: Group[A]): Group[() => A] =
     new Function0Group[A] { def A: Group[A] = G }

--- a/laws/src/main/scala/cats/laws/discipline/Eq.scala
+++ b/laws/src/main/scala/cats/laws/discipline/Eq.scala
@@ -35,113 +35,104 @@ import org.scalacheck.Arbitrary
 object eq {
 
   implicit def catsLawsEqForFn1Exhaustive[A, B](implicit A: ExhaustiveCheck[A], B: Eq[B]): Eq[A => B] =
-    Eq.instance((f, g) => A.allValues.forall(a => B.eqv(f(a), g(a))))
+    (f, g) => A.allValues.forall(a => B.eqv(f(a), g(a)))
 
   implicit def catsLawsEqForFn2[A, B, C](implicit ev: Eq[((A, B)) => C]): Eq[(A, B) => C] =
-    Eq.by((_: (A, B) => C).tupled)
+    Eq.by(_.tupled)
 
   implicit def catsLawsEqForPartialFunctionExhaustive[A: ExhaustiveCheck, B: Eq]: Eq[PartialFunction[A, B]] =
-    Eq.instance((f, g) =>
+    (f, g) =>
       ExhaustiveCheck[A].allValues
         .filter(a => f.isDefinedAt(a) || g.isDefinedAt(a))
         .forall(a => f.isDefinedAt(a) && g.isDefinedAt(a) && Eq[B].eqv(f(a), g(a)))
-    )
 
   implicit def catsLawsEqForAndThen[A, B](implicit eqAB: Eq[A => B]): Eq[AndThen[A, B]] =
-    Eq.by[AndThen[A, B], A => B](identity)
+    Eq.by(identity[A => B])
 
   implicit def catsLawsEqForShow[A](implicit ev: Eq[A => String]): Eq[Show[A]] =
-    Eq.by[Show[A], A => String](showA => a => showA.show(a))
+    Eq.by(showA => showA.show _)
 
   implicit def catsLawsEqForEq[A](implicit ev: Eq[(A, A) => Boolean]): Eq[Eq[A]] =
-    Eq.by[Eq[A], (A, A) => Boolean](e => (a1, a2) => e.eqv(a1, a2))
+    Eq.by(e => e.eqv _)
 
   implicit def catsLawsEqForEquiv[A](implicit ev: Eq[(A, A) => Boolean]): Eq[Equiv[A]] =
-    Eq.by[Equiv[A], (A, A) => Boolean](e => (a1, a2) => e.equiv(a1, a2))
+    Eq.by(e => e.equiv _)
 
   implicit def catsLawsEqForPartialOrder[A](implicit ev: Eq[(A, A) => Option[Int]]): Eq[PartialOrder[A]] =
-    Eq.by[PartialOrder[A], (A, A) => Option[Int]](o => (a1, a2) => o.tryCompare(a1, a2))
+    Eq.by(o => o.tryCompare _)
 
-  implicit def catsLawsEqForPartialOrdering[A](implicit
-    ev: Eq[(A, A) => Option[Int]]
-  ): Eq[PartialOrdering[A]] =
-    Eq.by[PartialOrdering[A], (A, A) => Option[Int]]((o: PartialOrdering[A]) => (a1, a2) => o.tryCompare(a1, a2))
+  implicit def catsLawsEqForPartialOrdering[A](implicit ev: Eq[(A, A) => Option[Int]]): Eq[PartialOrdering[A]] =
+    Eq.by(o => o.tryCompare _)
 
   implicit def catsLawsEqForOrder[A](implicit ev: Eq[(A, A) => Int]): Eq[Order[A]] =
-    Eq.by[Order[A], (A, A) => Int](o => (a1, a2) => o.compare(a1, a2))
+    Eq.by(o => o.compare _)
 
   implicit def catsLawsEqForOrdering[A](implicit ev: Eq[(A, A) => Int]): Eq[Ordering[A]] =
-    Eq.by[Ordering[A], (A, A) => Int](o => (a1, a2) => o.compare(a1, a2))
+    Eq.by(o => o.compare _)
 
   implicit def catsLawsEqForHash[A](implicit ev: Eq[A => Int]): Eq[Hash[A]] =
-    Eq.by[Hash[A], A => Int](h => a => h.hash(a))
+    Eq.by(h => h.hash _)
 
   implicit def catsLawsEqForSemigroup[A](implicit ev: Eq[(A, A) => A]): Eq[Semigroup[A]] =
-    Eq.by[Semigroup[A], (A, A) => A](s => (a1, a2) => s.combine(a1, a2))
+    Eq.by(s => s.combine _)
 
   implicit def catsLawsEqForCommutativeSemigroup[A](implicit
     eqA: Eq[A],
     ev: Eq[(A, A) => (A, A)]
   ): Eq[CommutativeSemigroup[A]] =
-    Eq.by[CommutativeSemigroup[A], (A, A) => (A, A)](s => (x, y) => (s.combine(x, y), s.combine(y, x)))
+    Eq.by(s => (x: A, y: A) => (s.combine(x, y), s.combine(y, x)))
 
   implicit def catsLawsEqForBand[A](implicit ev: Eq[(A, A) => (A, A)]): Eq[Band[A]] =
-    Eq.by[Band[A], (A, A) => (A, A)](f => (x, y) => (f.combine(x, y), f.combine(f.combine(x, y), y)))
+    Eq.by(f => (x: A, y: A) => (f.combine(x, y), f.combine(f.combine(x, y), y)))
 
   implicit def catsLawsEqForGroup[A](implicit ev1: Eq[(A, A) => (A, Boolean)], eqA: Eq[A]): Eq[Group[A]] =
-    Eq.by[Group[A], (A, A) => (A, Boolean)] {
-      f =>
-        { (x, y) =>
-          {
-            val xy = f.combine(x, y)
-            val p1 = f.combine(f.inverse(x), x) === f.empty && f.combine(x, f.inverse(x)) === f.empty
-            val p2 = f.combine(f.inverse(y), y) === f.empty && f.combine(y, f.inverse(y)) === f.empty
-            val p3 = f.inverse(f.empty) == f.empty
-
-            (xy, p1 && p2 && p3)
-          }
-        }
-    }
+    Eq.by(f => { (x: A, y: A) =>
+      val xy = f.combine(x, y)
+      val p1 = f.combine(f.inverse(x), x) === f.empty && f.combine(x, f.inverse(x)) === f.empty
+      val p2 = f.combine(f.inverse(y), y) === f.empty && f.combine(y, f.inverse(y)) === f.empty
+      val p3 = f.inverse(f.empty) == f.empty
+      (xy, p1 && p2 && p3)
+    })
 
   implicit def catsLawsEqForMonoid[A](implicit eqSA: Eq[Semigroup[A]], eqA: Eq[A]): Eq[Monoid[A]] =
-    Eq.instance((f, g) => eqSA.eqv(f, g) && eqA.eqv(f.empty, g.empty))
+    (f, g) => eqSA.eqv(f, g) && eqA.eqv(f.empty, g.empty)
 
   implicit def catsLawsEqForSemilattice[A](implicit
     eqBA: Eq[Band[A]],
     eqCA: Eq[CommutativeSemigroup[A]],
     eqA: Eq[A]
   ): Eq[Semilattice[A]] =
-    Eq.instance((f, g) => eqBA.eqv(f, g) && eqCA.eqv(f, g))
+    (f, g) => eqBA.eqv(f, g) && eqCA.eqv(f, g)
 
   implicit def catsLawsEqForCommutativeMonoid[A](implicit
     eqSA: Eq[CommutativeSemigroup[A]],
     eqMA: Eq[Monoid[A]],
     eqA: Eq[A]
   ): Eq[CommutativeMonoid[A]] =
-    Eq.instance((f, g) => eqSA.eqv(f, g) && eqMA.eqv(f, g))
+    (f, g) => eqSA.eqv(f, g) && eqMA.eqv(f, g)
 
   implicit def catsLawsEqForBoundedSemilattice[A](implicit
     eqSA: Eq[Semilattice[A]],
     eqCA: Eq[CommutativeMonoid[A]],
     eqA: Eq[A]
   ): Eq[BoundedSemilattice[A]] =
-    Eq.instance((f, g) => eqSA.eqv(f, g) && eqCA.eqv(f, g))
+    (f, g) => eqSA.eqv(f, g) && eqCA.eqv(f, g)
 
   implicit def catsLawsEqForCommutativeGroup[A](implicit
     eqMA: Eq[CommutativeMonoid[A]],
     eqGA: Eq[Group[A]],
     eqA: Eq[A]
   ): Eq[CommutativeGroup[A]] =
-    Eq.instance((f, g) => eqMA.eqv(f, g) && eqGA.eqv(f, g))
+    (f, g) => eqMA.eqv(f, g) && eqGA.eqv(f, g)
 
   implicit def catsLawsEqForRepresentableStore[F[_]: Representable, S, A](implicit
     eqFA: Eq[F[A]],
     eqS: Eq[S]
   ): Eq[RepresentableStore[F, S, A]] =
-    Eq.instance((s1, s2) => eqFA.eqv(s1.fa, s2.fa) && eqS.eqv(s1.index, s2.index))
+    (s1, s2) => eqFA.eqv(s1.fa, s2.fa) && eqS.eqv(s1.index, s2.index)
 
   implicit def catsLawsEqForStoreT[F[_], S, A](implicit eqF: Eq[F[S => A]], eqS: Eq[S]): Eq[StoreT[F, S, A]] =
-    Eq.instance((s1, s2) => eqF.eqv(s1.runF, s2.runF) && eqS.eqv(s1.index, s2.index))
+    (s1, s2) => eqF.eqv(s1.runF, s2.runF) && eqS.eqv(s1.index, s2.index)
 }
 
 @deprecated(
@@ -157,50 +148,47 @@ object eq {
     "This instance is problematic and will most likely be removed in a future version of Cats. Use catsLawsEqForFn1Exhaustive instead. See https://github.com/typelevel/cats/pull/2577 for more information.",
     "1.7"
   )
-  implicit def catsLawsEqForFn1[A, B](implicit A: Arbitrary[A], B: Eq[B]): Eq[A => B] =
-    Eq.instance { (f, g) =>
-      val sampleCnt = if (Platform.isJvm) 50 else 30
-      val samples = List.fill(sampleCnt)(A.arbitrary.sample).collect {
-        case Some(a) => a
-        case None    => sys.error("Could not generate arbitrary values to compare two functions")
-      }
-      samples.forall(s => B.eqv(f(s), g(s)))
+  implicit def catsLawsEqForFn1[A, B](implicit A: Arbitrary[A], B: Eq[B]): Eq[A => B] = { (f, g) =>
+    val sampleCnt = if (Platform.isJvm) 50 else 30
+    val samples = List.fill(sampleCnt)(A.arbitrary.sample).collect {
+      case Some(a) => a
+      case None    => sys.error("Could not generate arbitrary values to compare two functions")
     }
+    samples.forall(s => B.eqv(f(s), g(s)))
+  }
 
   /**
    * Create an approximation of Eq[(A, B) => C] by generating random values for A and B
    * and comparing the application of the two functions.
    */
   implicit def catsLawsEqForFn2[A, B, C](implicit A: Arbitrary[A], B: Arbitrary[B], C: Eq[C]): Eq[(A, B) => C] =
-    Eq.by((_: (A, B) => C).tupled)(catsLawsEqForFn1[(A, B), C])
+    Eq.by(_.tupled)
 
   /**
    * `Eq[AndThen]` instance, built by piggybacking on [[catsLawsEqForFn1]].
    */
   implicit def catsLawsEqForAndThen[A, B](implicit A: Arbitrary[A], B: Eq[B]): Eq[AndThen[A, B]] =
-    Eq.instance(catsLawsEqForFn1[A, B].eqv(_, _))
+    Eq.by(identity[A => B])
 
   /**
-   * Create an approximation of Eq[Show[A]] by using catsLawsEqForFn1[A, String]
+   * Create an approximation of `Eq[Show[A]]` by using catsLawsEqForFn1[A, String]
    */
   implicit def catsLawsEqForShow[A: Arbitrary]: Eq[Show[A]] =
-    Eq.by[Show[A], A => String] { showInstance => (a: A) =>
-      showInstance.show(a)
-    }(catsLawsEqForFn1)
+    Eq.by(showA => showA.show _)
 
   /**
    * Create an approximate Eq instance for some type A, by comparing
    * the behavior of `f(x, b)` and `f(y, b)` across many `b` samples.
    */
-  def sampledEq[A, B: Arbitrary, C: Eq](samples: Int)(f: (A, B) => C): Eq[A] =
-    Eq.instance { (x, y) =>
-      val gen = Arbitrary.arbitrary[B]
+  def sampledEq[A, B: Arbitrary, C: Eq](samples: Int)(f: (A, B) => C): Eq[A] = {
+    val gen = Arbitrary.arbitrary[B]
+    (x, y) =>
       Iterator
         .range(1, samples)
         .map(_ => gen.sample)
         .map(_.getOrElse(sys.error(s"generator $gen failed")))
         .forall(b => f(x, b) === f(y, b))
-    }
+  }
 
   implicit def catsLawsEqForEq[A](implicit arbA: Arbitrary[(A, A)]): Eq[Eq[A]] =
     sampledEq[Eq[A], (A, A), Boolean](100) { case (e, (l, r)) => e.eqv(l, r) }
@@ -230,35 +218,32 @@ object eq {
    * Creates an approximation of `Eq[Hash[A]]` by generating 100 values for A
    * and comparing the application of the two hash functions.
    */
-  implicit def catsLawsEqForHash[A](implicit arbA: Arbitrary[A]): Eq[Hash[A]] =
-    Eq.instance { (f, g) =>
-      val samples = List.fill(100)(arbA.arbitrary.sample).collect {
-        case Some(a) => a
-        case None    => sys.error("Could not generate arbitrary values to compare two Hash[A]")
-      }
-      samples.forall(x => f.hash(x) == g.hash(x))
+  implicit def catsLawsEqForHash[A](implicit arbA: Arbitrary[A]): Eq[Hash[A]] = { (f, g) =>
+    val samples = List.fill(100)(arbA.arbitrary.sample).collect {
+      case Some(a) => a
+      case None    => sys.error("Could not generate arbitrary values to compare two Hash[A]")
     }
+    samples.forall(x => f.hash(x) == g.hash(x))
+  }
 
   /**
-   * Create an approximation of Eq[Semigroup[A]] by generating values for A
+   * Create an approximation of `Eq[Semigroup[A]]` by generating values for A
    * and comparing the application of the two combine functions.
    */
-  implicit def catsLawsEqForSemigroup[A](implicit arbAA: Arbitrary[(A, A)], eqA: Eq[A]): Eq[Semigroup[A]] = {
-    val instance: Eq[((A, A)) => A] = catsLawsEqForFn1[(A, A), A]
-    Eq.by[Semigroup[A], ((A, A)) => A](f => Function.tupled((x, y) => f.combine(x, y)))(instance)
-  }
+  implicit def catsLawsEqForSemigroup[A](implicit arbAA: Arbitrary[(A, A)], eqA: Eq[A]): Eq[Semigroup[A]] =
+    Eq.by[Semigroup[A], ((A, A)) => A](f => { case (x, y) => f.combine(x, y) })
 
   implicit def catsLawsEqForCommutativeSemigroup[A](implicit
     arbAA: Arbitrary[(A, A)],
     eqA: Eq[A]
   ): Eq[CommutativeSemigroup[A]] = {
-    implicit val eqABool: Eq[(A, Boolean)] = Eq.instance { case ((x, boolX), (y, boolY)) =>
+    implicit val eqABool: Eq[(A, Boolean)] = { case ((x, boolX), (y, boolY)) =>
       x === y && boolX === boolY
     }
 
-    Eq.by[CommutativeSemigroup[A], ((A, A)) => (A, Boolean)](f =>
-      Function.tupled((x, y) => (f.combine(x, y), f.combine(x, y) === f.combine(y, x)))
-    )(catsLawsEqForFn1[(A, A), (A, Boolean)])
+    Eq.by[CommutativeSemigroup[A], ((A, A)) => (A, Boolean)](f => { case (x, y) =>
+      (f.combine(x, y), f.combine(x, y) === f.combine(y, x))
+    })
   }
 
   implicit def catsLawsEqForBand[A](implicit
@@ -266,30 +251,27 @@ object eq {
     eqSA: Eq[Semigroup[A]],
     eqA: Eq[A]
   ): Eq[Band[A]] =
-    Eq.by[Band[A], ((A, A)) => Boolean](f =>
-      Function.tupled((x, y) => f.combine(x, y) === f.combine(f.combine(x, y), y))
-    )(catsLawsEqForFn1[(A, A), Boolean])
+    Eq.by[Band[A], ((A, A)) => Boolean](f => { case (x, y) =>
+      f.combine(x, y) === f.combine(f.combine(x, y), y)
+    })
 
   implicit def catsLawsEqForGroup[A](implicit
     arbAA: Arbitrary[(A, A)],
     eqMA: Eq[Monoid[A]],
     eqA: Eq[A]
   ): Eq[Group[A]] = {
-    implicit val eqABool: Eq[(A, Boolean)] = Eq.instance { case ((x, boolX), (y, boolY)) =>
+    implicit val eqABool: Eq[(A, Boolean)] = { case ((x, boolX), (y, boolY)) =>
       x === y && boolX === boolY
     }
 
-    val inverseEq = Eq.by[Group[A], ((A, A)) => (A, Boolean)](f =>
-      Function.tupled { (x, y) =>
-        val xy = f.combine(x, y)
-        val p1 = f.combine(f.inverse(x), x) === f.empty && f.combine(x, f.inverse(x)) === f.empty
-        val p2 = f.combine(f.inverse(y), y) === f.empty && f.combine(y, f.inverse(y)) === f.empty
-        val p3 = f.inverse(f.empty) == f.empty
+    val inverseEq = Eq.by[Group[A], ((A, A)) => (A, Boolean)](f => { case (x, y) =>
+      val xy = f.combine(x, y)
+      val p1 = f.combine(f.inverse(x), x) === f.empty && f.combine(x, f.inverse(x)) === f.empty
+      val p2 = f.combine(f.inverse(y), y) === f.empty && f.combine(y, f.inverse(y)) === f.empty
+      val p3 = f.inverse(f.empty) == f.empty
+      (xy, p1 && p2 && p3)
+    })
 
-        (xy, p1 && p2 && p3)
-      }
-    )(catsLawsEqForFn1[(A, A), (A, Boolean)])
-
-    Eq.instance((f, g) => eqMA.eqv(f, g) && inverseEq.eqv(f, g))
+    (f, g) => eqMA.eqv(f, g) && inverseEq.eqv(f, g)
   }
 }

--- a/laws/src/main/scala/cats/laws/discipline/MiniInt.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MiniInt.scala
@@ -93,8 +93,6 @@ object MiniInt {
     def combine(x: MiniInt, y: MiniInt): MiniInt = x * y
   }
 
-  val miniIntOr: BoundedSemilattice[MiniInt] = new BoundedSemilattice[MiniInt] {
-    val empty = MiniInt.zero
-    def combine(x: MiniInt, y: MiniInt): MiniInt = x | y
-  }
+  val miniIntOr: BoundedSemilattice[MiniInt] =
+    BoundedSemilattice.instance(MiniInt.zero, _ | _)
 }

--- a/laws/src/main/scala/cats/laws/discipline/MiniInt.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MiniInt.scala
@@ -93,6 +93,8 @@ object MiniInt {
     def combine(x: MiniInt, y: MiniInt): MiniInt = x * y
   }
 
-  val miniIntOr: BoundedSemilattice[MiniInt] =
-    BoundedSemilattice.instance(MiniInt.zero, _ | _)
+  val miniIntOr: BoundedSemilattice[MiniInt] = new BoundedSemilattice[MiniInt] {
+    val empty = MiniInt.zero
+    def combine(x: MiniInt, y: MiniInt): MiniInt = x | y
+  }
 }

--- a/laws/src/main/scala/cats/laws/discipline/NonEmptyTraverseTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/NonEmptyTraverseTests.scala
@@ -30,7 +30,15 @@ import cats.laws.NonEmptyTraverseLaws
 trait NonEmptyTraverseTests[F[_]] extends TraverseTests[F] with ReducibleTests[F] {
   def laws: NonEmptyTraverseLaws[F]
 
-  def nonEmptyTraverse[G[_]: Applicative, A: Arbitrary, B: Arbitrary, C: Arbitrary, M: Arbitrary, X[_], Y[_]](implicit
+  def nonEmptyTraverse[
+    G[_]: Applicative,
+    A: Arbitrary,
+    B: Arbitrary,
+    C: Arbitrary,
+    M: Arbitrary,
+    X[_],
+    Y[_]
+  ](implicit
     ArbFA: Arbitrary[F[A]],
     ArbXB: Arbitrary[X[B]],
     ArbYB: Arbitrary[Y[B]],
@@ -64,26 +72,19 @@ trait NonEmptyTraverseTests[F[_]] extends TraverseTests[F] with ReducibleTests[F
     EqYFB: Eq[Y[F[B]]],
     EqYFM: Eq[Y[F[M]]],
     EqOptionA: Eq[Option[A]]
-  ): RuleSet = {
-    implicit def EqXFBYFB: Eq[(X[F[B]], Y[F[B]])] =
-      new Eq[(X[F[B]], Y[F[B]])] {
-        override def eqv(x: (X[F[B]], Y[F[B]]), y: (X[F[B]], Y[F[B]])): Boolean =
-          EqXFB.eqv(x._1, y._1) && EqYFB.eqv(x._2, y._2)
-      }
-    new RuleSet {
-      def name: String = "nonEmptyTraverse"
-      def bases: Seq[(String, RuleSet)] = Nil
-      def parents: Seq[RuleSet] = Seq(traverse[A, B, C, M, X, Y], reducible[G, A, B])
-      def props: Seq[(String, Prop)] =
-        Seq(
-          "nonEmptyTraverse identity" -> forAll(laws.nonEmptyTraverseIdentity[A, C] _),
-          "nonEmptyTraverse sequential composition" -> forAll(
-            laws.nonEmptyTraverseSequentialComposition[A, B, C, X, Y] _
-          ),
-          "nonEmptyTraverse parallel composition" -> forAll(laws.nonEmptyTraverseParallelComposition[A, B, X, Y] _),
-          "nonEmptyTraverse derive reduceMap" -> forAll(laws.reduceMapDerived[A, M] _)
-        )
-    }
+  ): RuleSet = new RuleSet {
+    def name: String = "nonEmptyTraverse"
+    def bases: Seq[(String, RuleSet)] = Nil
+    def parents: Seq[RuleSet] = Seq(traverse[A, B, C, M, X, Y], reducible[G, A, B])
+    def props: Seq[(String, Prop)] =
+      Seq(
+        "nonEmptyTraverse identity" -> forAll(laws.nonEmptyTraverseIdentity[A, C] _),
+        "nonEmptyTraverse sequential composition" -> forAll(
+          laws.nonEmptyTraverseSequentialComposition[A, B, C, X, Y] _
+        ),
+        "nonEmptyTraverse parallel composition" -> forAll(laws.nonEmptyTraverseParallelComposition[A, B, X, Y] _),
+        "nonEmptyTraverse derive reduceMap" -> forAll(laws.reduceMapDerived[A, M] _)
+      )
   }
 }
 

--- a/laws/src/main/scala/cats/laws/discipline/TraverseTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/TraverseTests.scala
@@ -31,9 +31,14 @@ import Prop._
 trait TraverseTests[F[_]] extends FunctorTests[F] with FoldableTests[F] with UnorderedTraverseTests[F] {
   def laws: TraverseLaws[F]
 
-  def traverse[A: Arbitrary, B: Arbitrary, C: Arbitrary, M: Arbitrary, X[_]: CommutativeApplicative, Y[
-    _
-  ]: CommutativeApplicative](implicit
+  def traverse[
+    A: Arbitrary,
+    B: Arbitrary,
+    C: Arbitrary,
+    M: Arbitrary,
+    X[_]: CommutativeApplicative,
+    Y[_]: CommutativeApplicative
+  ](implicit
     ArbFA: Arbitrary[F[A]],
     ArbFB: Arbitrary[F[B]],
     ArbXB: Arbitrary[X[B]],
@@ -58,31 +63,23 @@ trait TraverseTests[F[_]] extends FunctorTests[F] with FoldableTests[F] with Uno
     EqXFM: Eq[X[F[M]]],
     EqYFM: Eq[Y[F[M]]],
     EqOptionA: Eq[Option[A]]
-  ): RuleSet = {
-    implicit val EqXFBYFB: Eq[(X[F[B]], Y[F[B]])] =
-      new Eq[(X[F[B]], Y[F[B]])] {
-        override def eqv(x: (X[F[B]], Y[F[B]]), y: (X[F[B]], Y[F[B]])): Boolean =
-          EqXFB.eqv(x._1, y._1) && EqYFB.eqv(x._2, y._2)
-      }
-
-    new RuleSet {
-      def name: String = "traverse"
-      def bases: Seq[(String, RuleSet)] = Nil
-      def parents: Seq[RuleSet] = Seq(functor[A, B, C], foldable[A, M], unorderedTraverse[A, M, C, X, Y])
-      def props: Seq[(String, Prop)] =
-        Seq(
-          "traverse identity" -> forAll(laws.traverseIdentity[A, C] _),
-          "traverse sequential composition" -> forAll(laws.traverseSequentialComposition[A, B, C, X, Y] _),
-          "traverse parallel composition" -> forAll(laws.traverseParallelComposition[A, B, X, Y] _),
-          "traverse traverseTap" -> forAll(laws.traverseTap[B, M, X] _),
-          "traverse derive foldMap" -> forAll(laws.foldMapDerived[A, M] _),
-          "traverse order consistency" -> forAll(laws.traverseOrderConsistent[A] _),
-          "traverse ref mapAccumulate" -> forAll(laws.mapAccumulateRef[M, A, C] _),
-          "traverse ref mapWithIndex" -> forAll(laws.mapWithIndexRef[A, C] _),
-          "traverse ref traverseWithIndexM" -> forAll(laws.traverseWithIndexMRef[Option, A, C] _),
-          "traverse ref zipWithIndex" -> forAll(laws.zipWithIndexRef[A, C] _)
-        )
-    }
+  ): RuleSet = new RuleSet {
+    def name: String = "traverse"
+    def bases: Seq[(String, RuleSet)] = Nil
+    def parents: Seq[RuleSet] = Seq(functor[A, B, C], foldable[A, M], unorderedTraverse[A, M, C, X, Y])
+    def props: Seq[(String, Prop)] =
+      Seq(
+        "traverse identity" -> forAll(laws.traverseIdentity[A, C] _),
+        "traverse sequential composition" -> forAll(laws.traverseSequentialComposition[A, B, C, X, Y] _),
+        "traverse parallel composition" -> forAll(laws.traverseParallelComposition[A, B, X, Y] _),
+        "traverse traverseTap" -> forAll(laws.traverseTap[B, M, X] _),
+        "traverse derive foldMap" -> forAll(laws.foldMapDerived[A, M] _),
+        "traverse order consistency" -> forAll(laws.traverseOrderConsistent[A] _),
+        "traverse ref mapAccumulate" -> forAll(laws.mapAccumulateRef[M, A, C] _),
+        "traverse ref mapWithIndex" -> forAll(laws.mapWithIndexRef[A, C] _),
+        "traverse ref traverseWithIndexM" -> forAll(laws.traverseWithIndexMRef[Option, A, C] _),
+        "traverse ref zipWithIndex" -> forAll(laws.zipWithIndexRef[A, C] _)
+      )
   }
 }
 

--- a/laws/src/main/scala/cats/laws/discipline/UnorderedTraverseTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/UnorderedTraverseTests.scala
@@ -30,9 +30,13 @@ import cats.kernel.CommutativeMonoid
 trait UnorderedTraverseTests[F[_]] extends UnorderedFoldableTests[F] {
   def laws: UnorderedTraverseLaws[F]
 
-  def unorderedTraverse[A: Arbitrary, B: Arbitrary, C: Arbitrary, X[_]: CommutativeApplicative, Y[
-    _
-  ]: CommutativeApplicative](implicit
+  def unorderedTraverse[
+    A: Arbitrary,
+    B: Arbitrary,
+    C: Arbitrary,
+    X[_]: CommutativeApplicative,
+    Y[_]: CommutativeApplicative
+  ](implicit
     ArbFA: Arbitrary[F[A]],
     ArbFXB: Arbitrary[F[X[B]]],
     ArbXB: Arbitrary[X[B]],
@@ -47,22 +51,15 @@ trait UnorderedTraverseTests[F[_]] extends UnorderedFoldableTests[F] {
     EqXYFC: Eq[X[Y[F[C]]]],
     EqXFB: Eq[X[F[B]]],
     EqYFB: Eq[Y[F[B]]]
-  ): RuleSet = {
-    implicit def EqXFBYFB: Eq[(X[F[B]], Y[F[B]])] =
-      new Eq[(X[F[B]], Y[F[B]])] {
-        override def eqv(x: (X[F[B]], Y[F[B]]), y: (X[F[B]], Y[F[B]])): Boolean =
-          EqXFB.eqv(x._1, y._1) && EqYFB.eqv(x._2, y._2)
-      }
-    new DefaultRuleSet(
-      name = "unorderedTraverse",
-      parent = Some(unorderedFoldable[A, B]),
-      "unordered traverse sequential composition" -> forAll(
-        laws.unorderedTraverseSequentialComposition[A, B, C, X, Y] _
-      ),
-      "unordered traverse parallel composition" -> forAll(laws.unorderedTraverseParallelComposition[A, B, X, Y] _),
-      "unordered traverse consistent with sequence" -> forAll(laws.unorderedSequenceConsistent[B, X] _)
-    )
-  }
+  ): RuleSet = new DefaultRuleSet(
+    name = "unorderedTraverse",
+    parent = Some(unorderedFoldable[A, B]),
+    "unordered traverse sequential composition" -> forAll(
+      laws.unorderedTraverseSequentialComposition[A, B, C, X, Y] _
+    ),
+    "unordered traverse parallel composition" -> forAll(laws.unorderedTraverseParallelComposition[A, B, X, Y] _),
+    "unordered traverse consistent with sequence" -> forAll(laws.unorderedSequenceConsistent[B, X] _)
+  )
 }
 
 object UnorderedTraverseTests {

--- a/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
@@ -281,14 +281,9 @@ object arbitrary extends ArbitraryInstances0 with ScalaVersionSpecific.Arbitrary
     Arbitrary(getArbitrary[Eq[A]].map(Eq.catsKernelEquivForEq(_)))
 
   implicit def catsLawsArbitraryForPartialOrder[A: Arbitrary]: Arbitrary[PartialOrder[A]] =
-    Arbitrary(
-      getArbitrary[Int => Double].map(f =>
-        new PartialOrder[A] {
-          def partialCompare(x: A, y: A): Double =
-            if (x.## == y.##) 0.0 else f(x.##) - f(y.##)
-        }
-      )
-    )
+    Arbitrary(getArbitrary[Int => Double].map { f =>
+      PartialOrder.from((x, y) => if (x.## == y.##) 0.0 else f(x.##) - f(y.##))
+    })
 
   implicit def catsLawsArbitraryForPartialOrdering[A: Arbitrary]: Arbitrary[PartialOrdering[A]] =
     Arbitrary(getArbitrary[PartialOrder[A]].map(PartialOrder.catsKernelPartialOrderingForPartialOrder(_)))

--- a/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
@@ -275,15 +275,13 @@ object arbitrary extends ArbitraryInstances0 with ScalaVersionSpecific.Arbitrary
     Arbitrary(getArbitrary[Eq[A]].map(Eq.catsKernelEquivForEq(_)))
 
   implicit def catsLawsArbitraryForPartialOrder[A: Arbitrary]: Arbitrary[PartialOrder[A]] =
-    Arbitrary(getArbitrary[Int => Double].map { f =>
-      PartialOrder.from((x, y) => if (x.## == y.##) 0.0 else f(x.##) - f(y.##))
-    })
+    Arbitrary(getArbitrary[Int => Double].map(f => PartialOrder.by(x => f(x.##))))
 
   implicit def catsLawsArbitraryForPartialOrdering[A: Arbitrary]: Arbitrary[PartialOrdering[A]] =
     Arbitrary(getArbitrary[PartialOrder[A]].map(PartialOrder.catsKernelPartialOrderingForPartialOrder(_)))
 
   implicit def catsLawsArbitraryForOrder[A: Arbitrary]: Arbitrary[Order[A]] =
-    Arbitrary(getArbitrary[Int => Int].map(f => Order.from((x, y) => Integer.compare(f(x.##), f(y.##)))))
+    Arbitrary(getArbitrary[Int => Int].map(f => Order.by(x => f(x.##))))
 
   implicit def catsLawsArbitraryForSortedMap[K: Arbitrary: Order, V: Arbitrary]: Arbitrary[SortedMap[K, V]] =
     Arbitrary(getArbitrary[Map[K, V]].map(s => SortedMap.empty[K, V](implicitly[Order[K]].toOrdering) ++ s))

--- a/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
@@ -294,13 +294,7 @@ object arbitrary extends ArbitraryInstances0 with ScalaVersionSpecific.Arbitrary
     Arbitrary(getArbitrary[PartialOrder[A]].map(PartialOrder.catsKernelPartialOrderingForPartialOrder(_)))
 
   implicit def catsLawsArbitraryForOrder[A: Arbitrary]: Arbitrary[Order[A]] =
-    Arbitrary(
-      getArbitrary[Int => Int].map(f =>
-        new Order[A] {
-          def compare(x: A, y: A): Int = java.lang.Integer.compare(f(x.##), f(y.##))
-        }
-      )
-    )
+    Arbitrary(getArbitrary[Int => Int].map(f => Order.from((x, y) => Integer.compare(f(x.##), f(y.##)))))
 
   implicit def catsLawsArbitraryForSortedMap[K: Arbitrary: Order, V: Arbitrary]: Arbitrary[SortedMap[K, V]] =
     Arbitrary(getArbitrary[Map[K, V]].map(s => SortedMap.empty[K, V](implicitly[Order[K]].toOrdering) ++ s))

--- a/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
@@ -269,13 +269,7 @@ object arbitrary extends ArbitraryInstances0 with ScalaVersionSpecific.Arbitrary
   // implies equal, in order to avoid producing invalid instances.
 
   implicit def catsLawsArbitraryForEq[A: Arbitrary]: Arbitrary[Eq[A]] =
-    Arbitrary(
-      getArbitrary[Int => Int].map(f =>
-        new Eq[A] {
-          def eqv(x: A, y: A): Boolean = f(x.##) == f(y.##)
-        }
-      )
-    )
+    Arbitrary(getArbitrary[Int => Int].map(f => Eq.by(x => f(x.##))))
 
   implicit def catsLawsArbitraryForEquiv[A: Arbitrary]: Arbitrary[Equiv[A]] =
     Arbitrary(getArbitrary[Eq[A]].map(Eq.catsKernelEquivForEq(_)))

--- a/tests/js/src/test/scala/cats/js/instances/future.scala
+++ b/tests/js/src/test/scala/cats/js/instances/future.scala
@@ -48,10 +48,7 @@ sealed private[instances] trait FutureInstances0 extends FutureInstances1 {
     }
 
   def futureOrder[A: Order](atMost: FiniteDuration)(implicit ec: E): Order[Future[A]] =
-    new Order[Future[A]] {
-      def compare(x: Future[A], y: Future[A]): Int =
-        Await.result(x.zip(y).map { case (x, y) => x.compare(y) }, atMost)
-    }
+    Order.from((x, y) => Await.result(x.zip(y).map { case (x, y) => x.compare(y) }, atMost))
 }
 
 sealed private[instances] trait FutureInstances1 extends FutureInstances2 {

--- a/tests/js/src/test/scala/cats/js/instances/future.scala
+++ b/tests/js/src/test/scala/cats/js/instances/future.scala
@@ -48,12 +48,12 @@ sealed private[instances] trait FutureInstances0 extends FutureInstances1 {
     }
 
   def futureOrder[A: Order](atMost: FiniteDuration)(implicit ec: E): Order[Future[A]] =
-    Order.from((x, y) => Await.result(x.zip(y).map { case (x, y) => x.compare(y) }, atMost))
+    (x, y) => Await.result(x.zip(y).map { case (x, y) => x.compare(y) }, atMost)
 }
 
 sealed private[instances] trait FutureInstances1 extends FutureInstances2 {
   def futurePartialOrder[A: PartialOrder](atMost: FiniteDuration)(implicit ec: E): PartialOrder[Future[A]] =
-    PartialOrder.from((x, y) => Await.result(x.zip(y).map { case (x, y) => x.partialCompare(y) }, atMost))
+    (x, y) => Await.result(x.zip(y).map { case (x, y) => x.partialCompare(y) }, atMost)
 }
 
 sealed private[instances] trait FutureInstances2 {

--- a/tests/js/src/test/scala/cats/js/instances/future.scala
+++ b/tests/js/src/test/scala/cats/js/instances/future.scala
@@ -58,5 +58,5 @@ sealed private[instances] trait FutureInstances1 extends FutureInstances2 {
 
 sealed private[instances] trait FutureInstances2 {
   def futureEq[A: Eq](atMost: FiniteDuration)(implicit ec: E): Eq[Future[A]] =
-    Eq.instance((x, y) => Await.result(x.zip(y).map { case (x, y) => x === y }, atMost))
+    (x, y) => Await.result(x.zip(y).map { case (x, y) => x === y }, atMost)
 }

--- a/tests/js/src/test/scala/cats/js/instances/future.scala
+++ b/tests/js/src/test/scala/cats/js/instances/future.scala
@@ -53,11 +53,7 @@ sealed private[instances] trait FutureInstances0 extends FutureInstances1 {
 
 sealed private[instances] trait FutureInstances1 extends FutureInstances2 {
   def futurePartialOrder[A: PartialOrder](atMost: FiniteDuration)(implicit ec: E): PartialOrder[Future[A]] =
-    new PartialOrder[Future[A]] {
-      def partialCompare(x: Future[A], y: Future[A]): Double =
-        Await.result(x.zip(y).map { case (x, y) => x.partialCompare(y) }, atMost)
-    }
-
+    PartialOrder.from((x, y) => Await.result(x.zip(y).map { case (x, y) => x.partialCompare(y) }, atMost))
 }
 
 sealed private[instances] trait FutureInstances2 {

--- a/tests/js/src/test/scala/cats/js/instances/future.scala
+++ b/tests/js/src/test/scala/cats/js/instances/future.scala
@@ -58,8 +58,5 @@ sealed private[instances] trait FutureInstances1 extends FutureInstances2 {
 
 sealed private[instances] trait FutureInstances2 {
   def futureEq[A: Eq](atMost: FiniteDuration)(implicit ec: E): Eq[Future[A]] =
-    new Eq[Future[A]] {
-      def eqv(x: Future[A], y: Future[A]): Boolean =
-        Await.result(x.zip(y).map { case (x, y) => x === y }, atMost)
-    }
+    Eq.instance((x, y) => Await.result(x.zip(y).map { case (x, y) => x === y }, atMost))
 }

--- a/tests/js/src/test/scala/cats/tests/FutureTests.scala
+++ b/tests/js/src/test/scala/cats/tests/FutureTests.scala
@@ -56,11 +56,9 @@ class FutureTests extends CatsSuite {
     f.map(Either.right[Throwable, A]).recover { case t => Either.left(t) }
 
   implicit def eqfa[A: Eq]: Eq[Future[A]] =
-    new Eq[Future[A]] {
-      def eqv(fx: Future[A], fy: Future[A]): Boolean = {
-        val fz = futureEither(fx).zip(futureEither(fy))
-        Await.result(fz.map { case (tx, ty) => tx === ty }, timeout)
-      }
+    Eq.instance { (fx, fy) =>
+      val fz = futureEither(fx).zip(futureEither(fy))
+      Await.result(fz.map { case (tx, ty) => tx === ty }, timeout)
     }
 
   implicit val throwableEq: Eq[Throwable] =

--- a/tests/js/src/test/scala/cats/tests/FutureTests.scala
+++ b/tests/js/src/test/scala/cats/tests/FutureTests.scala
@@ -55,11 +55,10 @@ class FutureTests extends CatsSuite {
   def futureEither[A](f: Future[A]): Future[Either[Throwable, A]] =
     f.map(Either.right[Throwable, A]).recover { case t => Either.left(t) }
 
-  implicit def eqfa[A: Eq]: Eq[Future[A]] =
-    Eq.instance { (fx, fy) =>
-      val fz = futureEither(fx).zip(futureEither(fy))
-      Await.result(fz.map { case (tx, ty) => tx === ty }, timeout)
-    }
+  implicit def eqfa[A: Eq]: Eq[Future[A]] = { (fx, fy) =>
+    val fz = futureEither(fx).zip(futureEither(fy))
+    Await.result(fz.map { case (tx, ty) => tx === ty }, timeout)
+  }
 
   implicit val throwableEq: Eq[Throwable] =
     Eq.by[Throwable, String](_.toString)

--- a/tests/jvm/src/test/scala/cats/tests/FutureSuite.scala
+++ b/tests/jvm/src/test/scala/cats/tests/FutureSuite.scala
@@ -41,11 +41,9 @@ class FutureSuite extends CatsSuite {
     f.map(Either.right[Throwable, A]).recover { case t => Either.left(t) }
 
   implicit def eqfa[A: Eq]: Eq[Future[A]] =
-    new Eq[Future[A]] {
-      def eqv(fx: Future[A], fy: Future[A]): Boolean = {
-        val fz = futureEither(fx).zip(futureEither(fy))
-        Await.result(fz.map { case (tx, ty) => tx === ty }, timeout)
-      }
+    Eq.instance { (fx, fy) =>
+      val fz = futureEither(fx).zip(futureEither(fy))
+      Await.result(fz.map { case (tx, ty) => tx === ty }, timeout)
     }
 
   implicit def cogen[A: Cogen]: Cogen[Future[A]] =

--- a/tests/jvm/src/test/scala/cats/tests/FutureSuite.scala
+++ b/tests/jvm/src/test/scala/cats/tests/FutureSuite.scala
@@ -40,11 +40,10 @@ class FutureSuite extends CatsSuite {
   def futureEither[A](f: Future[A]): Future[Either[Throwable, A]] =
     f.map(Either.right[Throwable, A]).recover { case t => Either.left(t) }
 
-  implicit def eqfa[A: Eq]: Eq[Future[A]] =
-    Eq.instance { (fx, fy) =>
-      val fz = futureEither(fx).zip(futureEither(fy))
-      Await.result(fz.map { case (tx, ty) => tx === ty }, timeout)
-    }
+  implicit def eqfa[A: Eq]: Eq[Future[A]] = { (fx, fy) =>
+    val fz = futureEither(fx).zip(futureEither(fy))
+    Await.result(fz.map { case (tx, ty) => tx === ty }, timeout)
+  }
 
   implicit def cogen[A: Cogen]: Cogen[Future[A]] =
     Cogen[Future[A]] { (seed: Seed, t: Future[A]) =>

--- a/tests/native/src/test/scala/cats/native/tests/FutureSuite.scala
+++ b/tests/native/src/test/scala/cats/native/tests/FutureSuite.scala
@@ -53,11 +53,10 @@ class FutureSuite extends CatsSuite {
   def futureEither[A](f: Future[A]): Future[Either[Throwable, A]] =
     f.map(Either.right[Throwable, A]).recover { case t => Either.left(t) }
 
-  implicit def eqfa[A: Eq]: Eq[Future[A]] =
-    Eq.instance { (fx, fy) =>
-      val fz = futureEither(fx).zip(futureEither(fy))
-      Await.result(fz.map { case (tx, ty) => tx === ty }, timeout)
-    }
+  implicit def eqfa[A: Eq]: Eq[Future[A]] = { (fx, fy) =>
+    val fz = futureEither(fx).zip(futureEither(fy))
+    Await.result(fz.map { case (tx, ty) => tx === ty }, timeout)
+  }
 
   implicit def cogen[A: Cogen]: Cogen[Future[A]] =
     Cogen[Future[A]] { (seed: Seed, t: Future[A]) =>

--- a/tests/native/src/test/scala/cats/native/tests/FutureSuite.scala
+++ b/tests/native/src/test/scala/cats/native/tests/FutureSuite.scala
@@ -54,11 +54,9 @@ class FutureSuite extends CatsSuite {
     f.map(Either.right[Throwable, A]).recover { case t => Either.left(t) }
 
   implicit def eqfa[A: Eq]: Eq[Future[A]] =
-    new Eq[Future[A]] {
-      def eqv(fx: Future[A], fy: Future[A]): Boolean = {
-        val fz = futureEither(fx).zip(futureEither(fy))
-        Await.result(fz.map { case (tx, ty) => tx === ty }, timeout)
-      }
+    Eq.instance { (fx, fy) =>
+      val fz = futureEither(fx).zip(futureEither(fy))
+      Await.result(fz.map { case (tx, ty) => tx === ty }, timeout)
     }
 
   implicit def cogen[A: Cogen]: Cogen[Future[A]] =

--- a/tests/shared/src/test/scala/cats/tests/AlgebraInvariantSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/AlgebraInvariantSuite.scala
@@ -72,11 +72,6 @@ class AlgebraInvariantSuite extends CatsSuite with ScalaVersionSpecificAlgebraIn
       def combine(x: Option[A], y: Option[A]): Option[A] = y
     }
 
-  private val boundedSemilatticeMiniInt: BoundedSemilattice[MiniInt] = new BoundedSemilattice[MiniInt] {
-    def empty: MiniInt = MiniInt.zero
-    def combine(x: MiniInt, y: MiniInt): MiniInt = x | y
-  }
-
   private val genBoundedSemilatticeMiniInt: Gen[BoundedSemilattice[MiniInt]] =
     Gen.const(miniIntOr)
 

--- a/tests/shared/src/test/scala/cats/tests/ContTSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/ContTSuite.scala
@@ -40,12 +40,7 @@ class ContTSuite extends CatsSuite {
   implicit def eqContT[M[_], A, B](implicit arbFn: Arbitrary[B => M[A]], eqMA: Eq[M[A]]): Eq[ContT[M, A, B]] = {
     val genItems = Gen.listOfN(100, arbFn.arbitrary)
     val fns = genItems.sample.get
-    new Eq[ContT[M, A, B]] {
-      def eqv(a: ContT[M, A, B], b: ContT[M, A, B]) =
-        fns.forall { fn =>
-          eqMA.eqv(a.run(fn), b.run(fn))
-        }
-    }
+    Eq.instance((a, b) => fns.forall(fn => eqMA.eqv(a.run(fn), b.run(fn))))
   }
 
   checkAll("ContT[Function0, Int, *]", MonadTests[ContT[Function0, Int, *]].monad[Int, String, Int])

--- a/tests/shared/src/test/scala/cats/tests/ContTSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/ContTSuite.scala
@@ -40,7 +40,7 @@ class ContTSuite extends CatsSuite {
   implicit def eqContT[M[_], A, B](implicit arbFn: Arbitrary[B => M[A]], eqMA: Eq[M[A]]): Eq[ContT[M, A, B]] = {
     val genItems = Gen.listOfN(100, arbFn.arbitrary)
     val fns = genItems.sample.get
-    Eq.instance((a, b) => fns.forall(fn => eqMA.eqv(a.run(fn), b.run(fn))))
+    (a, b) => fns.forall(fn => eqMA.eqv(a.run(fn), b.run(fn)))
   }
 
   checkAll("ContT[Function0, Int, *]", MonadTests[ContT[Function0, Int, *]].monad[Int, String, Int])

--- a/tests/shared/src/test/scala/cats/tests/SetSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/SetSuite.scala
@@ -45,7 +45,7 @@ class SetSuite extends CatsSuite {
 
   test("show keeps separate entries for items that map to identical strings") {
     // note: this val name has to be the same to shadow the cats.instances instance
-    implicit val catsStdShowForInt: Show[Int] = Show.show(_ => "1")
+    implicit val catsStdShowForInt: Show[Int] = _ => "1"
     // an implementation implemented as set.map(_.show).mkString(", ") would
     // only show one entry in the result instead of 3, because Set.map combines
     // duplicate items in the codomain.

--- a/tests/shared/src/test/scala/cats/tests/ShowSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/ShowSuite.scala
@@ -39,13 +39,13 @@ class ShowSuite extends CatsSuite {
   sealed trait TimeOfDay
   case object Morning extends TimeOfDay
   object TimeOfDay {
-    implicit val showTimeOfDay: Show[TimeOfDay] = Show.show { case Morning => "morning" }
+    implicit val showTimeOfDay: Show[TimeOfDay] = { case Morning => "morning" }
   }
 
   test("show string interpolator") {
     case class Cat(name: String)
     object Cat {
-      implicit val showCat: Show[Cat] = Show.show(_.name)
+      implicit val showCat: Show[Cat] = _.name
     }
     val tod: TimeOfDay = Morning
     val cat = Cat("Whiskers")

--- a/tests/shared/src/test/scala/cats/tests/SortedSetSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/SortedSetSuite.scala
@@ -70,7 +70,7 @@ class SortedSetSuite extends CatsSuite {
 
   test("show keeps separate entries for items that map to identical strings") {
     // note: this val name has to be the same to shadow the cats.instances instance
-    implicit val catsStdShowForInt: Show[Int] = Show.show(_ => "1")
+    implicit val catsStdShowForInt: Show[Int] = _ => "1"
     // an implementation implemented as set.map(_.show).mkString(", ") would
     // only show one entry in the result instead of 3, because SortedSet.map combines
     // duplicate items in the codomain.


### PR DESCRIPTION
Definitions are shorter and don't generate anonymous classes in some cases.

Instances:
 - [x] `Show`
 - [x] `Eq`
 - [x] `PartialOrder`
 - [x] `Order`
 - [x] `Semigroup`, `CommutativeSemigroup`
 - [x] ~`Monoid`, `CommutativeMonoid`~
 - [x] `Band`
 - [x] `Semilattice`, `BoundedSemilattice`

Closes #3870


