### PR TITLE
Avoid using `NonFatal.unapply`

### DIFF
--- a/core/src/main/scala/cats/ApplicativeError.scala
+++ b/core/src/main/scala/cats/ApplicativeError.scala
@@ -247,7 +247,7 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
   def catchNonFatal[A](a: => A)(implicit ev: Throwable <:< E): F[A] =
     try pure(a)
     catch {
-      case NonFatal(e) => raiseError(e)
+      case e if NonFatal(e) => raiseError(e)
     }
 
   /**
@@ -257,7 +257,7 @@ trait ApplicativeError[F[_], E] extends Applicative[F] {
   def catchNonFatalEval[A](a: Eval[A])(implicit ev: Throwable <:< E): F[A] =
     try pure(a.value)
     catch {
-      case NonFatal(e) => raiseError(e)
+      case e if NonFatal(e) => raiseError(e)
     }
 
   /**

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -1137,7 +1137,7 @@ private[data] trait ValidatedFunctions {
     try {
       valid(f)
     } catch {
-      case scala.util.control.NonFatal(t) => invalid(t)
+      case t if scala.util.control.NonFatal(t) => invalid(t)
     }
 
   /**

--- a/core/src/main/scala/cats/instances/try.scala
+++ b/core/src/main/scala/cats/instances/try.scala
@@ -109,7 +109,7 @@ trait TryInstances extends TryInstances1 {
           ta match {
             case Success(a) => bind(a); case Failure(e) => recover(e)
           }
-        catch { case NonFatal(e) => Failure(e) }
+        catch { case e if NonFatal(e) => Failure(e) }
 
       override def recover[A](ta: Try[A])(pf: PartialFunction[Throwable, A]): Try[A] =
         ta.recover(pf)

--- a/core/src/main/scala/cats/syntax/either.scala
+++ b/core/src/main/scala/cats/syntax/either.scala
@@ -390,7 +390,7 @@ final class EitherObjectOps(private val either: Either.type) extends AnyVal {
     try {
       right(f)
     } catch {
-      case scala.util.control.NonFatal(t) => left(t)
+      case t if scala.util.control.NonFatal(t) => left(t)
     }
 
   /**

--- a/kernel-laws/shared/src/main/scala/cats/kernel/laws/SerializableLaws.scala
+++ b/kernel-laws/shared/src/main/scala/cats/kernel/laws/SerializableLaws.scala
@@ -61,7 +61,7 @@ object SerializableLaws {
           ois.close()
           Result(status = Proof)
         } catch {
-          case NonFatal(t) =>
+          case t if NonFatal(t) =>
             Result(status = Exception(t))
         } finally {
           oos.close()


### PR DESCRIPTION
Allows to skip an allocation of Option. It is a tiny micro-optimization, but since it not make code more complicated and less readable, why not ?) 
