### PR TITLE
add EitherNev alias and syntax

### DIFF
--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -602,6 +602,12 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
       case Left(a)  => Validated.invalidNel(a)
     }
 
+  def toValidatedNev(implicit F: Functor[F]): F[ValidatedNev[A, B]] =
+    F.map(value) {
+      case Right(b) => Validated.valid(b)
+      case Left(a)  => Validated.invalidNev(a)
+    }
+
   def toValidatedNec(implicit F: Functor[F]): F[ValidatedNec[A, B]] =
     F.map(value) {
       case Right(b) => Validated.valid(b)
@@ -680,6 +686,17 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
       F.map(value) {
         case Right(b) => Validated.valid(b)
         case Left(a)  => Validated.invalidNel(a)
+      }
+    )
+
+  /**
+   * Transform this `EitherT[F, A, B]` into a `[[Nested]][F, ValidatedNev[A, *], B]`.
+   */
+  def toNestedValidatedNev(implicit F: Functor[F]): Nested[F, ValidatedNev[A, *], B] =
+    Nested[F, ValidatedNev[A, *], B](
+      F.map(value) {
+        case Right(b) => Validated.valid(b)
+        case Left(a)  => Validated.invalidNev(a)
       }
     )
 

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -375,6 +375,8 @@ sealed abstract class Ior[+A, +B] extends Product with Serializable {
 
   final def toIorNec[AA >: A]: IorNec[AA, B] = leftMap(NonEmptyChain.one)
 
+  final def toIorNev[AA >: A]: IorNev[AA, B] = leftMap(NonEmptyVector.one)
+
   /**
    * Example:
    * {{{
@@ -1070,5 +1072,7 @@ sealed private[data] trait IorFunctions {
 
 sealed private[data] trait IorFunctions2 {
   def leftNec[A, B](a: A): IorNec[A, B] = Ior.left(NonEmptyChain.one(a))
+  def leftNev[A, B](a: A): IorNev[A, B] = Ior.left(NonEmptyVector.one(a))
   def bothNec[A, B](a: A, b: B): IorNec[A, B] = Ior.both(NonEmptyChain.one(a), b)
+  def bothNev[A, B](a: A, b: B): IorNev[A, B] = Ior.both(NonEmptyVector.one(a), b)
 }

--- a/core/src/main/scala/cats/data/package.scala
+++ b/core/src/main/scala/cats/data/package.scala
@@ -29,6 +29,7 @@ package object data extends ScalaVersionSpecificPackage {
   type IorNes[B, +A] = Ior[NonEmptySet[B], A]
   type EitherNel[+E, +A] = Either[NonEmptyList[E], A]
   type EitherNec[+E, +A] = Either[NonEmptyChain[E], A]
+  type EitherNev[+E, +A] = Either[NonEmptyVector[E], A]
   type EitherNes[E, +A] = Either[NonEmptySet[E], A]
   type ValidatedNec[+E, +A] = Validated[NonEmptyChain[E], A]
 

--- a/core/src/main/scala/cats/data/package.scala
+++ b/core/src/main/scala/cats/data/package.scala
@@ -24,14 +24,16 @@ package cats
 package object data extends ScalaVersionSpecificPackage {
 
   type ValidatedNel[+E, +A] = Validated[NonEmptyList[E], A]
+  type ValidatedNev[+E, +A] = Validated[NonEmptyVector[E], A]
+  type ValidatedNec[+E, +A] = Validated[NonEmptyChain[E], A]
   type IorNel[+B, +A] = Ior[NonEmptyList[B], A]
   type IorNec[+B, +A] = Ior[NonEmptyChain[B], A]
+  type IorNev[+B, +A] = Ior[NonEmptyVector[B], A]
   type IorNes[B, +A] = Ior[NonEmptySet[B], A]
   type EitherNel[+E, +A] = Either[NonEmptyList[E], A]
   type EitherNec[+E, +A] = Either[NonEmptyChain[E], A]
   type EitherNev[+E, +A] = Either[NonEmptyVector[E], A]
   type EitherNes[E, +A] = Either[NonEmptySet[E], A]
-  type ValidatedNec[+E, +A] = Validated[NonEmptyChain[E], A]
 
   type NonEmptyMap[K, +A] = NonEmptyMapImpl.Type[K, A]
   val NonEmptyMap = NonEmptyMapImpl

--- a/core/src/main/scala/cats/syntax/either.scala
+++ b/core/src/main/scala/cats/syntax/either.scala
@@ -160,6 +160,12 @@ final class EitherOps[A, B](private val eab: Either[A, B]) extends AnyVal {
       case Right(b) => Validated.valid(b)
     }
 
+  def toValidatedNev[AA >: A]: ValidatedNev[AA, B] =
+    eab match {
+      case Left(a)  => Validated.invalidNev(a)
+      case Right(b) => Validated.valid(b)
+    }
+
   def withValidated[AA, BB](f: Validated[A, B] => Validated[AA, BB]): Either[AA, BB] =
     f(toValidated).toEither
 

--- a/core/src/main/scala/cats/syntax/either.scala
+++ b/core/src/main/scala/cats/syntax/either.scala
@@ -337,6 +337,8 @@ final class EitherOps[A, B](private val eab: Either[A, B]) extends AnyVal {
 
   def toEitherNel[AA >: A]: EitherNel[AA, B] = leftMap(NonEmptyList.one)
 
+  def toEitherNev[AA >: A]: EitherNev[AA, B] = leftMap(NonEmptyVector.one)
+
   @deprecated("use liftTo instead", "2.0.0")
   def raiseOrPure[F[_]](implicit ev: ApplicativeError[F, A]): F[B] =
     ev.fromEither(eab)
@@ -363,6 +365,10 @@ final class EitherObjectOps(private val either: Either.type) extends AnyVal {
   def leftNec[A, B](a: A): EitherNec[A, B] = Left(NonEmptyChain.one(a))
 
   def rightNec[A, B](b: B): EitherNec[A, B] = Right(b)
+
+  def leftNev[A, B](a: A): EitherNev[A, B] = Left(NonEmptyVector.one(a))
+
+  def rightNev[A, B](b: B): EitherNev[A, B] = Right(b)
 
   def leftNes[A, B](a: A)(implicit O: Order[A]): EitherNes[A, B] = Left(NonEmptySet.one(a))
 

--- a/core/src/main/scala/cats/syntax/validated.scala
+++ b/core/src/main/scala/cats/syntax/validated.scala
@@ -22,7 +22,7 @@
 package cats
 package syntax
 
-import cats.data.{Validated, ValidatedNec, ValidatedNel}
+import cats.data.{Validated, ValidatedNec, ValidatedNel, ValidatedNev}
 
 trait ValidatedSyntax {
   implicit final def catsSyntaxValidatedId[A](a: A): ValidatedIdSyntax[A] = new ValidatedIdSyntax(a)
@@ -31,8 +31,10 @@ trait ValidatedSyntax {
 final class ValidatedIdSyntax[A](private val a: A) extends AnyVal {
   def valid[B]: Validated[B, A] = Validated.Valid(a)
   def validNel[B]: ValidatedNel[B, A] = Validated.Valid(a)
+  def validNev[B]: ValidatedNev[B, A] = Validated.Valid(a)
   def invalid[B]: Validated[A, B] = Validated.Invalid(a)
   def invalidNel[B]: ValidatedNel[A, B] = Validated.invalidNel(a)
+  def invalidNev[B]: ValidatedNev[A, B] = Validated.invalidNev(a)
 }
 
 trait ValidatedExtensionSyntax {

--- a/tests/shared/src/test/scala/cats/tests/EitherSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/EitherSuite.scala
@@ -22,12 +22,13 @@
 package cats.tests
 
 import cats._
-import cats.data.{EitherT, NonEmptyChain, NonEmptyList, NonEmptySet, Validated}
+import cats.data.{EitherT, NonEmptyChain, NonEmptyList, NonEmptySet, NonEmptyVector, Validated}
 import cats.kernel.laws.discipline.{EqTests, MonoidTests, OrderTests, PartialOrderTests, SemigroupTests}
 import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
 import cats.syntax.either._
+
 import scala.util.Try
 import cats.syntax.eq._
 import org.scalacheck.Prop._
@@ -175,11 +176,24 @@ class EitherSuite extends CatsSuite {
     }
   }
 
+  test("leftNev is consistent with left(NEC)") {
+    forAll { (s: String) =>
+      assert(Either.leftNev[String, Int](s) === (Either.left[NonEmptyVector[String], Int](NonEmptyVector.one(s))))
+    }
+  }
+
+  test("rightNev is consistent with right") {
+    forAll { (i: Int) =>
+      assert(Either.rightNev[String, Int](i) === (Either.right[NonEmptyVector[String], Int](i)))
+    }
+  }
+
   test("leftNes is consistent with left(NES)") {
     forAll { (s: String) =>
       assert(Either.leftNes[String, Int](s) === (Either.left[NonEmptySet[String], Int](NonEmptySet.one(s))))
     }
   }
+
   test("rightNes is consistent with right") {
     forAll { (i: Int) =>
       assert(Either.rightNes[String, Int](i) === (Either.right[NonEmptySet[String], Int](i)))
@@ -367,6 +381,16 @@ class EitherSuite extends CatsSuite {
   test("toEitherNel Right") {
     val either = Either.right[String, Int](42)
     assert(either.toEitherNel === (Either.right[NonEmptyList[String], Int](42)))
+  }
+
+  test("toEitherVec Left") {
+    val either = Either.left[String, Int]("oops")
+    assert(either.toEitherNev === (Either.left[NonEmptyVector[String], Int](NonEmptyVector.one("oops"))))
+  }
+
+  test("toEitherVec Right") {
+    val either = Either.right[String, Int](42)
+    assert(either.toEitherNev === (Either.right[NonEmptyVector[String], Int](42)))
   }
 
   test("ap consistent with Applicative") {

--- a/tests/shared/src/test/scala/cats/tests/EitherTSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/EitherTSuite.scala
@@ -212,6 +212,12 @@ class EitherTSuite extends CatsSuite {
     }
   }
 
+  test("toValidatedNev") {
+    forAll { (eithert: EitherT[List, String, Int]) =>
+      assert(eithert.toValidatedNev.map(_.toEither.leftMap(_.head)) === (eithert.value))
+    }
+  }
+
   test("toValidatedNec") {
     forAll { (eithert: EitherT[List, String, Int]) =>
       assert(eithert.toValidatedNec.map(_.toEither.leftMap(_.head)) === (eithert.value))
@@ -233,6 +239,12 @@ class EitherTSuite extends CatsSuite {
   test("toNestedValidatedNel") {
     forAll { (eithert: EitherT[List, String, Int]) =>
       assert(eithert.toNestedValidatedNel.value === (eithert.value.map(_.toValidatedNel)))
+    }
+  }
+
+  test("toNestedValidatedNev") {
+    forAll { (eithert: EitherT[List, String, Int]) =>
+      assert(eithert.toNestedValidatedNev.value === (eithert.value.map(_.toValidatedNev)))
     }
   }
 

--- a/tests/shared/src/test/scala/cats/tests/IorSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/IorSuite.scala
@@ -22,7 +22,7 @@
 package cats.tests
 
 import cats.{Bitraverse, MonadError, Semigroupal, Show, Traverse}
-import cats.data.{EitherT, Ior, NonEmptyChain, NonEmptyList, NonEmptySet}
+import cats.data.{EitherT, Ior, NonEmptyChain, NonEmptyList, NonEmptySet, NonEmptyVector}
 import cats.kernel.{Eq, Semigroup}
 import cats.kernel.laws.discipline.{OrderTests, SemigroupTests}
 import cats.laws.discipline.{
@@ -299,6 +299,19 @@ class IorSuite extends CatsSuite {
     assert(ior.toIorNec === (Ior.both[NonEmptyChain[String], Int](NonEmptyChain.one("oops"), 42)))
   }
 
+  test("toIorNev Left") {
+    val ior = Ior.left[String, Int]("oops")
+    assert(ior.toIorNev === (Ior.left[NonEmptyVector[String], Int](NonEmptyVector.one("oops"))))
+  }
+  test("toIorNev Right") {
+    val ior = Ior.right[String, Int](42)
+    assert(ior.toIorNev === (Ior.right[NonEmptyVector[String], Int](42)))
+  }
+  test("toIorNev Both") {
+    val ior = Ior.both[String, Int]("oops", 42)
+    assert(ior.toIorNev === (Ior.both[NonEmptyVector[String], Int](NonEmptyVector.one("oops"), 42)))
+  }
+
   test("toIorNes Left") {
     val ior = Ior.left[String, Int]("oops")
     assert(ior.toIorNes === (Ior.left[NonEmptySet[String], Int](NonEmptySet.one("oops"))))
@@ -339,9 +352,21 @@ class IorSuite extends CatsSuite {
     }
   }
 
+  test("leftNev") {
+    forAll { (x: String) =>
+      assert(Ior.leftNev(x).left === (Some(NonEmptyVector.one(x))))
+    }
+  }
+
   test("bothNel") {
     forAll { (x: Int, y: String) =>
       assert(Ior.bothNel(y, x).onlyBoth === (Some((NonEmptyList.one(y), x))))
+    }
+  }
+
+  test("bothNev") {
+    forAll { (x: Int, y: String) =>
+      assert(Ior.bothNev(y, x).onlyBoth === (Some((NonEmptyVector.one(y), x))))
     }
   }
 

--- a/tests/shared/src/test/scala/cats/tests/ValidatedSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/ValidatedSuite.scala
@@ -32,7 +32,7 @@ import cats.{
   Show,
   Traverse
 }
-import cats.data.{EitherT, Ior, NonEmptyChain, NonEmptyList, Validated, ValidatedNel}
+import cats.data.{EitherT, Ior, NonEmptyChain, NonEmptyList, NonEmptyVector, Validated, ValidatedNel, ValidatedNev}
 import cats.data.Validated.{Invalid, Valid}
 import cats.kernel.{Eq, Order, PartialOrder, Semigroup}
 import cats.kernel.laws.discipline.{EqTests, MonoidTests, OrderTests, PartialOrderTests, SemigroupTests}
@@ -44,6 +44,7 @@ import cats.syntax.apply._
 import cats.syntax.either._
 import cats.syntax.validated._
 import org.scalacheck.Arbitrary._
+
 import scala.util.Try
 import cats.syntax.eq._
 import org.scalacheck.Prop._
@@ -351,6 +352,12 @@ class ValidatedSuite extends CatsSuite {
   test("condNel consistent with Either.cond + toValidatedNel") {
     forAll { (cond: Boolean, s: String, i: Int) =>
       assert(Validated.condNel(cond, s, i) === (Either.cond(cond, s, i).toValidatedNel))
+    }
+  }
+
+  test("condNev consistent with Either.cond + toValidatedNev") {
+    forAll { (cond: Boolean, s: String, i: Int) =>
+      assert(Validated.condNev(cond, s, i) === (Either.cond(cond, s, i).toValidatedNev))
     }
   }
 


### PR DESCRIPTION
I'm using Vector a lot in my 2.13.7 codebase since it's one of the best collections right now and we either need to have those aliases in the business code or convert to List/Chanin in order to use cats' syntax. 
After asking if it exists somewhere @armanbilge [said](https://discord.com/channels/632277896739946517/632278570512678923/1012020048371662890) we can add it to cats.