### PR TITLE
Added `Align` instances for `Id` and `Kleisli`

### DIFF
--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -415,11 +415,11 @@ sealed abstract private[data] class KleisliInstances0_5 extends KleisliInstances
     }
 
   implicit def catsDataAlignForKleisli[F[_], R](implicit
-    evAlign: Align[F],
-    evFunctor: Functor[Kleisli[F, R, *]]
+    evFunctor: Functor[Kleisli[F, R, *]],
+    evAlign: Align[F]
   ): Align[Kleisli[F, R, *]] = new KleisliAlign[F, R] {
-    implicit val functor: Functor[Kleisli[F, R, *]] = evFunctor
-    implicit val FA: Align[F] = evAlign
+    override val functor: Functor[Kleisli[F, R, *]] = evFunctor
+    override val FA: Align[F] = evAlign
   }
 }
 
@@ -727,8 +727,7 @@ private trait KleisliDistributive[F[_], R] extends Distributive[Kleisli[F, R, *]
 }
 
 private trait KleisliAlign[F[_], R] extends Align[Kleisli[F, R, *]] {
-  implicit def functor: Functor[Kleisli[F, R, *]]
-  implicit def FA: Align[F]
+  def FA: Align[F]
 
   override def align[A, B](fa: Kleisli[F, R, A], fb: Kleisli[F, R, B]): Kleisli[F, R, Ior[A, B]] =
     Kleisli(r => FA.align(fa.run(r), fb.run(r)))

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -20,6 +20,7 @@
  */
 
 import scala.annotation.tailrec
+import cats.data.Ior
 
 /**
  * The `cats` root package contains all the trait signatures of most Scala type classes.
@@ -149,6 +150,13 @@ package object cats {
     override def tabulate[A](f: Unit => A): Id[A] = f(())
 
     override def index[A](f: Id[A]): Unit => A = (_: Unit) => f
+  }
+
+  implicit val catsAlignForId: Align[Id] = new Align[Id] {
+    override val functor: Functor[Id] = catsInstancesForId
+
+    override def align[A, B](fa: Id[A], fb: Id[B]): Id[Ior[A, B]] = Ior.both(fa, fb)
+
   }
 
   implicit val catsParallelForId: Parallel.Aux[Id, Id] = Parallel.identity

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -153,7 +153,7 @@ package object cats {
   }
 
   implicit val catsAlignForId: Align[Id] = new Align[Id] {
-    override val functor: Functor[Id] = catsInstancesForId
+    override val functor: Functor[Id] = Functor[Id]
 
     override def align[A, B](fa: Id[A], fb: Id[B]): Id[Ior[A, B]] = Ior.both(fa, fb)
 

--- a/tests/shared/src/test/scala/cats/tests/IdSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/IdSuite.scala
@@ -22,10 +22,12 @@
 package cats.tests
 
 import cats.laws.discipline._
+import cats.laws.discipline.arbitrary._
 import cats.syntax.applicative._
 import cats.syntax.eq._
 import cats.{Bimonad, CommutativeMonad, Id, Reducible, Semigroupal, Traverse}
 import org.scalacheck.Prop._
+import cats.Align
 
 class IdSuite extends CatsSuite {
   implicit val iso: SemigroupalTests.Isomorphisms[Id] =
@@ -42,6 +44,9 @@ class IdSuite extends CatsSuite {
 
   checkAll("Id[Int]", ReducibleTests[Id].reducible[Option, Int, Int])
   checkAll("Reducible[Id]", SerializableTests.serializable(Reducible[Id]))
+
+  checkAll("Id[Int]", AlignTests[Id].align[Int, Int, Int, Int])
+  checkAll("Align[Id]", SerializableTests.serializable(Align[Id]))
 
   test("Id#apply") {
     forAll { (i: Int) =>

--- a/tests/shared/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/KleisliSuite.scala
@@ -89,7 +89,10 @@ class KleisliSuite extends CatsSuite {
            SerializableTests.serializable(CommutativeMonad[Kleisli[Id, Int, *]])
   )
 
-  checkAll("Kleisli[Id, MiniInt, *]", AlignTests[Kleisli[Id, MiniInt, *]].align[Int, Int, Int, Int])
+  {
+    implicit val K: Align[Kleisli[Id, MiniInt, *]] = Kleisli.catsDataAlignForKleisli[Id, MiniInt]
+    checkAll("Kleisli[Id, MiniInt, *]", AlignTests[Kleisli[Id, MiniInt, *]].align[Int, Int, Int, Int])
+  }
   checkAll("Kleisli[Option, MiniInt, *]", AlignTests[Kleisli[Option, MiniInt, *]].align[Int, Int, Int, Int])
 
   checkAll("Kleisli[List, *, *]",

--- a/tests/shared/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/KleisliSuite.scala
@@ -89,6 +89,9 @@ class KleisliSuite extends CatsSuite {
            SerializableTests.serializable(CommutativeMonad[Kleisli[Id, Int, *]])
   )
 
+  checkAll("Kleisli[Id, MiniInt, *]", AlignTests[Kleisli[Id, MiniInt, *]].align[Int, Int, Int, Int])
+  checkAll("Kleisli[Option, MiniInt, *]", AlignTests[Kleisli[Option, MiniInt, *]].align[Int, Int, Int, Int])
+
   checkAll("Kleisli[List, *, *]",
            ArrowTests[Kleisli[List, *, *]].arrow[MiniInt, MiniInt, MiniInt, MiniInt, MiniInt, Boolean]
   )


### PR DESCRIPTION
This PR adds Align instances for Kleisli and Id.

I realized these two were not available while trying some code like (simplified):

```scala
type Env = Map[String, String]
type FromEnvPrefixed[A] = Reader[Env, A]

def prefixed(prefix: String): Reader[Env, Map[String, String]] = {
   Reader { (env: Env) => 
      env.filter(_._1.startsWith(prefix)).foldLeft(Map.empty[String, String]) { case (acc, (k, v)) =>
            val tKey = k.replace(prefix, "")
            acc + (tKey, v)
      }
   }
}

val inConfig = prefixed("label").align(prefixed("label2")).value.run(Map("labelprop1" -> "prop1", "label2prop1" -> "prop1", "labelprop2" -> "prop2")

inConfig.toList.traverse {
   case (k, Ior.Both(one, two)) => Right(k -> (one, two)) //Yeah!!
   case (k, _) => Left(s"Missing property for key '$k'") //Missing for one of the prefixes
}
```

Looking at docs and laws I see no reason why they shouldn't have it. Please let me know otherwise.
