### PR TITLE
Fix list formatting in docs / site

### DIFF
--- a/docs/datatypes/statet.md
+++ b/docs/datatypes/statet.md
@@ -8,6 +8,7 @@ capable of error handling via `MonadThrow[F]`, then Cats derives an
 instance of `MonadThrow[StateT[F, S, *]]`.
 
 The type parameters are:
+
 - `F[_]` represents the effect in which the computation is performed.
 - `S` represents the underlying state, shared between each step of the
   state machine.

--- a/docs/typeclasses/arrow.md
+++ b/docs/typeclasses/arrow.md
@@ -3,6 +3,7 @@
 `Arrow` is a type class for modeling composable relationships between two types. One example of such a composable relationship is function `A => B`; other examples include `cats.data.Kleisli`(wrapping an `A => F[B]`, also known as `ReaderT`), and `cats.data.Cokleisli`(wrapping an `F[A] => B`). These type constructors all have `Arrow` instances. An arrow `F[A, B]` can be thought of as representing a computation from `A` to `B` with some context, just like a functor/applicative/monad `F[A]` represents a value `A` with some context.
 
 Having an `Arrow` instance for a type constructor `F[_, _]` means that an `F[_, _]` can be composed and combined with other `F[_, _]`s. You will be able to do things like:
+
 - Lifting a function `ab: A => B` into arrow `F[A, B]` with `Arrow[F].lift(ab)`. If `F` is `Function1` then `A => B` is the same as `F[A, B]` so `lift` is just the identity function.
 - Composing `fab: F[A, B]` and `fbc: F[B, C]` into `fac: F[A, C]` with `Arrow[F].compose(fbc, fab)`, or `fab >>> fbc`. If `F` is `Function1` then `>>>` becomes an alias for `andThen`.
 - Taking two arrows `fab: F[A, B]` and `fcd: F[C, D]` and combining them into `F[(A, C), (B, D)]` with `fab.split(fcd)` or `fab *** fcd`. The resulting arrow takes two inputs and processes them with two arrows, one for each input.


### PR DESCRIPTION
This PR adds the needed blank newline before lists in the markdown of our docs.

At time of writing the list formatting is currently broken in [Arrow](https://typelevel.org/cats/typeclasses/arrow.html) and [StateT](https://typelevel.org/cats/datatypes/statet.html) docs:
<img width="780" alt="broken-list-formatting" src="https://user-images.githubusercontent.com/5440389/188868409-c6bbfcf1-6149-4b4c-9a76-7b8dab2e041e.png">


After this the list formatting should take effect and look like this:
<img width="799" alt="fixed-list-formatting" src="https://user-images.githubusercontent.com/5440389/188867981-b36f5e6e-c1d6-41ba-9c5c-07a9073db369.png">
