### PR TITLE
Add `EitherT#biSemiflatTap` which combines `leftSemiflatTap` and `semiflatTap`

### DIFF
--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -513,6 +513,14 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
   def leftSemiflatTap[C](f: A => F[C])(implicit F: Monad[F]): EitherT[F, A, B] =
     leftSemiflatMap(a => F.as(f(a), a))
 
+  def biSemiflatTap[C, D](fa: A => F[C], fb: B => F[D])(implicit F: FlatMap[F]): EitherT[F, A, B] =
+    EitherT(F.flatMap(value) {
+      case l @ Left(a) =>
+        F.as(fa(a), l)
+      case r @ Right(b) =>
+        F.as(fb(b), r)
+    })
+
   def compare(that: EitherT[F, A, B])(implicit o: Order[F[Either[A, B]]]): Int =
     o.compare(value, that.value)
 

--- a/tests/shared/src/test/scala/cats/tests/EitherTSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/EitherTSuite.scala
@@ -655,6 +655,33 @@ class EitherTSuite extends CatsSuite {
     }
   }
 
+  test("biSemiflatTap does not change the return value") {
+    type TestEffect[A] = State[List[Int], A]
+    forAll {
+      (eithert: EitherT[TestEffect, String, Int],
+       fa: String => TestEffect[Int],
+       fb: Int => TestEffect[Int],
+       initial: List[Int]
+      ) =>
+        assert(eithert.biSemiflatTap(v => fa(v), v => fb(v)).value.runA(initial) === eithert.value.runA(initial))
+    }
+  }
+
+  test("biSemiflatTap consistent with leftSemiflatTap and semiFlatTap") {
+    type TestEffect[A] = State[List[Int], A]
+    forAll {
+      (eithert: EitherT[TestEffect, String, Int],
+       fa: String => TestEffect[Int],
+       fb: Int => TestEffect[Int],
+       initial: List[Int]
+      ) =>
+        assert(
+          eithert.biSemiflatTap(fa, fb).value.runS(initial) ===
+            eithert.leftSemiflatTap(fa).semiflatTap(fb).value.runS(initial)
+        )
+    }
+  }
+
   test("biSemiflatMap consistent with leftSemiflatMap and semiFlatmap") {
     forAll { (eithert: EitherT[List, String, Int], fa: String => List[Int], fb: Int => List[String]) =>
       assert(eithert.biSemiflatMap(fa, fb) === (eithert.leftSemiflatMap(fa).semiflatMap(fb)))


### PR DESCRIPTION
Mostly a ergonomics style PR 😄 

I did notice some chatter around not wrapping/unwrapping so much because this method could be reduced to chaining `semiflatTap ` + `leftSemiflatTap`. Doesn't make too much of a difference to me either way if you guys want me to change it to chaining. 

Fixes https://github.com/typelevel/cats/issues/4292