### PR TITLE
Don't require `Order` for the value on `Cogen` for `SortedMap` and `NonEmptyMap`

### DIFF
--- a/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
@@ -140,7 +140,7 @@ object arbitrary extends ArbitraryInstances0 with ScalaVersionSpecific.Arbitrary
     implicit val cogenK: Cogen[K] = kCogen
     implicit val cogenA: Cogen[A] = aCogen
 
-    Cogen[SortedMap[K, A]].contramap(_.toSortedMap)
+    cogenNonEmptyMap[K, A]
   }
 
   implicit def cogenNonEmptyMap[K: Order: Cogen, A: Cogen]: Cogen[NonEmptyMap[K, A]] =
@@ -296,21 +296,21 @@ object arbitrary extends ArbitraryInstances0 with ScalaVersionSpecific.Arbitrary
   implicit def catsLawsArbitraryForOrder[A: Arbitrary]: Arbitrary[Order[A]] =
     Arbitrary(getArbitrary[Int => Int].map(f => Order.by(x => f(x.##))))
 
+  implicit def catsLawsArbitraryForSortedMap[K: Arbitrary: Order, V: Arbitrary]: Arbitrary[SortedMap[K, V]] =
+    Arbitrary(getArbitrary[Map[K, V]].map(s => SortedMap.empty[K, V](implicitly[Order[K]].toOrdering) ++ s))
+
   @deprecated("Preserved for bincompat", "2.9.0")
   def catsLawsCogenForSortedMap[K, V](kOrder: Order[K],
                                       kCogen: Cogen[K],
                                       vOrder: Order[V],
                                       vCogen: Cogen[V]
   ): Cogen[SortedMap[K, V]] = {
-    implicit val orderingK: Ordering[K] = kOrder.toOrdering
+    implicit val orderingK: Order[K] = kOrder
     implicit val cogenK: Cogen[K] = kCogen
     implicit val cogenA: Cogen[V] = vCogen
 
-    implicitly[Cogen[Map[K, V]]].contramap(_.toMap)
+    catsLawsCogenForSortedMap[K, V]
   }
-
-  implicit def catsLawsArbitraryForSortedMap[K: Arbitrary: Order, V: Arbitrary]: Arbitrary[SortedMap[K, V]] =
-    Arbitrary(getArbitrary[Map[K, V]].map(s => SortedMap.empty[K, V](implicitly[Order[K]].toOrdering) ++ s))
 
   implicit def catsLawsCogenForSortedMap[K: Order: Cogen, V: Cogen]: Cogen[SortedMap[K, V]] = {
     implicit val orderingK: Ordering[K] = Order[K].toOrdering

--- a/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
@@ -130,6 +130,19 @@ object arbitrary extends ArbitraryInstances0 with ScalaVersionSpecific.Arbitrary
       a <- A.arbitrary
     } yield NonEmptyMap((k, a), fa))
 
+  @deprecated("Preserved for bincompat", "2.9.0")
+  def cogenNonEmptyMap[K, A](kOrder: Order[K],
+                             kCogen: Cogen[K],
+                             aOrder: Order[A],
+                             aCogen: Cogen[A]
+  ): Cogen[NonEmptyMap[K, A]] = {
+    implicit val orderingK: Order[K] = kOrder
+    implicit val cogenK: Cogen[K] = kCogen
+    implicit val cogenA: Cogen[A] = aCogen
+
+    Cogen[SortedMap[K, A]].contramap(_.toSortedMap)
+  }
+
   implicit def cogenNonEmptyMap[K: Order: Cogen, A: Cogen]: Cogen[NonEmptyMap[K, A]] =
     Cogen[SortedMap[K, A]].contramap(_.toSortedMap)
 
@@ -282,6 +295,19 @@ object arbitrary extends ArbitraryInstances0 with ScalaVersionSpecific.Arbitrary
 
   implicit def catsLawsArbitraryForOrder[A: Arbitrary]: Arbitrary[Order[A]] =
     Arbitrary(getArbitrary[Int => Int].map(f => Order.by(x => f(x.##))))
+
+  @deprecated("Preserved for bincompat", "2.9.0")
+  def catsLawsCogenForSortedMap[K, V](kOrder: Order[K],
+                                      kCogen: Cogen[K],
+                                      vOrder: Order[V],
+                                      vCogen: Cogen[V]
+  ): Cogen[SortedMap[K, V]] = {
+    implicit val orderingK: Ordering[K] = kOrder.toOrdering
+    implicit val cogenK: Cogen[K] = kCogen
+    implicit val cogenA: Cogen[V] = vCogen
+
+    implicitly[Cogen[Map[K, V]]].contramap(_.toMap)
+  }
 
   implicit def catsLawsArbitraryForSortedMap[K: Arbitrary: Order, V: Arbitrary]: Arbitrary[SortedMap[K, V]] =
     Arbitrary(getArbitrary[Map[K, V]].map(s => SortedMap.empty[K, V](implicitly[Order[K]].toOrdering) ++ s))

--- a/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
@@ -130,7 +130,7 @@ object arbitrary extends ArbitraryInstances0 with ScalaVersionSpecific.Arbitrary
       a <- A.arbitrary
     } yield NonEmptyMap((k, a), fa))
 
-  implicit def cogenNonEmptyMap[K: Order: Cogen, A: Order: Cogen]: Cogen[NonEmptyMap[K, A]] =
+  implicit def cogenNonEmptyMap[K: Order: Cogen, A: Cogen]: Cogen[NonEmptyMap[K, A]] =
     Cogen[SortedMap[K, A]].contramap(_.toSortedMap)
 
   implicit def catsLawsArbitraryForEitherT[F[_], A, B](implicit
@@ -286,9 +286,8 @@ object arbitrary extends ArbitraryInstances0 with ScalaVersionSpecific.Arbitrary
   implicit def catsLawsArbitraryForSortedMap[K: Arbitrary: Order, V: Arbitrary]: Arbitrary[SortedMap[K, V]] =
     Arbitrary(getArbitrary[Map[K, V]].map(s => SortedMap.empty[K, V](implicitly[Order[K]].toOrdering) ++ s))
 
-  implicit def catsLawsCogenForSortedMap[K: Order: Cogen, V: Order: Cogen]: Cogen[SortedMap[K, V]] = {
+  implicit def catsLawsCogenForSortedMap[K: Order: Cogen, V: Cogen]: Cogen[SortedMap[K, V]] = {
     implicit val orderingK: Ordering[K] = Order[K].toOrdering
-    implicit val orderingV: Ordering[V] = Order[V].toOrdering
 
     implicitly[Cogen[Map[K, V]]].contramap(_.toMap)
   }


### PR DESCRIPTION
It seems we don't need to require an `Order` instance for `Cogen` of `SortedMap` and `NonEmptyMap`. We only need it for the keys

Fixes https://github.com/typelevel/cats/issues/4295