### PR TITLE
Avoid allocations for `Monoid` instances where possible

### DIFF
--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -1197,11 +1197,7 @@ object Chain extends ChainInstances with ChainCompanionCompat {
 }
 
 sealed abstract private[data] class ChainInstances extends ChainInstances1 {
-  implicit def catsDataMonoidForChain[A]: Monoid[Chain[A]] =
-    new Monoid[Chain[A]] {
-      def empty: Chain[A] = Chain.nil
-      def combine(c: Chain[A], c2: Chain[A]): Chain[A] = Chain.concat(c, c2)
-    }
+  implicit def catsDataMonoidForChain[A]: Monoid[Chain[A]] = ChainMonoid[A]
 
   implicit val catsDataInstancesForChain
     : Traverse[Chain] with Alternative[Chain] with Monad[Chain] with CoflatMap[Chain] with Align[Chain] =
@@ -1415,4 +1411,14 @@ private[data] trait ChainPartialOrder[A] extends PartialOrder[Chain[A]] {
     }
 
   override def eqv(x: Chain[A], y: Chain[A]): Boolean = x === y
+}
+
+private[data] object ChainMonoid {
+  private val singleton: Monoid[Chain[Any]] = new Monoid[Chain[Any]] {
+    def empty: Chain[Any] = Chain.nil
+
+    def combine(c: Chain[Any], c2: Chain[Any]): Chain[Any] = Chain.concat(c, c2)
+  }
+
+  def apply[A]: Monoid[Chain[A]] = singleton.asInstanceOf[Monoid[Chain[A]]]
 }

--- a/kernel/src/main/scala-2.13+/cats/kernel/instances/LazyListInstances.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/instances/LazyListInstances.scala
@@ -22,11 +22,14 @@
 package cats.kernel
 package instances
 
+import scala.annotation.nowarn
+
 trait LazyListInstances extends LazyListInstances1 {
   implicit def catsKernelStdOrderForLazyList[A: Order]: Order[LazyList[A]] =
     new LazyListOrder[A]
+
   implicit def catsKernelStdMonoidForLazyList[A]: Monoid[LazyList[A]] =
-    new LazyListMonoid[A]
+    LazyListMonoid[A]
 }
 
 private[instances] trait LazyListInstances1 extends LazyListInstances2 {
@@ -64,6 +67,7 @@ class LazyListEq[A](implicit ev: Eq[A]) extends Eq[LazyList[A]] {
     else StaticMethods.iteratorEq(xs.iterator, ys.iterator)
 }
 
+@deprecated("Use LazyListMonoid.apply, which does not allocate a new instance", "2.9.0")
 class LazyListMonoid[A] extends Monoid[LazyList[A]] {
   def empty: LazyList[A] = LazyList.empty
   def combine(x: LazyList[A], y: LazyList[A]): LazyList[A] = x ++ y
@@ -72,4 +76,10 @@ class LazyListMonoid[A] extends Monoid[LazyList[A]] {
 
   override def combineAll(xs: IterableOnce[LazyList[A]]): LazyList[A] =
     StaticMethods.combineAllIterable(LazyList.newBuilder[A], xs)
+}
+
+object LazyListMonoid {
+  @nowarn("msg=deprecated")
+  private val singleton: Monoid[LazyList[Any]] = new LazyListMonoid[Any]
+  def apply[A]: Monoid[LazyList[A]] = singleton.asInstanceOf[Monoid[LazyList[A]]]
 }

--- a/kernel/src/main/scala/cats/kernel/instances/ListInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/ListInstances.scala
@@ -22,15 +22,16 @@
 package cats.kernel
 package instances
 
-import scala.annotation.tailrec
+import scala.annotation.{nowarn, tailrec}
 import compat.scalaVersionSpecific._
 
 @suppressUnusedImportWarningForScalaVersionSpecific
 trait ListInstances extends ListInstances1 {
   implicit def catsKernelStdOrderForList[A: Order]: Order[List[A]] =
     new ListOrder[A]
+
   implicit def catsKernelStdMonoidForList[A]: Monoid[List[A]] =
-    new ListMonoid[A]
+    ListMonoid[A]
 }
 
 private[instances] trait ListInstances1 extends ListInstances2 {
@@ -104,6 +105,7 @@ class ListEq[A](implicit ev: Eq[A]) extends Eq[List[A]] {
   }
 }
 
+@deprecated("Use ListMonoid.apply, which does not allocate a new instance", "2.9.0")
 class ListMonoid[A] extends Monoid[List[A]] { self =>
   def empty: List[A] = Nil
   def combine(x: List[A], y: List[A]): List[A] = x ::: y
@@ -126,4 +128,10 @@ class ListMonoid[A] extends Monoid[List[A]] { self =>
 
       override def reverse = self
     }
+}
+
+object ListMonoid {
+  @nowarn("msg=deprecated")
+  private val singleton: Monoid[List[Any]] = new ListMonoid[Any]
+  def apply[A]: Monoid[List[A]] = singleton.asInstanceOf[Monoid[List[A]]]
 }

--- a/kernel/src/main/scala/cats/kernel/instances/QueueInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/QueueInstances.scala
@@ -25,12 +25,13 @@ package instances
 import scala.collection.immutable.Queue
 import compat.scalaVersionSpecific._
 
+import scala.annotation.nowarn
+
 @suppressUnusedImportWarningForScalaVersionSpecific
 trait QueueInstances extends QueueInstances1 {
   implicit def catsKernelStdOrderForQueue[A: Order]: Order[Queue[A]] =
     new QueueOrder[A]
-  implicit def catsKernelStdMonoidForQueue[A]: Monoid[Queue[A]] =
-    new QueueMonoid[A]
+  implicit def catsKernelStdMonoidForQueue[A]: Monoid[Queue[A]] = QueueMonoid[A]
 }
 
 private[instances] trait QueueInstances1 extends QueueInstances2 {
@@ -68,6 +69,7 @@ class QueueEq[A](implicit ev: Eq[A]) extends Eq[Queue[A]] {
     else StaticMethods.iteratorEq(xs.iterator, ys.iterator)
 }
 
+@deprecated("Use QueueMonoid.apply, which does not allocate a new instance", "2.9.0")
 class QueueMonoid[A] extends Monoid[Queue[A]] {
   def empty: Queue[A] = Queue.empty[A]
   def combine(x: Queue[A], y: Queue[A]): Queue[A] = x ++ y
@@ -77,4 +79,11 @@ class QueueMonoid[A] extends Monoid[Queue[A]] {
 
   override def combineAll(xs: IterableOnce[Queue[A]]): Queue[A] =
     StaticMethods.combineAllIterable(Queue.newBuilder[A], xs)
+}
+
+object QueueMonoid {
+  @nowarn("msg=deprecated")
+  private val singleton: Monoid[Queue[Any]] = new QueueMonoid[Any]
+
+  def apply[A]: Monoid[Queue[A]] = singleton.asInstanceOf[Monoid[Queue[A]]]
 }

--- a/kernel/src/main/scala/cats/kernel/instances/SeqInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/SeqInstances.scala
@@ -23,6 +23,8 @@ package cats.kernel
 package instances
 
 import compat.scalaVersionSpecific._
+
+import scala.annotation.nowarn
 import scala.collection.immutable.Seq
 
 @suppressUnusedImportWarningForScalaVersionSpecific
@@ -30,7 +32,7 @@ trait SeqInstances extends SeqInstances1 {
   implicit def catsKernelStdOrderForSeq[A: Order]: Order[Seq[A]] =
     new SeqOrder[A]
   implicit def catsKernelStdMonoidForSeq[A]: Monoid[Seq[A]] =
-    new SeqMonoid[A]
+    SeqMonoid[A]
 }
 
 private[instances] trait SeqInstances1 extends SeqInstances2 {
@@ -68,6 +70,7 @@ class SeqEq[A](implicit ev: Eq[A]) extends Eq[Seq[A]] {
     else StaticMethods.iteratorEq(xs.iterator, ys.iterator)
 }
 
+@deprecated("Use SeqMonoid.apply, which does not allocate a new instance", "2.9.0")
 class SeqMonoid[A] extends Monoid[Seq[A]] {
   def empty: Seq[A] = Seq.empty
   def combine(x: Seq[A], y: Seq[A]): Seq[A] = x ++ y
@@ -77,4 +80,10 @@ class SeqMonoid[A] extends Monoid[Seq[A]] {
 
   override def combineAll(xs: IterableOnce[Seq[A]]): Seq[A] =
     StaticMethods.combineAllIterable(Seq.newBuilder[A], xs)
+}
+
+object SeqMonoid {
+  @nowarn("msg=deprecated")
+  private val singleton: Monoid[Seq[Any]] = new SeqMonoid[Any]
+  def apply[A]: SeqMonoid[A] = singleton.asInstanceOf[SeqMonoid[A]]
 }

--- a/kernel/src/main/scala/cats/kernel/instances/VectorInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/VectorInstances.scala
@@ -23,12 +23,14 @@ package cats.kernel
 package instances
 import compat.scalaVersionSpecific._
 
+import scala.annotation.nowarn
+
 @suppressUnusedImportWarningForScalaVersionSpecific
 trait VectorInstances extends VectorInstances1 {
   implicit def catsKernelStdOrderForVector[A: Order]: Order[Vector[A]] =
     new VectorOrder[A]
   implicit def catsKernelStdMonoidForVector[A]: Monoid[Vector[A]] =
-    new VectorMonoid[A]
+    VectorMonoid[A]
 }
 
 private[instances] trait VectorInstances1 extends VectorInstances2 {
@@ -66,6 +68,7 @@ class VectorEq[A](implicit ev: Eq[A]) extends Eq[Vector[A]] {
     else StaticMethods.iteratorEq(xs.iterator, ys.iterator)
 }
 
+@deprecated("Use VectorMonoid.apply, which does not allocate a new instance", "2.9.0")
 class VectorMonoid[A] extends Monoid[Vector[A]] {
   def empty: Vector[A] = Vector.empty
   def combine(x: Vector[A], y: Vector[A]): Vector[A] = x ++ y
@@ -75,4 +78,11 @@ class VectorMonoid[A] extends Monoid[Vector[A]] {
 
   override def combineAll(xs: IterableOnce[Vector[A]]): Vector[A] =
     StaticMethods.combineAllIterable(Vector.newBuilder[A], xs)
+}
+
+object VectorMonoid {
+  @nowarn("msg=deprecated")
+  private val singleton: Monoid[Vector[Any]] = new VectorMonoid[Any]
+
+  def apply[A]: Monoid[Vector[A]] = singleton.asInstanceOf[Monoid[Vector[A]]]
 }


### PR DESCRIPTION
Prompted by https://github.com/http4s/http4s/pull/6712, which locally caches a particular `Monoid[List[*]]` instance - the issue is a generic one so it seems better to apply this optimisation here.

There are other cases where this kind of change could be made too but I wanted to get feedback before doing any more work on it.