### PR TITLE
Recreated compat as a package object in scala_3 to make the artifact usable from scala 2

### DIFF
--- a/core/src/main/scala-3/src/main/scala/cats/compat/package.scala
+++ b/core/src/main/scala-3/src/main/scala/cats/compat/package.scala
@@ -19,6 +19,8 @@
  * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
  */
 
-package cats.compat
+package cats
 
-private[cats] type targetName = scala.annotation.targetName
+package object compat {
+  private[cats] type targetName = scala.annotation.targetName
+}

--- a/mima.sbt
+++ b/mima.sbt
@@ -145,7 +145,7 @@ ThisBuild / mimaBinaryIssueFilters ++= {
       exclude[ReversedAbstractMethodProblem]("cats.free.ContravariantCoyoneda.k"),
       exclude[DirectAbstractMethodProblem]("cats.free.Coyoneda.k"),
       exclude[ReversedAbstractMethodProblem]("cats.free.Coyoneda.k")
-    ) ++ // https://github.com/typelevel/cats/issues/4304
+    ) ++ // https://github.com/typelevel/cats/pull/4315
     Seq(
       exclude[MissingClassProblem]("cats.compat.compat$package"),
       exclude[MissingClassProblem]("cats.compat.compat$package$")

--- a/mima.sbt
+++ b/mima.sbt
@@ -145,6 +145,10 @@ ThisBuild / mimaBinaryIssueFilters ++= {
       exclude[ReversedAbstractMethodProblem]("cats.free.ContravariantCoyoneda.k"),
       exclude[DirectAbstractMethodProblem]("cats.free.Coyoneda.k"),
       exclude[ReversedAbstractMethodProblem]("cats.free.Coyoneda.k")
+    ) ++ // https://github.com/typelevel/cats/issues/4304
+    Seq(
+      exclude[MissingClassProblem]("cats.compat.compat$package"),
+      exclude[MissingClassProblem]("cats.compat.compat$package$")
     )
 }
 


### PR DESCRIPTION
Hello! This should address #4304 in a bincompat way. Thanks to @bishabosha for the suggestion in https://github.com/typelevel/cats/issues/4304#issuecomment-1266562018

It was tested publishing the dep locally using the same scala-cli script mentioned in the issue

```scala
//> using scala "2.13.8"

//> using option "-Ytasty-reader"

//> using lib "org.typelevel:cats-core_3:2.8.0"

import cats.syntax.all._

object Main extends App {

}
```