### PR TITLE
Fix ambiguous `contains_` syntax

### DIFF
--- a/core/src/main/scala/cats/syntax/foldable.scala
+++ b/core/src/main/scala/cats/syntax/foldable.scala
@@ -27,7 +27,11 @@ trait FoldableSyntax extends Foldable.ToFoldableOps with UnorderedFoldable.ToUno
   implicit final def catsSyntaxNestedFoldable[F[_]: Foldable, G[_], A](fga: F[G[A]]): NestedFoldableOps[F, G, A] =
     new NestedFoldableOps[F, G, A](fga)
 
-  implicit final def catsSyntaxFoldOps[F[_]: Foldable, A](fa: F[A]): FoldableOps[F, A] =
+  implicit final def catsSyntaxFoldOps[F[_], A](fa: F[A]): FoldableOps[F, A] =
+    new FoldableOps[F, A](fa)
+
+  @deprecated("Use overload without Foldable parameter", "2.9.0")
+  final def catsSyntaxFoldOps[F[_], A](fa: F[A], F: Foldable[F]): FoldableOps[F, A] =
     new FoldableOps[F, A](fa)
 }
 

--- a/tests/shared/src/test/scala/cats/tests/RegressionSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/RegressionSuite.scala
@@ -203,4 +203,8 @@ class RegressionSuite extends CatsSuite with ScalaVersionSpecificRegressionSuite
     val program = StateT.modify[Either[Throwable, *], Int](_ + 1).reject { case _ if false => new Throwable }
     assert(program.runS(0).toOption === (Some(1)))
   }
+
+  test("#4244 ambiguous `contains_` syntax") {
+    assertEquals(List("a").map(List("a").contains_), List(true))
+  }
 }


### PR DESCRIPTION
Fixes https://github.com/typelevel/cats/issues/4244.

The trick seems to be not requiring a typeclass constraint on the implicit conversion method. See discussion in https://github.com/typelevel/cats/pull/4146#discussion_r822880801 for why this is an anti-pattern anyway.