### PR TITLE
Fix obvious and straightforward warnings

### DIFF
--- a/algebra-laws/shared/src/main/scala/algebra/laws/Rules.scala
+++ b/algebra-laws/shared/src/main/scala/algebra/laws/Rules.scala
@@ -99,7 +99,7 @@ object Rules {
     }
 
   def collect0[A: Arbitrary: Eq](name: String, sym: String, id: A)(c: Seq[A] => A): (String, Prop) =
-    s"$name(Nil) == $sym" -> forAll { (a: A) =>
+    s"$name(Nil) == $sym" -> forAll { (_: A) =>
       c(Nil) ?== id
     }
 

--- a/core/src/main/scala-2.13+/cats/instances/lazyList.scala
+++ b/core/src/main/scala-2.13+/cats/instances/lazyList.scala
@@ -159,7 +159,7 @@ trait LazyListInstances extends cats.kernel.instances.LazyListInstances {
 
       override def find[A](fa: LazyList[A])(f: A => Boolean): Option[A] = fa.find(f)
 
-      override def algebra[A]: Monoid[LazyList[A]] = new kernel.instances.LazyListMonoid[A]
+      override def algebra[A]: Monoid[LazyList[A]] = kernel.instances.LazyListMonoid[A]
 
       override def collectFirst[A, B](fa: LazyList[A])(pf: PartialFunction[A, B]): Option[B] = fa.collectFirst(pf)
 

--- a/core/src/main/scala-2.13+/cats/instances/stream.scala
+++ b/core/src/main/scala-2.13+/cats/instances/stream.scala
@@ -104,7 +104,7 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
               case Left(a) #:: tail =>
                 stack = fn(a) #::: tail
                 advance()
-              case empty =>
+              case _ => // empty
                 state = Right(None)
             }
 

--- a/core/src/main/scala-2/src/main/scala/cats/arrow/FunctionKMacros.scala
+++ b/core/src/main/scala-2/src/main/scala/cats/arrow/FunctionKMacros.scala
@@ -22,7 +22,6 @@
 package cats
 package arrow
 
-import scala.language.experimental.macros
 import scala.reflect.macros.blackbox
 
 private[arrow] class FunctionKMacroMethods {

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -1019,7 +1019,6 @@ abstract private[data] class EitherTInstances extends EitherTInstances1 {
       type F[x] = Nested[P.F, Validated[E, *], x]
 
       implicit val monadM: Monad[M] = P.monad
-      implicit val monadEither: Monad[Either[E, *]] = cats.instances.either.catsStdInstancesForEither
 
       def applicative: Applicative[Nested[P.F, Validated[E, *], *]] =
         cats.data.Nested.catsDataApplicativeForNested(P.applicative, Validated.catsDataApplicativeErrorForValidated)
@@ -1115,7 +1114,6 @@ abstract private[data] class EitherTInstances1 extends EitherTInstances2 {
       type F[x] = Nested[M, Validated[E, *], x]
 
       implicit val appValidated: Applicative[Validated[E, *]] = Validated.catsDataApplicativeErrorForValidated
-      implicit val monadEither: Monad[Either[E, *]] = cats.instances.either.catsStdInstancesForEither
 
       def applicative: Applicative[Nested[M, Validated[E, *], *]] =
         cats.data.Nested.catsDataApplicativeForNested[M, Validated[E, *]]
@@ -1187,14 +1185,14 @@ private[data] trait EitherTSemigroupK[F[_], L] extends SemigroupK[EitherT[F, L, 
   implicit val F: Monad[F]
   def combineK[A](x: EitherT[F, L, A], y: EitherT[F, L, A]): EitherT[F, L, A] =
     EitherT(F.flatMap(x.value) {
-      case l @ Left(_)  => y.value
       case r @ Right(_) => F.pure(r)
+      case _            => y.value
     })
 
   override def combineKEval[A](x: EitherT[F, L, A], y: Eval[EitherT[F, L, A]]): Eval[EitherT[F, L, A]] =
     Eval.now(EitherT(F.flatMap(x.value) {
-      case l @ Left(_)  => y.value.value
       case r @ Right(_) => F.pure(r: Either[L, A])
+      case _            => y.value.value
     }))
 }
 

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -1186,13 +1186,13 @@ private[data] trait EitherTSemigroupK[F[_], L] extends SemigroupK[EitherT[F, L, 
   def combineK[A](x: EitherT[F, L, A], y: EitherT[F, L, A]): EitherT[F, L, A] =
     EitherT(F.flatMap(x.value) {
       case r @ Right(_) => F.pure(r)
-      case _            => y.value
+      case Left(_)      => y.value
     })
 
   override def combineKEval[A](x: EitherT[F, L, A], y: Eval[EitherT[F, L, A]]): Eval[EitherT[F, L, A]] =
     Eval.now(EitherT(F.flatMap(x.value) {
       case r @ Right(_) => F.pure(r: Either[L, A])
-      case _            => y.value.value
+      case Left(_)      => y.value.value
     }))
 }
 

--- a/core/src/main/scala/cats/data/Func.scala
+++ b/core/src/main/scala/cats/data/Func.scala
@@ -113,7 +113,7 @@ sealed private[data] trait FuncApply[F[_], C] extends Apply[λ[α => Func[F, C, 
 sealed private[data] trait FuncApplicative[F[_], C] extends Applicative[λ[α => Func[F, C, α]]] with FuncApply[F, C] {
   def F: Applicative[F]
   def pure[A](a: A): Func[F, C, A] =
-    Func.func(c => F.pure(a))
+    Func.func(Function.const(F.pure(a)))
 }
 
 /**
@@ -167,5 +167,5 @@ sealed private[data] trait AppFuncApplicative[F[_], C] extends Applicative[λ[α
   override def product[A, B](fa: AppFunc[F, C, A], fb: AppFunc[F, C, B]): AppFunc[F, C, (A, B)] =
     Func.appFunc[F, C, (A, B)](c => F.product(fa.run(c), fb.run(c)))(F)
   def pure[A](a: A): AppFunc[F, C, A] =
-    Func.appFunc[F, C, A](c => F.pure(a))(F)
+    Func.appFunc[F, C, A](Function.const(F.pure(a)))(F)
 }

--- a/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
@@ -246,7 +246,7 @@ final class IndexedReaderWriterStateT[F[_], E, L, SA, SB, A](val runF: F[(E, SA)
    * Inspect a value from the input state, without modifying the state.
    */
   def inspect[B](f: SB => B)(implicit F: Functor[F]): IndexedReaderWriterStateT[F, E, L, SA, SB, B] =
-    transform { (l, sb, a) =>
+    transform { (l, sb, _) =>
       (l, sb, f(sb))
     }
 
@@ -287,7 +287,7 @@ final class IndexedReaderWriterStateT[F[_], E, L, SA, SB, A](val runF: F[(E, SA)
    * Retrieve the value written to the log.
    */
   def written(implicit F: Functor[F]): IndexedReaderWriterStateT[F, E, L, SA, SB, L] =
-    transform { (l, sb, a) =>
+    transform { (l, sb, _) =>
       (l, sb, l)
     }
 

--- a/core/src/main/scala/cats/data/IndexedStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedStateT.scala
@@ -482,8 +482,8 @@ sealed abstract private[data] class IndexedStateTContravariantMonoidal[F[_], S]
   implicit def F: ContravariantMonoidal[F]
   implicit def G: Applicative[F]
 
-  override def unit: IndexedStateT[F, S, S, Unit] =
-    IndexedStateT.applyF(G.pure((s: S) => F.trivial[(S, Unit)]))
+  override val unit: IndexedStateT[F, S, S, Unit] =
+    IndexedStateT.applyF(G.pure((_: S) => F.trivial[(S, Unit)]))
 
   override def contramap[A, B](fa: IndexedStateT[F, S, S, A])(f: B => A): IndexedStateT[F, S, S, B] =
     contramap2(fa, trivial)(((a: A) => (a, a)).compose(f))

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -794,9 +794,9 @@ sealed abstract class Ior[+A, +B] extends Product with Serializable {
 
   final def ===[AA >: A, BB >: B](that: AA Ior BB)(implicit AA: Eq[AA], BB: Eq[BB]): Boolean =
     fold(
-      a => that.fold(a2 => AA.eqv(a, a2), b2 => false, (a2, b2) => false),
-      b => that.fold(a2 => false, b2 => BB.eqv(b, b2), (a2, b2) => false),
-      (a, b) => that.fold(a2 => false, b2 => false, (a2, b2) => AA.eqv(a, a2) && BB.eqv(b, b2))
+      a => that.fold(a2 => AA.eqv(a, a2), _ => false, (_, _) => false),
+      b => that.fold(_ => false, b2 => BB.eqv(b, b2), (_, _) => false),
+      (a, b) => that.fold(_ => false, _ => false, (a2, b2) => AA.eqv(a, a2) && BB.eqv(b, b2))
     )
 
   final def compare[AA >: A, BB >: B](that: AA Ior BB)(implicit AA: Order[AA], BB: Order[BB]): Int =
@@ -938,9 +938,9 @@ sealed abstract private[data] class IorInstances extends IorInstances0 {
               }
             case Ior.Left(e1) =>
               ff match {
-                case Ior.Right(f)    => Ior.Left(e1)
-                case Ior.Both(e2, f) => Ior.Left(E.combine(e2, e1))
                 case Ior.Left(e2)    => Ior.Left(E.combine(e2, e1))
+                case Ior.Both(e2, _) => Ior.Left(E.combine(e2, e1))
+                case _               => Ior.Left(e1)
               }
           }
       }

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -941,7 +941,7 @@ sealed abstract private[data] class IorInstances extends IorInstances0 {
               ff match {
                 case Ior.Left(e2)    => Ior.Left(E.combine(e2, e1))
                 case Ior.Both(e2, _) => Ior.Left(E.combine(e2, e1))
-                case _               => Ior.Left(e1)
+                case Ior.Right(_)    => Ior.Left(e1)
               }
           }
       }

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -793,22 +793,11 @@ sealed abstract class Ior[+A, +B] extends Product with Serializable {
     }
 
   final def ===[AA >: A, BB >: B](that: AA Ior BB)(implicit AA: Eq[AA], BB: Eq[BB]): Boolean =
-    this match {
-      case Ior.Left(a) =>
-        that match {
-          case Ior.Left(aa) => AA.eqv(a, aa)
-          case _            => false
-        }
-      case Ior.Right(b) =>
-        that match {
-          case Ior.Right(bb) => BB.eqv(b, bb)
-          case _             => false
-        }
-      case Ior.Both(a, b) =>
-        that match {
-          case Ior.Both(aa, bb) => AA.eqv(a, aa) && BB.eqv(b, bb)
-          case _                => false
-        }
+    (this, that) match {
+      case (Ior.Left(a), Ior.Left(aa))        => AA.eqv(a, aa)
+      case (Ior.Right(b), Ior.Right(bb))      => BB.eqv(b, bb)
+      case (Ior.Both(a, b), Ior.Both(aa, bb)) => AA.eqv(a, aa) && BB.eqv(b, bb)
+      case _                                  => false
     }
 
   final def compare[AA >: A, BB >: B](that: AA Ior BB)(implicit AA: Order[AA], BB: Order[BB]): Int =

--- a/core/src/main/scala/cats/data/Ior.scala
+++ b/core/src/main/scala/cats/data/Ior.scala
@@ -793,11 +793,23 @@ sealed abstract class Ior[+A, +B] extends Product with Serializable {
     }
 
   final def ===[AA >: A, BB >: B](that: AA Ior BB)(implicit AA: Eq[AA], BB: Eq[BB]): Boolean =
-    fold(
-      a => that.fold(a2 => AA.eqv(a, a2), _ => false, (_, _) => false),
-      b => that.fold(_ => false, b2 => BB.eqv(b, b2), (_, _) => false),
-      (a, b) => that.fold(_ => false, _ => false, (a2, b2) => AA.eqv(a, a2) && BB.eqv(b, b2))
-    )
+    this match {
+      case Ior.Left(a) =>
+        that match {
+          case Ior.Left(aa) => AA.eqv(a, aa)
+          case _            => false
+        }
+      case Ior.Right(b) =>
+        that match {
+          case Ior.Right(bb) => BB.eqv(b, bb)
+          case _             => false
+        }
+      case Ior.Both(a, b) =>
+        that match {
+          case Ior.Both(aa, bb) => AA.eqv(a, aa) && BB.eqv(b, bb)
+          case _                => false
+        }
+    }
 
   final def compare[AA >: A, BB >: B](that: AA Ior BB)(implicit AA: Order[AA], BB: Order[BB]): Int =
     (this, that) match {

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -908,8 +908,8 @@ sealed abstract private[data] class ValidatedInstances extends ValidatedInstance
             }
           case Valid(a) =>
             fb match {
-              case Invalid(e) => Valid(f(Ior.left(a)))
-              case Valid(b)   => Valid(f(Ior.both(a, b)))
+              case Valid(b) => Valid(f(Ior.both(a, b)))
+              case _        => Valid(f(Ior.left(a)))
             }
         }
     }

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -908,8 +908,8 @@ sealed abstract private[data] class ValidatedInstances extends ValidatedInstance
             }
           case Valid(a) =>
             fb match {
-              case Valid(b) => Valid(f(Ior.both(a, b)))
-              case _        => Valid(f(Ior.left(a)))
+              case Valid(b)   => Valid(f(Ior.both(a, b)))
+              case Invalid(_) => Valid(f(Ior.left(a)))
             }
         }
     }

--- a/core/src/main/scala/cats/instances/either.scala
+++ b/core/src/main/scala/cats/instances/either.scala
@@ -201,12 +201,12 @@ trait EitherInstances extends cats.kernel.instances.EitherInstances {
           case Right(b) =>
             fc match {
               case Right(c) => Right(f(Ior.both(b, c)))
-              case _        => Right(f(Ior.left(b)))
+              case Left(_)  => Right(f(Ior.left(b)))
             }
           case left @ Left(_) =>
             fc match {
               case Right(c) => Right(f(Ior.right(c)))
-              case _        => left.rightCast[D]
+              case Left(_)  => left.rightCast[D]
             }
         }
 

--- a/core/src/main/scala/cats/instances/either.scala
+++ b/core/src/main/scala/cats/instances/either.scala
@@ -198,15 +198,15 @@ trait EitherInstances extends cats.kernel.instances.EitherInstances {
 
       override def alignWith[B, C, D](fb: Either[A, B], fc: Either[A, C])(f: Ior[B, C] => D): Either[A, D] =
         fb match {
-          case left @ Left(a) =>
-            fc match {
-              case Left(_)  => left.rightCast[D]
-              case Right(c) => Right(f(Ior.right(c)))
-            }
           case Right(b) =>
             fc match {
-              case Left(a)  => Right(f(Ior.left(b)))
               case Right(c) => Right(f(Ior.both(b, c)))
+              case _        => Right(f(Ior.left(b)))
+            }
+          case left @ Left(_) =>
+            fc match {
+              case Right(c) => Right(f(Ior.right(c)))
+              case _        => left.rightCast[D]
             }
         }
 

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -252,7 +252,7 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
 
       override def dropWhile_[A](fa: List[A])(p: A => Boolean): List[A] = fa.dropWhile(p)
 
-      override def algebra[A]: Monoid[List[A]] = new kernel.instances.ListMonoid[A]
+      override def algebra[A]: Monoid[List[A]] = kernel.instances.ListMonoid[A]
 
       override def collectFirst[A, B](fa: List[A])(pf: PartialFunction[A, B]): Option[B] = fa.collectFirst(pf)
 

--- a/core/src/main/scala/cats/instances/map.scala
+++ b/core/src/main/scala/cats/instances/map.scala
@@ -75,8 +75,8 @@ trait MapInstances extends cats.kernel.instances.MapInstances {
       def flatMap[A, B](fa: Map[K, A])(f: (A) => Map[K, B]): Map[K, B] =
         fa.flatMap { case (k, a) => f(a).get(k).map((k, _)) }
 
-      def unorderedFoldMap[A, B: CommutativeMonoid](fa: Map[K, A])(f: (A) => B) =
-        fa.foldLeft(Monoid[B].empty) { case (b, (k, a)) => Monoid[B].combine(b, f(a)) }
+      def unorderedFoldMap[A, B: CommutativeMonoid](fa: Map[K, A])(f: A => B): B =
+        Monoid[B].combineAll(fa.valuesIterator.map(f))
 
       def tailRecM[A, B](a: A)(f: A => Map[K, Either[A, B]]): Map[K, B] = {
         val bldr = Map.newBuilder[K, B]

--- a/core/src/main/scala/cats/instances/queue.scala
+++ b/core/src/main/scala/cats/instances/queue.scala
@@ -190,7 +190,7 @@ trait QueueInstances extends cats.kernel.instances.QueueInstances {
         fa.iterator.dropWhile(p).toList
 
       override def algebra[A]: Monoid[Queue[A]] =
-        new kernel.instances.QueueMonoid[A]
+        kernel.instances.QueueMonoid[A]
 
       override def collectFirst[A, B](fa: Queue[A])(pf: PartialFunction[A, B]): Option[B] = fa.collectFirst(pf)
 

--- a/core/src/main/scala/cats/instances/seq.scala
+++ b/core/src/main/scala/cats/instances/seq.scala
@@ -162,7 +162,7 @@ trait SeqInstances extends cats.kernel.instances.SeqInstances {
 
       override def find[A](fa: Seq[A])(f: A => Boolean): Option[A] = fa.find(f)
 
-      override def algebra[A]: Monoid[Seq[A]] = new kernel.instances.SeqMonoid[A]
+      override def algebra[A]: Monoid[Seq[A]] = kernel.instances.SeqMonoid[A]
 
       def functor: Functor[Seq] = this
 

--- a/core/src/main/scala/cats/instances/sortedMap.scala
+++ b/core/src/main/scala/cats/instances/sortedMap.scala
@@ -103,7 +103,7 @@ trait SortedMapInstances extends SortedMapInstances2 {
 
       def tailRecM[A, B](a: A)(f: A => SortedMap[K, Either[A, B]]): SortedMap[K, B] = {
         val fa = f(a)
-        var bldr = SortedMap.newBuilder[K, B](fa.ordering)
+        val bldr = SortedMap.newBuilder[K, B](fa.ordering)
 
         @tailrec def descend(k: K, either: Either[A, B]): Unit =
           either match {
@@ -204,10 +204,7 @@ class SortedMapEq[K, V](implicit V: Eq[V], O: Order[K]) extends cats.kernel.inst
 @deprecated("Use cats.kernel.instances.SortedMapCommutativeMonoid", "2.0.0-RC2")
 class SortedMapCommutativeMonoid[K, V](implicit V: CommutativeSemigroup[V], O: Order[K])
     extends SortedMapMonoid[K, V]
-    with CommutativeMonoid[SortedMap[K, V]] {
-  private[this] val underlying: CommutativeMonoid[SortedMap[K, V]] =
-    new cats.kernel.instances.SortedMapCommutativeMonoid[K, V]
-}
+    with CommutativeMonoid[SortedMap[K, V]]
 
 @deprecated("Use cats.kernel.instances.SortedMapMonoid", "2.0.0-RC2")
 class SortedMapMonoid[K, V](implicit V: Semigroup[V], O: Order[K]) extends cats.kernel.instances.SortedMapMonoid[K, V]

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -209,7 +209,7 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
 
       override def find[A](fa: Vector[A])(f: A => Boolean): Option[A] = fa.find(f)
 
-      override def algebra[A]: Monoid[Vector[A]] = new kernel.instances.VectorMonoid[A]
+      override def algebra[A]: Monoid[Vector[A]] = kernel.instances.VectorMonoid[A]
 
       def functor: Functor[Vector] = this
 

--- a/kernel-laws/shared/src/main/scala/cats/kernel/laws/SerializableLaws.scala
+++ b/kernel-laws/shared/src/main/scala/cats/kernel/laws/SerializableLaws.scala
@@ -57,7 +57,7 @@ object SerializableLaws {
           oos.close()
           val bais = new ByteArrayInputStream(baos.toByteArray())
           ois = new ObjectInputStream(bais)
-          val a2 = ois.readObject()
+          val _ = ois.readObject()
           ois.close()
           Result(status = Proof)
         } catch {

--- a/laws/src/main/scala/cats/laws/ApplicativeErrorLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplicativeErrorLaws.scala
@@ -65,7 +65,7 @@ trait ApplicativeErrorLaws[F[_], E] extends ApplicativeLaws[F] {
     F.onError(F.pure(a)) { case x => f(x) } <-> F.pure(a)
 
   def onErrorRaise[A](fa: F[A], e: E, fb: F[Unit]): IsEq[F[A]] =
-    F.onError(F.raiseError[A](e)) { case err => fb } <-> F.map2(fb, F.raiseError[A](e))((_, b) => b)
+    F.onError(F.raiseError[A](e)) { case _ => fb } <-> F.map2(fb, F.raiseError[A](e))((_, b) => b)
 
   def adaptErrorPure[A](a: A, f: E => E): IsEq[F[A]] =
     F.adaptError(F.pure(a)) { case x => f(x) } <-> F.pure(a)

--- a/laws/src/main/scala/cats/laws/DeferLaws.scala
+++ b/laws/src/main/scala/cats/laws/DeferLaws.scala
@@ -35,7 +35,7 @@ trait DeferLaws[F[_]] {
 
   def deferDoesNotEvaluate[A](fa: Unit => F[A]): IsEq[Boolean] = {
     var evaluated = false
-    val deferUnit = F.defer {
+    val _ = F.defer {
       evaluated = true;
       fa(())
     }

--- a/laws/src/main/scala/cats/laws/ShortCircuitingLaws.scala
+++ b/laws/src/main/scala/cats/laws/ShortCircuitingLaws.scala
@@ -35,7 +35,7 @@ trait ShortCircuitingLaws[F[_]] {
   def foldMapKShortCircuits[A](fa: F[A], empty: A)(implicit F: Foldable[F]): IsEq[Long] = {
     val size = fa.size
     val maxInvocationsAllowed = size / 2
-    val f = new RestrictedFunction[A, Option[A]]((a: A) => None, maxInvocationsAllowed, Some(empty))
+    val f = new RestrictedFunction[A, Option[A]](Function.const(None), maxInvocationsAllowed, Some(empty))
 
     fa.foldMapK(f)
     f.invocations.get <-> (maxInvocationsAllowed + 1).min(size)
@@ -44,7 +44,7 @@ trait ShortCircuitingLaws[F[_]] {
   def foldMapKWontShortCircuit[A](fa: F[A], empty: A)(implicit F: Foldable[F]): IsEq[Long] = {
     val size = fa.size
     val maxInvocationsAllowed = size / 2
-    val f = new RestrictedFunction[A, Option[A]]((a: A) => None, maxInvocationsAllowed, Some(empty))
+    val f = new RestrictedFunction[A, Option[A]](Function.const(None), maxInvocationsAllowed, Some(empty))
 
     fa.foldMapK(f)(F, nonShortCircuitingMonoidK)
     f.invocations.get <-> size


### PR DESCRIPTION
Although it was decided to postpone Cats codebase cleanup for a while until the Scalac options set gets settled completely, some compiler warnings are so obvious and easy-to-fix that I couldn't refrain from fixing them up. Apparently, it is not a complete solution but rather some small relief.

Can be considered as a prelude for #4187 series.

UPD. Turned out, there are also quite a bit of small code optimizations included.