### PR TITLE
Make string building a bit more efficient for `NonEmptySeq`

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptySeq.scala
+++ b/core/src/main/scala/cats/data/NonEmptySeq.scala
@@ -227,7 +227,7 @@ final class NonEmptySeq[+A] private (val toSeq: Seq[A]) extends AnyVal with NonE
    * universal .toString method.
    */
   def show[AA >: A](implicit AA: Show[AA]): String =
-    s"NonEmptySeq(${toSeq.iterator.map(Show[AA].show).mkString(", ")})"
+    s"NonEmptySeq(${toSeq.iterator.map(AA.show).mkString(", ")})"
 
   def length: Int = toSeq.length
 

--- a/core/src/main/scala/cats/data/NonEmptySeq.scala
+++ b/core/src/main/scala/cats/data/NonEmptySeq.scala
@@ -227,11 +227,11 @@ final class NonEmptySeq[+A] private (val toSeq: Seq[A]) extends AnyVal with NonE
    * universal .toString method.
    */
   def show[AA >: A](implicit AA: Show[AA]): String =
-    s"NonEmptySeq(${toSeq.map(Show[AA].show).mkString(", ")})"
+    s"NonEmptySeq(${toSeq.iterator.map(Show[AA].show).mkString(", ")})"
 
   def length: Int = toSeq.length
 
-  override def toString: String = s"NonEmptySeq(${toSeq.map(_.toString).mkString(", ")})"
+  override def toString: String = s"NonEmptySeq(${toSeq.iterator.map(_.toString).mkString(", ")})"
 
   /**
    * Remove duplicates. Duplicates are checked using `Order[_]` instance.


### PR DESCRIPTION
String building from `Iterator` is about 5% more efficient than from `Seq`. [Benchmarked](https://github.com/http4s/http4s/pull/6766) on 2.13, it should be the same on 2.12, I suppose.