### PR TITLE
More efficient size checking of `ArraySeq`s

### DIFF
--- a/core/src/main/scala-2.13+/cats/instances/arraySeq.scala
+++ b/core/src/main/scala-2.13+/cats/instances/arraySeq.scala
@@ -182,11 +182,12 @@ private[cats] object ArraySeqInstances {
       def functor: Functor[ArraySeq] = this
 
       def align[A, B](fa: ArraySeq[A], fb: ArraySeq[B]): ArraySeq[Ior[A, B]] = {
-        val aLarger = fa.size >= fb.size
+        val fbSize = fb.size
+        val aLarger = fa.sizeIs >= fbSize
         if (aLarger) {
-          fa.lazyZip(fb).map(Ior.both) ++ fa.drop(fb.size).map(Ior.left)
+          fa.lazyZip(fb).map(Ior.both) ++ fa.drop(fbSize).map(Ior.left)
         } else {
-          fa.lazyZip(fb).map(Ior.both) ++ fb.drop(fa.size).map(Ior.right)
+          fa.lazyZip(fb).map(Ior.both) ++ fb.drop(fbSize).map(Ior.right)
         }
       }
 

--- a/core/src/main/scala-2.13+/cats/instances/arraySeq.scala
+++ b/core/src/main/scala-2.13+/cats/instances/arraySeq.scala
@@ -147,7 +147,7 @@ private[cats] object ArraySeqInstances {
         fa.forall(p)
 
       override def get[A](fa: ArraySeq[A])(idx: Long): Option[A] =
-        if (idx >= 0 && idx < fa.length && idx.isValidInt) Some(fa(idx.toInt)) else None
+        if (idx >= 0 && idx.isValidInt && fa.sizeIs > idx.toInt) Some(fa(idx.toInt)) else None
 
       override def isEmpty[A](fa: ArraySeq[A]): Boolean =
         fa.isEmpty

--- a/core/src/main/scala-2.13+/cats/instances/arraySeq.scala
+++ b/core/src/main/scala-2.13+/cats/instances/arraySeq.scala
@@ -93,7 +93,7 @@ private[cats] object ArraySeqInstances {
 
       def foldRight[A, B](fa: ArraySeq[A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] = {
         def loop(i: Int): Eval[B] =
-          if (i < fa.length) f(fa(i), Eval.defer(loop(i + 1))) else lb
+          if (fa.sizeIs > i) f(fa(i), Eval.defer(loop(i + 1))) else lb
 
         Eval.defer(loop(0))
       }

--- a/core/src/main/scala-2.13+/cats/instances/arraySeq.scala
+++ b/core/src/main/scala-2.13+/cats/instances/arraySeq.scala
@@ -154,7 +154,7 @@ private[cats] object ArraySeqInstances {
 
       override def foldM[G[_], A, B](fa: ArraySeq[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
         G.tailRecM((z, 0)) { case (b, i) =>
-          if (i < fa.length) G.map(f(b, fa(i)))(b => Left((b, i + 1)))
+          if (fa.sizeIs > i) G.map(f(b, fa(i)))(b => Left((b, i + 1)))
           else G.pure(Right(b))
         }
 

--- a/kernel/src/main/scala-2.13+/cats/kernel/instances/ArraySeqInstances.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/instances/ArraySeqInstances.scala
@@ -52,7 +52,7 @@ object ArraySeqInstances {
   final private class ArraySeqOrder[A](implicit ev: Order[A]) extends Order[ArraySeq[A]] {
     final def compare(xs: ArraySeq[A], ys: ArraySeq[A]): Int = {
       @tailrec def loop(i: Int): Int =
-        (i < xs.length, i < ys.length) match {
+        (xs.sizeIs > i, ys.sizeIs > i) match {
           case (true, true) =>
             val n = ev.compare(xs(i), ys(i))
             if (n != 0) n else loop(i + 1)
@@ -68,7 +68,7 @@ object ArraySeqInstances {
   private class ArraySeqPartialOrder[A](implicit ev: PartialOrder[A]) extends PartialOrder[ArraySeq[A]] {
     final def partialCompare(xs: ArraySeq[A], ys: ArraySeq[A]): Double = {
       @tailrec def loop(i: Int): Double =
-        (i < xs.length, i < ys.length) match {
+        (xs.sizeIs > i, ys.sizeIs > i) match {
           case (true, true) =>
             val n = ev.partialCompare(xs(i), ys(i))
             if (n != 0) n else loop(i + 1)
@@ -88,7 +88,7 @@ object ArraySeqInstances {
   private class ArraySeqEq[A](implicit ev: Eq[A]) extends Eq[ArraySeq[A]] {
     final def eqv(xs: ArraySeq[A], ys: ArraySeq[A]): Boolean = {
       @tailrec def loop(i: Int): Boolean =
-        (i < xs.length, i < ys.length) match {
+        (xs.sizeIs > i, ys.sizeIs > i) match {
           case (true, true)   => if (ev.eqv(xs(i), ys(i))) loop(i + 1) else false
           case (true, false)  => false
           case (false, true)  => false


### PR DESCRIPTION
Sorry for not bringing benchmarks for cats' use cases, but `sizeIs` is a little better than `size` for comparing with numbers that are highly fewer than the actual collection size. Will be happy if a careful reviewer could do that checking for me 🙇🏻‍♂️