### PR TITLE
Add release notes config

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,31 @@
+changelog:
+  categories:
+
+  - title: Features
+    labels:
+    - enhancement
+
+  - title: Optimizations
+    labels:
+    - optimization
+
+  - title: Fixes
+    labels:
+    - bug
+
+  - title: Deprecations
+    labels:
+    - deprecation
+
+  - title: Documentation
+    labels:
+    - documentation
+
+  - title: Behind-the-scenes
+    labels:
+    - behind-the-scenes
+
+  # Not for published notes, just to make sure we don't forget any accidentally unlabeled PRs
+  - title: Uncategorized
+    labels:
+    - "*"


### PR DESCRIPTION
This is a configuration so that GitHub will auto-generate release notes with PRs already categorized. It relies on the labels I've been adding to PRs.

The categories mimic what I did for the v2.8.0 release notes but I am happy to bikeshed it.
https://github.com/typelevel/cats/releases/tag/v2.8.0