### PR TITLE
Add stack-safety test for `ContT#map`

### DIFF
--- a/tests/shared/src/test/scala/cats/tests/ContTSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/ContTSuite.scala
@@ -195,6 +195,16 @@ class ContTSuite extends CatsSuite {
     assert(contT.run(Eval.now(_)).value === maxIters)
   }
 
+  // test from issue 2950
+  test("ContT.map stack-safety") {
+    val maxIters = 20000
+    var k = ContT.defer[Eval, Int, Int](0)
+    for (_ <- 1 to maxIters) {
+      k = k.map(x => x + 1)
+    }
+    assert(k.run(_.pure[Eval]).value == maxIters)
+  }
+
   test("ContT.callCC short-circuits and invokes the continuation") {
     forAll { (cb: Unit => Eval[Int]) =>
       var shouldNotChange = false


### PR DESCRIPTION
Issue #2950 has a test that, as of its writing, blows up with a stack safety bug. Sometime in the subsequent 3 years, it must have been fixed. This PR adds the test.

cc @johnynek 

Closes #2950.