### PR TITLE
Enumerable (WIP)

### DIFF
--- a/kernel/src/main/scala-2.12/cats/kernel/ScalaVersionSpecificLazyListCompat.scala
+++ b/kernel/src/main/scala-2.12/cats/kernel/ScalaVersionSpecificLazyListCompat.scala
@@ -1,0 +1,9 @@
+package cats
+package kernel
+
+private[kernel] object ScalaVersionSpecificLazyListCompat extends LazyListCompatBase {
+  override final type T[A] = scala.collection.immutable.Stream[A]
+
+  override final def apply[A](a: A*): T[A] =
+    scala.collection.immutable.Stream.apply[A](a: _*)
+}

--- a/kernel/src/main/scala-2.13+/cats/kernel/ScalaVersionSpecificLazyListCompat.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/ScalaVersionSpecificLazyListCompat.scala
@@ -1,0 +1,9 @@
+package cats
+package kernel
+
+private[kernel] object ScalaVersionSpecificLazyListCompat extends LazyListCompatBase {
+  override final type T[A] = scala.collection.immutable.LazyList[A]
+
+  override final def apply[A](a: A*): T[A] =
+    scala.collection.immutable.LazyList.apply[A](a: _*)
+}

--- a/kernel/src/main/scala/cats/kernel/LazyListCompat.scala
+++ b/kernel/src/main/scala/cats/kernel/LazyListCompat.scala
@@ -1,0 +1,10 @@
+package cats
+package kernel
+
+private[kernel] trait LazyListCompatBase{
+  type T[A]
+
+  def apply[A](a: A*): T[A]
+
+  final def empty[A]: T[A] = apply[A]()
+}

--- a/kernel/src/main/scala/cats/kernel/instances/IntInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/IntInstances.scala
@@ -23,7 +23,7 @@ package cats.kernel
 package instances
 
 trait IntInstances {
-  implicit val catsKernelStdOrderForInt: Order[Int] with Hash[Int] with BoundedEnumerable[Int] with Countable[Int] =
+  implicit val catsKernelStdOrderForInt: Order[Int] with Hash[Int] with BoundedEnumerable[Int] with Enumerable[Int] =
     new IntOrder
   implicit val catsKernelStdGroupForInt: CommutativeGroup[Int] = new IntGroup
 }
@@ -47,7 +47,7 @@ trait IntBounded extends LowerBounded[Int] with UpperBounded[Int] {
   override def maxBound: Int = Int.MaxValue
 }
 
-class IntOrder extends Order[Int] with Hash[Int] with IntBounded with IntEnumerable with Countable[Int] { self =>
+class IntOrder extends Order[Int] with Hash[Int] with IntBounded with IntEnumerable with Enumerable[Int] { self =>
   def hash(x: Int): Int = x.hashCode()
   def compare(x: Int, y: Int): Int =
     if (x < y) -1 else if (x > y) 1 else 0

--- a/kernel/src/main/scala/cats/kernel/instances/IntInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/IntInstances.scala
@@ -23,7 +23,7 @@ package cats.kernel
 package instances
 
 trait IntInstances {
-  implicit val catsKernelStdOrderForInt: Order[Int] with Hash[Int] with BoundedEnumerable[Int] =
+  implicit val catsKernelStdOrderForInt: Order[Int] with Hash[Int] with BoundedEnumerable[Int] with Countable[Int] =
     new IntOrder
   implicit val catsKernelStdGroupForInt: CommutativeGroup[Int] = new IntGroup
 }
@@ -47,7 +47,7 @@ trait IntBounded extends LowerBounded[Int] with UpperBounded[Int] {
   override def maxBound: Int = Int.MaxValue
 }
 
-class IntOrder extends Order[Int] with Hash[Int] with IntBounded with IntEnumerable { self =>
+class IntOrder extends Order[Int] with Hash[Int] with IntBounded with IntEnumerable with Countable[Int] { self =>
   def hash(x: Int): Int = x.hashCode()
   def compare(x: Int, y: Int): Int =
     if (x < y) -1 else if (x > y) 1 else 0
@@ -65,4 +65,12 @@ class IntOrder extends Order[Int] with Hash[Int] with IntBounded with IntEnumera
     java.lang.Math.max(x, y)
 
   override val order: Order[Int] = self
+
+  override final def fromEnum(a: Int): BigInt = BigInt(a)
+  override final def toEnum(i: BigInt): Option[Int] =
+    if (i <= BigInt(Int.MaxValue) || i >= BigInt(Int.MinValue)) {
+      Some(i.toInt)
+    } else {
+      None
+    }
 }


### PR DESCRIPTION
Prototyping adding the `Enumerable` class to cats. This class is based on https://hackage.haskell.org/package/base-4.15.0.0/docs/GHC-Enum.html#v:toEnum but tries to avoid some pitfalls that the Haskell version has (e.g. `toEnum` doesn't throw in our version) and relates to the other classes currently defined in `Enumerable.scala`.

This isn't remotely complete, but I thought I'd start a PR so we can have a central place to discuss the work as it progresses.

## Open Questions ##

* How should all of these classes related to each other?
* Do we need a few more classes? @satorg talked about a `CycleNext` class for example in #4347. 
* What laws (if any) should this (these) classes have?
* Should `cycleNext` or `cyclePrevious` for types which have `Next` or `Previous` be defined as aliases for `next` and `previous`?
