### PR TITLE
Clean up benchmarks' dependencies

### DIFF
--- a/bench/src/main/scala/cats/bench/MapMonoidBench.scala
+++ b/bench/src/main/scala/cats/bench/MapMonoidBench.scala
@@ -25,10 +25,6 @@ import cats.instances.list._
 import cats.instances.int._
 import cats.instances.map._
 
-import scalaz.std.anyVal._
-import scalaz.std.list._
-import scalaz.std.map._
-
 import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
 
 @State(Scope.Benchmark)
@@ -50,11 +46,6 @@ class MapMonoidBench {
       cats.Monoid[Map[String, Int]].combine(acc, m)
     }
 
-  @Benchmark def combineScalaz: Map[String, Int] =
-    maps.foldLeft(Map.empty[String, Int]) { case (acc, m) =>
-      scalaz.Monoid[Map[String, Int]].append(acc, m)
-    }
-
   @Benchmark def combineDirect: Map[String, Int] =
     maps.foldLeft(Map.empty[String, Int]) { case (acc, m) =>
       m.foldLeft(acc) { case (m, (k, v)) =>
@@ -74,7 +65,4 @@ class MapMonoidBench {
 
   @Benchmark def foldMapCats: Map[String, Int] =
     cats.Foldable[List].foldMap(maps)(identity)
-
-  @Benchmark def foldMapScalaz: Map[String, Int] =
-    scalaz.Foldable[List].foldMap(maps)(identity)
 }

--- a/build.sbt
+++ b/build.sbt
@@ -270,9 +270,6 @@ lazy val bench = project
   .settings(moduleName := "cats-bench")
   .settings(commonJvmSettings)
   .settings(
-    libraryDependencies ++= Seq(
-      "org.scalaz" %% "scalaz-core" % "7.3.6"
-    ),
     evictionErrorLevel := Level.Warn
   )
   .enablePlugins(NoPublishPlugin, JmhPlugin)


### PR DESCRIPTION
It's been 6+ years since these benchmarks were added. They are seemingly outdated nowadays. More context https://github.com/typelevel/cats/pull/4354#pullrequestreview-1203676071.

Closes https://github.com/typelevel/cats/pull/4354.