### PR TITLE
add Bifunctor[λ[(A, B) => F[G[A, B]]]] instance for F[_]: Functor and G[_, _]: Bifunctor

### DIFF
--- a/core/src/main/scala/cats/Bifunctor.scala
+++ b/core/src/main/scala/cats/Bifunctor.scala
@@ -121,6 +121,11 @@ object Bifunctor extends cats.instances.NTupleBifunctorInstances {
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToBifunctorOps
 
+  implicit def bifunctorInFunctorInstance[F[_]: Functor, G[_, _]: Bifunctor]: Bifunctor[λ[(A, B) => F[G[A, B]]]] =
+    new Bifunctor[λ[(A, B) => F[G[A, B]]]] {
+      override def bimap[W, X, Y, Z](fab: F[G[W, X]])(f: W => Y, g: X => Z): F[G[Y, Z]] =
+        Functor[F].map(fab)(Bifunctor[G].bimap(_)(f, g))
+    }
 }
 
 private[cats] trait ComposedBifunctor[F[_, _], G[_, _]] extends Bifunctor[λ[(A, B) => F[G[A, B], G[A, B]]]] {

--- a/tests/shared/src/test/scala/cats/tests/BifunctorSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/BifunctorSuite.scala
@@ -45,4 +45,12 @@ class BifunctorSuite extends CatsSuite {
     implicit val leftFunctor: Functor[RightFunctor] = tuple2ComposeEither.rightFunctor
     checkAll("Bifunctor[Tuple2 compose Either].rightFunctor", FunctorTests[RightFunctor].functor[Int, Int, Int])
   }
+
+  {
+    type Tuple2InsideOption[A, B] = Option[(A, B)]
+    checkAll(
+      "Bifunctor[Option[(A, B)]",
+      BifunctorTests[Tuple2InsideOption].bifunctor[String, String, String, Int, Int, Int]
+    )
+  }
 }


### PR DESCRIPTION
Motivated by the desire to `leftMap` on a tuple inside an effect, e.g.

```scala
val fab: F[(A, B)] = ???
val f: A => C = ???
Bifunctor[λ[(A, B) => F[(A, B)]]].leftMap(fab)(f) // returns F[(C, B)]
```

If folks aren't comfortable adding this kind of instance, it'd be pretty easy to implement this via a new wrapper class, similar to `Binested`. AFAICT `Bifunctor[λ[(A, B) => F[G[A, B]]]]` is lawful, but it doesn't infer very well—I don't think you can summon it using the syntax enhancements (e.g. `Option("a" -> "b").leftMap(_.length)` doesn't work, but `Bifunctor[λ[(A, B) => Option[(A, B)]]].leftMap(Option("a" -> "b"))(_.length)` should). Or, we could add both this instance and a new wrapper class.

Just for clarity, [cats already has `Binested`](https://github.com/typelevel/cats/blob/708cbaba2e6ac07a5ac1819b6c18b0c83a2faaba/core/src/main/scala/cats/data/Binested.scala#L46), but its type parameters are the wrong shape for this use case—it has `F[_, _]`, `G[_]`, and `H[_]` for `F[G[A], H[B]]`, but we need `F[_]` and `G[_, _]` for `F[G[A, B]]`.

If we decide not to merge this and want to move forward with a new wrapper, I'll follow up with a new PR.