### PR TITLE
Move `catsTraverseForSeq` to lower-priority implicit scope

### DIFF
--- a/core/src/main/scala/cats/UnorderedFoldable.scala
+++ b/core/src/main/scala/cats/UnorderedFoldable.scala
@@ -98,13 +98,13 @@ trait UnorderedFoldable[F[_]] extends Serializable {
     unorderedFoldMap(fa)(a => if (p(a)) 1L else 0L)
 }
 
-protected trait UnorderedFoldableLowPriority {
+private[cats] trait UnorderedFoldableLowPriority {
   implicit def catsTraverseForSeq: Traverse[Seq] = cats.instances.seq.catsStdInstancesForSeq
 }
 
 object UnorderedFoldable
     extends ScalaVersionSpecificTraverseInstances
-    with cats.instances.NTupleUnorderedFoldableInstances 
+    with cats.instances.NTupleUnorderedFoldableInstances
     with UnorderedFoldableLowPriority {
 
   private val orEvalMonoid: CommutativeMonoid[Eval[Boolean]] = new CommutativeMonoid[Eval[Boolean]] {

--- a/core/src/main/scala/cats/UnorderedFoldable.scala
+++ b/core/src/main/scala/cats/UnorderedFoldable.scala
@@ -98,13 +98,14 @@ trait UnorderedFoldable[F[_]] extends Serializable {
     unorderedFoldMap(fa)(a => if (p(a)) 1L else 0L)
 }
 
-private trait UnorderedFoldableLowPriority {
+protected trait UnorderedFoldableLowPriority {
   implicit def catsTraverseForSeq: Traverse[Seq] = cats.instances.seq.catsStdInstancesForSeq
 }
 
 object UnorderedFoldable
     extends ScalaVersionSpecificTraverseInstances
-    with cats.instances.NTupleUnorderedFoldableInstances with LowPriorityImplicits{
+    with cats.instances.NTupleUnorderedFoldableInstances 
+    with UnorderedFoldableLowPriority {
 
   private val orEvalMonoid: CommutativeMonoid[Eval[Boolean]] = new CommutativeMonoid[Eval[Boolean]] {
     val empty: Eval[Boolean] = Eval.False

--- a/core/src/main/scala/cats/UnorderedFoldable.scala
+++ b/core/src/main/scala/cats/UnorderedFoldable.scala
@@ -98,9 +98,13 @@ trait UnorderedFoldable[F[_]] extends Serializable {
     unorderedFoldMap(fa)(a => if (p(a)) 1L else 0L)
 }
 
+trait LowPriorityImplicits {
+  implicit def catsTraverseForSeq: Traverse[Seq] = cats.instances.seq.catsStdInstancesForSeq
+}
+
 object UnorderedFoldable
     extends ScalaVersionSpecificTraverseInstances
-    with cats.instances.NTupleUnorderedFoldableInstances {
+    with cats.instances.NTupleUnorderedFoldableInstances with LowPriorityImplicits{
 
   private val orEvalMonoid: CommutativeMonoid[Eval[Boolean]] = new CommutativeMonoid[Eval[Boolean]] {
     val empty: Eval[Boolean] = Eval.False
@@ -125,7 +129,6 @@ object UnorderedFoldable
   implicit def catsNonEmptyTraverseForId: NonEmptyTraverse[Id] = catsInstancesForId
   implicit def catsTraverseForOption: Traverse[Option] = cats.instances.option.catsStdInstancesForOption
   implicit def catsTraverseForList: Traverse[List] = cats.instances.list.catsStdInstancesForList
-  implicit def catsTraverseForSeq: Traverse[Seq] = cats.instances.seq.catsStdInstancesForSeq
   implicit def catsTraverseForVector: Traverse[Vector] = cats.instances.vector.catsStdInstancesForVector
   implicit def catsTraverseForQueue: Traverse[Queue] = cats.instances.queue.catsStdInstancesForQueue
   implicit def catsUnorderedTraverseForSet: UnorderedTraverse[Set] = cats.instances.set.catsStdInstancesForSet

--- a/core/src/main/scala/cats/UnorderedFoldable.scala
+++ b/core/src/main/scala/cats/UnorderedFoldable.scala
@@ -98,7 +98,7 @@ trait UnorderedFoldable[F[_]] extends Serializable {
     unorderedFoldMap(fa)(a => if (p(a)) 1L else 0L)
 }
 
-trait LowPriorityImplicits {
+private trait UnorderedFoldableLowPriority {
   implicit def catsTraverseForSeq: Traverse[Seq] = cats.instances.seq.catsStdInstancesForSeq
 }
 


### PR DESCRIPTION
Hi, first (try)pr here. Trying to solve the bug at [issue #4370](https://github.com/typelevel/cats/issues/4370).

I followed the idea to de-prioritize the Seq instance. Though it solves the issue mentioned, it prompts some other warnings at compilation time (I'm not sure it's specific to this change). 

As told in the issue, I'll be reading a bit if there is another way around it, unless the solution is considered good enough.
Any ideas or directions are welcome.