### PR TITLE
Update CONTRIBUTING.md microsite information

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -189,14 +189,9 @@ The documentation for this website is stored alongside the source, in the [docs 
 
 ### Generating the Site
 
-The microsite generation requires a specific scala version that might
-differ from the project's one. We strongly suggest to check the CI's
-workflow to discover the proper version:
-[CI scala-version matrix](https://github.com/typelevel/cats/blob/main/.github/workflows/ci.yml#L230) and [CI makeMicrosite
-command](https://github.com/typelevel/cats/blob/main/.github/workflows/ci.yml#L281)
+The command is: `sbt docs/tlSite`
 
-At the moment the command is:
-`sbt ++2.12.15 docs/tlSite`
+We suggest checking the CI's workflow to discover any changes at [CI site job](https://github.com/typelevel/cats/blob/v2.9.0/.github/workflows/ci.yml#L418).
 
 ### Previewing the site
 


### PR DESCRIPTION
Update information on the microsite generation and pinned the blob to the latest release to avoid confusion if the site job gets moved around or changed.