### PR TITLE
Avoid allocating an `Option` in `NonEmptyList#last`

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -56,7 +56,7 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
    * res0: Int = 5
    * }}}
    */
-  def last: A = tail.lastOption.getOrElse(head)
+  def last: A = if (tail.isEmpty) head else tail.last
 
   /**
    * Selects all elements except the last


### PR DESCRIPTION
Change `NonEmptyList#last` to avoid allocating an `Option` via `lastOption`

This is a possible micro-optimization.
I did not benchmark this.


