### PR TITLE
add `zip` for `NonEmptySeq`

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptySeq.scala
+++ b/core/src/main/scala/cats/data/NonEmptySeq.scala
@@ -278,8 +278,8 @@ final class NonEmptySeq[+A] private (val toSeq: Seq[A]) extends AnyVal with NonE
    * res0: cats.data.NonEmptySeq[(Int, String)] = NonEmptySeq((1,A), (2,B), (3,C))
    * }}}
    */
-  def zip[B](nel: NonEmptySeq[B]): NonEmptySeq[(A, B)] =
-    NonEmptySeq((head, nel.head), tail.zip(nel.tail))
+  def zip[B](nes: NonEmptySeq[B]): NonEmptySeq[(A, B)] =
+    NonEmptySeq((head, nes.head), tail.zip(nes.tail))
 
   def mapWithIndex[B](f: (A, Int) => B): NonEmptySeq[B] =
     new NonEmptySeq(toSeq.zipWithIndex.map(ai => f(ai._1, ai._2)))

--- a/core/src/main/scala/cats/data/NonEmptySeq.scala
+++ b/core/src/main/scala/cats/data/NonEmptySeq.scala
@@ -267,6 +267,20 @@ final class NonEmptySeq[+A] private (val toSeq: Seq[A]) extends AnyVal with NonE
   def reverse: NonEmptySeq[A] =
     new NonEmptySeq(toSeq.reverse)
 
+  /**
+   * Zips this `NonEmptySeq` with another `NonEmptySeq` and returns the pairs of elements.
+   *
+   * {{{
+   * scala> import cats.data.NonEmptySeq
+   * scala> val as = NonEmptySeq.of(1, 2, 3)
+   * scala> val bs = NonEmptySeq.of("A", "B", "C")
+   * scala> as.zip(bs)
+   * res0: cats.data.NonEmptySeq[(Int, String)] = NonEmptySeq((1,A), (2,B), (3,C))
+   * }}}
+   */
+  def zip[B](nel: NonEmptySeq[B]): NonEmptySeq[(A, B)] =
+    NonEmptySeq((head, nel.head), tail.zip(nel.tail))
+
   def mapWithIndex[B](f: (A, Int) => B): NonEmptySeq[B] =
     new NonEmptySeq(toSeq.zipWithIndex.map(ai => f(ai._1, ai._2)))
 

--- a/tests/shared/src/test/scala/cats/tests/NonEmptySeqSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NonEmptySeqSuite.scala
@@ -84,4 +84,11 @@ class NonEmptySeqSuite extends NonEmptyCollectionSuite[Seq, NonEmptySeq, NonEmpt
   test("toNeSeq on empty Seq returns None") {
     assert(Seq.empty[Int].toNeSeq == None)
   }
+
+
+  test("NonEmptySeq#zip is consistent with Seq#zip") {
+    forAll { (a: NonEmptySeq[Int], b: NonEmptySeq[Int], f: (Int, Int) => Int) =>
+      assert(a.zip(b).toSeq === (a.toSeq.zip(b.toSeq)))
+    }
+  }
 }

--- a/tests/shared/src/test/scala/cats/tests/NonEmptySeqSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NonEmptySeqSuite.scala
@@ -85,7 +85,6 @@ class NonEmptySeqSuite extends NonEmptyCollectionSuite[Seq, NonEmptySeq, NonEmpt
     assert(Seq.empty[Int].toNeSeq == None)
   }
 
-
   test("NonEmptySeq#zip is consistent with Seq#zip") {
     forAll { (a: NonEmptySeq[Int], b: NonEmptySeq[Int], f: (Int, Int) => Int) =>
       assert(a.zip(b).toSeq === (a.toSeq.zip(b.toSeq)))

--- a/tests/shared/src/test/scala/cats/tests/NonEmptySeqSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NonEmptySeqSuite.scala
@@ -86,7 +86,7 @@ class NonEmptySeqSuite extends NonEmptyCollectionSuite[Seq, NonEmptySeq, NonEmpt
   }
 
   test("NonEmptySeq#zip is consistent with Seq#zip") {
-    forAll { (a: NonEmptySeq[Int], b: NonEmptySeq[Int], f: (Int, Int) => Int) =>
+    forAll { (a: NonEmptySeq[Int], b: NonEmptySeq[Int]) =>
       assert(a.zip(b).toSeq === (a.toSeq.zip(b.toSeq)))
     }
   }


### PR DESCRIPTION
Currently, there is a zip method defined on _NonEmptyList_ (apparently added by a colleague of mine), but none defined for _NonEmptySeq_. So this adds _NonEmptySeq.zip_ too 😸 . 
