### PR TITLE
Add more `MonoidK` based folds

### DIFF
--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -483,6 +483,9 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
     }
   }
 
+  def foldMK[A, G[_], H[_]](fgha: F[G[H[A]]])(implicit G: Monad[G], M: MonoidK[H]): G[H[A]] =
+    foldMapMK(fgha)(identity)
+
   /**
    * Fold implemented using the given `Applicative[G]` and `Monoid[A]` instance.
    *
@@ -499,6 +502,9 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
    */
   def foldA[G[_], A](fga: F[G[A]])(implicit G: Applicative[G], A: Monoid[A]): G[A] =
     foldMapA(fga)(identity)
+
+  def foldAK[A, G[_], H[_]](fgha: F[G[H[A]]])(implicit G: Applicative[G], M: MonoidK[H]): G[H[A]] =
+    foldMapAK(fgha)(identity)
 
   /**
    * Fold implemented by mapping `A` values into `B` in a context `G` and then
@@ -545,6 +551,9 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
   def foldMapM[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: Monad[G], B: Monoid[B]): G[B] =
     foldM(fa, B.empty)((b, a) => G.map(f(a))(B.combine(b, _)))
 
+  def foldMapMK[A, B, G[_], H[_]](fa: F[A])(f: A => G[H[B]])(implicit G: Monad[G], M: MonoidK[H]): G[H[B]] =
+    foldMapM(fa)(f)(G, M.algebra)
+
   /**
    * Fold in an [[Applicative]] context by mapping the `A` values to `G[B]`. combining
    * the `B` values using the given `Monoid[B]` instance.
@@ -565,6 +574,9 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
    */
   def foldMapA[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: Applicative[G], B: Monoid[B]): G[B] =
     foldRight(fa, Eval.now(G.pure(B.empty)))((a, egb) => G.map2Eval(f(a), egb)(B.combine)).value
+
+  def foldMapAK[A, B, G[_], H[_]](fa: F[A])(f: A => G[H[B]])(implicit G: Applicative[G], M: MonoidK[H]): G[H[B]] =
+    foldMapA(fa)(f)(G, M.algebra)
 
   /**
    * Traverse `F[A]` using `Applicative[G]`.

--- a/core/src/main/scala/cats/Traverse.scala
+++ b/core/src/main/scala/cats/Traverse.scala
@@ -213,22 +213,6 @@ trait Traverse[F[_]] extends Functor[F] with Foldable[F] with UnorderedTraverse[
 
   override def unorderedSequence[G[_]: CommutativeApplicative, A](fga: F[G[A]]): G[F[A]] =
     sequence(fga)
-
-  def foldTraverse[A, B, G[_]](fa: F[A])(f: A => G[B])(implicit G: Monad[G], M: Monoid[B]): G[B] =
-    foldM(fa, M.empty) { case (acc, a) =>
-      G.map(f(a)) { b =>
-        M.combine(acc, b)
-      }
-    }
-
-  def foldTraverseK[A, B, G[_], H[_]](fa: F[A])(f: A => G[H[B]])(implicit G: Monad[G], M: MonoidK[H]): G[H[B]] =
-    foldTraverse(fa)(f)(G, M.algebra)
-
-  def foldSequence[A, G[_]](fga: F[G[A]])(implicit G: Monad[G], M: Monoid[A]): G[A] =
-    foldTraverse(fga)(identity)
-
-  def foldSequenceK[A, G[_], H[_]](fgha: F[G[H[A]]])(implicit G: Monad[G], M: MonoidK[H]): G[H[A]] =
-    foldTraverseK(fgha)(identity)
 }
 
 object Traverse {


### PR DESCRIPTION
I am opening this before adding tests and docs to get feedback and see if it is a worth-it addition or not; or even to confirm this doesn't exist already 😅

I found myself needing `foldSequenceK` today having a `List[Resource[IO, HttpRoutes[IO]]` and wanting to get back a `Resource[IO, HttpRoutes[IO]]` in an easy way.