### PR TITLE
Add `Functor#composeBifunctor`

### DIFF
--- a/core/src/main/scala/cats/Bifunctor.scala
+++ b/core/src/main/scala/cats/Bifunctor.scala
@@ -138,11 +138,6 @@ object Bifunctor extends cats.instances.NTupleBifunctorInstances {
   @deprecated("Use cats.syntax object imports", "2.2.0")
   object nonInheritedOps extends ToBifunctorOps
 
-  implicit def bifunctorInFunctorInstance[F[_]: Functor, G[_, _]: Bifunctor]: Bifunctor[λ[(A, B) => F[G[A, B]]]] =
-    new Bifunctor[λ[(A, B) => F[G[A, B]]]] {
-      override def bimap[W, X, Y, Z](fab: F[G[W, X]])(f: W => Y, g: X => Z): F[G[Y, Z]] =
-        Functor[F].map(fab)(Bifunctor[G].bimap(_)(f, g))
-    }
 }
 
 private[cats] trait ComposedBifunctor[F[_, _], G[_, _]] extends Bifunctor[λ[(A, B) => F[G[A, B], G[A, B]]]] {

--- a/core/src/main/scala/cats/Composed.scala
+++ b/core/src/main/scala/cats/Composed.scala
@@ -46,6 +46,14 @@ private[cats] trait ComposedFunctor[F[_], G[_]] extends Functor[λ[α => F[G[α]
     F.map(fga)(ga => G.map(ga)(f))
 }
 
+private[cats] trait ComposedFunctorBifunctor[F[_], G[_, _]] extends Bifunctor[λ[(α, β) => F[G[α, β]]]] { outer =>
+  def F: Functor[F]
+  def G: Bifunctor[G]
+
+  def bimap[W, X, Y, Z](fab: F[G[W, X]])(f: W => Y, g: X => Z): F[G[Y, Z]] =
+    F.map(fab)(G.bimap(_)(f, g))
+}
+
 private[cats] trait ComposedApply[F[_], G[_]] extends Apply[λ[α => F[G[α]]]] with ComposedFunctor[F, G] { outer =>
   def F: Apply[F]
   def G: Apply[G]

--- a/core/src/main/scala/cats/Functor.scala
+++ b/core/src/main/scala/cats/Functor.scala
@@ -214,6 +214,12 @@ trait Functor[F[_]] extends Invariant[F] { self =>
       val G = Functor[G]
     }
 
+  def composeBifunctor[G[_, _]: Bifunctor]: Bifunctor[λ[(α, β) => F[G[α, β]]]] =
+    new ComposedFunctorBifunctor[F, G] {
+      val F = self
+      val G = Bifunctor[G]
+    }
+
   override def composeContravariant[G[_]: Contravariant]: Contravariant[λ[α => F[G[α]]]] =
     new ComposedCovariantContravariant[F, G] {
       val F = self

--- a/tests/shared/src/test/scala/cats/tests/BifunctorSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/BifunctorSuite.scala
@@ -48,6 +48,7 @@ class BifunctorSuite extends CatsSuite {
 
   {
     type Tuple2InsideOption[A, B] = Option[(A, B)]
+    implicit val composedBifunctor: Bifunctor[Tuple2InsideOption] = Functor[Option].composeBifunctor[(*, *)]
     checkAll(
       "Bifunctor[Option[(A, B)]",
       BifunctorTests[Tuple2InsideOption].bifunctor[String, String, String, Int, Int, Int]


### PR DESCRIPTION
This PR proposes a different encoding of https://github.com/typelevel/cats/pull/4362 (note, which is not yet released). /cc @bpholt

Specifically, Cats has a precedent of offering various `compose` methods for creating nested instances, but I'm not sure if there is much precedent for offering these instances as `implicit`s. Furthermore as noted in https://github.com/typelevel/cats/pull/4362 inference does not work very well for this implicit anyway.

So I think replacing the implicit with a `composeBifunctor` method may yield better and more consistent ergonomics i.e. Instead of:
```scala
Bifunctor[λ[(A, B) => F[(A, B)]]].leftMap(fab)(f)
```
now you would write:
```scala
Functor[F].composeBifunctor[(*, *)].leftMap(fab)(f)
// or
F.composeBifunctor[(*, *)].leftMap(fab)(f)
```

Thoughts?