### PR TITLE
Add `raiseWhen`/`raiseUnless` convenience methods to `EitherObjectOps`

### DIFF
--- a/core/src/main/scala/cats/syntax/either.scala
+++ b/core/src/main/scala/cats/syntax/either.scala
@@ -416,6 +416,30 @@ final class EitherObjectOps(private val either: Either.type) extends AnyVal {
    * Cached value of `Right(())` to avoid allocations for a common case.
    */
   def unit[A]: Either[A, Unit] = EitherUtil.unit
+
+  /**
+   * Returns `Left(ifTrue)` when the `cond` is true, otherwise `Right(())`
+   *
+   * @example {{{
+   * val tooMany = 5
+   * val x: Int = ???
+   * Either.raiseWhen(x >= tooMany)(new IllegalArgumentException("Too many"))
+   * }}}
+   */
+  def raiseWhen[A](cond: Boolean)(ifTrue: => A): Either[A, Unit] =
+    ApplicativeError[Either[A, *], A].raiseWhen(cond)(ifTrue)
+
+  /**
+   * Returns `Left(ifFalse)` when `cond` is false, otherwise `Right(())`
+   *
+   * @example {{{
+   * val tooMany = 5
+   * val x: Int = ???
+   * Either.raiseUnless(x < tooMany)(new IllegalArgumentException("Too many"))
+   * }}}
+   */
+  def raiseUnless[A](cond: Boolean)(ifFalse: => A): Either[A, Unit] =
+    ApplicativeError[Either[A, *], A].raiseUnless(cond)(ifFalse)
 }
 
 final class LeftOps[A, B](private val left: Left[A, B]) extends AnyVal {

--- a/tests/shared/src/test/scala/cats/tests/EitherSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/EitherSuite.scala
@@ -414,6 +414,16 @@ class EitherSuite extends CatsSuite {
       assert(either.leftFlatMap(f) === (either.swap.flatMap(a => f(a).swap).swap))
     }
   }
+
+  test("raiseWhen raises when true") {
+    val result = Either.raiseWhen(true)("ok")
+    assert(result === Left("ok"))
+  }
+
+  test("raiseUnless raises when false") {
+    val result = Either.raiseUnless(false)("ok")
+    assert(result === Left("ok"))
+  }
 }
 
 final class EitherInstancesSuite extends munit.FunSuite {


### PR DESCRIPTION
Similar to the ones for `IO`

