### PR TITLE
Fix ambiguous `Const` instances and add missing instances

### DIFF
--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -110,7 +110,7 @@ sealed abstract private[data] class ConstInstances extends ConstInstances0 {
   implicit def catsDataShowForConst[A: Show, B]: Show[Const[A, B]] = _.show
 
   implicit def catsDataTraverseForConst[C]: Traverse[Const[C, *]] =
-    new Traverse[Const[C, *]] {
+    new Traverse[Const[C, *]] with ConstFunctor[C] {
       def foldLeft[A, B](fa: Const[C, A], b: B)(f: (B, A) => B): B = b
 
       def foldRight[A, B](fa: Const[C, A], lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] = lb
@@ -244,7 +244,7 @@ sealed abstract private[data] class ConstInstances3 extends ConstInstances4 {
 sealed abstract private[data] class ConstInstances4
 
 sealed private[data] trait ConstFunctor[C] extends Functor[Const[C, *]] {
-  def map[A, B](fa: Const[C, A])(f: A => B): Const[C, B] =
+  final override def map[A, B](fa: Const[C, A])(f: A => B): Const[C, B] =
     fa.retag[B]
 }
 
@@ -264,7 +264,7 @@ sealed private[data] trait ConstApply[C] extends ConstFunctor[C] with Apply[Cons
     fa.retag[(A, B)].combine(fb.retag[(A, B)])
 }
 
-sealed private[data] trait ConstApplicative[C] extends ConstApply[C] with Applicative[Const[C, *]] {
+sealed private[data] trait ConstApplicative[C] extends Applicative[Const[C, *]] with ConstApply[C] {
 
   implicit def C0: Monoid[C]
 

--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -24,6 +24,8 @@ package data
 
 import cats.kernel.{CommutativeMonoid, CommutativeSemigroup, LowerBounded, UpperBounded}
 
+import scala.annotation.nowarn
+
 /**
  * [[Const]] is a phantom type, it does not contain a value of its second type parameter `B`
  * [[Const]] can be seen as a type level version of `Function.const[A, B]: A => B => A`
@@ -39,6 +41,7 @@ final case class Const[A, B](getConst: A) {
   def combine(that: Const[A, B])(implicit A: Semigroup[A]): Const[A, B] =
     Const(A.combine(getConst, that.getConst))
 
+  @nowarn("cat=unused")
   def traverse[F[_], C](f: B => F[C])(implicit F: Applicative[F]): F[Const[A, C]] =
     F.pure(retag[C])
 
@@ -50,6 +53,9 @@ final case class Const[A, B](getConst: A) {
 
   def compare(that: Const[A, B])(implicit A: Order[A]): Int =
     A.compare(getConst, that.getConst)
+
+  def hash(implicit A: Hash[A]): Int =
+    Const(A.hash(getConst)).hashCode()
 
   def show(implicit A: Show[A]): String =
     s"Const(${A.show(getConst)})"
@@ -92,11 +98,13 @@ sealed abstract private[data] class ConstInstances extends ConstInstances0 {
 
   implicit def catsDataOrderForConst[A: Order, B]: Order[Const[A, B]] = _ compare _
 
+  implicit def catsDataPartialOrderForConst[A: PartialOrder, B]: PartialOrder[Const[A, B]] = _ partialCompare _
+
   implicit def catsDataAlignForConst[A: Semigroup]: Align[Const[A, *]] =
     new Align[Const[A, *]] {
       def align[B, C](fa: Const[A, B], fb: Const[A, C]): Const[A, Ior[B, C]] =
         Const(Semigroup[A].combine(fa.getConst, fb.getConst))
-      def functor: Functor[Const[A, *]] = catsDataFunctorForConst
+      def functor: Functor[Const[A, *]] = catsDataTraverseForConst
     }
 
   implicit def catsDataShowForConst[A: Show, B]: Show[Const[A, B]] = _.show
@@ -121,22 +129,22 @@ sealed abstract private[data] class ConstInstances extends ConstInstances0 {
   implicit def catsDataTraverseFilterForConst[C]: TraverseFilter[Const[C, *]] =
     new TraverseFilter[Const[C, *]] {
 
-      override def mapFilter[A, B](fa: Const[C, A])(f: (A) => Option[B]): Const[C, B] = fa.retag
+      override def mapFilter[A, B](fa: Const[C, A])(f: A => Option[B]): Const[C, B] = fa.retag
 
       override def collect[A, B](fa: Const[C, A])(f: PartialFunction[A, B]): Const[C, B] = fa.retag
 
       override def flattenOption[A](fa: Const[C, Option[A]]): Const[C, A] = fa.retag
 
-      override def filter[A](fa: Const[C, A])(f: (A) => Boolean): Const[C, A] = fa.retag
+      override def filter[A](fa: Const[C, A])(f: A => Boolean): Const[C, A] = fa.retag
 
       override def filterNot[A](fa: Const[C, A])(f: A => Boolean): Const[C, A] = fa.retag
 
       def traverseFilter[G[_], A, B](
         fa: Const[C, A]
-      )(f: (A) => G[Option[B]])(implicit G: Applicative[G]): G[Const[C, B]] =
+      )(f: A => G[Option[B]])(implicit G: Applicative[G]): G[Const[C, B]] =
         G.pure(fa.retag[B])
 
-      override def filterA[G[_], A](fa: Const[C, A])(f: (A) => G[Boolean])(implicit G: Applicative[G]): G[Const[C, A]] =
+      override def filterA[G[_], A](fa: Const[C, A])(f: A => G[Boolean])(implicit G: Applicative[G]): G[Const[C, A]] =
         G.pure(fa)
 
       val traverse: Traverse[Const[C, *]] = Const.catsDataTraverseForConst[C]
@@ -151,6 +159,8 @@ sealed abstract private[data] class ConstInstances extends ConstInstances0 {
         x.combine(y)
     }
 
+  implicit def catsDataSemigroupForConst[A: Semigroup, B]: Semigroup[Const[A, B]] = _ combine _
+
   implicit val catsDataBifoldableForConst: Bifoldable[Const] =
     new Bifoldable[Const] {
       def bifoldLeft[A, B, C](fab: Const[A, B], c: C)(f: (C, A) => C, g: (C, B) => C): C =
@@ -161,9 +171,25 @@ sealed abstract private[data] class ConstInstances extends ConstInstances0 {
       ): Eval[C] =
         f(fab.getConst, c)
     }
+
+  implicit def catsDataMonoidKForConst[C: Monoid]: MonoidK[Const[C, *]] = new MonoidK[Const[C, *]] {
+    override def empty[A]: Const[C, A] = Const.empty
+    override def combineK[A](x: Const[C, A], y: Const[C, A]): Const[C, A] = x.combine(y)
+  }
+
+  implicit def catsDataSemigroupKForConst[C: Semigroup]: SemigroupK[Const[C, *]] = new SemigroupK[Const[C, *]] {
+    override def combineK[A](x: Const[C, A], y: Const[C, A]): Const[C, A] = x.combine(y)
+  }
 }
 
 sealed abstract private[data] class ConstInstances0 extends ConstInstances1 {
+
+  implicit def catsDataEqForConst[A: Eq, B]: Eq[Const[A, B]] = _ === _
+
+  implicit def catsDataHashForConst[A: Hash, B]: Hash[Const[A, B]] = new Hash[Const[A, B]] {
+    override def hash(x: Const[A, B]): Int = x.hash
+    override def eqv(x: Const[A, B], y: Const[A, B]): Boolean = x === y
+  }
 
   implicit def catsDataContravariantMonoidalForConst[D: Monoid]: ContravariantMonoidal[Const[D, *]] =
     new ContravariantMonoidal[Const[D, *]] {
@@ -174,13 +200,23 @@ sealed abstract private[data] class ConstInstances0 extends ConstInstances1 {
         fa.retag[(A, B)].combine(fb.retag[(A, B)])
     }
 
-  implicit def catsDataCommutativeApplicativeForConst[C](implicit
-    C: CommutativeMonoid[C]
-  ): CommutativeApplicative[Const[C, *]] =
-    new ConstApplicative[C] with CommutativeApplicative[Const[C, *]] { val C0: CommutativeMonoid[C] = C }
+  implicit def catsDataContravariantSemigroupalForConst[D: Semigroup]: ContravariantSemigroupal[Const[D, *]] =
+    new ContravariantSemigroupal[Const[D, *]] {
+      override def contramap[A, B](fa: Const[D, A])(f: B => A): Const[D, B] =
+        fa.retag[B]
+      override def product[A, B](fa: Const[D, A], fb: Const[D, B]): Const[D, (A, B)] =
+        fa.retag[(A, B)].combine(fb.retag[(A, B)])
+    }
 }
 
 sealed abstract private[data] class ConstInstances1 extends ConstInstances2 {
+
+  implicit def catsDataCommutativeApplicativeForConst[C](implicit
+    C: CommutativeMonoid[C]
+  ): CommutativeApplicative[Const[C, *]] =
+    new ConstApplicative[C] with CommutativeApplicative[Const[C, *]] {
+      val C0: CommutativeMonoid[C] = C
+    }
 
   implicit def catsDataCommutativeApplyForConst[C](implicit C: CommutativeSemigroup[C]): CommutativeApply[Const[C, *]] =
     new ConstApply[C] with CommutativeApply[Const[C, *]] { val C0: CommutativeSemigroup[C] = C }
@@ -188,29 +224,24 @@ sealed abstract private[data] class ConstInstances1 extends ConstInstances2 {
 
 sealed abstract private[data] class ConstInstances2 extends ConstInstances3 {
 
-  implicit def catsDataSemigroupForConst[A: Semigroup, B]: Semigroup[Const[A, B]] = _ combine _
-
-  implicit def catsDataPartialOrderForConst[A: PartialOrder, B]: PartialOrder[Const[A, B]] = _ partialCompare _
-
   implicit def catsDataApplicativeForConst[C](implicit C: Monoid[C]): Applicative[Const[C, *]] =
     new ConstApplicative[C] { val C0: Monoid[C] = C }
-}
-
-sealed abstract private[data] class ConstInstances3 extends ConstInstances4 {
-  implicit def catsDataEqForConst[A: Eq, B]: Eq[Const[A, B]] = _ === _
 
   implicit def catsDataApplyForConst[C](implicit C: Semigroup[C]): Apply[Const[C, *]] =
     new ConstApply[C] { val C0: Semigroup[C] = C }
 }
 
-sealed abstract private[data] class ConstInstances4 {
+sealed abstract private[data] class ConstInstances3 extends ConstInstances4 {
 
-  implicit def catsDataFunctorForConst[C]: Functor[Const[C, *]] =
+  @deprecated("Use catsDataTraverseForConst instead", "2.10.0")
+  def catsDataFunctorForConst[C]: Functor[Const[C, *]] =
     new ConstFunctor[C] {}
 
   implicit def catsDataContravariantForConst[C]: Contravariant[Const[C, *]] =
     new ConstContravariant[C] {}
 }
+
+sealed abstract private[data] class ConstInstances4
 
 sealed private[data] trait ConstFunctor[C] extends Functor[Const[C, *]] {
   def map[A, B](fa: Const[C, A])(f: A => B): Const[C, B] =

--- a/tests/shared/src/test/scala/cats/tests/ConstSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/ConstSuite.scala
@@ -128,7 +128,7 @@ class ConstSuite extends CatsSuite {
     forAll { (const: Const[Int, String]) =>
       assert(const.show.startsWith("Const(") === true)
       const.show.contains(const.getConst.show)
-      assert(const.show === implicitly[Show[Const[Int, String]]].show(const))
+      assert(const.show === Show[Const[Int, String]].show(const))
       assert(const.show === const.retag[Boolean].show)
     }
   }

--- a/tests/shared/src/test/scala/cats/tests/ConstSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/ConstSuite.scala
@@ -26,6 +26,7 @@ import cats.data.{Const, NonEmptyList}
 import cats.kernel.Semigroup
 import cats.kernel.laws.discipline.{
   EqTests,
+  HashTests,
   LowerBoundedTests,
   MonoidTests,
   OrderTests,
@@ -33,12 +34,12 @@ import cats.kernel.laws.discipline.{
   SemigroupTests,
   UpperBoundedTests
 }
-import cats.laws.discipline._
 import cats.laws.discipline.SemigroupalTests.Isomorphisms
+import cats.laws.discipline._
 import cats.laws.discipline.arbitrary._
-import cats.syntax.show._
-import cats.tests.Helpers.{CMono, CSemi}
 import cats.syntax.eq._
+import cats.syntax.show._
+import cats.tests.Helpers.{CMono, CSemi, Semi}
 import org.scalacheck.Prop._
 
 class ConstSuite extends CatsSuite {
@@ -100,9 +101,16 @@ class ConstSuite extends CatsSuite {
   checkAll("Const[String, Int]", ContravariantTests[Const[String, *]].contravariant[Int, Int, Int])
   checkAll("Contravariant[Const[String, *]]", SerializableTests.serializable(Contravariant[Const[String, *]]))
 
-  checkAll("Const[String, Int]", ContravariantMonoidalTests[Const[String, *]].contravariantMonoidal[Int, Int, Int])
-  checkAll("ContravariantMonoidal[Const[String, *]]",
-           SerializableTests.serializable(ContravariantMonoidal[Const[String, *]])
+  checkAll("ContravariantMonoidal[Const[Int, *]]",
+           ContravariantMonoidalTests[Const[Int, *]].contravariantMonoidal[Int, Int, Int]
+  )
+  checkAll("ContravariantMonoidal[Const[Int, *]]", SerializableTests.serializable(ContravariantMonoidal[Const[Int, *]]))
+
+  checkAll("ContravariantSemigroupal[Const[Semi, *]]",
+           ContravariantSemigroupalTests[Const[Semi, *]].contravariantSemigroupal[Int, Int, Int]
+  )
+  checkAll("ContravariantSemigroupal[Const[Semi, *]]",
+           SerializableTests.serializable(ContravariantSemigroupal[Const[Semi, *]])
   )
 
   checkAll("Const[*, *]", BifoldableTests[Const].bifoldable[Int, Int, Int])
@@ -120,8 +128,8 @@ class ConstSuite extends CatsSuite {
     forAll { (const: Const[Int, String]) =>
       assert(const.show.startsWith("Const(") === true)
       const.show.contains(const.getConst.show)
-      assert(const.show === (implicitly[Show[Const[Int, String]]].show(const)))
-      assert(const.show === (const.retag[Boolean].show))
+      assert(const.show === implicitly[Show[Const[Int, String]]].show(const))
+      assert(const.show === const.retag[Boolean].show)
     }
   }
 
@@ -130,7 +138,7 @@ class ConstSuite extends CatsSuite {
 
   {
     implicit val iso: Isomorphisms[Const[CMono, *]] =
-      Isomorphisms.invariant[Const[CMono, *]](Const.catsDataFunctorForConst)
+      Isomorphisms.invariant[Const[CMono, *]](Const.catsDataTraverseForConst)
     checkAll("Const[CMono, Int]", CommutativeApplicativeTests[Const[CMono, *]].commutativeApplicative[Int, Int, Int])
     checkAll("CommutativeApplicative[Const[CMono, *]]",
              SerializableTests.serializable(CommutativeApplicative[Const[CMono, *]])
@@ -139,4 +147,23 @@ class ConstSuite extends CatsSuite {
 
   checkAll("Const[CSemi, Int]", CommutativeApplyTests[Const[CSemi, *]].commutativeApply[Int, Int, Int])
   checkAll("CommutativeApply[Const[CSemi, *]]", SerializableTests.serializable(CommutativeApply[Const[CSemi, *]]))
+
+  checkAll("Hash[Const[Int, String]]", HashTests[Const[Int, String]].hash)
+  checkAll("Hash[Const[Int, String]]", SerializableTests.serializable(Hash[Const[Int, String]]))
+
+  checkAll("MonoidK[Const[Int, *]]", MonoidKTests[Const[Int, *]].monoidK[Int])
+  checkAll("MonoidK[Const[Int, *]]", SerializableTests.serializable(MonoidK[Const[Int, *]]))
+
+  checkAll("SemigroupK[Const[Int, *]]", SemigroupKTests[Const[Semi, *]].semigroupK[Int])
+  checkAll("SemigroupK[Const[Int, *]]", SerializableTests.serializable(SemigroupK[Const[Semi, *]]))
+}
+
+object ConstSuite {
+  def summonInstances[A, B: Hash](): Unit = {
+    InvariantMonoidal[Const[Int, *]]
+    Invariant[Const[A, *]]
+    Functor[Const[A, *]]
+    Eq[Const[B, Int]]
+    ()
+  }
 }


### PR DESCRIPTION
 - Reorder instances in `Const` systematically
 - Fix ambiguous `InvariantMonoidal` instance
 - Add `ContravariantSemigroupal` instance
 - Deprecate unnecessary `Functor` instance
 - Add `Hash` instance and `hash` method
 - Add `SemigroupK` and `MonoidK` instances


