### PR TITLE
Delete PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,0 @@
-Thank you for contributing to Cats!
-
-This is a kind reminder to run `sbt +prePR` and commit the changed files, if any, before submitting.
-
-


### PR DESCRIPTION
Stop asking contributors to run `+prePR`.
That's a way too heavy operation for a laptop due to Scala native. It's better to open a PR and let CI check it.

> Thank you for contributing to Cats!

> This is a kind reminder to run `sbt +prePR` and commit the changed files, if any, before submitting.

No, thanks! I have to `kill -9` it if I try 😄 


