### PR TITLE
Add `Empty` instance for `Option`

### DIFF
--- a/alleycats-core/src/main/scala/alleycats/Empty.scala
+++ b/alleycats-core/src/main/scala/alleycats/Empty.scala
@@ -21,7 +21,7 @@
 
 package alleycats
 
-import cats.{Eq, Monoid}
+import cats.{Eq, Monoid, MonoidK}
 import cats.syntax.eq._
 
 trait Empty[A] extends Serializable {
@@ -80,7 +80,7 @@ object Empty extends EmptyInstances0 {
 }
 
 private[alleycats] trait EmptyInstances0 extends compat.IterableEmptyInstance with EmptyInstances1 {
-  implicit def optionIsEmpty[A]: Empty[Option[A]] = Empty(None)
+  implicit def monoidKIsEmpty[F[_]: MonoidK, A]: Empty[F[A]] = Empty(MonoidK[F].empty[A])
 }
 
 private[alleycats] trait EmptyInstances1 {

--- a/alleycats-core/src/main/scala/alleycats/Empty.scala
+++ b/alleycats-core/src/main/scala/alleycats/Empty.scala
@@ -79,7 +79,9 @@ object Empty extends EmptyInstances0 {
 
 }
 
-private[alleycats] trait EmptyInstances0 extends compat.IterableEmptyInstance with EmptyInstances1
+private[alleycats] trait EmptyInstances0 extends compat.IterableEmptyInstance with EmptyInstances1 {
+  implicit def optionIsEmpty[A]: Empty[Option[A]] = Empty(None)
+}
 
 private[alleycats] trait EmptyInstances1 {
   // If Monoid extended Empty then this could be an exported subclass instance provided by Monoid


### PR DESCRIPTION
## 🚀 What's included in this PR?

This PR provides an out-of-the-box instance for any `Option`, not just the ones with an underlying `Monoid` instance.

## References

Fixes: #3617