### PR TITLE
Specify impl for `Show[Symbol]`

### DIFF
--- a/core/src/main/scala/cats/instances/SymbolInstances.scala
+++ b/core/src/main/scala/cats/instances/SymbolInstances.scala
@@ -25,5 +25,5 @@ import cats.Show
 
 trait SymbolInstances extends cats.kernel.instances.SymbolInstances {
   implicit val catsStdShowForSymbol: Show[Symbol] =
-    Show.fromToString[Symbol]
+    Show.show("'" + _.name)
 }


### PR DESCRIPTION
On 2.12, `Symbol.toString` is e.g. `'foo`. On 2.13, it's `Symbol(foo)`.

I want to use `Show` to get away from the vagaries of relying on `.toString` - to have a reliable nailed-down String representation for types.

Want to use `Show` to build a pretty-printer, without having the output depend on which Scala version you're using.

I tried overriding the `Show[Symbol]` instance locally, but I just got an ambiguous implicit error. Don't know how to not import this instance, since it's on the companion object for `Show`.