### PR TITLE
Bump base version to 2.11

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "2.10"
+ThisBuild / tlBaseVersion := "2.11"
 
 val scalaCheckVersion = "1.17.0"
 


### PR DESCRIPTION
In anticipation of the next round of feature PRs. If the need arises to make a backwards+forwards compatible patch release, we can cut a `series/2.10` branch.