### PR TITLE
Add `OptionT#unlessM`

### DIFF
--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -788,6 +788,14 @@ object OptionT extends OptionTInstances {
     OptionT.whenF(!cond)(fa)
 
   /**
+   * Creates a non-empty `OptionT[F, A]` from an `F[A]` value if the given F-condition is considered `false`.
+   * Otherwise, `none[F, A]` is returned. Analogous to `Option.unless` but for effectful conditions.
+   */
+  def unlessM[F[_], A](cond: F[Boolean])(fa: => F[A])(implicit F: Monad[F]): OptionT[F, A] = OptionT(
+    F.ifM(cond)(ifTrue = F.pure(None), ifFalse = F.map(fa)(Some(_)))
+  )
+
+  /**
    * Same as `unlessF`, but expressed as a FunctionK for use with mapK.
    */
   def unlessK[F[_]](cond: Boolean)(implicit F: Applicative[F]): F ~> OptionT[F, *] =

--- a/tests/shared/src/test/scala/cats/tests/OptionTSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/OptionTSuite.scala
@@ -421,6 +421,21 @@ class OptionTSuite extends CatsSuite {
     }
   }
 
+  test("OptionT.unlessM[Id, A] consistent with Option.unless") {
+    // Option.unless is inlined here because it is not available before Scala 2.13
+    def unless[A]: (Boolean, A) => Option[A] = (c: Boolean, a: A) => if (!c) Some(a) else None
+
+    forAll { (i: Int, b: Boolean) =>
+      assert(OptionT.unlessM[Id, Int](b)(i).value === (unless(b, i)))
+    }
+  }
+
+  test("OptionT.unlessF and OptionT.unlessM consistent") {
+    forAll { (li: List[Int], bs: List[Boolean]) =>
+      assert(bs.flatMap(OptionT.unlessF(_)(li).value) === OptionT.unlessM(bs)(li).value)
+    }
+  }
+
   test("OptionT.unlessK and OptionT.unlessF consistent") {
     forAll { (li: List[Int], b: Boolean) =>
       assert(IdT(li).mapK(OptionT.unlessK(b)).value === (OptionT.unlessF(b)(li)))


### PR DESCRIPTION
Perhaps I'm missing something, but this seems like an obvious counterpart to `whenM` and I was surprised to not find it? There are already `unlessF` and `unlessK` but no `unlessM`.