### PR TITLE
Update flatMapF in nomenclature.md

### DIFF
--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -206,7 +206,7 @@ For convenience, in these types we use the symbol `OT` to abbreviate `OptionT`.
 | `OT[F, A] => (A => Option[B]) => OT[F, B]` | `mapFilter` | `F: Functor`
 | `OT[F, A] => B => (A => B) => F[B]` | `fold` or `cata`
 | `OT[F, A] => (A => OT[F, B]) => OT[F,B]` | `flatMap`
-| `OT[F, A] => (A => F[Option[B]]) => F[B]` | `flatMapF`  | `F: Monad` |
+| `OT[F, A] => (A => F[Option[B]]) => OT[F,B]` | `flatMapF`  | `F: Monad` |
 | `OT[F, A] => A => F[A]` | `getOrElse` | `F: Functor`  |
 | `OT[F, A] => F[A] => F[A]` | `getOrElseF` | `F: Monad`  |
 | `OT[F, A] => OT[F, A] => OT[F, A]` |


### PR DESCRIPTION
Fix type signature of flatMapF:
https://www.javadoc.io/static/org.typelevel/cats-docs_2.13/2.10.0/cats/data/OptionT.html#flatMapF[B](f:A=%3EF[Option[B]])(implicitF:cats.Monad[F]):cats.data.OptionT[F,B]