### PR TITLE
enforce new wildcard syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -26,3 +26,8 @@ fileOverride {
 project.excludeFilters = [
   "scalafix/*"
 ]
+rewrite.scala3.convertToNewSyntax = true
+runner.dialectOverride.allowSignificantIndentation = false
+runner.dialectOverride.allowAsForImportRename = false
+runner.dialectOverride.allowStarWildcardImport = false
+runner.dialectOverride.allowPostfixStarVarargSplices = false

--- a/algebra-core/src/main/scala/algebra/ring/Additive.scala
+++ b/algebra-core/src/main/scala/algebra/ring/Additive.scala
@@ -155,7 +155,7 @@ trait AdditiveCommutativeGroup[@sp(Int, Long, Float, Double) A]
 trait AdditiveSemigroupFunctions[S[T] <: AdditiveSemigroup[T]] {
 
   def isAdditiveCommutative[A](implicit ev: S[A]): Boolean =
-    ev.isInstanceOf[AdditiveCommutativeSemigroup[_]]
+    ev.isInstanceOf[AdditiveCommutativeSemigroup[?]]
 
   def plus[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: S[A]): A =
     ev.plus(x, y)

--- a/build.sbt
+++ b/build.sbt
@@ -121,12 +121,12 @@ lazy val kernelLaws = crossProject(JSPlatform, JVMPlatform, NativePlatform)
   .jvmSettings(commonJvmSettings)
   .nativeSettings(commonNativeSettings)
 
-lazy val algebraSettings = Seq[Setting[_]](
+lazy val algebraSettings = Seq[Setting[?]](
   tlMimaPreviousVersions += "2.2.3",
   tlVersionIntroduced := List("2.12", "2.13", "3").map(_ -> "2.7.0").toMap
 )
 
-lazy val algebraNativeSettings = Seq[Setting[_]](
+lazy val algebraNativeSettings = Seq[Setting[?]](
   tlMimaPreviousVersions ~= (_ - "2.2.3"),
   tlVersionIntroduced += ("3" -> "2.8.0")
 )

--- a/core/src/main/scala/cats/ApplicativeError.scala
+++ b/core/src/main/scala/cats/ApplicativeError.scala
@@ -365,7 +365,7 @@ object ApplicativeError {
   def apply[F[_], E](implicit F: ApplicativeError[F, E]): ApplicativeError[F, E] = F
 
   final private[cats] class LiftFromOptionPartially[F[_]](private val dummy: Boolean = true) extends AnyVal {
-    def apply[E, A](oa: Option[A], ifEmpty: => E)(implicit F: ApplicativeError[F, _ >: E]): F[A] =
+    def apply[E, A](oa: Option[A], ifEmpty: => E)(implicit F: ApplicativeError[F, ? >: E]): F[A] =
       oa match {
         case Some(a) => F.pure(a)
         case None    => F.raiseError(ifEmpty)

--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -165,7 +165,7 @@ sealed abstract class Chain[+A] extends ChainCompat[A] {
   /**
    * Returns true if there are no elements in this collection.
    */
-  def isEmpty: Boolean = !this.isInstanceOf[Chain.NonEmpty[_]]
+  def isEmpty: Boolean = !this.isInstanceOf[Chain.NonEmpty[?]]
 
   /**
    * Returns false if there are no elements in this collection.
@@ -174,7 +174,7 @@ sealed abstract class Chain[+A] extends ChainCompat[A] {
 
   // Quick check whether the chain is either empty or contains one element only.
   @inline private def isEmptyOrSingleton: Boolean =
-    isEmpty || this.isInstanceOf[Chain.Singleton[_]]
+    isEmpty || this.isInstanceOf[Chain.Singleton[?]]
 
   /**
    * Concatenates this with `c` in O(1) runtime.
@@ -863,7 +863,7 @@ sealed abstract class Chain[+A] extends ChainCompat[A] {
 
   override def equals(o: Any): Boolean =
     o match {
-      case thatChain: Chain[_] =>
+      case thatChain: Chain[?] =>
         (this: Chain[Any]).===(thatChain: Chain[Any])(Eq.fromUniversalEquals[Any])
       case _ => false
     }

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -150,7 +150,7 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
    * res0: Try[Int] = Failure(java.lang.RuntimeException: ERROR!)
    * }}}
    */
-  def getOrRaise[E](e: => E)(implicit F: MonadError[F, _ >: E]): F[B] =
+  def getOrRaise[E](e: => E)(implicit F: MonadError[F, ? >: E]): F[B] =
     getOrElseF(F.raiseError(e))
 
   /**
@@ -248,7 +248,7 @@ final case class EitherT[F[_], A, B](value: F[Either[A, B]]) {
    * res3: util.Try[String] = Failure(java.lang.Exception: sad cats)
    * }}}
    */
-  def rethrowT(implicit F: MonadError[F, _ >: A]): F[B] =
+  def rethrowT(implicit F: MonadError[F, ? >: A]): F[B] =
     F.rethrow(value)
 
   /**

--- a/core/src/main/scala/cats/data/IorT.scala
+++ b/core/src/main/scala/cats/data/IorT.scala
@@ -78,7 +78,7 @@ final case class IorT[F[_], A, B](value: F[Ior[A, B]]) {
    * res0: Try[Int] = Failure(java.lang.RuntimeException: ERROR!)
    * }}}
    */
-  def getOrRaise[E](e: => E)(implicit F: MonadError[F, _ >: E]): F[B] =
+  def getOrRaise[E](e: => E)(implicit F: MonadError[F, ? >: E]): F[B] =
     getOrElseF(F.raiseError(e))
 
   def valueOr[BB >: B](f: A => BB)(implicit F: Functor[F], BB: Semigroup[BB]): F[BB] = F.map(value)(_.valueOr(f))

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -76,7 +76,7 @@ final case class Kleisli[F[_], -A, B](run: A => F[B]) { self =>
     }
 
   def flatMapF[C](f: B => F[C])(implicit F: FlatMap[F]): Kleisli[F, A, C] = run match {
-    case run: StrictConstFunction1[_] => Kleisli(run.andThen(F.flatMap(_: F[B])(f)))
+    case run: StrictConstFunction1[?] => Kleisli(run.andThen(F.flatMap(_: F[B])(f)))
     case _                            => Kleisli.shift(a => F.flatMap(run(a))(f))
   }
 

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -315,7 +315,7 @@ final case class OptionT[F[_], A](value: F[Option[A]]) {
    * res0: Try[Int] = Failure(java.lang.RuntimeException: ERROR!)
    * }}}
    */
-  def getOrRaise[E](e: => E)(implicit F: MonadError[F, _ >: E]): F[A] =
+  def getOrRaise[E](e: => E)(implicit F: MonadError[F, ? >: E]): F[A] =
     getOrElseF(F.raiseError(e))
 
   /**

--- a/core/src/main/scala/cats/syntax/applicativeError.scala
+++ b/core/src/main/scala/cats/syntax/applicativeError.scala
@@ -63,7 +63,7 @@ final private[syntax] class ApplicativeErrorExtensionOps[F[_], E](F: Applicative
 }
 
 final class ApplicativeErrorIdOps[E](private val e: E) extends AnyVal {
-  def raiseError[F[_], A](implicit F: ApplicativeError[F, _ >: E]): F[A] =
+  def raiseError[F[_], A](implicit F: ApplicativeError[F, ? >: E]): F[A] =
     F.raiseError(e)
 }
 

--- a/core/src/main/scala/cats/syntax/either.scala
+++ b/core/src/main/scala/cats/syntax/either.scala
@@ -352,7 +352,7 @@ final class EitherOps[A, B](private val eab: Either[A, B]) extends AnyVal {
    * res0: cats.data.EitherT[Option, CharSequence, Int] = EitherT(Some(Right(3)))
    * }}}
    */
-  def liftTo[F[_]](implicit F: ApplicativeError[F, _ >: A]): F[B] = F.fromEither(eab)
+  def liftTo[F[_]](implicit F: ApplicativeError[F, ? >: A]): F[B] = F.fromEither(eab)
 }
 
 final class EitherObjectOps(private val either: Either.type) extends AnyVal {

--- a/core/src/main/scala/cats/syntax/monadError.scala
+++ b/core/src/main/scala/cats/syntax/monadError.scala
@@ -28,7 +28,7 @@ trait MonadErrorSyntax {
 
   implicit final def catsSyntaxMonadErrorRethrow[F[_], E, A](
     fea: F[Either[E, A]]
-  )(implicit F: MonadError[F, _ >: E]): MonadErrorRethrowOps[F, E, A] =
+  )(implicit F: MonadError[F, ? >: E]): MonadErrorRethrowOps[F, E, A] =
     new MonadErrorRethrowOps(fea)
 }
 
@@ -59,7 +59,7 @@ final class MonadErrorOps[F[_], E, A](private val fa: F[A]) extends AnyVal {
 }
 
 final class MonadErrorRethrowOps[F[_], E, A](private val fea: F[Either[E, A]]) extends AnyVal {
-  def rethrow(implicit F: MonadError[F, _ >: E]): F[A] =
+  def rethrow(implicit F: MonadError[F, ? >: E]): F[A] =
     F.flatMap(fea)(
       _.fold(F.raiseError, F.pure)
     ) // dup from the type class impl, due to https://github.com/scala/bug/issues/11562. Once fixed should be able to replace with `F.rethrow(fea)`

--- a/core/src/main/scala/cats/syntax/option.scala
+++ b/core/src/main/scala/cats/syntax/option.scala
@@ -391,7 +391,7 @@ final class OptionOps[A](private val oa: Option[A]) extends AnyVal {
 
 object OptionOps {
   final class LiftToPartiallyApplied[F[_], A](oa: Option[A]) {
-    def apply[E](ifEmpty: => E)(implicit F: ApplicativeError[F, _ >: E]): F[A] =
+    def apply[E](ifEmpty: => E)(implicit F: ApplicativeError[F, ? >: E]): F[A] =
       ApplicativeError.liftFromOption(oa, ifEmpty)
   }
 }

--- a/core/src/main/scala/cats/syntax/validated.scala
+++ b/core/src/main/scala/cats/syntax/validated.scala
@@ -41,7 +41,7 @@ trait ValidatedExtensionSyntax {
 }
 
 final class ValidatedExtension[E, A](private val self: Validated[E, A]) extends AnyVal {
-  def liftTo[F[_]](implicit F: ApplicativeError[F, _ >: E]): F[A] =
+  def liftTo[F[_]](implicit F: ApplicativeError[F, ? >: E]): F[A] =
     F.fromValidated(self)
 }
 

--- a/free/src/main/scala/cats/free/FreeApplicative.scala
+++ b/free/src/main/scala/cats/free/FreeApplicative.scala
@@ -80,7 +80,7 @@ sealed abstract class FreeApplicative[F[_], A] extends Product with Serializable
       argsFLength -= 1
 
       // rip off every `Ap` in `argF` in function position
-      if (argF.isInstanceOf[Ap[F, _, _]]) {
+      if (argF.isInstanceOf[Ap[F, ?, ?]]) {
         val lengthInitial = argsFLength
         // reassociate the functions into a single fn,
         // and move the arguments into argsF
@@ -89,7 +89,7 @@ sealed abstract class FreeApplicative[F[_], A] extends Product with Serializable
           argsF ::= ap.fp
           argsFLength += 1
           argF = ap.fn.asInstanceOf[FA[F, Any]]
-          argF.isInstanceOf[Ap[F, _, _]]
+          argF.isInstanceOf[Ap[F, ?, ?]]
         }) ()
         // consecutive `ap` calls have been queued as operations;
         // argF is no longer an `Ap` node, so the entire topmost left-associated

--- a/kernel/src/main/scala/cats/kernel/Semigroup.scala
+++ b/kernel/src/main/scala/cats/kernel/Semigroup.scala
@@ -140,10 +140,10 @@ abstract class SemigroupFunctions[S[T] <: Semigroup[T]] {
     }
 
   def isCommutative[A](implicit ev: S[A]): Boolean =
-    ev.isInstanceOf[CommutativeSemigroup[_]]
+    ev.isInstanceOf[CommutativeSemigroup[?]]
 
   def isIdempotent[A](implicit ev: S[A]): Boolean =
-    ev.isInstanceOf[Band[_]]
+    ev.isInstanceOf[Band[?]]
 
   def combineN[@sp(Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: S[A]): A =
     ev.combineN(a, n)

--- a/tests/shared/src/test/scala/cats/tests/EitherSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/EitherSuite.scala
@@ -108,9 +108,9 @@ class EitherSuite extends CatsSuite {
 
   test("implicit instances resolve specifically") {
     val eq = cats.kernel.instances.either.catsStdEqForEither[Int, String]
-    assert(!eq.isInstanceOf[PartialOrder[_]])
-    assert(!eq.isInstanceOf[Order[_]])
-    assert(!partialOrder.isInstanceOf[Order[_]])
+    assert(!eq.isInstanceOf[PartialOrder[?]])
+    assert(!eq.isInstanceOf[Order[?]])
+    assert(!partialOrder.isInstanceOf[Order[?]])
   }
 
   test("show isn't empty") {


### PR DESCRIPTION
- Scala 3 report warnings since 3.4 https://github.com/lampepfl/dotty/pull/18813
- Scala 2.12 and 2.13 support new syntax without `-Xsource:3` option https://github.com/scala/scala/pull/10005