### PR TITLE
Add Char/Byte specialization to kernel typeclasses

### DIFF
--- a/kernel/src/main/scala/cats/kernel/Band.scala
+++ b/kernel/src/main/scala/cats/kernel/Band.scala
@@ -27,7 +27,7 @@ import scala.{specialized => sp}
  * Bands are semigroups whose operation
  * (i.e. combine) is also idempotent.
  */
-trait Band[@sp(Int, Long, Float, Double) A] extends Any with Semigroup[A] {
+trait Band[@sp(Byte, Char, Int, Long, Float, Double) A] extends Any with Semigroup[A] {
   override protected[this] def repeatedCombineN(a: A, n: Int): A =
     a // combine(a, a) == a
 }
@@ -37,7 +37,7 @@ object Band extends SemigroupFunctions[Band] {
   /**
    * Access an implicit `Band[A]`.
    */
-  @inline final def apply[@sp(Int, Long, Float, Double) A](implicit ev: Band[A]): Band[A] = ev
+  @inline final def apply[@sp(Byte, Char, Int, Long, Float, Double) A](implicit ev: Band[A]): Band[A] = ev
 
   /**
    * Create a `Band` instance from the given function.

--- a/kernel/src/main/scala/cats/kernel/BoundedSemilattice.scala
+++ b/kernel/src/main/scala/cats/kernel/BoundedSemilattice.scala
@@ -23,7 +23,10 @@ package cats.kernel
 
 import scala.{specialized => sp}
 
-trait BoundedSemilattice[@sp(Byte, Char, Int, Long, Float, Double) A] extends Any with Semilattice[A] with CommutativeMonoid[A] {
+trait BoundedSemilattice[@sp(Byte, Char, Int, Long, Float, Double) A]
+    extends Any
+    with Semilattice[A]
+    with CommutativeMonoid[A] {
   override def combineN(a: A, n: Int): A =
     if (n < 0) throw new IllegalArgumentException("Repeated combining for monoids must have n >= 0")
     else if (n == 0) empty
@@ -35,7 +38,9 @@ object BoundedSemilattice extends SemilatticeFunctions[BoundedSemilattice] {
   /**
    * Access an implicit `BoundedSemilattice[A]`.
    */
-  @inline final def apply[@sp(Byte, Char, Int, Long, Float, Double) A](implicit ev: BoundedSemilattice[A]): BoundedSemilattice[A] =
+  @inline final def apply[@sp(Byte, Char, Int, Long, Float, Double) A](implicit
+    ev: BoundedSemilattice[A]
+  ): BoundedSemilattice[A] =
     ev
 
   /**

--- a/kernel/src/main/scala/cats/kernel/BoundedSemilattice.scala
+++ b/kernel/src/main/scala/cats/kernel/BoundedSemilattice.scala
@@ -23,7 +23,7 @@ package cats.kernel
 
 import scala.{specialized => sp}
 
-trait BoundedSemilattice[@sp(Int, Long, Float, Double) A] extends Any with Semilattice[A] with CommutativeMonoid[A] {
+trait BoundedSemilattice[@sp(Byte, Char, Int, Long, Float, Double) A] extends Any with Semilattice[A] with CommutativeMonoid[A] {
   override def combineN(a: A, n: Int): A =
     if (n < 0) throw new IllegalArgumentException("Repeated combining for monoids must have n >= 0")
     else if (n == 0) empty
@@ -35,7 +35,7 @@ object BoundedSemilattice extends SemilatticeFunctions[BoundedSemilattice] {
   /**
    * Access an implicit `BoundedSemilattice[A]`.
    */
-  @inline final def apply[@sp(Int, Long, Float, Double) A](implicit ev: BoundedSemilattice[A]): BoundedSemilattice[A] =
+  @inline final def apply[@sp(Byte, Char, Int, Long, Float, Double) A](implicit ev: BoundedSemilattice[A]): BoundedSemilattice[A] =
     ev
 
   /**

--- a/kernel/src/main/scala/cats/kernel/CommutativeGroup.scala
+++ b/kernel/src/main/scala/cats/kernel/CommutativeGroup.scala
@@ -27,7 +27,7 @@ import scala.{specialized => sp}
  * An commutative group (also known as an abelian group) is a group
  * whose combine operation is commutative.
  */
-trait CommutativeGroup[@sp(Int, Long, Float, Double) A] extends Any with Group[A] with CommutativeMonoid[A]
+trait CommutativeGroup[@sp(Byte, Char, Int, Long, Float, Double) A] extends Any with Group[A] with CommutativeMonoid[A]
 
 object CommutativeGroup extends GroupFunctions[CommutativeGroup] {
 

--- a/kernel/src/main/scala/cats/kernel/CommutativeMonoid.scala
+++ b/kernel/src/main/scala/cats/kernel/CommutativeMonoid.scala
@@ -28,7 +28,10 @@ import scala.{specialized => sp}
  *
  * A monoid is commutative if for all x and y, x |+| y === y |+| x.
  */
-trait CommutativeMonoid[@sp(Byte, Char, Int, Long, Float, Double) A] extends Any with Monoid[A] with CommutativeSemigroup[A] {
+trait CommutativeMonoid[@sp(Byte, Char, Int, Long, Float, Double) A]
+    extends Any
+    with Monoid[A]
+    with CommutativeSemigroup[A] {
   self =>
   override def reverse: CommutativeMonoid[A] = self
 }

--- a/kernel/src/main/scala/cats/kernel/CommutativeMonoid.scala
+++ b/kernel/src/main/scala/cats/kernel/CommutativeMonoid.scala
@@ -28,7 +28,7 @@ import scala.{specialized => sp}
  *
  * A monoid is commutative if for all x and y, x |+| y === y |+| x.
  */
-trait CommutativeMonoid[@sp(Int, Long, Float, Double) A] extends Any with Monoid[A] with CommutativeSemigroup[A] {
+trait CommutativeMonoid[@sp(Byte, Char, Int, Long, Float, Double) A] extends Any with Monoid[A] with CommutativeSemigroup[A] {
   self =>
   override def reverse: CommutativeMonoid[A] = self
 }

--- a/kernel/src/main/scala/cats/kernel/CommutativeSemigroup.scala
+++ b/kernel/src/main/scala/cats/kernel/CommutativeSemigroup.scala
@@ -28,7 +28,7 @@ import scala.{specialized => sp}
  *
  * A semigroup is commutative if for all x and y, x |+| y === y |+| x.
  */
-trait CommutativeSemigroup[@sp(Int, Long, Float, Double) A] extends Any with Semigroup[A] { self =>
+trait CommutativeSemigroup[@sp(Byte, Char, Int, Long, Float, Double) A] extends Any with Semigroup[A] { self =>
   override def reverse: CommutativeSemigroup[A] = self
   override def intercalate(middle: A): CommutativeSemigroup[A] =
     new CommutativeSemigroup[A] {

--- a/kernel/src/main/scala/cats/kernel/Group.scala
+++ b/kernel/src/main/scala/cats/kernel/Group.scala
@@ -26,7 +26,7 @@ import scala.{specialized => sp}
 /**
  * A group is a monoid where each element has an inverse.
  */
-trait Group[@sp(Int, Long, Float, Double) A] extends Any with Monoid[A] {
+trait Group[@sp(Byte, Char, Int, Long, Float, Double) A] extends Any with Monoid[A] {
 
   /**
    * Find the inverse of `a`.
@@ -82,10 +82,10 @@ trait Group[@sp(Int, Long, Float, Double) A] extends Any with Monoid[A] {
 }
 
 abstract class GroupFunctions[G[T] <: Group[T]] extends MonoidFunctions[G] {
-  def inverse[@sp(Int, Long, Float, Double) A](a: A)(implicit ev: G[A]): A =
+  def inverse[@sp(Byte, Char, Int, Long, Float, Double) A](a: A)(implicit ev: G[A]): A =
     ev.inverse(a)
 
-  def remove[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: G[A]): A =
+  def remove[@sp(Byte, Char, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: G[A]): A =
     ev.remove(x, y)
 }
 

--- a/kernel/src/main/scala/cats/kernel/Monoid.scala
+++ b/kernel/src/main/scala/cats/kernel/Monoid.scala
@@ -30,7 +30,7 @@ import compat.scalaVersionSpecific._
  * `combine(x, empty) == combine(empty, x) == x`. For example, if we have `Monoid[String]`,
  * with `combine` as string concatenation, then `empty = ""`.
  */
-trait Monoid[@sp(Int, Long, Float, Double) A] extends Any with Semigroup[A] { self =>
+trait Monoid[@sp(Byte, Char, Int, Long, Float, Double) A] extends Any with Semigroup[A] { self =>
 
   /**
    * Return the identity element for this monoid.
@@ -117,13 +117,13 @@ trait Monoid[@sp(Int, Long, Float, Double) A] extends Any with Semigroup[A] { se
 
 @suppressUnusedImportWarningForScalaVersionSpecific
 abstract class MonoidFunctions[M[T] <: Monoid[T]] extends SemigroupFunctions[M] {
-  def empty[@sp(Int, Long, Float, Double) A](implicit ev: M[A]): A =
+  def empty[@sp(Byte, Char, Int, Long, Float, Double) A](implicit ev: M[A]): A =
     ev.empty
 
-  def isEmpty[@sp(Int, Long, Float, Double) A](a: A)(implicit m: M[A], ev: Eq[A]): Boolean =
+  def isEmpty[@sp(Byte, Char, Int, Long, Float, Double) A](a: A)(implicit m: M[A], ev: Eq[A]): Boolean =
     m.isEmpty(a)
 
-  def combineAll[@sp(Int, Long, Float, Double) A](as: IterableOnce[A])(implicit ev: M[A]): A =
+  def combineAll[@sp(Byte, Char, Int, Long, Float, Double) A](as: IterableOnce[A])(implicit ev: M[A]): A =
     ev.combineAll(as)
 }
 

--- a/kernel/src/main/scala/cats/kernel/Semigroup.scala
+++ b/kernel/src/main/scala/cats/kernel/Semigroup.scala
@@ -32,7 +32,7 @@ import compat.scalaVersionSpecific._
 /**
  * A semigroup is any set `A` with an associative operation (`combine`).
  */
-trait Semigroup[@sp(Int, Long, Float, Double) A] extends Any with Serializable { self =>
+trait Semigroup[@sp(Byte, Char, Int, Long, Float, Double) A] extends Any with Serializable { self =>
 
   /**
    * Associative operation which combines two values.
@@ -124,16 +124,16 @@ trait Semigroup[@sp(Int, Long, Float, Double) A] extends Any with Serializable {
 }
 
 abstract class SemigroupFunctions[S[T] <: Semigroup[T]] {
-  def combine[@sp(Int, Long, Float, Double) A](x: A, y: A)(implicit ev: S[A]): A =
+  def combine[@sp(Byte, Char, Int, Long, Float, Double) A](x: A, y: A)(implicit ev: S[A]): A =
     ev.combine(x, y)
 
-  def maybeCombine[@sp(Int, Long, Float, Double) A](ox: Option[A], y: A)(implicit ev: S[A]): A =
+  def maybeCombine[@sp(Byte, Char, Int, Long, Float, Double) A](ox: Option[A], y: A)(implicit ev: S[A]): A =
     ox match {
       case Some(x) => ev.combine(x, y)
       case None    => y
     }
 
-  def maybeCombine[@sp(Int, Long, Float, Double) A](x: A, oy: Option[A])(implicit ev: S[A]): A =
+  def maybeCombine[@sp(Byte, Char, Int, Long, Float, Double) A](x: A, oy: Option[A])(implicit ev: S[A]): A =
     oy match {
       case Some(y) => ev.combine(x, y)
       case None    => x
@@ -145,7 +145,7 @@ abstract class SemigroupFunctions[S[T] <: Semigroup[T]] {
   def isIdempotent[A](implicit ev: S[A]): Boolean =
     ev.isInstanceOf[Band[_]]
 
-  def combineN[@sp(Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: S[A]): A =
+  def combineN[@sp(Byte, Char, Int, Long, Float, Double) A](a: A, n: Int)(implicit ev: S[A]): A =
     ev.combineN(a, n)
 
   def combineAllOption[A](as: IterableOnce[A])(implicit ev: S[A]): Option[A] =

--- a/kernel/src/main/scala/cats/kernel/Semilattice.scala
+++ b/kernel/src/main/scala/cats/kernel/Semilattice.scala
@@ -27,7 +27,8 @@ import scala.{specialized => sp}
  * Semilattices are commutative semigroups whose operation
  * (i.e. combine) is also idempotent.
  */
-trait Semilattice[@sp(Byte, Char, Int, Long, Float, Double) A] extends Any with Band[A] with CommutativeSemigroup[A] { self =>
+trait Semilattice[@sp(Byte, Char, Int, Long, Float, Double) A] extends Any with Band[A] with CommutativeSemigroup[A] {
+  self =>
 
   /**
    * Given Eq[A], return a PartialOrder[A] using the `combine`

--- a/kernel/src/main/scala/cats/kernel/Semilattice.scala
+++ b/kernel/src/main/scala/cats/kernel/Semilattice.scala
@@ -27,7 +27,7 @@ import scala.{specialized => sp}
  * Semilattices are commutative semigroups whose operation
  * (i.e. combine) is also idempotent.
  */
-trait Semilattice[@sp(Int, Long, Float, Double) A] extends Any with Band[A] with CommutativeSemigroup[A] { self =>
+trait Semilattice[@sp(Byte, Char, Int, Long, Float, Double) A] extends Any with Band[A] with CommutativeSemigroup[A] { self =>
 
   /**
    * Given Eq[A], return a PartialOrder[A] using the `combine`
@@ -80,7 +80,7 @@ object Semilattice extends SemilatticeFunctions[Semilattice] {
   /**
    * Access an implicit `Semilattice[A]`.
    */
-  @inline final def apply[@sp(Int, Long, Float, Double) A](implicit ev: Semilattice[A]): Semilattice[A] = ev
+  @inline final def apply[@sp(Byte, Char, Int, Long, Float, Double) A](implicit ev: Semilattice[A]): Semilattice[A] = ev
 
   /**
    * Create a `Semilattice` instance from the given function.


### PR DESCRIPTION
This PR add specialization for two more primitive types for Typeclasses in the kernel.

Bytes and, in a lesser extend, Chars, are fundamental types in many domains and I feel this is worth an addition. This does have an effect in JAR size though.

Size tested using scala 2.13 (`publishLocal`).

| | size |
|-|-|
|Current (`5c5fe56`) | 3.58 MB |
|This PR (`82a342e`) | 3.72 MB |

Looking forward your feedback !