### PR TITLE
Replaces other `Applicative.pure(())` with `.unit`

### DIFF
--- a/free/src/test/scala/cats/free/FreeTSuite.scala
+++ b/free/src/test/scala/cats/free/FreeTSuite.scala
@@ -72,7 +72,7 @@ class FreeTSuite extends CatsSuite {
   checkAll("FreeT[Option, Option, Int", DeferTests[FreeTOption].defer[Int])
 
   test("FlatMap stack safety tested with 50k flatMaps") {
-    val expected = Applicative[FreeTOption].pure(())
+    val expected = Applicative[FreeTOption].unit
     val result =
       Monad[FreeTOption].tailRecM(0)((i: Int) =>
         if (i < 50000)
@@ -85,9 +85,9 @@ class FreeTSuite extends CatsSuite {
   }
 
   test("Stack safe with 50k left-associated flatMaps") {
-    val expected = Applicative[FreeTOption].pure(())
+    val expected = Applicative[FreeTOption].unit
     val result =
-      (0 until 50000).foldLeft(Applicative[FreeTOption].pure(()))((fu, i) =>
+      (0 until 50000).foldLeft(Applicative[FreeTOption].unit)((fu, i) =>
         fu.flatMap(u => Applicative[FreeTOption].pure(u))
       )
 
@@ -95,7 +95,7 @@ class FreeTSuite extends CatsSuite {
   }
 
   test("Stack safe with flatMap followed by 50k maps") {
-    val expected = Applicative[FreeTOption].pure(())
+    val expected = Applicative[FreeTOption].unit
     val result =
       (0 until 50000).foldLeft(().pure[FreeTOption].flatMap(_.pure[FreeTOption]))((fu, i) => fu.map(identity))
 
@@ -110,7 +110,7 @@ class FreeTSuite extends CatsSuite {
   }
 
   test("mapK stack-safety") {
-    val a = (0 until 50000).foldLeft(Applicative[FreeTOption].pure(()))((fu, i) =>
+    val a = (0 until 50000).foldLeft(Applicative[FreeTOption].unit)((fu, i) =>
       fu.flatMap(u => Applicative[FreeTOption].pure(u))
     )
     val b = a.mapK(FunctionK.id)
@@ -126,7 +126,7 @@ class FreeTSuite extends CatsSuite {
   }
 
   test("compile stack-safety") {
-    val a = (0 until 50000).foldLeft(Applicative[FreeTOption].pure(()))((fu, i) =>
+    val a = (0 until 50000).foldLeft(Applicative[FreeTOption].unit)((fu, i) =>
       fu.flatMap(u => Applicative[FreeTOption].pure(u))
     )
     val b = a.compile(FunctionK.id) // used to overflow
@@ -147,7 +147,7 @@ class FreeTSuite extends CatsSuite {
     type F[A] = FreeT[Id, Option, A]
     val F = MonadError[F, Unit]
 
-    val eff = F.flatMap(F.pure(()))(_ => F.raiseError[String](()))
+    val eff = F.flatMap(F.unit)(_ => F.raiseError[String](()))
     assert(F.attempt(eff).runM(Some(_)) === Some(Left(())))
   }
 

--- a/laws/src/main/scala/cats/laws/ApplicativeLaws.scala
+++ b/laws/src/main/scala/cats/laws/ApplicativeLaws.scala
@@ -66,10 +66,10 @@ trait ApplicativeLaws[F[_]] extends ApplyLaws[F] {
   // Semigroupal's associativity law.
 
   def monoidalLeftIdentity[A](fa: F[A]): (F[(Unit, A)], F[A]) =
-    (F.product(F.pure(()), fa), fa)
+    (F.product(F.unit, fa), fa)
 
   def monoidalRightIdentity[A](fa: F[A]): (F[(A, Unit)], F[A]) =
-    (F.product(fa, F.pure(())), fa)
+    (F.product(fa, F.unit), fa)
 }
 
 object ApplicativeLaws {


### PR DESCRIPTION
A follow up for #4557 – other uses of `Applicative.pure(())` are found (with **grep**) and replaced with `.unit`.

Note, that there are other places where `.pure(())` is in use, however those calls don't belong to `Applicative` and to replace them the `.unit` methods have to be added accordingly:
```
./free/src/main/scala/cats/free/FreeInvariantMonoidal.scala:104:      def unit: FA[S, Unit] = FreeInvariantMonoidal.pure(())
./tests/shared/src/test/scala/cats/tests/IndexedReaderWriterStateTSuite.scala:111:      val rws: ReaderWriterState[String, String, Int, Unit] = ReaderWriterState.pure(())
```
