### PR TITLE
Reduce visibility of value member in the `NonEmptyMap` syntax

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -70,7 +70,7 @@ object NonEmptyMapImpl extends NonEmptyMapInstances with Newtype2 {
 
 }
 
-sealed class NonEmptyMapOps[K, A](val value: NonEmptyMap[K, A]) {
+sealed class NonEmptyMapOps[K, A](private[data] val value: NonEmptyMap[K, A]) {
 
   /**
    * Converts this map to a `SortedMap`.

--- a/core/src/main/scala/cats/data/NonEmptySet.scala
+++ b/core/src/main/scala/cats/data/NonEmptySet.scala
@@ -62,7 +62,7 @@ object NonEmptySetImpl extends NonEmptySetInstances with Newtype {
 }
 
 @suppressUnusedImportWarningForScalaVersionSpecific
-sealed class NonEmptySetOps[A](val value: NonEmptySet[A]) {
+sealed class NonEmptySetOps[A](private[data] val value: NonEmptySet[A]) {
 
   implicit private val ordering: Ordering[A] = toSortedSet.ordering
   implicit private val order: Order[A] = Order.fromOrdering


### PR DESCRIPTION
Simple fix for this annoying behaviour:

```scala
//> using dep org.typelevel::cats-core::2.10.0

import cats.data.NonEmptyMap

val nem: NonEmptyMap[Int,Int] = NonEmptyMap.of(1 -> 1)
val alsoNem: NonEmptyMap[Int,Int] = nem.value.value.value.value
```

The fix passes the Mima check, but ofc it will become impossible to explicitly call `.value` on `NonEmptyMap` instances (but that's what we want, right?)
Thanks to @reardonj for the solution