### PR TITLE
Fix `choice` alias render in docs

### DIFF
--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -283,7 +283,7 @@ Here, we use `Ki` as a short-hand for `Kleisli`.
 | `F[A, B] => F[C, A] => F[C, B]` | `compose` | `<<<` |
 | `F[A, B] => F[B, C] => F[A, C]` | `andThen` | `>>>` |
 | `=> F[A,A]` | `id`  |
-| `F[A, B] => F[C, B] => F[Either[A, C], B]` | `choice` | `|||`
+| `F[A, B] => F[C, B] => F[Either[A, C], B]` | `choice` | `|||` |
 | `=> F[ Either[A, A], A]` | `codiagonal` |
 
 #### Arrow


### PR DESCRIPTION
In the current docs `choice` alias rendered like this:

<img width="360" alt="Docs screenshot where choice alias rendered as signle backtick, not three vertical lines" src="https://github.com/typelevel/cats/assets/47028153/a97e33a5-310d-4c99-a343-50b8c9d38b80">

Meanwhile it should be rendered as `|||`. I closed markdown table row with `|`, I hope it fixes the problem, because I am unable to render docs locally