### PR TITLE
Add `scanLeft`/`scanLeftTail` to all non-empty collections

### DIFF
--- a/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
+++ b/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
@@ -274,6 +274,9 @@ class NonEmptyLazyListOps[A](private val value: NonEmptyLazyList[A])
   final def foldRight[B](z: B)(f: (A, B) => B): B =
     toLazyList.foldRight(z)(f)
 
+  final def scanLeft[B](b: B)(f: (B, A) => B): NonEmptyLazyList[B] =
+    create(toLazyList.scanLeft(b)(f))
+
   /**
    * Left-associative reduce using f.
    */

--- a/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
+++ b/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
@@ -277,6 +277,9 @@ class NonEmptyLazyListOps[A](private val value: NonEmptyLazyList[A])
   final def scanLeft[B](b: B)(f: (B, A) => B): NonEmptyLazyList[B] =
     create(toLazyList.scanLeft(b)(f))
 
+  final def scanLeftTail[B](b: B)(f: (B, A) => B): NonEmptyLazyList[B] =
+    create(toLazyList.scanLeft(b)(f).tail)
+
   /**
    * Left-associative reduce using f.
    */

--- a/core/src/main/scala/cats/data/NonEmptyChain.scala
+++ b/core/src/main/scala/cats/data/NonEmptyChain.scala
@@ -313,6 +313,9 @@ class NonEmptyChainOps[A](private val value: NonEmptyChain[A])
     create(result)
   }
 
+  final def scanLeftTail[B](b: B)(f: (B, A) => B): NonEmptyChain[B] =
+    create(scanLeft(b)(f).tail)
+
   /**
    * Right-associative fold using f.
    */

--- a/core/src/main/scala/cats/data/NonEmptyChain.scala
+++ b/core/src/main/scala/cats/data/NonEmptyChain.scala
@@ -302,6 +302,17 @@ class NonEmptyChainOps[A](private val value: NonEmptyChain[A])
   final def foldLeft[B](b: B)(f: (B, A) => B): B =
     toChain.foldLeft(b)(f)
 
+  final def scanLeft[B](b: B)(f: (B, A) => B): NonEmptyChain[B] = {
+    var current = b
+    var result = Chain.one[B](b)
+    val iter = toChain.iterator
+    while (iter.hasNext) {
+      current = f(current, iter.next())
+      result = result :+ current
+    }
+    create(result)
+  }
+
   /**
    * Right-associative fold using f.
    */

--- a/core/src/main/scala/cats/data/NonEmptyCollection.scala
+++ b/core/src/main/scala/cats/data/NonEmptyCollection.scala
@@ -47,6 +47,7 @@ private[cats] trait NonEmptyCollection[+A, U[+_], NE[+_]] extends Any {
 
   def foldLeft[B](b: B)(f: (B, A) => B): B
   def scanLeft[B](b: B)(f: (B, A) => B): NE[B]
+  def scanLeftTail[B](b: B)(f: (B, A) => B): NE[B]
   def reduce[AA >: A](implicit S: Semigroup[AA]): AA
 
   def zipWith[B, C](b: NE[B])(f: (A, B) => C): NE[C]

--- a/core/src/main/scala/cats/data/NonEmptyCollection.scala
+++ b/core/src/main/scala/cats/data/NonEmptyCollection.scala
@@ -46,6 +46,7 @@ private[cats] trait NonEmptyCollection[+A, U[+_], NE[+_]] extends Any {
   def forall(p: A => Boolean): Boolean
 
   def foldLeft[B](b: B)(f: (B, A) => B): B
+  def scanLeft[B](b: B)(f: (B, A) => B): NE[B]
   def reduce[AA >: A](implicit S: Semigroup[AA]): AA
 
   def zipWith[B, C](b: NE[B])(f: (A, B) => C): NE[C]

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -302,6 +302,9 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
   def foldRight[B](lb: Eval[B])(f: (A, Eval[B]) => Eval[B]): Eval[B] =
     Foldable[List].foldRight(toList, lb)(f)
 
+  def scanLeft[B](b: B)(f: (B, A) => B): NonEmptyList[B] =
+    NonEmptyList(b, tail.scanLeft(f(b, head))(f))
+
   /**
    * Left-associative reduce using f.
    */

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -305,6 +305,9 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
   def scanLeft[B](b: B)(f: (B, A) => B): NonEmptyList[B] =
     NonEmptyList(b, tail.scanLeft(f(b, head))(f))
 
+  def scanLeftTail[B](b: B)(f: (B, A) => B): NonEmptyList[B] =
+    NonEmptyList.fromListUnsafe(tail.scanLeft(f(b, head))(f))
+
   /**
    * Left-associative reduce using f.
    */

--- a/core/src/main/scala/cats/data/NonEmptySeq.scala
+++ b/core/src/main/scala/cats/data/NonEmptySeq.scala
@@ -178,6 +178,9 @@ final class NonEmptySeq[+A] private (val toSeq: Seq[A]) extends AnyVal with NonE
   def foldLeft[B](b: B)(f: (B, A) => B): B =
     toSeq.foldLeft(b)(f)
 
+  def scanLeft[B](b: B)(f: (B, A) => B): NonEmptySeq[B] =
+    new NonEmptySeq(toSeq.scanLeft(b)(f))
+
   /**
    * Right-associative fold using f.
    */

--- a/core/src/main/scala/cats/data/NonEmptySeq.scala
+++ b/core/src/main/scala/cats/data/NonEmptySeq.scala
@@ -181,6 +181,9 @@ final class NonEmptySeq[+A] private (val toSeq: Seq[A]) extends AnyVal with NonE
   def scanLeft[B](b: B)(f: (B, A) => B): NonEmptySeq[B] =
     new NonEmptySeq(toSeq.scanLeft(b)(f))
 
+  def scanLeftTail[B](b: B)(f: (B, A) => B): NonEmptySeq[B] =
+    new NonEmptySeq(toSeq.scanLeft(b)(f).tail)
+
   /**
    * Right-associative fold using f.
    */

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -191,6 +191,9 @@ final class NonEmptyVector[+A] private (val toVector: Vector[A])
   def scanLeft[B](b: B)(f: (B, A) => B): NonEmptyVector[B] =
     NonEmptyVector.fromVectorUnsafe(toVector.scanLeft(b)(f))
 
+  def scanLeftTail[B](b: B)(f: (B, A) => B): NonEmptyVector[B] =
+    NonEmptyVector.fromVectorUnsafe(tail.scanLeft(f(b, head))(f))
+
   /**
    * Right-associative fold using f.
    */

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -188,6 +188,9 @@ final class NonEmptyVector[+A] private (val toVector: Vector[A])
   def foldLeft[B](b: B)(f: (B, A) => B): B =
     toVector.foldLeft(b)(f)
 
+  def scanLeft[B](b: B)(f: (B, A) => B): NonEmptyVector[B] =
+    NonEmptyVector.fromVectorUnsafe(toVector.scanLeft(b)(f))
+
   /**
    * Right-associative fold using f.
    */


### PR DESCRIPTION
I was quite surprised to find that there were no `scanLeft` on any of the non-empty collections. Furthermore, the tail of a scan on a non-empty collection is itself non-empty, which might be a useful property to expose. The name `scanLeftTail` was the best I could come up with for now and it's of course open to bike-shedding.

Putting out this PR as a draft to get some input on it. Will add tests and documentation if you all consider it useful!

```scala
val nel = NonEmptyList.of(1, 2, 3)
val f: (Int, Int) => Int = ???
// Before
nel.toList.scanLeftNel(0)(f)
// After
nel.scanLeft(0)(f)

// And, before
nel.tail.scanLeftNel(f(0, nel.head))(f)
// After
nel.scanLeftTail(0)(f)
```

The others (`NonEmptyChain`, etc.) don't have the `scanLeftNel` syntax and requires more work to get the same result.

Finally, the implementations in this draft are a bit mixed. Don't worry about that for now. Again, I'm mostly checking if people would find this useful or not.