### PR TITLE
Expose FunctionK.liftFunction as a part of the Scala 3 API

### DIFF
--- a/core/src/main/scala-2/cats/arrow/FunctionKMacros.scala
+++ b/core/src/main/scala-2/cats/arrow/FunctionKMacros.scala
@@ -24,8 +24,7 @@ package arrow
 
 import scala.reflect.macros.blackbox
 
-private[arrow] class FunctionKMacroMethods {
-  protected type τ[F[_], G[_]]
+private[arrow] class FunctionKMacroMethods extends FunctionKLift {
 
   /**
    * Lifts function `f` of `F[A] => G[A]` into a `FunctionK[F, G]`.
@@ -48,22 +47,6 @@ private[arrow] class FunctionKMacroMethods {
    */
   def lift[F[_], G[_]](f: (F[α] => G[α]) forSome { type α }): FunctionK[F, G] =
     macro FunctionKMacros.lift[F, G]
-
-  /**
-   * Lifts function `f` of `F[A] => G[A]` into a `FunctionK[F, G]`.
-   *
-   * {{{
-   *   def headOption[A](list: List[A]): Option[A] = list.headOption
-   *   val lifted = FunctionK.liftFunction[List, Option](headOption)
-   * }}}
-   *
-   * Note: The weird `τ[F, G]` parameter is there to compensate for
-   * the lack of polymorphic function types in Scala 2.
-   */
-  def liftFunction[F[_], G[_]](f: F[τ[F, G]] => G[τ[F, G]]): FunctionK[F, G] =
-    new FunctionK[F, G] {
-      def apply[A](fa: F[A]): G[A] = f.asInstanceOf[F[A] => G[A]](fa)
-    }
 }
 
 private[arrow] object FunctionKMacros {

--- a/core/src/main/scala/cats/arrow/FunctionKLift.scala
+++ b/core/src/main/scala/cats/arrow/FunctionKLift.scala
@@ -22,18 +22,24 @@
 package cats
 package arrow
 
-private[arrow] class FunctionKMacroMethods extends FunctionKLift {
+private[arrow] trait FunctionKLift {
+  protected type τ[F[_], G[_]]
 
   /**
-   * Lifts function `f` of `[X] => F[X] => G[X]` into a `FunctionK[F, G]`.
+   * Lifts function `f` of `F[A] => G[A]` into a `FunctionK[F, G]`.
    *
    * {{{
-   *   val headOptionK = FunctionK.lift[List, Option]([X] => (_: List[X]).headOption)
+   *   def headOption[A](list: List[A]): Option[A] = list.headOption
+   *   val lifted = FunctionK.liftFunction[List, Option](headOption)
    * }}}
+   *
+   * Note: The weird `τ[F, G]` parameter is there to compensate for
+   * the lack of polymorphic function types in Scala 2.
+   * 
+   * It is present in the Scala 3 API to simplify cross-compilation.
    */
-  def lift[F[_], G[_]](f: [X] => F[X] => G[X]): FunctionK[F, G] =
+  def liftFunction[F[_], G[_]](f: F[τ[F, G]] => G[τ[F, G]]): FunctionK[F, G] =
     new FunctionK[F, G] {
-      def apply[A](fa: F[A]): G[A] = f(fa)
+      def apply[A](fa: F[A]): G[A] = f.asInstanceOf[F[A] => G[A]](fa)
     }
-
 }

--- a/tests/shared/src/test/scala-3/cats/tests/FunctionKLiftSuite.scala
+++ b/tests/shared/src/test/scala-3/cats/tests/FunctionKLiftSuite.scala
@@ -34,4 +34,12 @@ class FunctionKLiftSuite extends CatsSuite {
       assert(fHeadOption(a) === a.headOption)
     }
   }
+
+  test("lift a function directly using Scala 2 compatible syntax") {
+    def headOption[A](list: List[A]): Option[A] = list.headOption
+    val fHeadOption = FunctionK.liftFunction[List, Option](headOption)
+    forAll { (a: List[Int]) =>
+      assert(fHeadOption(a) === a.headOption)
+    }
+  }
 }


### PR DESCRIPTION
This PR adds liftFunction into the Scala 3 API. 

That would help us to remove [FunctionKLift](https://github.com/typelevel/cats-tagless/blob/master/core/src/main/scala/cats/tagless/FunctionKLift.scala) from cats-tagless and from a couple of other libraries. Right now I'm just borrowing this file around :D

Closes #4449

cc @joroKr21 

