### PR TITLE
Fix/suppress warnings in kernel and kernel-laws

### DIFF
--- a/kernel-laws/shared/src/main/scala/cats/kernel/laws/MonoidLaws.scala
+++ b/kernel-laws/shared/src/main/scala/cats/kernel/laws/MonoidLaws.scala
@@ -35,7 +35,7 @@ trait MonoidLaws[A] extends SemigroupLaws[A] {
   def repeat0(x: A): IsEq[A] =
     S.combineN(x, 0) <-> S.empty
 
-  def collect0(x: A): IsEq[A] =
+  def collect0: IsEq[A] =
     S.combineAll(Nil) <-> S.empty
 
   def combineAll(xs: Vector[A]): IsEq[A] =
@@ -44,6 +44,8 @@ trait MonoidLaws[A] extends SemigroupLaws[A] {
   def isId(x: A, eqv: Eq[A]): IsEq[Boolean] =
     eqv.eqv(x, S.empty) <-> S.isEmpty(x)(eqv)
 
+  @deprecated("use `collect0` without parameters", "2.12.1")
+  def collect0(x: A): IsEq[A] = collect0
 }
 
 object MonoidLaws {

--- a/kernel-laws/shared/src/main/scala/cats/kernel/laws/OrderLaws.scala
+++ b/kernel-laws/shared/src/main/scala/cats/kernel/laws/OrderLaws.scala
@@ -22,8 +22,6 @@
 package cats.kernel
 package laws
 
-import cats.kernel.Order
-
 trait OrderLaws[A] extends PartialOrderLaws[A] {
 
   implicit override def E: Order[A]

--- a/kernel-laws/shared/src/main/scala/cats/kernel/laws/discipline/BoundedTests.scala
+++ b/kernel-laws/shared/src/main/scala/cats/kernel/laws/discipline/BoundedTests.scala
@@ -31,12 +31,16 @@ import org.scalacheck.Prop.forAll
 trait LowerBoundedTests[A] extends PartialOrderTests[A] {
   def laws: LowerBoundedLaws[A]
 
-  def lowerBounded(implicit arbA: Arbitrary[A], arbF: Arbitrary[A => A], eqOA: Eq[Option[A]], eqA: Eq[A]): RuleSet =
+  def lowerBounded(implicit arbA: Arbitrary[A], arbF: Arbitrary[A => A]): RuleSet =
     new DefaultRuleSet(
       "lowerBounded",
       Some(partialOrder),
       "bound is less than or equals" -> forAll(laws.boundLteqv _)
     )
+
+  @deprecated("use `lowerBounded` without `Eq` parameters", "2.12.1")
+  def lowerBounded(arbA: Arbitrary[A], arbF: Arbitrary[A => A], eqOA: Eq[Option[A]], eqA: Eq[A]): RuleSet =
+    lowerBounded(arbA, arbF)
 }
 
 object LowerBoundedTests {
@@ -47,12 +51,16 @@ object LowerBoundedTests {
 trait UpperBoundedTests[A] extends PartialOrderTests[A] {
   def laws: UpperBoundedLaws[A]
 
-  def upperBounded(implicit arbA: Arbitrary[A], arbF: Arbitrary[A => A], eqOA: Eq[Option[A]], eqA: Eq[A]): RuleSet =
+  def upperBounded(implicit arbA: Arbitrary[A], arbF: Arbitrary[A => A]): RuleSet =
     new DefaultRuleSet(
       "upperBounded",
       Some(partialOrder),
       "bound is greater than or equals" -> forAll(laws.boundGteqv _)
     )
+
+  @deprecated("use `upperBounded` without `Eq` parameters", "2.12.1")
+  def upperBounded(arbA: Arbitrary[A], arbF: Arbitrary[A => A], eqOA: Eq[Option[A]], eqA: Eq[A]): RuleSet =
+    upperBounded(arbA, arbF)
 }
 
 object UpperBoundedTests {

--- a/kernel-laws/shared/src/main/scala/cats/kernel/laws/discipline/EnumerableTests.scala
+++ b/kernel-laws/shared/src/main/scala/cats/kernel/laws/discipline/EnumerableTests.scala
@@ -32,7 +32,7 @@ trait PartialNextTests[A] extends PartialOrderTests[A] {
 
   def laws: PartialNextLaws[A]
 
-  def partialNext(implicit arbA: Arbitrary[A], arbF: Arbitrary[A => A], eqOA: Eq[Option[A]], eqA: Eq[A]): RuleSet =
+  def partialNext(implicit arbA: Arbitrary[A], arbF: Arbitrary[A => A]): RuleSet =
     new DefaultRuleSet(
       "partialNext",
       Some(partialOrder),
@@ -40,13 +40,16 @@ trait PartialNextTests[A] extends PartialOrderTests[A] {
       "forall a, b. if a < b. next(a) <= b" -> forAll(laws.nextOrderStrong _)
     )
 
+  @deprecated("use `partialNext` without `Eq` parameters", "2.12.1")
+  def partialNext(arbA: Arbitrary[A], arbF: Arbitrary[A => A], eqOA: Eq[Option[A]], eqA: Eq[A]): RuleSet =
+    partialNext(arbA, arbF)
 }
 
 trait PartialPreviousTests[A] extends PartialOrderTests[A] {
 
   def laws: PartialPreviousLaws[A]
 
-  def partialPrevious(implicit arbA: Arbitrary[A], arbF: Arbitrary[A => A], eqOA: Eq[Option[A]], eqA: Eq[A]): RuleSet =
+  def partialPrevious(implicit arbA: Arbitrary[A], arbF: Arbitrary[A => A]): RuleSet =
     new DefaultRuleSet(
       "partialPrevious",
       Some(partialOrder),
@@ -54,18 +57,16 @@ trait PartialPreviousTests[A] extends PartialOrderTests[A] {
       "forall a, b. if a < b. next(a) <= b" -> forAll(laws.previousOrderStrong _)
     )
 
+  @deprecated("use `partialPrevious` without `Eq` parameters", "2.12.1")
+  def partialPrevious(arbA: Arbitrary[A], arbF: Arbitrary[A => A], eqOA: Eq[Option[A]], eqA: Eq[A]): RuleSet =
+    partialPrevious(arbA, arbF)
 }
 
 trait BoundedEnumerableTests[A] extends OrderTests[A] with PartialNextTests[A] with PartialPreviousTests[A] {
 
   def laws: BoundedEnumerableLaws[A]
 
-  def boundedEnumerable(implicit
-    arbA: Arbitrary[A],
-    arbF: Arbitrary[A => A],
-    eqOA: Eq[Option[A]],
-    eqA: Eq[A]
-  ): RuleSet =
+  def boundedEnumerable(implicit arbA: Arbitrary[A], arbF: Arbitrary[A => A], eqOA: Eq[Option[A]]): RuleSet =
     new RuleSet {
       val name: String = "boundedEnumerable"
       val bases: Seq[(String, RuleSet)] = Nil
@@ -78,6 +79,14 @@ trait BoundedEnumerableTests[A] extends OrderTests[A] with PartialNextTests[A] w
       )
     }
 
+  @deprecated("use `boundedEnumerable` without `Eq[A]` parameter", "2.12.1")
+  def boundedEnumerable(
+    arbA: Arbitrary[A],
+    arbF: Arbitrary[A => A],
+    eqOA: Eq[Option[A]],
+    eqA: Eq[A]
+  ): RuleSet =
+    boundedEnumerable(arbA, arbF, eqOA)
 }
 
 object BoundedEnumerableTests {

--- a/kernel-laws/shared/src/main/scala/cats/kernel/laws/discipline/HashTests.scala
+++ b/kernel-laws/shared/src/main/scala/cats/kernel/laws/discipline/HashTests.scala
@@ -34,13 +34,16 @@ trait HashTests[A] extends EqTests[A] {
 
   def laws: HashLaws[A]
 
-  def hash(implicit arbA: Arbitrary[A], arbF: Arbitrary[A => A], eqA: Eq[A], hashA: Hashing[A]): RuleSet =
+  def hash(implicit arbA: Arbitrary[A], arbF: Arbitrary[A => A]): RuleSet =
     new DefaultRuleSet(
       "hash",
       Some(eqv),
       "hash compatibility" -> forAll(laws.hashCompatibility _)
     )
 
+  @deprecated("use `hash` without `Hashing` parameter", "2.12.1")
+  def hash(arbA: Arbitrary[A], arbF: Arbitrary[A => A], eqA: Eq[A], hashA: Hashing[A]): RuleSet =
+    hash(arbA, arbF)
 }
 
 object HashTests {

--- a/kernel-laws/shared/src/main/scala/cats/kernel/laws/discipline/MonoidTests.scala
+++ b/kernel-laws/shared/src/main/scala/cats/kernel/laws/discipline/MonoidTests.scala
@@ -26,6 +26,7 @@ package discipline
 
 import cats.kernel.instances.boolean._
 import org.scalacheck.Arbitrary
+import org.scalacheck.Prop
 import org.scalacheck.Prop.forAll
 
 trait MonoidTests[A] extends SemigroupTests[A] {
@@ -39,7 +40,7 @@ trait MonoidTests[A] extends SemigroupTests[A] {
       "left identity" -> forAll(laws.leftIdentity _),
       "right identity" -> forAll(laws.rightIdentity _),
       "combine all" -> forAll(laws.combineAll _),
-      "collect0" -> forAll(laws.collect0 _),
+      "collect0" -> (laws.collect0: Prop),
       "is id" -> forAll((a: A) => laws.isId(a, eqA)),
       "repeat0" -> forAll(laws.repeat0 _)
     )

--- a/kernel-laws/shared/src/main/scala/cats/kernel/laws/discipline/OrderTests.scala
+++ b/kernel-laws/shared/src/main/scala/cats/kernel/laws/discipline/OrderTests.scala
@@ -32,7 +32,7 @@ trait OrderTests[A] extends PartialOrderTests[A] {
 
   def laws: OrderLaws[A]
 
-  def order(implicit arbA: Arbitrary[A], arbF: Arbitrary[A => A], eqOA: Eq[Option[A]], eqA: Eq[A]): RuleSet =
+  def order(implicit arbA: Arbitrary[A], arbF: Arbitrary[A => A]): RuleSet =
     new DefaultRuleSet(
       "order",
       Some(partialOrder),
@@ -42,6 +42,9 @@ trait OrderTests[A] extends PartialOrderTests[A] {
       "min" -> forAll(laws.min _)
     )
 
+  @deprecated("use `order` without `Eq` parameters", "2.12.1")
+  def order(arbA: Arbitrary[A], arbF: Arbitrary[A => A], eqOA: Eq[Option[A]], eqA: Eq[A]): RuleSet =
+    order(arbA, arbF)
 }
 
 object OrderTests {

--- a/kernel-laws/shared/src/main/scala/cats/kernel/laws/discipline/PartialOrderTests.scala
+++ b/kernel-laws/shared/src/main/scala/cats/kernel/laws/discipline/PartialOrderTests.scala
@@ -32,7 +32,7 @@ trait PartialOrderTests[A] extends EqTests[A] {
 
   def laws: PartialOrderLaws[A]
 
-  def partialOrder(implicit arbA: Arbitrary[A], arbF: Arbitrary[A => A], eqOA: Eq[Option[A]], eqA: Eq[A]): RuleSet =
+  def partialOrder(implicit arbA: Arbitrary[A], arbF: Arbitrary[A => A]): RuleSet =
     new DefaultRuleSet(
       "partialOrder",
       Some(eqv),
@@ -48,6 +48,9 @@ trait PartialOrderTests[A] extends EqTests[A] {
       "pmin" -> forAll(laws.pmin _)
     )
 
+  @deprecated("use `partialOrder` without `Eq` parameters", "2.12.1")
+  def partialOrder(arbA: Arbitrary[A], arbF: Arbitrary[A => A], eqOA: Eq[Option[A]], eqA: Eq[A]): RuleSet =
+    partialOrder(arbA, arbF)
 }
 
 object PartialOrderTests {

--- a/kernel/src/main/scala-2.12/cats/kernel/compat/HashCompat.scala
+++ b/kernel/src/main/scala-2.12/cats/kernel/compat/HashCompat.scala
@@ -43,9 +43,11 @@ package compat
  * limitations under the License.
  */
 
+import scala.annotation.nowarn
+
 private[kernel] class HashCompat {
   // Adapted from scala.util.hashing.MurmurHash#productHash.
-  private[kernel] def product1HashWithPrefix(_1Hash: Int, prefix: String): Int = {
+  private[kernel] def product1HashWithPrefix(_1Hash: Int, @nowarn("cat=unused") prefix: String): Int = {
     import scala.util.hashing.MurmurHash3._
     var h = productSeed
     h = mix(h, _1Hash)
@@ -53,7 +55,7 @@ private[kernel] class HashCompat {
   }
 
   // Adapted from scala.util.hashing.MurmurHash#productHash.
-  private[cats] def product2HashWithPrefix(_1Hash: Int, _2Hash: Int, prefix: String): Int = {
+  private[cats] def product2HashWithPrefix(_1Hash: Int, _2Hash: Int, @nowarn("cat=unused") prefix: String): Int = {
     import scala.util.hashing.MurmurHash3._
     var h = productSeed
     h = mix(h, _1Hash)

--- a/kernel/src/main/scala/cats/kernel/instances/MapInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/MapInstances.scala
@@ -42,12 +42,15 @@
 package cats.kernel
 package instances
 
+import org.typelevel.scalaccompat.annotation.unused
+
 import scala.collection.mutable
+
 import compat.scalaVersionSpecific._
 
 @suppressUnusedImportWarningForScalaVersionSpecific
 trait MapInstances extends MapInstances1 {
-  implicit def catsKernelStdHashForMap[K: Hash, V: Hash]: Hash[Map[K, V]] =
+  implicit def catsKernelStdHashForMap[K, V](implicit @unused K: Hash[K], V: Hash[V]): Hash[Map[K, V]] =
     new MapHash[K, V]
 
   implicit def catsKernelStdCommutativeMonoidForMap[K, V: CommutativeSemigroup]: CommutativeMonoid[Map[K, V]] =

--- a/kernel/src/main/scala/cats/kernel/instances/SeqInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/SeqInstances.scala
@@ -22,10 +22,10 @@
 package cats.kernel
 package instances
 
-import compat.scalaVersionSpecific._
-
 import scala.annotation.nowarn
 import scala.collection.immutable.Seq
+
+import compat.scalaVersionSpecific._
 
 @suppressUnusedImportWarningForScalaVersionSpecific
 trait SeqInstances extends SeqInstances1 {
@@ -83,7 +83,9 @@ class SeqMonoid[A] extends Monoid[Seq[A]] {
 }
 
 object SeqMonoid {
-  @nowarn("msg=deprecated")
+  @nowarn("cat=deprecation")
   private[this] val singleton: Monoid[Seq[Any]] = new SeqMonoid[Any]
+
+  @nowarn("cat=deprecation")
   def apply[A]: SeqMonoid[A] = singleton.asInstanceOf[SeqMonoid[A]]
 }


### PR DESCRIPTION
Supersedes #4187.

This PR fixes or suppresses compiler warnings in the **kernel** and **kernel-laws** modules.