### PR TITLE
Fix broken internal link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ builds:
 
 ### Write code
 
-[See guidelines](docs/guidelines.md).
+[See guidelines](https://typelevel.org/cats/guidelines.html).
 
 ### Attributions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ builds:
 
 ### Write code
 
-[See guidelines](guidelines.md).
+[See guidelines](docs/guidelines.md).
 
 ### Attributions
 


### PR DESCRIPTION
[Current version](https://github.com/typelevel/cats/blob/main/CONTRIBUTING.md#write-code) of the link 404s.