### PR TITLE
Adjust the JVM options to heal the Native build on CI

### DIFF
--- a/.jvmopts
+++ b/.jvmopts
@@ -1,6 +1,9 @@
 -Dfile.encoding=UTF8
--Xms1G
--Xmx5G
--XX:ReservedCodeCacheSize=500M
--XX:+TieredCompilation
+-Xms2G
+-Xmx8G
+-Xss4m
+-XX:ReservedCodeCacheSize=512m
+-XX:MaxMetaspaceSize=512M
 -XX:+UseParallelGC
+-XX:+TieredCompilation
+-XX:+UseAdaptiveSizePolicy


### PR DESCRIPTION
It's been five years since these options were last touched. Too many things have become complicated since then. But let's see if this actually fixes the Native build.