### PR TITLE
Point to sbt 1.x

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -96,7 +96,7 @@ git clone git@github.com:typelevel/cats.git
 ```
 
 To build Cats you should have
-[sbt](http://www.scala-sbt.org/0.13/tutorial/Setup.html) and [Node.js](https://nodejs.org/)
+[sbt](https://www.scala-sbt.org/1.x/docs/Setup.html) and [Node.js](https://nodejs.org/)
  installed. If you'd like, you can use the [Nix Cats development environment](#nix-cats-development-environment).
 
  Run `sbt`, and then use any of the following commands:


### PR DESCRIPTION
I don't know if this is strictly necessary, but it aligns with the [build.properties](https://github.com/typelevel/cats/blob/main/project/build.properties) file.