### PR TITLE
Writer can be covariant?

### DIFF
--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -25,7 +25,7 @@ package data
 import cats.Foldable
 import cats.kernel.CommutativeMonoid
 
-final case class WriterT[F[_], L, V](run: F[(L, V)]) {
+final case class WriterT[F[_], +L, +V](run: F[(L, V)]) {
 
   /**
    * Example:


### PR DESCRIPTION
I found `Writer[L, V]` is currently invariant.

https://github.com/typelevel/cats/blob/824b1cb2e77d9efd33ab3deb9b55e8bf1ce271c1/core/src/main/scala/cats/data/WriterT.scala#L28

Can it be covariant?

- [ZIO](https://zio.dev/zio-prelude/zpure/#basic-operations)
  - This is not code itself, but they accepts treating `Writer` as covariant.
- [Scalaz](https://github.com/scalaz/scalaz/blob/fa2c5b73b8a507f3d06f6722d507b6c5c23c1617/core/src/main/scala/scalaz/WriterT.scala#L5)
  - Currently not treating `Writer` as covariant.
- Meanwhile, `Reader[-R, A]` is contra-variant on parameter `R` in Cats.

I'm newbie to contribute Cats, so any editing/closing is welcome.

## Example that we want covariance for `Writer`

```scala
import cats.data.Writer
type Words[A] = Writer[List[String], A]

trait LongCat[F[_]]:
  def the: F["the"]
  def long(expr: F["the" | "long"]): F["long"]
  def cat(expr: F["long"]): F["cat"]
end LongCat

object LongCatImpl extends LongCat[Words]:
  def the: Words["the"] = Writer(List("the"), "the")
  def long(expr: Words["the" | "long"]): Words["long"] =
    expr.mapBoth((l, v) => ("long" :: l, "long"))
  def cat(expr: Words["long"]): Words["cat"] =
    expr.mapBoth((l, v) => ("cat" :: l, "cat"))
end LongCatImpl

locally:
  import LongCatImpl.*
  val repr = cat(long(long(the)))
  // => Found:    Words[("the" : String)]
  //    Required: Words[("the" : String) | ("long" : String)] 
  println(repr.run._1.reverse) // What I want: "the" :: "long" :: "long" :: "cat" :: Nil
```

