### PR TITLE
Fix typos

### DIFF
--- a/algebra-core/src/main/scala/algebra/ring/DivisionRing.scala
+++ b/algebra-core/src/main/scala/algebra/ring/DivisionRing.scala
@@ -31,7 +31,7 @@ trait DivisionRing[@sp(Byte, Short, Int, Long, Float, Double) A] extends Any wit
    * This is implemented in terms of basic Ring ops. However, this is
    * probably significantly less efficient than can be done with a
    * specific type. So, it is recommended that this method be
-   * overriden.
+   * overridden.
    *
    * This is possible because a Double is a rational number.
    */

--- a/core/src/main/scala/cats/TraverseFilter.scala
+++ b/core/src/main/scala/cats/TraverseFilter.scala
@@ -139,7 +139,7 @@ trait TraverseFilter[F[_]] extends FunctorFilter[F] {
 
   /**
    * Removes duplicate elements from a list, keeping only the first occurrence.
-   * This is usually faster than ordDistinct, especially for things that have a slow comparion (like String).
+   * This is usually faster than ordDistinct, especially for things that have a slow comparison (like String).
    */
   def hashDistinct[A](fa: F[A])(implicit H: Hash[A]): F[A] =
     traverseFilter(fa) { a =>

--- a/core/src/main/scala/cats/data/ContT.scala
+++ b/core/src/main/scala/cats/data/ContT.scala
@@ -141,7 +141,7 @@ object ContT {
    *     _ <- ContT.callCC( (k: Unit => ContT[IO, Unit, Unit]) =>
    *       ContT.liftF(IO.println("this will print first")) >>
    *         k(()) >>
-   *         ContT.liftF(IO.println("this will NOT print as we short-circuit to the contination"))
+   *         ContT.liftF(IO.println("this will NOT print as we short-circuit to the continuation"))
    *     )
    *     _ <- ContT.liftF(IO.println("this will print second")])
    *   } yield ()


### PR DESCRIPTION
Fix some small typos I found. Two are clearly non-semantic, the other "should" (taking it at its word) be non-semantic.