### PR TITLE
Replace tut with mdoc on the colophon page

### DIFF
--- a/docs/colophon.md
+++ b/docs/colophon.md
@@ -12,7 +12,7 @@ integrating them into your own projects.
  * [scalacheck](http://scalacheck.org) for property-based testing
  * [discipline](https://github.com/typelevel/discipline) for encoding and testing laws
  * [kind-projector](https://github.com/typelevel/kind-projector) for type lambda syntax
- * [tut](https://github.com/tpolecat/tut) type-checked example code makes sure that our examples stay in sync with the rest of our source
+ * [mdoc](https://github.com/scalameta/mdoc) type-checked example code makes sure that our examples stay in sync with the rest of our source
 
 There are other libraries that aim to foster Functional Programming in the Scala programming language which Cats has a relationship to:
 


### PR DESCRIPTION
`tut` impacted the whole ecosystem, but it has been three years since it was archived, and we no longer depend on it.