### PR TITLE
Fix some awkward imports

### DIFF
--- a/core/src/main/scala/cats/Bifunctor.scala
+++ b/core/src/main/scala/cats/Bifunctor.scala
@@ -80,7 +80,7 @@ trait Bifunctor[F[_, _]] extends Serializable { self =>
    * Lift left into F using Applicative.
    * * Example:
    * {{{
-   * scala> import cats.implicits._
+   * scala> import cats.syntax.all._
    * scala> val x0: Either[String, Int] = Either.left("foo")
    * scala> val x1: Either[List[String], Int] = x0.leftLiftTo[List]
    * }}}

--- a/core/src/main/scala/cats/Functor.scala
+++ b/core/src/main/scala/cats/Functor.scala
@@ -79,7 +79,7 @@ trait Functor[F[_]] extends Invariant[F] { self =>
    * Example:
    * {{{
    * scala> import cats.Functor
-   * scala> import cats.implicits.catsStdInstancesForOption
+   * scala> import cats.syntax.all._
    *
    * scala> val o = Option(42)
    * scala> Functor[Option].lift((x: Int) => x + 10)(o)
@@ -189,7 +189,7 @@ trait Functor[F[_]] extends Invariant[F] { self =>
    *
    * {{{
    * scala> import cats.Functor
-   * scala> import cats.implicits.catsStdInstancesForList
+   * scala> import cats.syntax.all._
    *
    * scala> Functor[List].unzip(List((1,2), (3, 4)))
    * res0: (List[Int], List[Int]) = (List(1, 3),List(2, 4))
@@ -203,7 +203,7 @@ trait Functor[F[_]] extends Invariant[F] { self =>
    * Example:
    * {{{
    * scala> import cats.Functor
-   * scala> import cats.implicits.catsStdInstancesForList
+   * scala> import cats.syntax.all._
    *
    * scala> Functor[List].ifF(List(true, false, false))(1, 0)
    * res0: List[Int] = List(1, 0, 0)

--- a/tests/shared/src/test/scala/cats/tests/IndexedStateTSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/IndexedStateTSuite.scala
@@ -350,7 +350,6 @@ class IndexedStateTSuite extends CatsSuite {
 
   test("fromState correctly turns State[A, F[B]] into StateT[F, A, B]") {
     val state: State[Int, Option[Int]] = add1.map(Some.apply)
-    import cats.implicits.catsStdInstancesForOption
     forAll { (initial: Int) =>
       assert(StateT.fromState(state).run(initial).get === {
         val (s, Some(result)) = state.run(initial).value: @unchecked // non-exhaustive match warning


### PR DESCRIPTION
There are some imports in examples that look like `import cats.implicits.catsStdInstancesForOption`
I don't think we should ever suggest such imports.
This PR replaces such imports with the "officially" recommended `import cats.syntax.all._`
