### PR TITLE
use `&` instead of `with`

### DIFF
--- a/alleycats-core/src/main/scala/alleycats/std/set.scala
+++ b/alleycats-core/src/main/scala/alleycats/std/set.scala
@@ -55,7 +55,7 @@ trait SetInstances {
   // If we accept Monad for Set, we can also have Alternative, as
   // Alternative only requires MonoidK (already accepted by cats-core) and
   // the Applicative that comes from Monad.
-  implicit val alleyCatsStdSetMonad: Monad[Set] with Alternative[Set] =
+  implicit val alleyCatsStdSetMonad: Monad[Set] & Alternative[Set] =
     new Monad[Set] with Alternative[Set] {
       def pure[A](a: A): Set[A] = Set(a)
       override def map[A, B](fa: Set[A])(f: A => B): Set[B] = fa.map(f)

--- a/core/src/main/scala-2.13+/cats/ScalaVersionSpecificInstances.scala
+++ b/core/src/main/scala-2.13+/cats/ScalaVersionSpecificInstances.scala
@@ -67,13 +67,13 @@ private[cats] trait ScalaVersionSpecificParallelInstances {
 
 private[cats] trait ScalaVersionSpecificInvariantInstances {
   @deprecated("Use catsInstancesForLazyList", "3.0.0")
-  implicit def catsInstancesForStream: Monad[Stream] with Alternative[Stream] with CoflatMap[Stream] =
+  implicit def catsInstancesForStream: Monad[Stream] & Alternative[Stream] & CoflatMap[Stream] =
     cats.instances.stream.catsStdInstancesForStream
 
-  implicit def catsInstancesForLazyList: Monad[LazyList] with Alternative[LazyList] with CoflatMap[LazyList] =
+  implicit def catsInstancesForLazyList: Monad[LazyList] & Alternative[LazyList] & CoflatMap[LazyList] =
     cats.instances.lazyList.catsStdInstancesForLazyList
 
-  implicit def catsInstancesForArraySeq: Monad[ArraySeq] with Alternative[ArraySeq] with CoflatMap[ArraySeq] =
+  implicit def catsInstancesForArraySeq: Monad[ArraySeq] & Alternative[ArraySeq] & CoflatMap[ArraySeq] =
     cats.instances.arraySeq.catsStdInstancesForArraySeq
 }
 

--- a/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
+++ b/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
@@ -38,7 +38,7 @@ object NonEmptyLazyList extends NonEmptyLazyListInstances {
   private[data] type Base
   private[data] trait Tag extends Any
   /* aliased in data package as NonEmptyLazyList */
-  type Type[+A] <: Base with Tag
+  type Type[+A] <: Base & Tag
 
   private[data] def create[A](s: LazyList[A]): Type[A] =
     s.asInstanceOf[Type[A]]
@@ -510,10 +510,9 @@ class NonEmptyLazyListOps[A](private val value: NonEmptyLazyList[A])
 
 sealed abstract private[data] class NonEmptyLazyListInstances extends NonEmptyLazyListInstances1 {
 
-  implicit val catsDataInstancesForNonEmptyLazyList: Bimonad[NonEmptyLazyList]
-    with NonEmptyTraverse[NonEmptyLazyList]
-    with NonEmptyAlternative[NonEmptyLazyList]
-    with Align[NonEmptyLazyList] =
+  implicit val catsDataInstancesForNonEmptyLazyList: Bimonad[NonEmptyLazyList] & NonEmptyTraverse[
+    NonEmptyLazyList
+  ] & NonEmptyAlternative[NonEmptyLazyList] & Align[NonEmptyLazyList] =
     new AbstractNonEmptyInstances[LazyList, NonEmptyLazyList] with Align[NonEmptyLazyList] {
 
       def extract[A](fa: NonEmptyLazyList[A]): A = fa.head

--- a/core/src/main/scala-2.13+/cats/data/ZipLazyList.scala
+++ b/core/src/main/scala-2.13+/cats/data/ZipLazyList.scala
@@ -28,7 +28,7 @@ object ZipLazyList {
 
   def apply[A](value: LazyList[A]): ZipLazyList[A] = new ZipLazyList(value)
 
-  implicit val catsDataAlternativeForZipLazyList: Alternative[ZipLazyList] with CommutativeApplicative[ZipLazyList] =
+  implicit val catsDataAlternativeForZipLazyList: Alternative[ZipLazyList] & CommutativeApplicative[ZipLazyList] =
     new Alternative[ZipLazyList] with CommutativeApplicative[ZipLazyList] {
       def pure[A](x: A): ZipLazyList[A] = new ZipLazyList(LazyList.continually(x))
 

--- a/core/src/main/scala-2.13+/cats/data/ZipStream.scala
+++ b/core/src/main/scala-2.13+/cats/data/ZipStream.scala
@@ -30,7 +30,7 @@ object ZipStream {
 
   def apply[A](value: Stream[A]): ZipStream[A] = new ZipStream(value)
 
-  implicit val catsDataAlternativeForZipStream: Alternative[ZipStream] with CommutativeApplicative[ZipStream] =
+  implicit val catsDataAlternativeForZipStream: Alternative[ZipStream] & CommutativeApplicative[ZipStream] =
     new Alternative[ZipStream] with CommutativeApplicative[ZipStream] {
       def pure[A](x: A): ZipStream[A] = new ZipStream(Stream.continually(x))
 

--- a/core/src/main/scala-2.13+/cats/instances/arraySeq.scala
+++ b/core/src/main/scala-2.13+/cats/instances/arraySeq.scala
@@ -29,7 +29,7 @@ import scala.collection.mutable.Builder
 
 trait ArraySeqInstances extends cats.kernel.instances.ArraySeqInstances {
   implicit def catsStdInstancesForArraySeq
-    : Traverse[ArraySeq] with Monad[ArraySeq] with Alternative[ArraySeq] with CoflatMap[ArraySeq] with Align[ArraySeq] =
+    : Traverse[ArraySeq] & Monad[ArraySeq] & Alternative[ArraySeq] & CoflatMap[ArraySeq] & Align[ArraySeq] =
     ArraySeqInstances.stdInstances
 
   implicit def catsStdTraverseFilterForArraySeq: TraverseFilter[ArraySeq] =
@@ -41,7 +41,7 @@ trait ArraySeqInstances extends cats.kernel.instances.ArraySeqInstances {
 
 private[cats] object ArraySeqInstances {
   final private val stdInstances
-    : Traverse[ArraySeq] with Monad[ArraySeq] with Alternative[ArraySeq] with CoflatMap[ArraySeq] with Align[ArraySeq] =
+    : Traverse[ArraySeq] & Monad[ArraySeq] & Alternative[ArraySeq] & CoflatMap[ArraySeq] & Align[ArraySeq] =
     new Traverse[ArraySeq]
       with Monad[ArraySeq]
       with Alternative[ArraySeq]

--- a/core/src/main/scala-2.13+/cats/instances/lazyList.scala
+++ b/core/src/main/scala-2.13+/cats/instances/lazyList.scala
@@ -34,7 +34,7 @@ import scala.annotation.tailrec
 trait LazyListInstances extends cats.kernel.instances.LazyListInstances {
 
   implicit val catsStdInstancesForLazyList
-    : Traverse[LazyList] with Alternative[LazyList] with Monad[LazyList] with CoflatMap[LazyList] with Align[LazyList] =
+    : Traverse[LazyList] & Alternative[LazyList] & Monad[LazyList] & CoflatMap[LazyList] & Align[LazyList] =
     new Traverse[LazyList]
       with Alternative[LazyList]
       with Monad[LazyList]

--- a/core/src/main/scala-2.13+/cats/instances/stream.scala
+++ b/core/src/main/scala-2.13+/cats/instances/stream.scala
@@ -33,7 +33,7 @@ trait StreamInstances extends cats.kernel.instances.StreamInstances {
 
   @deprecated("Use cats.instances.lazyList", "2.0.0-RC2")
   implicit val catsStdInstancesForStream
-    : Traverse[Stream] with Alternative[Stream] with Monad[Stream] with CoflatMap[Stream] with Align[Stream] =
+    : Traverse[Stream] & Alternative[Stream] & Monad[Stream] & CoflatMap[Stream] & Align[Stream] =
     new Traverse[Stream] with Alternative[Stream] with Monad[Stream] with CoflatMap[Stream] with Align[Stream] {
 
       def empty[A]: Stream[A] = Stream.Empty

--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -389,7 +389,7 @@ object Eval extends EvalInstances {
 
 sealed abstract private[cats] class EvalInstances extends EvalInstances0 {
 
-  implicit val catsBimonadForEval: Bimonad[Eval] with CommutativeMonad[Eval] =
+  implicit val catsBimonadForEval: Bimonad[Eval] & CommutativeMonad[Eval] =
     new Bimonad[Eval] with StackSafeMonad[Eval] with CommutativeMonad[Eval] {
       override def map[A, B](fa: Eval[A])(f: A => B): Eval[B] = fa.map(f)
       def pure[A](a: A): Eval[A] = Now(a)

--- a/core/src/main/scala/cats/Invariant.scala
+++ b/core/src/main/scala/cats/Invariant.scala
@@ -124,8 +124,7 @@ trait Invariant[F[_]] extends Serializable { self =>
 
 @suppressUnusedImportWarningForScalaVersionSpecific
 object Invariant extends ScalaVersionSpecificInvariantInstances with InvariantInstances0 {
-  implicit def catsInstancesForId
-    : Distributive[Id] with Bimonad[Id] with CommutativeMonad[Id] with NonEmptyTraverse[Id] =
+  implicit def catsInstancesForId: Distributive[Id] & Bimonad[Id] & CommutativeMonad[Id] & NonEmptyTraverse[Id] =
     cats.catsInstancesForId
   @deprecated("Added for bincompat", "2.8.0")
   @targetName3("catsInstancesForId")
@@ -134,13 +133,13 @@ object Invariant extends ScalaVersionSpecificInvariantInstances with InvariantIn
   implicit def catsMonadErrorForEither[A]: MonadError[Either[A, *], A] =
     cats.instances.either.catsStdInstancesForEither[A]
   implicit def catsInstancesForOption
-    : MonadError[Option, Unit] with Alternative[Option] with CoflatMap[Option] with CommutativeMonad[Option] =
+    : MonadError[Option, Unit] & Alternative[Option] & CoflatMap[Option] & CommutativeMonad[Option] =
     cats.instances.option.catsStdInstancesForOption
-  implicit def catsInstancesForList: Monad[List] with Alternative[List] with CoflatMap[List] =
+  implicit def catsInstancesForList: Monad[List] & Alternative[List] & CoflatMap[List] =
     cats.instances.list.catsStdInstancesForList
-  implicit def catsInstancesForVector: Monad[Vector] with Alternative[Vector] with CoflatMap[Vector] =
+  implicit def catsInstancesForVector: Monad[Vector] & Alternative[Vector] & CoflatMap[Vector] =
     cats.instances.vector.catsStdInstancesForVector
-  implicit def catsInstancesForQueue: Monad[Queue] with Alternative[Queue] with CoflatMap[Queue] =
+  implicit def catsInstancesForQueue: Monad[Queue] & Alternative[Queue] & CoflatMap[Queue] =
     cats.instances.queue.catsStdInstancesForQueue
   implicit def catsMonadForTailRec: Monad[TailRec] = cats.instances.tailRec.catsInstancesForTailRec
 
@@ -152,7 +151,7 @@ object Invariant extends ScalaVersionSpecificInvariantInstances with InvariantIn
     cats.instances.function.catsStdContravariantMonoidalForFunction1[R]
   implicit def catsFunctorForPair: Functor[λ[P => (P, P)]] = cats.instances.tuple.catsDataFunctorForPair
 
-  implicit def catsInstancesForTry: MonadThrow[Try] with CoflatMap[Try] =
+  implicit def catsInstancesForTry: MonadThrow[Try] & CoflatMap[Try] =
     cats.instances.try_.catsStdInstancesForTry
 
   /**
@@ -166,7 +165,7 @@ object Invariant extends ScalaVersionSpecificInvariantInstances with InvariantIn
    */
   implicit def catsInstancesForFuture(implicit
     ec: ExecutionContext
-  ): MonadThrow[Future] with CoflatMap[Future] =
+  ): MonadThrow[Future] & CoflatMap[Future] =
     cats.instances.future.catsStdInstancesForFuture(ec)
 
   implicit def catsContravariantMonoidalForOrder: ContravariantMonoidal[Order] =
@@ -339,7 +338,7 @@ private trait InvariantInstances1 extends InvariantInstances2 {
 private[cats] trait InvariantInstances2 extends cats.instances.NTupleMonadInstances with TupleInstances0 {
   implicit def catsApplicativeForArrow[F[_, _], A](implicit F: Arrow[F]): Applicative[F[A, *]] =
     new ArrowApplicative[F, A](F)
-  implicit def catsInstancesForSeq: Monad[Seq] with Alternative[Seq] with CoflatMap[Seq] =
+  implicit def catsInstancesForSeq: Monad[Seq] & Alternative[Seq] & CoflatMap[Seq] =
     cats.instances.seq.catsStdInstancesForSeq
 }
 

--- a/core/src/main/scala/cats/UnorderedFoldable.scala
+++ b/core/src/main/scala/cats/UnorderedFoldable.scala
@@ -165,7 +165,7 @@ object UnorderedFoldable
   implicit def catsTraverseForTry: Traverse[Try] = cats.instances.try_.catsStdInstancesForTry
 
   @deprecated("Use catsStdInstancesForTuple2 in cats.instances.NTupleMonadInstances", "2.4.0")
-  def catsInstancesForTuple[A]: Traverse[(A, *)] with Reducible[(A, *)] =
+  def catsInstancesForTuple[A]: Traverse[(A, *)] & Reducible[(A, *)] =
     cats.instances.tuple.catsStdInstancesForTuple2[A]
 
   /**

--- a/core/src/main/scala/cats/arrow/Compose.scala
+++ b/core/src/main/scala/cats/arrow/Compose.scala
@@ -53,11 +53,11 @@ trait Compose[F[_, _]] extends Serializable { self =>
 }
 
 object Compose {
-  implicit def catsInstancesForFunction1: ArrowChoice[Function1] with CommutativeArrow[Function1] =
+  implicit def catsInstancesForFunction1: ArrowChoice[Function1] & CommutativeArrow[Function1] =
     cats.instances.function.catsStdInstancesForFunction1
   implicit def catsComposeForMap: Compose[Map] = cats.instances.map.catsStdComposeForMap
 
-  implicit def catsInstancesForPartialFunction: ArrowChoice[PartialFunction] with CommutativeArrow[PartialFunction] =
+  implicit def catsInstancesForPartialFunction: ArrowChoice[PartialFunction] & CommutativeArrow[PartialFunction] =
     cats.instances.partialFunction.catsStdInstancesForPartialFunction
 
   /**

--- a/core/src/main/scala/cats/data/AndThen.scala
+++ b/core/src/main/scala/cats/data/AndThen.scala
@@ -310,7 +310,7 @@ abstract private[data] class AndThenInstances0 extends AndThenInstances1 {
    * [[cats.arrow.CommutativeArrow CommutativeArrow]] instances
    * for [[AndThen]].
    */
-  implicit val catsDataArrowForAndThen: ArrowChoice[AndThen] with CommutativeArrow[AndThen] =
+  implicit val catsDataArrowForAndThen: ArrowChoice[AndThen] & CommutativeArrow[AndThen] =
     new ArrowChoice[AndThen] with CommutativeArrow[AndThen] {
       // Piggybacking on the instance for Function1
       private[this] val fn1 = instances.all.catsStdInstancesForFunction1

--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -1203,7 +1203,7 @@ sealed abstract private[data] class ChainInstances extends ChainInstances1 {
   implicit def catsDataMonoidForChain[A]: Monoid[Chain[A]] = theMonoid.asInstanceOf[Monoid[Chain[A]]]
 
   implicit val catsDataInstancesForChain
-    : Traverse[Chain] with Alternative[Chain] with Monad[Chain] with CoflatMap[Chain] with Align[Chain] =
+    : Traverse[Chain] & Alternative[Chain] & Monad[Chain] & CoflatMap[Chain] & Align[Chain] =
     new Traverse[Chain] with Alternative[Chain] with Monad[Chain] with CoflatMap[Chain] with Align[Chain] {
       def foldLeft[A, B](fa: Chain[A], b: B)(f: (B, A) => B): B =
         fa.foldLeft(b)(f)
@@ -1357,7 +1357,7 @@ sealed abstract private[data] class ChainInstances extends ChainInstances1 {
     }
 
   implicit val catsDataTraverseFilterForChain: TraverseFilter[Chain] = new TraverseFilter[Chain] {
-    def traverse: Traverse[Chain] with Alternative[Chain] = Chain.catsDataInstancesForChain
+    def traverse: Traverse[Chain] & Alternative[Chain] = Chain.catsDataInstancesForChain
 
     override def filter[A](fa: Chain[A])(f: A => Boolean): Chain[A] = fa.filter(f)
 

--- a/core/src/main/scala/cats/data/IndexedStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedStateT.scala
@@ -279,7 +279,7 @@ sealed abstract private[data] class IndexedStateTInstances extends IndexedStateT
   implicit def catsDataAlternativeForIndexedStateT[F[_], S](implicit
     FM: Monad[F],
     FA: Alternative[F]
-  ): Alternative[IndexedStateT[F, S, S, *]] with Monad[IndexedStateT[F, S, S, *]] =
+  ): Alternative[IndexedStateT[F, S, S, *]] & Monad[IndexedStateT[F, S, S, *]] =
     new IndexedStateTAlternative[F, S] { implicit def F = FM; implicit def G = FA }
 
   implicit def catsDataDeferForIndexedStateT[F[_], SA, SB](implicit F: Defer[F]): Defer[IndexedStateT[F, SA, SB, *]] =

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -389,7 +389,7 @@ sealed abstract private[data] class KleisliInstances0 extends KleisliInstances0_
 
   implicit def catsDataCommutativeArrowForKleisli[F[_]](implicit
     M: CommutativeMonad[F]
-  ): CommutativeArrow[Kleisli[F, *, *]] with ArrowChoice[Kleisli[F, *, *]] =
+  ): CommutativeArrow[Kleisli[F, *, *]] & ArrowChoice[Kleisli[F, *, *]] =
     new KleisliCommutativeArrow[F] { def F: CommutativeMonad[F] = M }
 
   implicit def catsDataCommutativeMonadForKleisli[F[_], A](implicit

--- a/core/src/main/scala/cats/data/Newtype.scala
+++ b/core/src/main/scala/cats/data/Newtype.scala
@@ -31,5 +31,5 @@ package data
 private[data] trait Newtype { self =>
   private[data] type Base
   private[data] trait Tag extends Any
-  type Type[A] <: Base with Tag
+  type Type[A] <: Base & Tag
 }

--- a/core/src/main/scala/cats/data/Newtype2.scala
+++ b/core/src/main/scala/cats/data/Newtype2.scala
@@ -30,5 +30,5 @@ package data
 private[data] trait Newtype2 { self =>
   private[data] type Base
   private[data] trait Tag extends Any
-  type Type[A, +B] <: Base with Tag
+  type Type[A, +B] <: Base & Tag
 }

--- a/core/src/main/scala/cats/data/NonEmptyChain.scala
+++ b/core/src/main/scala/cats/data/NonEmptyChain.scala
@@ -42,7 +42,7 @@ object NonEmptyChainImpl extends NonEmptyChainInstances with ScalaVersionSpecifi
   private[data] type Base
   private[data] trait Tag extends Any
   /* aliased in data package as NonEmptyChain */
-  type Type[+A] <: Base with Tag
+  type Type[+A] <: Base & Tag
 
   private[data] def create[A](s: Chain[A]): Type[A] =
     s.asInstanceOf[Type[A]]
@@ -624,16 +624,16 @@ sealed abstract private[data] class NonEmptyChainInstances extends NonEmptyChain
     "maintained for the sake of binary compatibility only, use catsDataInstancesForNonEmptyChainBinCompat1 instead",
     "2.9.0"
   )
-  def catsDataInstancesForNonEmptyChain: SemigroupK[NonEmptyChain]
-    with NonEmptyTraverse[NonEmptyChain]
-    with Bimonad[NonEmptyChain]
-    with Align[NonEmptyChain] =
+  def catsDataInstancesForNonEmptyChain
+    : SemigroupK[NonEmptyChain] & NonEmptyTraverse[NonEmptyChain] & Bimonad[NonEmptyChain] & Align[
+      NonEmptyChain
+    ] =
     catsDataInstancesForNonEmptyChainBinCompat1
 
-  implicit val catsDataInstancesForNonEmptyChainBinCompat1: Align[NonEmptyChain]
-    with Bimonad[NonEmptyChain]
-    with NonEmptyAlternative[NonEmptyChain]
-    with NonEmptyTraverse[NonEmptyChain] =
+  implicit val catsDataInstancesForNonEmptyChainBinCompat1
+    : Align[NonEmptyChain] & Bimonad[NonEmptyChain] & NonEmptyAlternative[NonEmptyChain] & NonEmptyTraverse[
+      NonEmptyChain
+    ] =
     new AbstractNonEmptyInstances[Chain, NonEmptyChain] with Align[NonEmptyChain] {
       def extract[A](fa: NonEmptyChain[A]): A = fa.head
 

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -796,7 +796,7 @@ sealed abstract private[data] class NonEmptyListInstances extends NonEmptyListIn
     "2.9.0"
   )
   def catsDataInstancesForNonEmptyList
-    : SemigroupK[NonEmptyList] with Bimonad[NonEmptyList] with NonEmptyTraverse[NonEmptyList] with Align[NonEmptyList] =
+    : SemigroupK[NonEmptyList] & Bimonad[NonEmptyList] & NonEmptyTraverse[NonEmptyList] & Align[NonEmptyList] =
     catsDataInstancesForNonEmptyListBinCompat1
 
   /**
@@ -805,10 +805,10 @@ sealed abstract private[data] class NonEmptyListInstances extends NonEmptyListIn
    *
    * Also see the discussion: PR #3541 and issue #3069.
    */
-  implicit val catsDataInstancesForNonEmptyListBinCompat1: NonEmptyAlternative[NonEmptyList]
-    with Bimonad[NonEmptyList]
-    with NonEmptyTraverse[NonEmptyList]
-    with Align[NonEmptyList] =
+  implicit val catsDataInstancesForNonEmptyListBinCompat1
+    : NonEmptyAlternative[NonEmptyList] & Bimonad[NonEmptyList] & NonEmptyTraverse[NonEmptyList] & Align[
+      NonEmptyList
+    ] =
     new NonEmptyReducible[NonEmptyList, List]
       with NonEmptyAlternative[NonEmptyList]
       with Bimonad[NonEmptyList]

--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -296,7 +296,7 @@ sealed class NonEmptyMapOps[K, A](private[data] val value: NonEmptyMap[K, A]) {
 sealed abstract private[data] class NonEmptyMapInstances extends NonEmptyMapInstances0 {
 
   implicit def catsDataInstancesForNonEmptyMap[K]
-    : SemigroupK[NonEmptyMap[K, *]] with NonEmptyTraverse[NonEmptyMap[K, *]] with Align[NonEmptyMap[K, *]] =
+    : SemigroupK[NonEmptyMap[K, *]] & NonEmptyTraverse[NonEmptyMap[K, *]] & Align[NonEmptyMap[K, *]] =
     new SemigroupK[NonEmptyMap[K, *]] with NonEmptyTraverse[NonEmptyMap[K, *]] with Align[NonEmptyMap[K, *]] {
 
       override def map[A, B](fa: NonEmptyMap[K, A])(f: A => B): NonEmptyMap[K, B] =
@@ -354,7 +354,7 @@ sealed abstract private[data] class NonEmptyMapInstances extends NonEmptyMapInst
   @deprecated("Use catsDataInstancesForNonEmptyMap override without Order", "2.2.0-M3")
   def catsDataInstancesForNonEmptyMap[K](
     orderK: Order[K]
-  ): SemigroupK[NonEmptyMap[K, *]] with NonEmptyTraverse[NonEmptyMap[K, *]] with Align[NonEmptyMap[K, *]] =
+  ): SemigroupK[NonEmptyMap[K, *]] & NonEmptyTraverse[NonEmptyMap[K, *]] & Align[NonEmptyMap[K, *]] =
     catsDataInstancesForNonEmptyMap[K]
 
   implicit def catsDataHashForNonEmptyMap[K: Hash, A: Hash]: Hash[NonEmptyMap[K, A]] =

--- a/core/src/main/scala/cats/data/NonEmptySeq.scala
+++ b/core/src/main/scala/cats/data/NonEmptySeq.scala
@@ -403,7 +403,7 @@ sealed abstract private[data] class NonEmptySeqInstances {
     "2.9.0"
   )
   def catsDataInstancesForNonEmptySeq
-    : SemigroupK[NonEmptySeq] with Bimonad[NonEmptySeq] with NonEmptyTraverse[NonEmptySeq] with Align[NonEmptySeq] =
+    : SemigroupK[NonEmptySeq] & Bimonad[NonEmptySeq] & NonEmptyTraverse[NonEmptySeq] & Align[NonEmptySeq] =
     catsDataInstancesForNonEmptySeqBinCompat1
 
   /**
@@ -412,10 +412,8 @@ sealed abstract private[data] class NonEmptySeqInstances {
    *
    * Also see the discussion: PR #3541 and issue #3069.
    */
-  implicit val catsDataInstancesForNonEmptySeqBinCompat1: NonEmptyAlternative[NonEmptySeq]
-    with Bimonad[NonEmptySeq]
-    with NonEmptyTraverse[NonEmptySeq]
-    with Align[NonEmptySeq] =
+  implicit val catsDataInstancesForNonEmptySeqBinCompat1
+    : NonEmptyAlternative[NonEmptySeq] & Bimonad[NonEmptySeq] & NonEmptyTraverse[NonEmptySeq] & Align[NonEmptySeq] =
     new NonEmptyReducible[NonEmptySeq, Seq]
       with NonEmptyAlternative[NonEmptySeq]
       with Bimonad[NonEmptySeq]

--- a/core/src/main/scala/cats/data/NonEmptySet.scala
+++ b/core/src/main/scala/cats/data/NonEmptySet.scala
@@ -373,7 +373,7 @@ sealed class NonEmptySetOps[A](private[data] val value: NonEmptySet[A]) {
 }
 
 sealed abstract private[data] class NonEmptySetInstances extends NonEmptySetInstances0 {
-  implicit val catsDataInstancesForNonEmptySet: SemigroupK[NonEmptySet] with Reducible[NonEmptySet] =
+  implicit val catsDataInstancesForNonEmptySet: SemigroupK[NonEmptySet] & Reducible[NonEmptySet] =
     new SemigroupK[NonEmptySet] with Reducible[NonEmptySet] {
 
       def combineK[A](a: NonEmptySet[A], b: NonEmptySet[A]): NonEmptySet[A] =

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -393,10 +393,8 @@ sealed abstract private[data] class NonEmptyVectorInstances extends NonEmptyVect
     "maintained for the sake of binary compatibility only - use catsDataInstancesForNonEmptyChainBinCompat1 instead",
     "2.9.0"
   )
-  def catsDataInstancesForNonEmptyVector: SemigroupK[NonEmptyVector]
-    with Bimonad[NonEmptyVector]
-    with NonEmptyTraverse[NonEmptyVector]
-    with Align[NonEmptyVector] =
+  def catsDataInstancesForNonEmptyVector
+    : SemigroupK[NonEmptyVector] & Bimonad[NonEmptyVector] & NonEmptyTraverse[NonEmptyVector] & Align[NonEmptyVector] =
     catsDataInstancesForNonEmptyVectorBinCompat1
 
   /**
@@ -405,10 +403,10 @@ sealed abstract private[data] class NonEmptyVectorInstances extends NonEmptyVect
    *
    * Also see the discussion: PR #3541 and issue #3069.
    */
-  implicit val catsDataInstancesForNonEmptyVectorBinCompat1: NonEmptyAlternative[NonEmptyVector]
-    with Bimonad[NonEmptyVector]
-    with NonEmptyTraverse[NonEmptyVector]
-    with Align[NonEmptyVector] =
+  implicit val catsDataInstancesForNonEmptyVectorBinCompat1
+    : NonEmptyAlternative[NonEmptyVector] & Bimonad[NonEmptyVector] & NonEmptyTraverse[NonEmptyVector] & Align[
+      NonEmptyVector
+    ] =
     new NonEmptyReducible[NonEmptyVector, Vector]
       with NonEmptyAlternative[NonEmptyVector]
       with Bimonad[NonEmptyVector]

--- a/core/src/main/scala/cats/instances/either.scala
+++ b/core/src/main/scala/cats/instances/either.scala
@@ -57,7 +57,7 @@ trait EitherInstances extends cats.kernel.instances.EitherInstances {
     }
 
   implicit def catsStdInstancesForEither[A]
-    : MonadError[Either[A, *], A] with Traverse[Either[A, *]] with Align[Either[A, *]] =
+    : MonadError[Either[A, *], A] & Traverse[Either[A, *]] & Align[Either[A, *]] =
     new MonadError[Either[A, *], A] with Traverse[Either[A, *]] with Align[Either[A, *]] {
       override def unit: Either[A, Unit] = Either.unit
 

--- a/core/src/main/scala/cats/instances/function.scala
+++ b/core/src/main/scala/cats/instances/function.scala
@@ -178,7 +178,7 @@ sealed private[instances] trait Function1Instances extends Function1Instances0 {
         }
     }
 
-  implicit val catsStdInstancesForFunction1: ArrowChoice[Function1] with CommutativeArrow[Function1] =
+  implicit val catsStdInstancesForFunction1: ArrowChoice[Function1] & CommutativeArrow[Function1] =
     new ArrowChoice[Function1] with CommutativeArrow[Function1] {
       def choose[A, B, C, D](f: A => C)(g: B => D): Either[A, B] => Either[C, D] = {
         case Left(a)  => Left(f(a))

--- a/core/src/main/scala/cats/instances/future.scala
+++ b/core/src/main/scala/cats/instances/future.scala
@@ -38,7 +38,7 @@ trait FutureInstances extends FutureInstances1 {
 
   implicit def catsStdInstancesForFuture(implicit
     ec: ExecutionContext
-  ): MonadThrow[Future] with CoflatMap[Future] with Monad[Future] =
+  ): MonadThrow[Future] & CoflatMap[Future] & Monad[Future] =
     new FutureCoflatMap with MonadThrow[Future] with Monad[Future] with StackSafeMonad[Future] {
       override def pure[A](x: A): Future[A] =
         Future.successful(x)

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -34,7 +34,7 @@ import scala.collection.mutable.ListBuffer
 trait ListInstances extends cats.kernel.instances.ListInstances {
 
   implicit val catsStdInstancesForList
-    : Traverse[List] with Alternative[List] with Monad[List] with CoflatMap[List] with Align[List] =
+    : Traverse[List] & Alternative[List] & Monad[List] & CoflatMap[List] & Align[List] =
     new Traverse[List] with Alternative[List] with Monad[List] with CoflatMap[List] with Align[List] {
       def empty[A]: List[A] = Nil
 

--- a/core/src/main/scala/cats/instances/map.scala
+++ b/core/src/main/scala/cats/instances/map.scala
@@ -36,7 +36,7 @@ trait MapInstances extends cats.kernel.instances.MapInstances {
       .map { case (a, b) => showA.show(a) + " -> " + showB.show(b) }
       .mkString("Map(", ", ", ")")
 
-  implicit def catsStdInstancesForMap[K]: UnorderedTraverse[Map[K, *]] with FlatMap[Map[K, *]] with Align[Map[K, *]] =
+  implicit def catsStdInstancesForMap[K]: UnorderedTraverse[Map[K, *]] & FlatMap[Map[K, *]] & Align[Map[K, *]] =
     new UnorderedTraverse[Map[K, *]] with FlatMap[Map[K, *]] with Align[Map[K, *]] {
 
       def unorderedTraverse[G[_], A, B](

--- a/core/src/main/scala/cats/instances/option.scala
+++ b/core/src/main/scala/cats/instances/option.scala
@@ -28,12 +28,9 @@ import cats.kernel.compat.scalaVersionSpecific._
 
 trait OptionInstances extends cats.kernel.instances.OptionInstances {
 
-  implicit val catsStdInstancesForOption: Traverse[Option]
-    with MonadError[Option, Unit]
-    with Alternative[Option]
-    with CommutativeMonad[Option]
-    with CoflatMap[Option]
-    with Align[Option] =
+  implicit val catsStdInstancesForOption: Traverse[Option] & MonadError[Option, Unit] & Alternative[
+    Option
+  ] & CommutativeMonad[Option] & CoflatMap[Option] & Align[Option] =
     new Traverse[Option]
       with MonadError[Option, Unit]
       with Alternative[Option]

--- a/core/src/main/scala/cats/instances/partialFunction.scala
+++ b/core/src/main/scala/cats/instances/partialFunction.scala
@@ -24,13 +24,13 @@ import cats.arrow.{ArrowChoice, CommutativeArrow}
 
 trait PartialFunctionInstances {
 
-  implicit def catsStdInstancesForPartialFunction: ArrowChoice[PartialFunction] with CommutativeArrow[PartialFunction] =
+  implicit def catsStdInstancesForPartialFunction: ArrowChoice[PartialFunction] & CommutativeArrow[PartialFunction] =
     PartialFunctionInstances.instance
 }
 
 private object PartialFunctionInstances {
 
-  private val instance: ArrowChoice[PartialFunction] with CommutativeArrow[PartialFunction] =
+  private val instance: ArrowChoice[PartialFunction] & CommutativeArrow[PartialFunction] =
     new ArrowChoice[PartialFunction] with CommutativeArrow[PartialFunction] {
 
       /**

--- a/core/src/main/scala/cats/instances/queue.scala
+++ b/core/src/main/scala/cats/instances/queue.scala
@@ -33,8 +33,7 @@ import scala.util.Try
 
 trait QueueInstances extends cats.kernel.instances.QueueInstances {
 
-  implicit val catsStdInstancesForQueue
-    : Traverse[Queue] with Alternative[Queue] with Monad[Queue] with CoflatMap[Queue] =
+  implicit val catsStdInstancesForQueue: Traverse[Queue] & Alternative[Queue] & Monad[Queue] & CoflatMap[Queue] =
     new Traverse[Queue] with Alternative[Queue] with Monad[Queue] with CoflatMap[Queue] {
       def empty[A]: Queue[A] = Queue.empty
 
@@ -223,7 +222,7 @@ trait QueueInstances extends cats.kernel.instances.QueueInstances {
 @suppressUnusedImportWarningForScalaVersionSpecific
 private object QueueInstances {
   private val catsStdTraverseFilterForQueue: TraverseFilter[Queue] = new TraverseFilter[Queue] {
-    val traverse: Traverse[Queue] with Alternative[Queue] = cats.instances.queue.catsStdInstancesForQueue
+    val traverse: Traverse[Queue] & Alternative[Queue] = cats.instances.queue.catsStdInstancesForQueue
 
     override def mapFilter[A, B](fa: Queue[A])(f: (A) => Option[B]): Queue[B] =
       fa.collect(Function.unlift(f))

--- a/core/src/main/scala/cats/instances/seq.scala
+++ b/core/src/main/scala/cats/instances/seq.scala
@@ -32,8 +32,7 @@ import scala.collection.immutable.Seq
 
 @suppressUnusedImportWarningForScalaVersionSpecific
 trait SeqInstances extends cats.kernel.instances.SeqInstances {
-  implicit val catsStdInstancesForSeq
-    : Traverse[Seq] with Monad[Seq] with Alternative[Seq] with CoflatMap[Seq] with Align[Seq] =
+  implicit val catsStdInstancesForSeq: Traverse[Seq] & Monad[Seq] & Alternative[Seq] & CoflatMap[Seq] & Align[Seq] =
     new Traverse[Seq] with Monad[Seq] with Alternative[Seq] with CoflatMap[Seq] with Align[Seq] {
 
       def empty[A]: Seq[A] = Seq.empty[A]

--- a/core/src/main/scala/cats/instances/set.scala
+++ b/core/src/main/scala/cats/instances/set.scala
@@ -26,7 +26,7 @@ import cats.kernel.CommutativeMonoid
 
 trait SetInstances extends cats.kernel.instances.SetInstances {
 
-  implicit val catsStdInstancesForSet: UnorderedTraverse[Set] with MonoidK[Set] =
+  implicit val catsStdInstancesForSet: UnorderedTraverse[Set] & MonoidK[Set] =
     new UnorderedTraverse[Set] with MonoidK[Set] {
 
       def unorderedTraverse[G[_]: CommutativeApplicative, A, B](sa: Set[A])(f: A => G[B]): G[Set[B]] =

--- a/core/src/main/scala/cats/instances/sortedMap.scala
+++ b/core/src/main/scala/cats/instances/sortedMap.scala
@@ -49,7 +49,7 @@ trait SortedMapInstances extends SortedMapInstances2 {
     catsStdShowForSortedMap(showA, showB)
 
   implicit def catsStdInstancesForSortedMap[K]
-    : Traverse[SortedMap[K, *]] with FlatMap[SortedMap[K, *]] with Align[SortedMap[K, *]] =
+    : Traverse[SortedMap[K, *]] & FlatMap[SortedMap[K, *]] & Align[SortedMap[K, *]] =
     new Traverse[SortedMap[K, *]] with FlatMap[SortedMap[K, *]] with Align[SortedMap[K, *]] {
 
       def traverse[G[_], A, B](fa: SortedMap[K, A])(f: A => G[B])(implicit G: Applicative[G]): G[SortedMap[K, B]] = {
@@ -174,7 +174,7 @@ trait SortedMapInstances extends SortedMapInstances2 {
   @deprecated("Use catsStdInstancesForSortedMap override without Order", "2.2.0-M3")
   def catsStdInstancesForSortedMap[K](
     orderK: Order[K]
-  ): Traverse[SortedMap[K, *]] with FlatMap[SortedMap[K, *]] with Align[SortedMap[K, *]] =
+  ): Traverse[SortedMap[K, *]] & FlatMap[SortedMap[K, *]] & Align[SortedMap[K, *]] =
     catsStdInstancesForSortedMap[K]
 }
 

--- a/core/src/main/scala/cats/instances/sortedSet.scala
+++ b/core/src/main/scala/cats/instances/sortedSet.scala
@@ -28,7 +28,7 @@ import scala.annotation.tailrec
 
 trait SortedSetInstances extends SortedSetInstances1 {
 
-  implicit val catsStdInstancesForSortedSet: Foldable[SortedSet] with SemigroupK[SortedSet] =
+  implicit val catsStdInstancesForSortedSet: Foldable[SortedSet] & SemigroupK[SortedSet] =
     new Foldable[SortedSet] with SemigroupK[SortedSet] {
 
       def combineK[A](x: SortedSet[A], y: SortedSet[A]): SortedSet[A] = x | y

--- a/core/src/main/scala/cats/instances/tailrec.scala
+++ b/core/src/main/scala/cats/instances/tailrec.scala
@@ -25,12 +25,12 @@ package instances
 import scala.util.control.TailCalls.{done, tailcall, TailRec}
 
 trait TailRecInstances {
-  implicit def catsInstancesForTailRec: StackSafeMonad[TailRec] with Defer[TailRec] =
+  implicit def catsInstancesForTailRec: StackSafeMonad[TailRec] & Defer[TailRec] =
     TailRecInstances.catsInstancesForTailRec
 }
 
 private object TailRecInstances {
-  val catsInstancesForTailRec: StackSafeMonad[TailRec] with Defer[TailRec] =
+  val catsInstancesForTailRec: StackSafeMonad[TailRec] & Defer[TailRec] =
     new StackSafeMonad[TailRec] with Defer[TailRec] {
       def defer[A](fa: => TailRec[A]): TailRec[A] = tailcall(fa)
 

--- a/core/src/main/scala/cats/instances/try.scala
+++ b/core/src/main/scala/cats/instances/try.scala
@@ -30,7 +30,7 @@ import scala.annotation.tailrec
 
 trait TryInstances extends TryInstances1 {
 
-  implicit def catsStdInstancesForTry: MonadThrow[Try] with CoflatMap[Try] with Traverse[Try] with Monad[Try] =
+  implicit def catsStdInstancesForTry: MonadThrow[Try] & CoflatMap[Try] & Traverse[Try] & Monad[Try] =
     new TryCoflatMap with MonadThrow[Try] with Traverse[Try] with Monad[Try] {
       def pure[A](x: A): Try[A] = Success(x)
 

--- a/core/src/main/scala/cats/instances/tuple.scala
+++ b/core/src/main/scala/cats/instances/tuple.scala
@@ -75,7 +75,7 @@ sealed private[instances] trait Tuple2Instances extends Tuple2Instances1 {
   }
 
   @deprecated("Use catsStdInstancesForTuple2 in cats.instances.NTupleMonadInstances", "2.4.0")
-  def catsStdInstancesForTuple2[X]: Traverse[(X, *)] with Comonad[(X, *)] with Reducible[(X, *)] =
+  def catsStdInstancesForTuple2[X]: Traverse[(X, *)] & Comonad[(X, *)] & Reducible[(X, *)] =
     new Traverse[(X, *)] with Comonad[(X, *)] with Reducible[(X, *)] {
       def traverse[G[_], A, B](fa: (X, A))(f: A => G[B])(implicit G: Applicative[G]): G[(X, B)] =
         G.map(f(fa._2))((fa._1, _))

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -31,7 +31,7 @@ import scala.collection.immutable.VectorBuilder
 
 trait VectorInstances extends cats.kernel.instances.VectorInstances {
   implicit val catsStdInstancesForVector
-    : Traverse[Vector] with Monad[Vector] with Alternative[Vector] with CoflatMap[Vector] with Align[Vector] =
+    : Traverse[Vector] & Monad[Vector] & Alternative[Vector] & CoflatMap[Vector] & Align[Vector] =
     new Traverse[Vector] with Monad[Vector] with Alternative[Vector] with CoflatMap[Vector] with Align[Vector] {
 
       def empty[A]: Vector[A] = Vector.empty[A]

--- a/core/src/main/scala/cats/package.scala
+++ b/core/src/main/scala/cats/package.scala
@@ -96,7 +96,7 @@ package object cats {
 
   type Endo[A] = A => A
 
-  val catsInstancesForId: Bimonad[Id] with CommutativeMonad[Id] with NonEmptyTraverse[Id] with Distributive[Id] =
+  val catsInstancesForId: Bimonad[Id] & CommutativeMonad[Id] & NonEmptyTraverse[Id] & Distributive[Id] =
     new Bimonad[Id] with CommutativeMonad[Id] with NonEmptyTraverse[Id] with Distributive[Id] {
       def pure[A](a: A): A = a
       def extract[A](a: A): A = a

--- a/kernel-laws/shared/src/main/scala/cats/kernel/laws/EnumerableLaws.scala
+++ b/kernel-laws/shared/src/main/scala/cats/kernel/laws/EnumerableLaws.scala
@@ -94,13 +94,13 @@ trait BoundedEnumerableLaws[A]
     extends PartialPreviousNextLaws[A]
     with PartialPreviousBoundedLaws[A]
     with PartialNextBoundedLaws[A] {
-  override def B: LowerBounded[A] with UpperBounded[A]
+  override def B: LowerBounded[A] & UpperBounded[A]
 }
 
 object BoundedEnumerableLaws {
   def apply[A](implicit ev: BoundedEnumerable[A]): BoundedEnumerableLaws[A] =
     new BoundedEnumerableLaws[A] {
-      val B: LowerBounded[A] with UpperBounded[A] = ev
+      val B: LowerBounded[A] & UpperBounded[A] = ev
       val E = ev.order
       val N: PartialNext[A] = ev
       val P: PartialPrevious[A] = ev

--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -464,7 +464,7 @@ class Tests extends TestsConfig with DisciplineSuite {
         .flatMap(x => Iterator.tabulate(nMax)(N).map((x, _)))
         .forall { case (x, y) => a.eqv(x, y) == b.eqv(x, y) }
 
-    implicit val monoidOrderN: Monoid[Order[N]] with Band[Order[N]] = Order.whenEqualMonoid[N]
+    implicit val monoidOrderN: Monoid[Order[N]] & Band[Order[N]] = Order.whenEqualMonoid[N]
     checkAll("Monoid[Order[N]]", MonoidTests[Order[N]].monoid)
     checkAll("Band[Order[N]]", BandTests[Order[N]].band)
 

--- a/kernel/src/main/scala/cats/kernel/Comparison.scala
+++ b/kernel/src/main/scala/cats/kernel/Comparison.scala
@@ -47,7 +47,7 @@ object Comparison {
     else if (double == 0.0) SomeEq
     else SomeLt
 
-  implicit val catsKernelEqForComparison: Eq[Comparison] with Monoid[Comparison] =
+  implicit val catsKernelEqForComparison: Eq[Comparison] & Monoid[Comparison] =
     new Eq[Comparison] with Monoid[Comparison] {
       def eqv(x: Comparison, y: Comparison): Boolean = x == y
       def empty: Comparison = EqualTo

--- a/kernel/src/main/scala/cats/kernel/Eq.scala
+++ b/kernel/src/main/scala/cats/kernel/Eq.scala
@@ -149,43 +149,43 @@ object Eq
         }
     }
 
-  implicit def catsKernelInstancesForBitSet: PartialOrder[BitSet] with Hash[BitSet] =
+  implicit def catsKernelInstancesForBitSet: PartialOrder[BitSet] & Hash[BitSet] =
     cats.kernel.instances.bitSet.catsKernelStdOrderForBitSet
   implicit def catsKernelPartialOrderForSet[A]: PartialOrder[Set[A]] =
     cats.kernel.instances.set.catsKernelStdPartialOrderForSet[A]
   implicit def catsKernelOrderForEither[A: Order, B: Order]: Order[Either[A, B]] =
     cats.kernel.instances.either.catsStdOrderForEither[A, B]
 
-  implicit def catsKernelInstancesForUnit: Order[Unit] with Hash[Unit] =
+  implicit def catsKernelInstancesForUnit: Order[Unit] & Hash[Unit] =
     cats.kernel.instances.unit.catsKernelStdOrderForUnit
-  implicit def catsKernelInstancesForBoolean: Order[Boolean] with Hash[Boolean] =
+  implicit def catsKernelInstancesForBoolean: Order[Boolean] & Hash[Boolean] =
     cats.kernel.instances.boolean.catsKernelStdOrderForBoolean
-  implicit def catsKernelInstancesForByte: Order[Byte] with Hash[Byte] =
+  implicit def catsKernelInstancesForByte: Order[Byte] & Hash[Byte] =
     cats.kernel.instances.byte.catsKernelStdOrderForByte
-  implicit def catsKernelInstancesForShort: Order[Short] with Hash[Short] =
+  implicit def catsKernelInstancesForShort: Order[Short] & Hash[Short] =
     cats.kernel.instances.short.catsKernelStdOrderForShort
-  implicit def catsKernelInstancesForInt: Order[Int] with Hash[Int] = cats.kernel.instances.int.catsKernelStdOrderForInt
-  implicit def catsKernelInstancesForLong: Order[Long] with Hash[Long] =
+  implicit def catsKernelInstancesForInt: Order[Int] & Hash[Int] = cats.kernel.instances.int.catsKernelStdOrderForInt
+  implicit def catsKernelInstancesForLong: Order[Long] & Hash[Long] =
     cats.kernel.instances.long.catsKernelStdOrderForLong
-  implicit def catsKernelInstancesForBigInt: Order[BigInt] with Hash[BigInt] =
+  implicit def catsKernelInstancesForBigInt: Order[BigInt] & Hash[BigInt] =
     cats.kernel.instances.bigInt.catsKernelStdOrderForBigInt
-  implicit def catsKernelInstancesForBigDecimal: Order[BigDecimal] with Hash[BigDecimal] =
+  implicit def catsKernelInstancesForBigDecimal: Order[BigDecimal] & Hash[BigDecimal] =
     cats.kernel.instances.bigDecimal.catsKernelStdOrderForBigDecimal
-  implicit def catsKernelInstancesForDuration: Order[Duration] with Hash[Duration] =
+  implicit def catsKernelInstancesForDuration: Order[Duration] & Hash[Duration] =
     cats.kernel.instances.duration.catsKernelStdOrderForDuration
-  implicit def catsKernelInstancesForFiniteDuration: Order[FiniteDuration] with Hash[FiniteDuration] =
+  implicit def catsKernelInstancesForFiniteDuration: Order[FiniteDuration] & Hash[FiniteDuration] =
     cats.kernel.instances.all.catsKernelStdOrderForFiniteDuration
-  implicit def catsKernelInstancesForChar: Order[Char] with Hash[Char] =
+  implicit def catsKernelInstancesForChar: Order[Char] & Hash[Char] =
     cats.kernel.instances.char.catsKernelStdOrderForChar
-  implicit def catsKernelInstancesForSymbol: Order[Symbol] with Hash[Symbol] =
+  implicit def catsKernelInstancesForSymbol: Order[Symbol] & Hash[Symbol] =
     cats.kernel.instances.symbol.catsKernelStdOrderForSymbol
-  implicit def catsKernelInstancesForString: Order[String] with Hash[String] =
+  implicit def catsKernelInstancesForString: Order[String] & Hash[String] =
     cats.kernel.instances.string.catsKernelStdOrderForString
-  implicit def catsKernelInstancesForUUID: Order[UUID] with Hash[UUID] =
+  implicit def catsKernelInstancesForUUID: Order[UUID] & Hash[UUID] =
     cats.kernel.instances.uuid.catsKernelStdOrderForUUID
-  implicit def catsKernelInstancesForDouble: Order[Double] with Hash[Double] =
+  implicit def catsKernelInstancesForDouble: Order[Double] & Hash[Double] =
     cats.kernel.instances.double.catsKernelStdOrderForDouble
-  implicit def catsKernelInstancesForFloat: Order[Float] with Hash[Float] =
+  implicit def catsKernelInstancesForFloat: Order[Float] & Hash[Float] =
     cats.kernel.instances.float.catsKernelStdOrderForFloat
 
   implicit def catsKernelOrderForOption[A: Order]: Order[Option[A]] =

--- a/kernel/src/main/scala/cats/kernel/Order.scala
+++ b/kernel/src/main/scala/cats/kernel/Order.scala
@@ -220,7 +220,7 @@ object Order extends OrderFunctions[Order] with OrderToOrderingConversion {
    *
    * @see [[Order.whenEqual]]
    */
-  def whenEqualMonoid[A]: Monoid[Order[A]] with Band[Order[A]] =
+  def whenEqualMonoid[A]: Monoid[Order[A]] & Band[Order[A]] =
     new Monoid[Order[A]] with Band[Order[A]] {
       val empty: Order[A] = allEqual[A]
       def combine(x: Order[A], y: Order[A]): Order[A] = Order.whenEqual(x, y)

--- a/kernel/src/main/scala/cats/kernel/Semigroup.scala
+++ b/kernel/src/main/scala/cats/kernel/Semigroup.scala
@@ -180,7 +180,7 @@ object Semigroup
 
   implicit def catsKernelBoundedSemilatticeForBitSet: BoundedSemilattice[BitSet] =
     cats.kernel.instances.bitSet.catsKernelStdSemilatticeForBitSet
-  implicit def catsKernelInstancesForUnit: BoundedSemilattice[Unit] with CommutativeGroup[Unit] =
+  implicit def catsKernelInstancesForUnit: BoundedSemilattice[Unit] & CommutativeGroup[Unit] =
     cats.kernel.instances.unit.catsKernelStdAlgebraForUnit
   implicit def catsKernelCommutativeGroupForByte: CommutativeGroup[Byte] =
     cats.kernel.instances.byte.catsKernelStdGroupForByte

--- a/kernel/src/main/scala/cats/kernel/instances/BigDecimalInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/BigDecimalInstances.scala
@@ -23,7 +23,7 @@ package cats.kernel
 package instances
 
 trait BigDecimalInstances {
-  implicit val catsKernelStdOrderForBigDecimal: Order[BigDecimal] with Hash[BigDecimal] =
+  implicit val catsKernelStdOrderForBigDecimal: Order[BigDecimal] & Hash[BigDecimal] =
     new BigDecimalOrder
   implicit val catsKernelStdGroupForBigDecimal: CommutativeGroup[BigDecimal] =
     new BigDecimalGroup

--- a/kernel/src/main/scala/cats/kernel/instances/BigIntInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/BigIntInstances.scala
@@ -23,7 +23,7 @@ package cats.kernel
 package instances
 
 trait BigIntInstances {
-  implicit val catsKernelStdOrderForBigInt: Order[BigInt] with Hash[BigInt] with UnboundedEnumerable[BigInt] =
+  implicit val catsKernelStdOrderForBigInt: Order[BigInt] & Hash[BigInt] & UnboundedEnumerable[BigInt] =
     new BigIntOrder
   implicit val catsKernelStdGroupForBigInt: CommutativeGroup[BigInt] =
     new BigIntGroup

--- a/kernel/src/main/scala/cats/kernel/instances/BitSetInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/BitSetInstances.scala
@@ -25,7 +25,7 @@ package instances
 import scala.collection.immutable.BitSet
 
 trait BitSetInstances {
-  implicit val catsKernelStdOrderForBitSet: PartialOrder[BitSet] with Hash[BitSet] =
+  implicit val catsKernelStdOrderForBitSet: PartialOrder[BitSet] & Hash[BitSet] =
     new BitSetPartialOrder
 
   implicit val catsKernelStdSemilatticeForBitSet: BoundedSemilattice[BitSet] =

--- a/kernel/src/main/scala/cats/kernel/instances/BooleanInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/BooleanInstances.scala
@@ -23,7 +23,7 @@ package cats.kernel
 package instances
 
 trait BooleanInstances {
-  implicit val catsKernelStdOrderForBoolean: Order[Boolean] with Hash[Boolean] with BoundedEnumerable[Boolean] =
+  implicit val catsKernelStdOrderForBoolean: Order[Boolean] & Hash[Boolean] & BoundedEnumerable[Boolean] =
     new BooleanOrder
 }
 

--- a/kernel/src/main/scala/cats/kernel/instances/ByteInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/ByteInstances.scala
@@ -23,7 +23,7 @@ package cats.kernel
 package instances
 
 trait ByteInstances {
-  implicit val catsKernelStdOrderForByte: Order[Byte] with Hash[Byte] with BoundedEnumerable[Byte] =
+  implicit val catsKernelStdOrderForByte: Order[Byte] & Hash[Byte] & BoundedEnumerable[Byte] =
     new ByteOrder
   implicit val catsKernelStdGroupForByte: CommutativeGroup[Byte] = new ByteGroup
 }

--- a/kernel/src/main/scala/cats/kernel/instances/CharInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/CharInstances.scala
@@ -23,7 +23,7 @@ package cats.kernel
 package instances
 
 trait CharInstances {
-  implicit val catsKernelStdOrderForChar: CharOrder with Hash[Char] with BoundedEnumerable[Char] = new CharOrder
+  implicit val catsKernelStdOrderForChar: CharOrder & Hash[Char] & BoundedEnumerable[Char] = new CharOrder
 }
 
 trait CharEnumerable extends BoundedEnumerable[Char] {

--- a/kernel/src/main/scala/cats/kernel/instances/DeadlineInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/DeadlineInstances.scala
@@ -27,7 +27,7 @@ import scala.concurrent.duration.{Deadline, FiniteDuration}
 
 trait DeadlineInstances {
   implicit val catsKernelStdOrderForDeadline
-    : Order[Deadline] with Hash[Deadline] with LowerBounded[Deadline] with UpperBounded[Deadline] = new DeadlineOrder
+    : Order[Deadline] & Hash[Deadline] & LowerBounded[Deadline] & UpperBounded[Deadline] = new DeadlineOrder
 }
 
 trait DeadlineBounded extends LowerBounded[Deadline] with UpperBounded[Deadline] {

--- a/kernel/src/main/scala/cats/kernel/instances/DoubleInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/DoubleInstances.scala
@@ -23,7 +23,7 @@ package cats.kernel
 package instances
 
 trait DoubleInstances {
-  implicit val catsKernelStdOrderForDouble: Order[Double] with Hash[Double] = new DoubleOrder
+  implicit val catsKernelStdOrderForDouble: Order[Double] & Hash[Double] = new DoubleOrder
   implicit val catsKernelStdGroupForDouble: CommutativeGroup[Double] = new DoubleGroup
 }
 

--- a/kernel/src/main/scala/cats/kernel/instances/DurationInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/DurationInstances.scala
@@ -26,7 +26,7 @@ import scala.concurrent.duration.Duration
 
 trait DurationInstances {
   implicit val catsKernelStdOrderForDuration
-    : Order[Duration] with Hash[Duration] with LowerBounded[Duration] with UpperBounded[Duration] = new DurationOrder
+    : Order[Duration] & Hash[Duration] & LowerBounded[Duration] & UpperBounded[Duration] = new DurationOrder
   implicit val catsKernelStdGroupForDuration: CommutativeGroup[Duration] = new DurationGroup
 }
 

--- a/kernel/src/main/scala/cats/kernel/instances/FiniteDurationInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/FiniteDurationInstances.scala
@@ -27,10 +27,9 @@ import java.util.concurrent.TimeUnit
 import scala.concurrent.duration.{Duration, FiniteDuration}
 
 trait FiniteDurationInstances {
-  implicit val catsKernelStdOrderForFiniteDuration: Order[FiniteDuration]
-    with Hash[FiniteDuration]
-    with LowerBounded[FiniteDuration]
-    with UpperBounded[FiniteDuration] = new FiniteDurationOrder
+  implicit val catsKernelStdOrderForFiniteDuration
+    : Order[FiniteDuration] & Hash[FiniteDuration] & LowerBounded[FiniteDuration] & UpperBounded[FiniteDuration] =
+    new FiniteDurationOrder
   implicit val catsKernelStdGroupForFiniteDuration: CommutativeGroup[FiniteDuration] = new FiniteDurationGroup
 }
 

--- a/kernel/src/main/scala/cats/kernel/instances/FloatInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/FloatInstances.scala
@@ -23,7 +23,7 @@ package cats.kernel
 package instances
 
 trait FloatInstances {
-  implicit val catsKernelStdOrderForFloat: Order[Float] with Hash[Float] = new FloatOrder
+  implicit val catsKernelStdOrderForFloat: Order[Float] & Hash[Float] = new FloatOrder
   implicit val catsKernelStdGroupForFloat: CommutativeGroup[Float] = new FloatGroup
 }
 

--- a/kernel/src/main/scala/cats/kernel/instances/IntInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/IntInstances.scala
@@ -23,7 +23,7 @@ package cats.kernel
 package instances
 
 trait IntInstances {
-  implicit val catsKernelStdOrderForInt: Order[Int] with Hash[Int] with BoundedEnumerable[Int] =
+  implicit val catsKernelStdOrderForInt: Order[Int] & Hash[Int] & BoundedEnumerable[Int] =
     new IntOrder
   implicit val catsKernelStdGroupForInt: CommutativeGroup[Int] = new IntGroup
 }

--- a/kernel/src/main/scala/cats/kernel/instances/LongInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/LongInstances.scala
@@ -23,7 +23,7 @@ package cats.kernel
 package instances
 
 trait LongInstances {
-  implicit val catsKernelStdOrderForLong: Order[Long] with Hash[Long] with BoundedEnumerable[Long] =
+  implicit val catsKernelStdOrderForLong: Order[Long] & Hash[Long] & BoundedEnumerable[Long] =
     new LongOrder
   implicit val catsKernelStdGroupForLong: CommutativeGroup[Long] = new LongGroup
 }

--- a/kernel/src/main/scala/cats/kernel/instances/ShortInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/ShortInstances.scala
@@ -23,7 +23,7 @@ package cats.kernel
 package instances
 
 trait ShortInstances {
-  implicit val catsKernelStdOrderForShort: Order[Short] with Hash[Short] with BoundedEnumerable[Short] = new ShortOrder
+  implicit val catsKernelStdOrderForShort: Order[Short] & Hash[Short] & BoundedEnumerable[Short] = new ShortOrder
   implicit val catsKernelStdGroupForShort: CommutativeGroup[Short] = new ShortGroup
 }
 

--- a/kernel/src/main/scala/cats/kernel/instances/StringInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/StringInstances.scala
@@ -24,7 +24,7 @@ package instances
 import compat.scalaVersionSpecific._
 @suppressUnusedImportWarningForScalaVersionSpecific
 trait StringInstances {
-  implicit val catsKernelStdOrderForString: Order[String] with Hash[String] with LowerBounded[String] = new StringOrder
+  implicit val catsKernelStdOrderForString: Order[String] & Hash[String] & LowerBounded[String] = new StringOrder
   implicit val catsKernelStdMonoidForString: Monoid[String] = new StringMonoid
 }
 

--- a/kernel/src/main/scala/cats/kernel/instances/SymbolInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/SymbolInstances.scala
@@ -23,7 +23,7 @@ package cats.kernel
 package instances
 
 trait SymbolInstances {
-  implicit val catsKernelStdOrderForSymbol: Order[Symbol] with Hash[Symbol] with LowerBounded[Symbol] = new SymbolOrder
+  implicit val catsKernelStdOrderForSymbol: Order[Symbol] & Hash[Symbol] & LowerBounded[Symbol] = new SymbolOrder
 }
 
 trait SymbolLowerBounded extends LowerBounded[Symbol] {

--- a/kernel/src/main/scala/cats/kernel/instances/UUIDInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/UUIDInstances.scala
@@ -25,7 +25,7 @@ package instances
 import java.util.UUID
 
 trait UUIDInstances {
-  implicit val catsKernelStdOrderForUUID: Order[UUID] with Hash[UUID] with LowerBounded[UUID] with UpperBounded[UUID] =
+  implicit val catsKernelStdOrderForUUID: Order[UUID] & Hash[UUID] & LowerBounded[UUID] & UpperBounded[UUID] =
     new Order[UUID] with Hash[UUID] with UUIDBounded { self =>
       def compare(x: UUID, y: UUID): Int = x.compareTo(y)
       def hash(x: UUID): Int = x.hashCode()

--- a/kernel/src/main/scala/cats/kernel/instances/UnitInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/UnitInstances.scala
@@ -25,10 +25,10 @@ import compat.scalaVersionSpecific._
 
 @suppressUnusedImportWarningForScalaVersionSpecific
 trait UnitInstances {
-  implicit val catsKernelStdOrderForUnit: Order[Unit] with Hash[Unit] with BoundedEnumerable[Unit] =
+  implicit val catsKernelStdOrderForUnit: Order[Unit] & Hash[Unit] & BoundedEnumerable[Unit] =
     new UnitOrder
 
-  implicit val catsKernelStdAlgebraForUnit: BoundedSemilattice[Unit] with CommutativeGroup[Unit] =
+  implicit val catsKernelStdAlgebraForUnit: BoundedSemilattice[Unit] & CommutativeGroup[Unit] =
     new UnitAlgebra
 }
 

--- a/laws/src/main/scala/cats/laws/discipline/MiniInt.scala
+++ b/laws/src/main/scala/cats/laws/discipline/MiniInt.scala
@@ -72,7 +72,7 @@ object MiniInt {
 
   val allValues: List[MiniInt] = (minIntValue to maxIntValue).map(unsafeFromInt).toList
 
-  implicit val catsLawsEqInstancesForMiniInt: Order[MiniInt] with Hash[MiniInt] =
+  implicit val catsLawsEqInstancesForMiniInt: Order[MiniInt] & Hash[MiniInt] =
     new Order[MiniInt] with Hash[MiniInt] {
       def hash(x: MiniInt): Int = Hash[Int].hash(x.intBits)
 

--- a/tests/shared/src/test/scala/cats/tests/AlgebraInvariantSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/AlgebraInvariantSuite.scala
@@ -174,8 +174,7 @@ class AlgebraInvariantSuite extends CatsSuite with ScalaVersionSpecificAlgebraIn
   implicit private val arbCommutativeGroupInt: Arbitrary[CommutativeGroup[Int]] =
     Arbitrary(genCommutativeGroupInt)
 
-  protected val integralForMiniInt: Numeric[MiniInt] with Integral[MiniInt] = new MiniIntNumeric
-    with Integral[MiniInt] {
+  protected val integralForMiniInt: Numeric[MiniInt] & Integral[MiniInt] = new MiniIntNumeric with Integral[MiniInt] {
     def quot(x: MiniInt, y: MiniInt): MiniInt = MiniInt.unsafeFromInt(x.toInt / y.toInt)
     def rem(x: MiniInt, y: MiniInt): MiniInt = MiniInt.unsafeFromInt(x.toInt % y.toInt)
   }


### PR DESCRIPTION
prepare latest Scala 3

```
Welcome to Scala 3.6.1 (21.0.5, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                                                                                                                                 
scala> trait A ; trait B
// defined trait A
// defined trait B

scala> def x: A with B = ???
1 warning found
-- [E003] Syntax Warning: ------------------------------------------------------
1 |def x: A with B = ???
  |         ^^^^
  |         with as a type operator has been deprecated; use & instead
  |
  | longer explanation available when compiling with `-explain`
def x: A & B
                                                                                                                                                                                                                                                 
scala> def x: A & B = ???
def x: A & B
```
