### PR TITLE
Use alignWith in alignMergeWith

### DIFF
--- a/core/src/main/scala/cats/Align.scala
+++ b/core/src/main/scala/cats/Align.scala
@@ -84,7 +84,7 @@ trait Align[F[_]] extends Serializable {
    * }}}
    */
   def alignMergeWith[A](fa1: F[A], fa2: F[A])(f: (A, A) => A): F[A] =
-    functor.map(align(fa1, fa2))(_.mergeWith(f))
+    alignWith(fa1, fa2)(_.mergeWith(f))
 
   /**
    * Same as `align`, but forgets from the type that one of the two elements must be present.

--- a/laws/src/main/scala/cats/laws/AlignLaws.scala
+++ b/laws/src/main/scala/cats/laws/AlignLaws.scala
@@ -45,6 +45,9 @@ trait AlignLaws[F[_]] {
   def alignWithConsistent[A, B, C](fa: F[A], fb: F[B], f: A Ior B => C): IsEq[F[C]] =
     fa.alignWith(fb)(f) <-> fa.align(fb).map(f)
 
+  def alignMergeWithConsistent[A](fa1: F[A], fa2: F[A], f: (A, A) => A): IsEq[F[A]] =
+    fa1.alignMergeWith(fa2)(f) <-> fa1.align(fa2).map(_.mergeWith(f))
+
   private def assoc[A, B, C](x: Ior[A, Ior[B, C]]): Ior[Ior[A, B], C] =
     x match {
       case Left(a) => Left(Left(a))

--- a/laws/src/main/scala/cats/laws/discipline/AlignTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/AlignTests.scala
@@ -54,12 +54,9 @@ trait AlignTests[F[_]] extends Laws {
       name = "align",
       parent = None,
       "align associativity" -> forAll(laws.alignAssociativity[A, B, C] _),
-      "align homomorphism" -> forAll { (fa: F[A], fb: F[B], f: A => C, g: B => D) =>
-        laws.alignHomomorphism[A, B, C, D](fa, fb, f, g)
-      },
-      "alignWith consistent" -> forAll { (fa: F[A], fb: F[B], f: A Ior B => C) =>
-        laws.alignWithConsistent[A, B, C](fa, fb, f)
-      }
+      "align homomorphism" -> forAll(laws.alignHomomorphism[A, B, C, D] _),
+      "alignWith consistent" -> forAll(laws.alignWithConsistent[A, B, C] _),
+      "alignMergeWith consistent" -> forAll(laws.alignMergeWithConsistent[A] _)
     )
 }
 


### PR DESCRIPTION
`alignWith` is usually overridden for efficiency