### PR TITLE
Aliases `traverseVoid`/`sequenceVoid` and their counterparts

### DIFF
--- a/bench/src/main/scala/cats/bench/TraverseBench.scala
+++ b/bench/src/main/scala/cats/bench/TraverseBench.scala
@@ -89,9 +89,10 @@ class TraverseBench {
     }
   }
 
+  // TODO: consider renaming to `traverseVoidList`
   @Benchmark
-  def traverse_List(bh: Blackhole) = {
-    val result = listT.traverse_(list) { i =>
+  def traverse_List(bh: Blackhole): Unit = {
+    val result = listT.traverseVoid(list) { i =>
       Eval.later {
         Blackhole.consumeCPU(Work)
         i * 2
@@ -155,9 +156,10 @@ class TraverseBench {
     bh.consume(result.value)
   }
 
+  // TODO: consider renaming to `traverseVoidVector`
   @Benchmark
-  def traverse_Vector(bh: Blackhole) = {
-    val result = vectorT.traverse_(vector) { i =>
+  def traverse_Vector(bh: Blackhole): Unit = {
+    val result = vectorT.traverseVoid(vector) { i =>
       Eval.later {
         Blackhole.consumeCPU(Work)
         i * 2
@@ -242,9 +244,10 @@ class TraverseBench {
     bh.consume(result.value)
   }
 
+  // TODO: consider renaming to `traverseVoidChain`
   @Benchmark
-  def traverse_Chain(bh: Blackhole) = {
-    val result = chainT.traverse_(chain) { i =>
+  def traverse_Chain(bh: Blackhole): Unit = {
+    val result = chainT.traverseVoid(chain) { i =>
       Eval.later {
         Blackhole.consumeCPU(Work)
         i * 2

--- a/core/src/main/scala-2.13+/cats/instances/arraySeq.scala
+++ b/core/src/main/scala-2.13+/cats/instances/arraySeq.scala
@@ -110,9 +110,9 @@ private[cats] object ArraySeqInstances {
 
         }
 
-      override def traverse_[G[_], A, B](fa: ArraySeq[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
+      override def traverseVoid[G[_], A, B](fa: ArraySeq[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
         G match {
-          case x: StackSafeMonad[G] => Traverse.traverse_Directly(fa)(f)(x)
+          case x: StackSafeMonad[G] => Traverse.traverseVoidDirectly(fa)(f)(x)
           case _ =>
             foldRight(fa, Eval.now(G.unit)) { (a, acc) =>
               G.map2Eval(f(a), acc) { (_, _) =>

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -598,8 +598,7 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
   /**
    * Alias for `traverseVoid`.
    *
-   * @deprecated this method should be considered as deprecated;
-   *             refrain from using this method and consider switching to `traverseVoid`.
+   * @deprecated this method should be considered as deprecated and replaced by `traverseVoid`.
    */
   def traverse_[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
     traverseVoid(fa)(f)
@@ -627,8 +626,7 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
   /**
    * Alias for `sequenceVoid`.
    *
-   * @deprecated this method should be considered as deprecated;
-   *             refrain from using this method and consider switching to `sequenceVoid`.
+   * @deprecated this method should be considered as deprecated and replaced by `sequenceVoid`.
    */
   def sequence_[G[_]: Applicative, A](fga: F[G[A]]): G[Unit] =
     sequenceVoid(fga)

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -578,9 +578,9 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
    * scala> import cats.syntax.all._
    * scala> def parseInt(s: String): Option[Int] = Either.catchOnly[NumberFormatException](s.toInt).toOption
    * scala> val F = Foldable[List]
-   * scala> F.traverse_(List("333", "444"))(parseInt)
+   * scala> F.traverseVoid(List("333", "444"))(parseInt)
    * res0: Option[Unit] = Some(())
-   * scala> F.traverse_(List("333", "zzz"))(parseInt)
+   * scala> F.traverseVoid(List("333", "zzz"))(parseInt)
    * res1: Option[Unit] = None
    * }}}
    *
@@ -588,7 +588,7 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
    * or effect, and the specific `A` aspect of `G[A]` is not otherwise
    * needed.
    */
-  def traverse_[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
+  def traverseVoid[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
     foldRight(fa, Always(G.unit)) { (a, acc) =>
       G.map2Eval(f(a), acc) { (_, _) =>
         ()
@@ -596,9 +596,18 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
     }.value
 
   /**
+   * Alias for `traverseVoid`.
+   *
+   * @deprecated this method should be considered as deprecated;
+   *             refrain from using this method and consider switching to `traverseVoid`.
+   */
+  def traverse_[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
+    traverseVoid(fa)(f)
+
+  /**
    * Sequence `F[G[A]]` using `Applicative[G]`.
    *
-   * This is similar to `traverse_` except it operates on `F[G[A]]`
+   * This is similar to `traverseVoid` except it operates on `F[G[A]]`
    * values, so no additional functions are needed.
    *
    * For example:
@@ -606,14 +615,23 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
    * {{{
    * scala> import cats.syntax.all._
    * scala> val F = Foldable[List]
-   * scala> F.sequence_(List(Option(1), Option(2), Option(3)))
+   * scala> F.sequenceVoid(List(Option(1), Option(2), Option(3)))
    * res0: Option[Unit] = Some(())
-   * scala> F.sequence_(List(Option(1), None, Option(3)))
+   * scala> F.sequenceVoid(List(Option(1), None, Option(3)))
    * res1: Option[Unit] = None
    * }}}
    */
+  def sequenceVoid[G[_]: Applicative, A](fga: F[G[A]]): G[Unit] =
+    traverseVoid(fga)(identity)
+
+  /**
+   * Alias for `sequenceVoid`.
+   *
+   * @deprecated this method should be considered as deprecated;
+   *             refrain from using this method and consider switching to `sequenceVoid`.
+   */
   def sequence_[G[_]: Applicative, A](fga: F[G[A]]): G[Unit] =
-    traverse_(fga)(identity)
+    sequenceVoid(fga)
 
   /**
    * Fold implemented using the given `MonoidK[G]` instance.
@@ -1053,10 +1071,17 @@ object Foldable {
       typeClassInstance.foldMapM[G, A, B](self)(f)(G, B)
     def foldMapA[G[_], B](f: A => G[B])(implicit G: Applicative[G], B: Monoid[B]): G[B] =
       typeClassInstance.foldMapA[G, A, B](self)(f)(G, B)
+    def traverseVoid[G[_], B](f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
+      typeClassInstance.traverseVoid[G, A, B](self)(f)(G)
     def traverse_[G[_], B](f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
-      typeClassInstance.traverse_[G, A, B](self)(f)(G)
+      traverseVoid[G, B](f)
+    // TODO: looks like these two methods below duplicate the same named methods from `NestedFoldableOps`.
+    //       Moreover, the other two methods take precedence, thereby these two are not in use whatsoever.
+    //       Perhaps it makes sense to deprecate one pair of them either here or there.
+    def sequenceVoid[G[_], B](implicit ev$1: A <:< G[B], ev$2: Applicative[G]): G[Unit] =
+      typeClassInstance.sequenceVoid[G, B](self.asInstanceOf[F[G[B]]])
     def sequence_[G[_], B](implicit ev$1: A <:< G[B], ev$2: Applicative[G]): G[Unit] =
-      typeClassInstance.sequence_[G, B](self.asInstanceOf[F[G[B]]])
+      sequenceVoid[G, B]
     def foldK[G[_], B](implicit ev$1: A <:< G[B], G: MonoidK[G]): G[B] =
       typeClassInstance.foldK[G, B](self.asInstanceOf[F[G[B]]])(G)
     def find(f: A => Boolean): Option[A] = typeClassInstance.find[A](self)(f)

--- a/core/src/main/scala/cats/Parallel.scala
+++ b/core/src/main/scala/cats/Parallel.scala
@@ -271,8 +271,7 @@ object Parallel extends ParallelArityFunctions2 {
   /**
    * Alias for `parSequenceVoid`.
    *
-   * @deprecated this method should be considered as deprecated;
-   *             refrain from using this method and consider switching to `parSequenceVoid`.
+   * @deprecated this method should be considered as deprecated and replaced by `parSequenceVoid`.
    */
   def parSequence_[T[_]: Foldable, M[_], A](tma: T[M[A]])(implicit P: Parallel[M]): M[Unit] =
     parSequenceVoid(tma)
@@ -289,8 +288,7 @@ object Parallel extends ParallelArityFunctions2 {
   /**
    * Alias for `parTraverseVoid`.
    *
-   * @deprecated this method should be considered as deprecated;
-   *             refrain from using this method and consider switching to `parTraverseVoid`.
+   * @deprecated this method should be considered as deprecated and replaced by `parTraverseVoid`.
    */
   def parTraverse_[T[_]: Foldable, M[_], A, B](ta: T[A])(f: A => M[B])(implicit P: Parallel[M]): M[Unit] =
     parTraverseVoid(ta)(f)
@@ -374,8 +372,7 @@ object Parallel extends ParallelArityFunctions2 {
   /**
    * Alias for `parNonEmptySequenceVoid`.
    *
-   * @deprecated this method should be considered as deprecated;
-   *             refrain from using this method and consider switching to `parNonEmptySequenceVoid`.
+   * @deprecated this method should be considered as deprecated and replaced by `parNonEmptySequenceVoid`.
    */
   def parNonEmptySequence_[T[_]: Reducible, M[_], A](
     tma: T[M[A]]
@@ -396,8 +393,7 @@ object Parallel extends ParallelArityFunctions2 {
   /**
    * Alias for `parNonEmptyTraverseVoid`.
    *
-   * @deprecated this method should be considered as deprecated;
-   *             refrain from using this method and consider switching to `parNonEmptyTraverseVoid`.
+   * @deprecated this method should be considered as deprecated and replaced by `parNonEmptyTraverseVoid`.
    */
   def parNonEmptyTraverse_[T[_]: Reducible, M[_], A, B](
     ta: T[A]

--- a/core/src/main/scala/cats/Parallel.scala
+++ b/core/src/main/scala/cats/Parallel.scala
@@ -260,24 +260,40 @@ object Parallel extends ParallelArityFunctions2 {
   }
 
   /**
-   * Like `Foldable[A].sequence_`, but uses the applicative instance
+   * Like `Foldable[A].sequenceVoid`, but uses the applicative instance
    * corresponding to the Parallel instance instead.
    */
-  def parSequence_[T[_]: Foldable, M[_], A](tma: T[M[A]])(implicit P: Parallel[M]): M[Unit] = {
-    val fu: P.F[Unit] = Foldable[T].traverse_(tma)(P.parallel.apply(_))(P.applicative)
+  def parSequenceVoid[T[_]: Foldable, M[_], A](tma: T[M[A]])(implicit P: Parallel[M]): M[Unit] = {
+    val fu: P.F[Unit] = Foldable[T].traverseVoid(tma)(P.parallel.apply(_))(P.applicative)
     P.sequential(fu)
   }
 
   /**
-   * Like `Foldable[A].traverse_`, but uses the applicative instance
+   * Alias for `parSequenceVoid`.
+   *
+   * @deprecated this method should be considered as deprecated;
+   *             refrain from using this method and consider switching to `parSequenceVoid`.
+   */
+  def parSequence_[T[_]: Foldable, M[_], A](tma: T[M[A]])(implicit P: Parallel[M]): M[Unit] =
+    parSequenceVoid(tma)
+
+  /**
+   * Like `Foldable[A].traverseVoid`, but uses the applicative instance
    * corresponding to the Parallel instance instead.
    */
-  def parTraverse_[T[_]: Foldable, M[_], A, B](
-    ta: T[A]
-  )(f: A => M[B])(implicit P: Parallel[M]): M[Unit] = {
-    val gtb: P.F[Unit] = Foldable[T].traverse_(ta)(a => P.parallel(f(a)))(P.applicative)
+  def parTraverseVoid[T[_]: Foldable, M[_], A, B](ta: T[A])(f: A => M[B])(implicit P: Parallel[M]): M[Unit] = {
+    val gtb: P.F[Unit] = Foldable[T].traverseVoid(ta)(a => P.parallel(f(a)))(P.applicative)
     P.sequential(gtb)
   }
+
+  /**
+   * Alias for `parTraverseVoid`.
+   *
+   * @deprecated this method should be considered as deprecated;
+   *             refrain from using this method and consider switching to `parTraverseVoid`.
+   */
+  def parTraverse_[T[_]: Foldable, M[_], A, B](ta: T[A])(f: A => M[B])(implicit P: Parallel[M]): M[Unit] =
+    parTraverseVoid(ta)(f)
 
   def parUnorderedTraverse[T[_]: UnorderedTraverse, M[_], F[_]: CommutativeApplicative, A, B](
     ta: T[A]
@@ -345,26 +361,48 @@ object Parallel extends ParallelArityFunctions2 {
   }
 
   /**
-   * Like `Reducible[A].nonEmptySequence_`, but uses the apply instance
+   * Like `Reducible[A].nonEmptySequenceVoid`, but uses the apply instance
    * corresponding to the Parallel instance instead.
    */
-  def parNonEmptySequence_[T[_]: Reducible, M[_], A](
+  def parNonEmptySequenceVoid[T[_]: Reducible, M[_], A](
     tma: T[M[A]]
   )(implicit P: NonEmptyParallel[M]): M[Unit] = {
-    val fu: P.F[Unit] = Reducible[T].nonEmptyTraverse_(tma)(P.parallel.apply(_))(P.apply)
+    val fu: P.F[Unit] = Reducible[T].nonEmptyTraverseVoid(tma)(P.parallel.apply(_))(P.apply)
     P.sequential(fu)
   }
 
   /**
-   * Like `Reducible[A].nonEmptyTraverse_`, but uses the apply instance
+   * Alias for `parNonEmptySequenceVoid`.
+   *
+   * @deprecated this method should be considered as deprecated;
+   *             refrain from using this method and consider switching to `parNonEmptySequenceVoid`.
+   */
+  def parNonEmptySequence_[T[_]: Reducible, M[_], A](
+    tma: T[M[A]]
+  )(implicit P: NonEmptyParallel[M]): M[Unit] =
+    parNonEmptySequenceVoid[T, M, A](tma)
+
+  /**
+   * Like `Reducible[A].nonEmptyTraverseVoid`, but uses the apply instance
    * corresponding to the Parallel instance instead.
+   */
+  def parNonEmptyTraverseVoid[T[_]: Reducible, M[_], A, B](
+    ta: T[A]
+  )(f: A => M[B])(implicit P: NonEmptyParallel[M]): M[Unit] = {
+    val gtb: P.F[Unit] = Reducible[T].nonEmptyTraverseVoid(ta)(a => P.parallel(f(a)))(P.apply)
+    P.sequential(gtb)
+  }
+
+  /**
+   * Alias for `parNonEmptyTraverseVoid`.
+   *
+   * @deprecated this method should be considered as deprecated;
+   *             refrain from using this method and consider switching to `parNonEmptyTraverseVoid`.
    */
   def parNonEmptyTraverse_[T[_]: Reducible, M[_], A, B](
     ta: T[A]
-  )(f: A => M[B])(implicit P: NonEmptyParallel[M]): M[Unit] = {
-    val gtb: P.F[Unit] = Reducible[T].nonEmptyTraverse_(ta)(a => P.parallel(f(a)))(P.apply)
-    P.sequential(gtb)
-  }
+  )(f: A => M[B])(implicit P: NonEmptyParallel[M]): M[Unit] =
+    parNonEmptyTraverseVoid[T, M, A, B](ta)(f)
 
   /**
    * Like `Bitraverse[A].bitraverse`, but uses the applicative instance

--- a/core/src/main/scala/cats/Reducible.scala
+++ b/core/src/main/scala/cats/Reducible.scala
@@ -21,7 +21,6 @@
 
 package cats
 
-import cats.Foldable.Source
 import cats.data.{Ior, NonEmptyList}
 
 /**
@@ -202,31 +201,49 @@ trait Reducible[F[_]] extends Foldable[F] { self =>
    * `A` values will be mapped into `G[B]` and combined using
    * `Apply#map2`.
    *
-   * This method is similar to [[Foldable.traverse_]]. There are two
+   * This method is similar to [[Foldable.traverseVoid]]. There are two
    * main differences:
    *
    * 1. We only need an [[Apply]] instance for `G` here, since we
    * don't need to call [[Applicative.pure]] for a starting value.
    * 2. This performs a strict left-associative traversal and thus
    * must always traverse the entire data structure. Prefer
-   * [[Foldable.traverse_]] if you have an [[Applicative]] instance
+   * [[Foldable.traverseVoid]] if you have an [[Applicative]] instance
    * available for `G` and want to take advantage of short-circuiting
    * the traversal.
    */
-  def nonEmptyTraverse_[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: Apply[G]): G[Unit] = {
+  def nonEmptyTraverseVoid[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: Apply[G]): G[Unit] = {
     val f1 = f.andThen(G.void)
     reduceRightTo(fa)(f1)((x, y) => G.map2Eval(f1(x), y)((_, b) => b)).value
   }
 
   /**
+   * Alias for `nonEmptyTraverseVoid`.
+   *
+   * @deprecated this method should be considered as deprecated;
+   *             refrain from using this method and consider switching to `nonEmptyTraverseVoid`.
+   */
+  def nonEmptyTraverse_[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: Apply[G]): G[Unit] =
+    nonEmptyTraverseVoid(fa)(f)
+
+  /**
    * Sequence `F[G[A]]` using `Apply[G]`.
    *
-   * This method is similar to [[Foldable.sequence_]] but requires only
+   * This method is similar to [[Foldable.sequenceVoid]] but requires only
    * an [[Apply]] instance for `G` instead of [[Applicative]]. See the
-   * [[nonEmptyTraverse_]] documentation for a description of the differences.
+   * [[nonEmptyTraverseVoid]] documentation for a description of the differences.
+   */
+  def nonEmptySequenceVoid[G[_], A](fga: F[G[A]])(implicit G: Apply[G]): G[Unit] =
+    nonEmptyTraverseVoid(fga)(identity)
+
+  /**
+   * Alias for `nonEmptySequenceVoid`.
+   *
+   * @deprecated this method should be considered as deprecated;
+   *             refrain from using this method and consider switching to `nonEmptySequenceVoid`.
    */
   def nonEmptySequence_[G[_], A](fga: F[G[A]])(implicit G: Apply[G]): G[Unit] =
-    nonEmptyTraverse_(fga)(identity)
+    nonEmptySequenceVoid(fga)
 
   def toNonEmptyList[A](fa: F[A]): NonEmptyList[A] =
     reduceRightTo(fa)(a => NonEmptyList(a, Nil)) { (a, lnel) =>
@@ -399,10 +416,14 @@ object Reducible {
       typeClassInstance.reduceMapM[G, A, B](self)(f)(G, B)
     def reduceRightTo[B](f: A => B)(g: (A, Eval[B]) => Eval[B]): Eval[B] =
       typeClassInstance.reduceRightTo[A, B](self)(f)(g)
+    def nonEmptyTraverseVoid[G[_], B](f: A => G[B])(implicit G: Apply[G]): G[Unit] =
+      typeClassInstance.nonEmptyTraverseVoid[G, A, B](self)(f)
     def nonEmptyTraverse_[G[_], B](f: A => G[B])(implicit G: Apply[G]): G[Unit] =
-      typeClassInstance.nonEmptyTraverse_[G, A, B](self)(f)(G)
+      nonEmptyTraverseVoid[G, B](f)
+    def nonEmptySequenceVoid[G[_], B](implicit ev$1: A <:< G[B], G: Apply[G]): G[Unit] =
+      typeClassInstance.nonEmptySequenceVoid[G, B](self.asInstanceOf[F[G[B]]])
     def nonEmptySequence_[G[_], B](implicit ev$1: A <:< G[B], G: Apply[G]): G[Unit] =
-      typeClassInstance.nonEmptySequence_[G, B](self.asInstanceOf[F[G[B]]])(G)
+      nonEmptySequenceVoid[G, B]
     def toNonEmptyList: NonEmptyList[A] = typeClassInstance.toNonEmptyList[A](self)
     def minimum(implicit A: Order[A]): A = typeClassInstance.minimum[A](self)(A)
     def maximum(implicit A: Order[A]): A = typeClassInstance.maximum[A](self)(A)

--- a/core/src/main/scala/cats/Reducible.scala
+++ b/core/src/main/scala/cats/Reducible.scala
@@ -220,8 +220,7 @@ trait Reducible[F[_]] extends Foldable[F] { self =>
   /**
    * Alias for `nonEmptyTraverseVoid`.
    *
-   * @deprecated this method should be considered as deprecated;
-   *             refrain from using this method and consider switching to `nonEmptyTraverseVoid`.
+   * @deprecated this method should be considered as deprecated and replaced by `nonEmptyTraverseVoid`.
    */
   def nonEmptyTraverse_[G[_], A, B](fa: F[A])(f: A => G[B])(implicit G: Apply[G]): G[Unit] =
     nonEmptyTraverseVoid(fa)(f)
@@ -239,8 +238,7 @@ trait Reducible[F[_]] extends Foldable[F] { self =>
   /**
    * Alias for `nonEmptySequenceVoid`.
    *
-   * @deprecated this method should be considered as deprecated;
-   *             refrain from using this method and consider switching to `nonEmptySequenceVoid`.
+   * @deprecated this method should be considered as deprecated and replaced by `nonEmptySequenceVoid`.
    */
   def nonEmptySequence_[G[_], A](fga: F[G[A]])(implicit G: Apply[G]): G[Unit] =
     nonEmptySequenceVoid(fga)

--- a/core/src/main/scala/cats/Traverse.scala
+++ b/core/src/main/scala/cats/Traverse.scala
@@ -296,7 +296,7 @@ object Traverse {
     }
   }
 
-  private[cats] def traverse_Directly[G[_], A, B](
+  private[cats] def traverseVoidDirectly[G[_], A, B](
     fa: IterableOnce[A]
   )(f: A => G[B])(implicit G: StackSafeMonad[G]): G[Unit] = {
     val iter = fa.iterator

--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -1254,9 +1254,9 @@ sealed abstract private[data] class ChainInstances extends ChainInstances1 {
               }(f)
           }
 
-      override def traverse_[G[_], A, B](fa: Chain[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
+      override def traverseVoid[G[_], A, B](fa: Chain[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
         G match {
-          case x: StackSafeMonad[G] => Traverse.traverse_Directly(fa.iterator)(f)(x)
+          case x: StackSafeMonad[G] => Traverse.traverseVoidDirectly(fa.iterator)(f)(x)
           case _ =>
             foldRight(fa, Eval.now(G.unit)) { (a, acc) =>
               G.map2Eval(f(a), acc) { (_, _) =>

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -134,9 +134,9 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
       /**
        * This avoids making a very deep stack by building a tree instead
        */
-      override def traverse_[G[_], A, B](fa: List[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] = {
+      override def traverseVoid[G[_], A, B](fa: List[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] = {
         G match {
-          case x: StackSafeMonad[G] => Traverse.traverse_Directly(fa)(f)(x)
+          case x: StackSafeMonad[G] => Traverse.traverseVoidDirectly(fa)(f)(x)
           case _                    =>
             // the cost of this is O(size log size)
             // c(n) = n + 2 * c(n/2) = n + 2(n/2 log (n/2)) = n + n (logn - 1) = n log n

--- a/core/src/main/scala/cats/instances/queue.scala
+++ b/core/src/main/scala/cats/instances/queue.scala
@@ -134,9 +134,9 @@ trait QueueInstances extends cats.kernel.instances.QueueInstances {
               }
           }
 
-      override def traverse_[G[_], A, B](fa: Queue[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
+      override def traverseVoid[G[_], A, B](fa: Queue[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
         G match {
-          case x: StackSafeMonad[G] => Traverse.traverse_Directly(fa)(f)(x)
+          case x: StackSafeMonad[G] => Traverse.traverseVoidDirectly(fa)(f)(x)
           case _ =>
             foldRight(fa, Eval.now(G.unit)) { (a, acc) =>
               G.map2Eval(f(a), acc) { (_, _) =>

--- a/core/src/main/scala/cats/instances/seq.scala
+++ b/core/src/main/scala/cats/instances/seq.scala
@@ -134,9 +134,9 @@ trait SeqInstances extends cats.kernel.instances.SeqInstances {
             G.map(Chain.traverseViaChain(fa.toIndexedSeq)(f))(_.toList)
         }
 
-      override def traverse_[G[_], A, B](fa: Seq[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
+      override def traverseVoid[G[_], A, B](fa: Seq[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
         G match {
-          case x: StackSafeMonad[G] => Traverse.traverse_Directly(fa)(f)(x)
+          case x: StackSafeMonad[G] => Traverse.traverseVoidDirectly(fa)(f)(x)
           case _ =>
             foldRight(fa, Eval.now(G.unit)) { (a, acc) =>
               G.map2Eval(f(a), acc) { (_, _) =>

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -140,9 +140,9 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
       /**
        * This avoids making a very deep stack by building a tree instead
        */
-      override def traverse_[G[_], A, B](fa: Vector[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] = {
+      override def traverseVoid[G[_], A, B](fa: Vector[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] = {
         G match {
-          case x: StackSafeMonad[G] => Traverse.traverse_Directly(fa)(f)(x)
+          case x: StackSafeMonad[G] => Traverse.traverseVoidDirectly(fa)(f)(x)
           case _                    =>
             // the cost of this is O(size)
             // c(n) = 1 + 2 * c(n/2)

--- a/core/src/main/scala/cats/syntax/foldable.scala
+++ b/core/src/main/scala/cats/syntax/foldable.scala
@@ -47,7 +47,10 @@ private[syntax] trait FoldableSyntaxBinCompat1 {
 }
 
 final class NestedFoldableOps[F[_], G[_], A](private val fga: F[G[A]]) extends AnyVal {
-  def sequence_(implicit F: Foldable[F], G: Applicative[G]): G[Unit] = F.sequence_(fga)
+  // TODO: looks like these two methods below duplicate the same named methods from `Foldable.Ops`.
+  //       Perhaps it makes sense to deprecate one pair of them either here or there.
+  def sequenceVoid(implicit F: Foldable[F], G: Applicative[G]): G[Unit] = F.sequenceVoid(fga)
+  def sequence_(implicit F: Foldable[F], G: Applicative[G]): G[Unit] = sequenceVoid
 
   /**
    * @see [[Foldable.foldK]].
@@ -61,6 +64,8 @@ final class NestedFoldableOps[F[_], G[_], A](private val fga: F[G[A]]) extends A
    * res0: Set[Int] = Set(1, 2, 3, 4)
    * }}}
    */
+  // TODO: looks like this method below duplicate the same named one from `Foldable.Ops`.
+  //       Perhaps it makes sense to deprecate one of them.
   def foldK(implicit F: Foldable[F], G: MonoidK[G]): G[A] = F.foldK(fga)
 }
 

--- a/core/src/main/scala/cats/syntax/parallel.scala
+++ b/core/src/main/scala/cats/syntax/parallel.scala
@@ -108,9 +108,13 @@ trait ParallelTraverseFilterSyntax {
 }
 
 trait ParallelTraverseSyntax {
+  // Note: this could be renamed to `catsSyntaxParallelTraverseVoid` for consistency,
+  // but it looks like too much of a hassle of fighting binary compatibility issues for the implicit part of the API.
   implicit final def catsSyntaxParallelTraverse_[T[_]: Foldable, A](ta: T[A]): ParallelTraversable_Ops[T, A] =
     new ParallelTraversable_Ops(ta)
 
+  // Note: this could be renamed to `catsSyntaxParallelSequenceVoid` for consistency,
+  // but it looks like too much of a hassle of fighting binary compatibility issues for the implicit part of the API.
   implicit final def catsSyntaxParallelSequence_[T[_]: Foldable, M[_], A](tma: T[M[A]]): ParallelSequence_Ops[T, M, A] =
     new ParallelSequence_Ops(tma)
 }
@@ -188,9 +192,13 @@ final class ParallelSequenceFilterOps[T[_], M[_], A](private val tmoa: T[M[Optio
     Parallel.parSequenceFilter(tmoa)
 }
 
+// Note: this could be renamed to `ParallelTraversableVoidOps` for consistency,
+// but it looks like too much of a hassle of fighting binary compatibility issues for the implicit part of the API.
 final class ParallelTraversable_Ops[T[_], A](private val ta: T[A]) extends AnyVal {
+  def parTraverseVoid[M[_], B](f: A => M[B])(implicit T: Foldable[T], P: Parallel[M]): M[Unit] =
+    Parallel.parTraverseVoid(ta)(f)
   def parTraverse_[M[_], B](f: A => M[B])(implicit T: Foldable[T], P: Parallel[M]): M[Unit] =
-    Parallel.parTraverse_(ta)(f)
+    parTraverseVoid(f)
 }
 
 @deprecated("Kept for binary compatibility", "2.6.0")
@@ -217,9 +225,13 @@ final class ParallelSequenceOps1[T[_], M[_], A](private val tma: T[M[A]]) extend
     Parallel.parSequence(tma)
 }
 
+// Note: this could be renamed to `ParallelSequenceVoidOps` for consistency,
+// but it looks like too much of a hassle of fighting binary compatibility issues for the implicit part of the API.
 final class ParallelSequence_Ops[T[_], M[_], A](private val tma: T[M[A]]) extends AnyVal {
+  def parSequenceVoid(implicit T: Foldable[T], P: Parallel[M]): M[Unit] =
+    Parallel.parSequenceVoid(tma)
   def parSequence_(implicit T: Foldable[T], P: Parallel[M]): M[Unit] =
-    Parallel.parSequence_(tma)
+    parSequenceVoid
 }
 
 @deprecated("Kept for binary compatibility", "2.6.0")

--- a/laws/src/main/scala/cats/laws/ReducibleLaws.scala
+++ b/laws/src/main/scala/cats/laws/ReducibleLaws.scala
@@ -54,10 +54,10 @@ trait ReducibleLaws[F[_]] extends FoldableLaws[F] {
     fa.reduce <-> fa.reduceLeft(B.combine)
 
   def traverseConsistent[G[_]: Applicative, A, B](fa: F[A], f: A => G[B]): IsEq[G[Unit]] =
-    fa.nonEmptyTraverse_(f) <-> fa.traverse_(f)
+    fa.nonEmptyTraverseVoid(f) <-> fa.traverseVoid(f)
 
   def sequenceConsistent[G[_]: Applicative, A](fa: F[G[A]]): IsEq[G[Unit]] =
-    fa.nonEmptySequence_ <-> fa.sequence_
+    fa.nonEmptySequenceVoid <-> fa.sequenceVoid
 
   def sizeConsistent[A](fa: F[A]): IsEq[Long] =
     fa.size <-> fa.reduceMap(_ => 1L)

--- a/laws/src/main/scala/cats/laws/discipline/ReducibleTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/ReducibleTests.scala
@@ -58,8 +58,8 @@ trait ReducibleTests[F[_]] extends FoldableTests[F] {
         forAll(laws.reduceRightConsistentWithReduceRightOption[A] _),
       "reduce consistent with reduceLeft" ->
         forAll(laws.reduceReduceLeftConsistent[B] _),
-      "nonEmptyTraverse_ consistent with traverse_" -> forAll(laws.traverseConsistent[G, A, B] _),
-      "nonEmptySequence_ consistent with sequence_" -> forAll(laws.sequenceConsistent[G, A] _),
+      "nonEmptyTraverseVoid consistent with traverseVoid" -> forAll(laws.traverseConsistent[G, A, B] _),
+      "nonEmptySequenceVoid consistent with sequenceVoid" -> forAll(laws.sequenceConsistent[G, A] _),
       "size consistent with reduceMap" -> forAll(laws.sizeConsistent[A] _)
     )
 }

--- a/mima.sbt
+++ b/mima.sbt
@@ -157,5 +157,8 @@ ThisBuild / mimaBinaryIssueFilters ++= {
     ) ++ Seq(
       ProblemFilters.exclude[MissingClassProblem]("cats.compat.package"),
       ProblemFilters.exclude[MissingClassProblem]("cats.compat.package$")
+    ) ++ Seq( // PR#4682
+      // Renamed to `cats.Traverse.traverseVoidDirectly`
+      ProblemFilters.exclude[DirectMissingMethodProblem]("cats.Traverse.traverse_Directly")
     )
 }

--- a/tests/shared/src/test/scala-2.13+/cats/tests/ScalaVersionSpecific.scala
+++ b/tests/shared/src/test/scala-2.13+/cats/tests/ScalaVersionSpecific.scala
@@ -179,7 +179,7 @@ trait ScalaVersionSpecificRegressionSuite { self: RegressionSuite =>
     // shouldn't have ever evaluated validate(8)
     checkAndResetCount(3)
 
-    assert(LazyList(1, 2, 6, 8).traverse_(validate) === (Either.left("6 is greater than 5")))
+    assert(LazyList(1, 2, 6, 8).traverseVoid(validate) === Either.left("6 is greater than 5"))
     checkAndResetCount(3)
   }
 }

--- a/tests/shared/src/test/scala/cats/tests/KleisliSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/KleisliSuite.scala
@@ -378,16 +378,16 @@ class KleisliSuite extends CatsSuite {
     assertEquals(program.run(A123), List((1, "2", true)))
   }
 
-  test("traverse_ doesn't stack overflow") {
+  test("traverseVoid doesn't stack overflow") {
     // see: https://github.com/typelevel/cats/issues/3947
-    val resL = (1 to 10000).toList.traverse_(_ => Kleisli.liftF[Id, String, Unit](())).run("")
-    val resV = (1 to 10000).toVector.traverse_(_ => Kleisli.liftF[Id, String, Unit](())).run("")
+    val resL = (1 to 10000).toList.traverseVoid(_ => Kleisli.liftF[Id, String, Unit](())).run("")
+    val resV = (1 to 10000).toVector.traverseVoid(_ => Kleisli.liftF[Id, String, Unit](())).run("")
     assert(resL === resV)
   }
 
-  test("traverse_ doesn't stack overflow with List + Eval") {
+  test("traverseVoid doesn't stack overflow with List + Eval") {
     // see: https://github.com/typelevel/cats/issues/3947
-    (1 to 10000).toList.traverse_(_ => Kleisli.liftF[Eval, String, Unit](Eval.Unit)).run("").value
+    (1 to 10000).toList.traverseVoid(_ => Kleisli.liftF[Eval, String, Unit](Eval.Unit)).run("").value
   }
 
   /**

--- a/tests/shared/src/test/scala/cats/tests/ParallelSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/ParallelSuite.scala
@@ -78,24 +78,24 @@ class ParallelSuite
     }
   }
 
-  test("ParTraverse_ identity should be equivalent to parSequence_") {
+  test("ParTraverseVoid identity should be equivalent to parSequenceVoid") {
     forAll { (es: SortedSet[Either[String, Int]]) =>
-      assert(Parallel.parTraverse_(es)(identity) === (Parallel.parSequence_[SortedSet, Either[String, *], Int](es)))
+      assert(Parallel.parTraverseVoid(es)(identity) === Parallel.parSequenceVoid[SortedSet, Either[String, *], Int](es))
     }
   }
 
-  test("ParTraverse_ syntax should be equivalent to Parallel.parTraverse_") {
+  test("ParTraverseVoid syntax should be equivalent to Parallel.parTraverseVoid") {
     forAll { (es: SortedSet[Either[String, Int]]) =>
       assert(
-        Parallel.parTraverse_[SortedSet, Either[String, *], Either[String, Int], Int](es)(identity) === (es
-          .parTraverse_(identity))
+        Parallel.parTraverseVoid[SortedSet, Either[String, *], Either[String, Int], Int](es)(identity) ===
+          es.parTraverseVoid(identity)
       )
     }
   }
 
-  test("ParSequence_ syntax should be equivalent to Parallel.parSequence_") {
+  test("ParSequenceVoid syntax should be equivalent to Parallel.parSequenceVoid") {
     forAll { (es: SortedSet[Either[String, Int]]) =>
-      assert(Parallel.parSequence_[SortedSet, Either[String, *], Int](es) === (es.parSequence_))
+      assert(Parallel.parSequenceVoid[SortedSet, Either[String, *], Int](es) === es.parSequenceVoid)
     }
   }
 
@@ -105,9 +105,9 @@ class ParallelSuite
     }
   }
 
-  test("ParNonEmptyTraverse_ identity should be equivalent to parNonEmptySequence_") {
+  test("ParNonEmptyTraverseVoid identity should be equivalent to parNonEmptySequenceVoid") {
     forAll { (es: NonEmptyList[Either[String, Int]]) =>
-      assert(Parallel.parNonEmptyTraverse_(es)(identity) === (Parallel.parNonEmptySequence_(es)))
+      assert(Parallel.parNonEmptyTraverseVoid(es)(identity) === Parallel.parNonEmptySequenceVoid(es))
     }
   }
 
@@ -310,10 +310,10 @@ class ParallelSuite
     }
   }
 
-  test("ParReplicateA_ should be equivalent to fill parSequence_") {
+  test("ParReplicateA_ should be equivalent to fill parSequenceVoid") {
     forAll(Gen.choose(1, 20), Arbitrary.arbitrary[Either[String, String]]) {
       (repetitions: Int, e: Either[String, String]) =>
-        assert(Parallel.parReplicateA_(repetitions, e) === Parallel.parSequence_(List.fill(repetitions)(e)))
+        assert(Parallel.parReplicateA_(repetitions, e) === Parallel.parSequenceVoid(List.fill(repetitions)(e)))
     }
   }
 

--- a/tests/shared/src/test/scala/cats/tests/ReducibleSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/ReducibleSuite.scala
@@ -234,11 +234,11 @@ abstract class ReducibleSuite[F[_]: Reducible](name: String)(implicit
     assert(out.toList === List(2, 4, 6, 9))
   }
 
-  test(s"Reducible[$name].nonEmptyTraverse_ can breakout") {
+  test(s"Reducible[$name].nonEmptyTraverseVoid can breakout") {
     val notAllEven = fromValues(2, 4, 6, 9, 10, 12, 14)
     val out = mutable.ListBuffer[Int]()
 
-    notAllEven.nonEmptyTraverse_ { a => out += a; if (a % 2 == 0) Some(a) else None }
+    notAllEven.nonEmptyTraverseVoid { a => out += a; if (a % 2 == 0) Some(a) else None }
 
     assert(out.toList === List(2, 4, 6, 9))
   }

--- a/tests/shared/src/test/scala/cats/tests/RegressionSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/RegressionSuite.scala
@@ -162,23 +162,23 @@ class RegressionSuite extends CatsSuite with ScalaVersionSpecificRegressionSuite
     assert(Vector(1, 2, 6, 8).traverse(validate) === (Either.left("6 is greater than 5")))
     checkAndResetCount(3)
 
-    assert(List(1, 2, 6, 8).traverse_(validate) === (Either.left("6 is greater than 5")))
+    assert(List(1, 2, 6, 8).traverseVoid(validate) === Either.left("6 is greater than 5"))
     checkAndResetCount(3)
 
     {
       @annotation.nowarn("cat=deprecation")
-      val obtained = Stream(1, 2, 6, 8).traverse_(validate)
+      val obtained = Stream(1, 2, 6, 8).traverseVoid(validate)
       assert(obtained === Either.left("6 is greater than 5"))
     }
     checkAndResetCount(3)
 
-    assert(Vector(1, 2, 6, 8).traverse_(validate) === (Either.left("6 is greater than 5")))
+    assert(Vector(1, 2, 6, 8).traverseVoid(validate) === Either.left("6 is greater than 5"))
     checkAndResetCount(3)
 
-    assert(NonEmptyList.of(1, 2, 6, 7, 8).traverse_(validate) === (Either.left("6 is greater than 5")))
+    assert(NonEmptyList.of(1, 2, 6, 7, 8).traverseVoid(validate) === Either.left("6 is greater than 5"))
     checkAndResetCount(3)
 
-    assert(NonEmptyList.of(6, 7, 8).traverse_(validate) === (Either.left("6 is greater than 5")))
+    assert(NonEmptyList.of(6, 7, 8).traverseVoid(validate) === Either.left("6 is greater than 5"))
     checkAndResetCount(1)
   }
 

--- a/tests/shared/src/test/scala/cats/tests/TraverseSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/TraverseSuite.scala
@@ -83,9 +83,9 @@ abstract class TraverseSuite[F[_]: Traverse](name: String)(implicit ArbFInt: Arb
     }
   }
 
-  test(s"Traverse[$name].traverse matches traverse_ with Option") {
+  test(s"Traverse[$name].traverse matches traverseVoid with Option") {
     forAll { (fa: F[Int], fn: Int => Option[Int]) =>
-      assert(Applicative[Option].void(fa.traverse(fn)) == fa.traverse_(fn))
+      assert(Applicative[Option].void(fa.traverse(fn)) == fa.traverseVoid(fn))
     }
   }
 


### PR DESCRIPTION
Closes #4611.

The feedback on the original proposal seems generally favorable, therefore here is the PR. Overall, it does the following:
- adds `traverseVoid`/`sequenceVoid` to `Foldable` (convering `traverse_` and `sequence_` to aliases for the new methods);
- similarly, adds `nonEmptyTraverseVoid`/`nonEmptySequenceVoid`;
- similarly, adds corresponding new methods to `Parallel`/`NonEmptyParallel`;
- redirects customized implementations in data instances to the new methods;
- makes laws and tests using the new methods instead of the old ones.

Also it adds some comments to the places that haven't been changed but could be and thereby explaining why.