### PR TITLE
Optimize Chain.traverseVoid

### DIFF
--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -1264,7 +1264,7 @@ sealed abstract private[data] class ChainInstances extends ChainInstances1 {
                 case Append(l, r) =>
                   go(l, if (rhs.isEmpty) r else Append(r, rhs), acc)
                 case Wrap(as) =>
-                  val va = Foldable[Seq].traverseVoid(as)(f)
+                  val va = Foldable[collection.immutable.Seq].traverseVoid(as)(f)
                   val acc1 = G.productL(acc)(va)
                   rhs match {
                     case Empty => acc1

--- a/tests/shared/src/test/scala/cats/tests/TraverseSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/TraverseSuite.scala
@@ -22,7 +22,9 @@
 package cats.tests
 
 import cats._
+import cats.data.Chain
 import cats.kernel.compat.scalaVersionSpecific._
+import cats.laws.discipline.arbitrary._
 import cats.syntax.all._
 import org.scalacheck.Arbitrary
 import org.scalacheck.Prop._
@@ -119,6 +121,7 @@ object TraverseSuite {
 
 class TraverseListSuite extends TraverseSuite[List]("List")
 class TraverseVectorSuite extends TraverseSuite[Vector]("Vector")
+class TraverseChainSuite extends TraverseSuite[Chain]("Chain")
 
 @annotation.nowarn("cat=deprecation")
 class TraverseStreamSuite extends TraverseSuite[Stream]("Stream")


### PR DESCRIPTION
we can directly iterate through traverseVoid (which is really a kind of monoidal aggregation), so we don't need to use the expensive foldRight to do this.