### PR TITLE
set tlBaseVersion := "2.13"

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "2.12"
+ThisBuild / tlBaseVersion := "2.13"
 
 val scalaCheckVersion = "1.18.1"
 


### PR DESCRIPTION
Seems required to prevent CI from failing with
> java.lang.RuntimeException: Your tlBaseVersion 2.12 is behind the latest tag 2.13.0

(see https://github.com/typelevel/cats/pull/4703#issuecomment-2605753073)