### PR TITLE
Create Empty from EmptyK

### DIFF
--- a/alleycats-core/src/main/scala/alleycats/Empty.scala
+++ b/alleycats-core/src/main/scala/alleycats/Empty.scala
@@ -38,8 +38,6 @@ object Empty extends EmptyInstances0 {
   def apply[A](a: => A): Empty[A] =
     new Empty[A] { lazy val empty: A = a }
 
-  def fromEmptyK[F[_], T](implicit ekf: EmptyK[F]): Empty[F[T]] = ekf.synthesize[T]
-
   /**
    * Summon an instance of [[Empty]] for `A`.
    */
@@ -81,8 +79,12 @@ object Empty extends EmptyInstances0 {
 
 private[alleycats] trait EmptyInstances0 extends compat.IterableEmptyInstance with EmptyInstances1
 
-private[alleycats] trait EmptyInstances1 {
+private[alleycats] trait EmptyInstances1 extends EmptyInstances2 {
   // If Monoid extended Empty then this could be an exported subclass instance provided by Monoid
   implicit def monoidIsEmpty[A: Monoid]: Empty[A] =
     Empty(Monoid[A].empty)
+}
+
+private[alleycats] trait EmptyInstances2 {
+  implicit def fromEmptyK[F[_], T](implicit ekf: EmptyK[F]): Empty[F[T]] = ekf.synthesize[T]
 }

--- a/alleycats-core/src/test/scala/alleycats/SyntaxSuite.scala
+++ b/alleycats-core/src/test/scala/alleycats/SyntaxSuite.scala
@@ -54,6 +54,18 @@ object SyntaxSuite {
     val a1: Boolean = x.nonEmpty
   }
 
+  def testOptionEmpty: Unit = {
+    case class A[T](x: T)
+    case class B()
+
+    import alleycats.std.option.*
+    implicit def emptyA[T: Empty]: Empty[A[T]] = new Empty[A[T]] {
+      def empty: A[T] = A(Empty[T].empty)
+    }
+
+    Empty[A[Option[B]]].empty
+  }
+
   def testFoldable[F[_]: Foldable, A]: Unit = {
     val x = mock[F[A]]
     val y = mock[A => Unit]


### PR DESCRIPTION
This is solving the case where we have an instance of `Empty[T]` but looking for a `Empty[Option[T]]`:
https://scastie.scala-lang.org/Jv24ybPQRQeQ2IEZy5azmA