### PR TITLE
Remove "Chain#hashCode is consistent with List#hashCode"

### DIFF
--- a/tests/shared/src/test/scala/cats/tests/ChainSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/ChainSuite.scala
@@ -408,12 +408,6 @@ class ChainSuite extends CatsSuite {
     }
   }
 
-  test("Chain#hashCode is consistent with List#hashCode") {
-    forAll { (x: Chain[Int]) =>
-      assert(x.hashCode === (x.toList.hashCode))
-    }
-  }
-
   test("Chain#takeWhile is consistent with List#takeWhile") {
     forAll { (x: Chain[Int], p: Int => Boolean) =>
       assert(x.takeWhile(p).toList === (x.toList.takeWhile(p)))


### PR DESCRIPTION
It's no longer true as of Scala 2.13.16, and was probably overspecified in the first place.

Fixes #4716.