### PR TITLE
Backport hash improvements from Scala 2.13.16's MurmurHash3

### DIFF
--- a/kernel/src/main/scala-2.13+/cats/kernel/compat/HashCompat.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/compat/HashCompat.scala
@@ -89,7 +89,7 @@ private[kernel] class HashCompat {
           rangeDiff = hash - prev
           rangeState = 2
         case 2 =>
-          if (rangeDiff != hash - prev) rangeState = 3
+          if (rangeDiff != hash - prev || rangeDiff == 0) rangeState = 3
         case _ =>
       }
       prev = hash
@@ -120,7 +120,7 @@ private[kernel] class HashCompat {
     while (it.hasNext) {
       h = mix(h, prev)
       val hash = A.hash(it.next())
-      if (rangeDiff != hash - prev) {
+      if (rangeDiff != hash - prev || rangeDiff == 0) {
         h = mix(h, hash)
         i += 1
         while (it.hasNext) {


### PR DESCRIPTION
Either this or #4718 is sufficient to fix #4716.  I propose we want both, but they are orthogonal.

Original problem and solution are from https://github.com/scala/scala/pull/10912.