### PR TITLE
Fix Sponsor Duplicates

### DIFF
--- a/docs/js/sponsors.js
+++ b/docs/js/sponsors.js
@@ -71,7 +71,7 @@ var sponsors = async function () {
 
             addedSponsors[member.account.slug] = true;
             switch (member.tier ? member.tier.name : null) {
-                case 'Platinum Sponsor':  
+                case 'Platinum Sponsor':
                     addSponsor('platinum-sponsors', member.account, PlatinumSize);
                     break;
                 case 'Gold Sponsor':


### PR DESCRIPTION
Fixes #4663

There were actually 2 issues. Some sponsors were duplicated, with and without a tier in the GraphQL response. The switch was also falling through due to lack of breaks. I added code to sort by level + name, then only add a sponsor the first time they are seen.

Testing locally, we can see Aruna now only appears in Gold, and Silver sponsors are no longer duplicated to backers. @jducoeur is no longer duplicated in other contributors.

![image](https://github.com/user-attachments/assets/2ff2bc7b-2e40-4a53-9864-b3d4130b4c34)
