### PR TITLE
Add the `Empty[Option[A]]` instance in alleycats 

### DIFF
--- a/alleycats-core/src/main/scala/alleycats/Empty.scala
+++ b/alleycats-core/src/main/scala/alleycats/Empty.scala
@@ -77,7 +77,10 @@ object Empty extends EmptyInstances0 {
 
 }
 
-private[alleycats] trait EmptyInstances0 extends compat.IterableEmptyInstance with EmptyInstances1
+private[alleycats] trait EmptyInstances0 extends compat.IterableEmptyInstance with EmptyInstances1 {
+  private[this] val emptyOptionSingleton: Empty[Option[Nothing]] = Empty(None)
+  implicit def alleycatsEmptyForOption[A]: Empty[Option[A]] = emptyOptionSingleton.asInstanceOf[Empty[Option[A]]]
+}
 
 private[alleycats] trait EmptyInstances1 extends EmptyInstances2 {
   // If Monoid extended Empty then this could be an exported subclass instance provided by Monoid


### PR DESCRIPTION
It turns out that an instance of `alleycats.Empty[Option[A]]` isn't automatically derived if there is no `Semigroup` instance for `A` in scope. See the example: https://scastie.scala-lang.org/gndrZPa1QA6deeYzhNhvQw. Interestingly, adding an import of `alleycats.std.option` doesn't help either.