### PR TITLE
`Order.fromComparable` Method Signature Change to Allow `java.sql.Date`

### DIFF
--- a/kernel/src/main/scala/cats/kernel/Order.scala
+++ b/kernel/src/main/scala/cats/kernel/Order.scala
@@ -232,7 +232,7 @@ object Order extends OrderFunctions[Order] with OrderToOrderingConversion {
       override def toOrdering: Ordering[A] = ev
     }
 
-  private type ContravariantComparable[A] = Comparable[_ >: A]
+  private type ContravariantComparable[A] = Comparable[? >: A]
 
   def fromComparable[A <: ContravariantComparable[A]]: Order[A] = _ compareTo _
 }

--- a/kernel/src/main/scala/cats/kernel/Order.scala
+++ b/kernel/src/main/scala/cats/kernel/Order.scala
@@ -232,5 +232,5 @@ object Order extends OrderFunctions[Order] with OrderToOrderingConversion {
       override def toOrdering: Ordering[A] = ev
     }
 
-  def fromComparable[A <: Comparable[A]]: Order[A] = _ compareTo _
+  def fromComparable[A <: Comparable[_ >: A]]: Order[A] = _ compareTo _
 }

--- a/kernel/src/main/scala/cats/kernel/Order.scala
+++ b/kernel/src/main/scala/cats/kernel/Order.scala
@@ -232,5 +232,7 @@ object Order extends OrderFunctions[Order] with OrderToOrderingConversion {
       override def toOrdering: Ordering[A] = ev
     }
 
-  def fromComparable[A <: Comparable[_ >: A]]: Order[A] = _ compareTo _
+  private type ContravariantComparable[A] = Comparable[_ >: A]
+
+  def fromComparable[A <: ContravariantComparable[A]]: Order[A] = _ compareTo _
 }

--- a/tests/shared/src/test/scala/cats/tests/OrderSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/OrderSuite.scala
@@ -65,6 +65,17 @@ class OrderSuite extends CatsSuite {
       assert((i.pmax(j)) === (PartialOrder.pmax(i, j)))
     }
   }
+
+  test("Order.fromComparable") {
+    val OrderOfCmp = Order.fromComparable[OrderSuite.Cmp]
+    assert(OrderOfCmp.lt(OrderSuite.Cmp(1), OrderSuite.Cmp(2)))
+    assert(OrderOfCmp.gt(OrderSuite.Cmp(2), OrderSuite.Cmp(1)))
+    assert(OrderOfCmp.eqv(OrderSuite.Cmp(1), OrderSuite.Cmp(1)))
+    val OrderOfCmpSub = Order.fromComparable[OrderSuite.CmpSub]
+    assert(OrderOfCmpSub.lt(OrderSuite.CmpSub(1, "ignored"), OrderSuite.CmpSub(2, "ignored")))
+    assert(OrderOfCmpSub.gt(OrderSuite.CmpSub(2, "ignored"), OrderSuite.CmpSub(1, "ignored")))
+    assert(OrderOfCmpSub.eqv(OrderSuite.CmpSub(1, "a"), OrderSuite.CmpSub(1, "b")))
+  }
 }
 
 object OrderSuite {
@@ -86,5 +97,16 @@ object OrderSuite {
     }
     implicit val ord: Order[C] = Order.allEqual
     Ordering[C]
+  }
+
+  class Cmp(protected val n: Int) extends Comparable[Cmp] {
+    override def compareTo(o: Cmp): Int = n.compare(o.n)
+  }
+  object Cmp {
+    def apply(n: Int): Cmp = new Cmp(n)
+  }
+  class CmpSub(override protected val n: Int, private val ignored: String) extends Cmp(n)
+  object CmpSub {
+    def apply(n: Int, ignored: String): CmpSub = new CmpSub(n, ignored)
   }
 }


### PR DESCRIPTION
The `Order.fromComparable` method signature in `Order.scala` has been modified to allow it to accept `java.sql.Date`.
This change enables the method to work with types such as `java.sql.Date` and other subtypes of `java.util.Date` which implements `Comparable<java.util.Date>`.

