### PR TITLE
Add the `Empty[Map[A, B]]` instance in alleycats

### DIFF
--- a/alleycats-core/src/main/scala/alleycats/Empty.scala
+++ b/alleycats-core/src/main/scala/alleycats/Empty.scala
@@ -24,6 +24,8 @@ package alleycats
 import cats.{Eq, Monoid}
 import cats.syntax.eq.*
 
+import scala.collection.immutable.SortedMap
+
 trait Empty[A] extends Serializable {
   def empty: A
 
@@ -84,6 +86,9 @@ private[alleycats] trait EmptyInstances0 extends compat.IterableEmptyInstance wi
 
   private[this] val emptyMapSingleton: Empty[Map[Nothing, Nothing]] = Empty(Map.empty)
   implicit def alleycatsEmptyForMap[A, B]: Empty[Map[A, B]] = emptyMapSingleton.asInstanceOf[Empty[Map[A, B]]]
+
+  implicit def alleycatsEmptyForSortedMap[A: Ordering, B]: Empty[SortedMap[A, B]] =
+    Empty(SortedMap.empty[A, B])
 }
 
 private[alleycats] trait EmptyInstances1 extends EmptyInstances2 {

--- a/alleycats-core/src/main/scala/alleycats/Empty.scala
+++ b/alleycats-core/src/main/scala/alleycats/Empty.scala
@@ -78,8 +78,12 @@ object Empty extends EmptyInstances0 {
 }
 
 private[alleycats] trait EmptyInstances0 extends compat.IterableEmptyInstance with EmptyInstances1 {
+
   private[this] val emptyOptionSingleton: Empty[Option[Nothing]] = Empty(None)
   implicit def alleycatsEmptyForOption[A]: Empty[Option[A]] = emptyOptionSingleton.asInstanceOf[Empty[Option[A]]]
+
+  private[this] val emptyMapSingleton: Empty[Map[Nothing, Nothing]] = Empty(Map.empty)
+  implicit def alleycatsEmptyForMap[A, B]: Empty[Map[A, B]] = emptyMapSingleton.asInstanceOf[Empty[Map[A, B]]]
 }
 
 private[alleycats] trait EmptyInstances1 extends EmptyInstances2 {

--- a/alleycats-core/src/test/scala/alleycats/SyntaxSuite.scala
+++ b/alleycats-core/src/test/scala/alleycats/SyntaxSuite.scala
@@ -47,33 +47,31 @@ object SyntaxSuite {
   // pretend we have a value of type A
   def mock[A]: A = ???
 
-  def testEmpty[A: Empty]: Unit = {
+  def testEmpty[A: Empty](): Unit = {
     val x = mock[A]
     implicit val y: Eq[A] = mock[Eq[A]]
-    val a0: Boolean = x.isEmpty
-    val a1: Boolean = x.nonEmpty
+    val _ = x.isEmpty | x.nonEmpty
   }
 
-  def testOptionEmpty: Unit = {
+  def testOptionEmpty(): Unit = {
     case class A[T](x: T)
     case class B()
 
-    import alleycats.std.option.*
     implicit def emptyA[T: Empty]: Empty[A[T]] = new Empty[A[T]] {
       def empty: A[T] = A(Empty[T].empty)
     }
 
-    Empty[A[Option[B]]].empty
+    val _ = Empty[A[Option[B]]].empty
   }
 
-  def testFoldable[F[_]: Foldable, A]: Unit = {
+  def testFoldable[F[_]: Foldable, A](): Unit = {
     val x = mock[F[A]]
     val y = mock[A => Unit]
-    x.foreach(y)
+    val _ = x.foreach(y)
   }
 
-  def testExtract[F[_]: Extract, A]: Unit = {
+  def testExtract[F[_]: Extract, A](): Unit = {
     val x = mock[F[A]]
-    val y = x.extract
+    val _ = x.extract
   }
 }

--- a/alleycats-core/src/test/scala/alleycats/SyntaxSuite.scala
+++ b/alleycats-core/src/test/scala/alleycats/SyntaxSuite.scala
@@ -64,6 +64,12 @@ object SyntaxSuite {
     val _ = Empty[A[Option[B]]].empty
   }
 
+  def testMapEmpty(): Any = {
+    case class Foo[A](foo: A)
+
+    val _ = Empty[Map[Foo[Int], Foo[String]]].empty
+  }
+
   def testFoldable[F[_]: Foldable, A](): Unit = {
     val x = mock[F[A]]
     val y = mock[A => Unit]

--- a/alleycats-core/src/test/scala/alleycats/SyntaxSuite.scala
+++ b/alleycats-core/src/test/scala/alleycats/SyntaxSuite.scala
@@ -24,6 +24,8 @@ package alleycats
 import cats.{Eq, Foldable}
 import alleycats.syntax.all.{catsSyntaxExtract, EmptyOps, ExtraFoldableOps}
 
+import scala.collection.immutable.SortedMap
+
 /**
  * Test that our syntax implicits are working.
  *
@@ -68,6 +70,14 @@ object SyntaxSuite {
     case class Foo[A](foo: A)
 
     val _ = Empty[Map[Foo[Int], Foo[String]]].empty
+  }
+
+  def testSortedMapEmpty(): Any = {
+    case class Foo[A](foo: A)
+
+    implicit def fooOrd[A: Ordering]: Ordering[Foo[A]] = Ordering.by(_.foo)
+
+    val _ = Empty[SortedMap[Foo[Int], Foo[String]]].empty
   }
 
   def testFoldable[F[_]: Foldable, A](): Unit = {


### PR DESCRIPTION
Adding yet another instance of `Empty` that might be commonly used (at the very least, I need it). I thought of adding this:
```scala
implicit def alleycatsEmptyForMap[CC[_, _] <: Iterable[(_, _)], A, B](implicit
  factory: Factory[(A, B), CC[A, B]]
): Empty[CC[A, B]] = Empty(factory.newBuilder.result())
```
but as @johnynek pointed out in #4733, it will also add support for `mutable.Map`, which isn't a desirable outcome.
The existing derivation capabilities fail to derive `Empty[Map[A, B]]` when the key/value types are case classes or more sophisticated than primitives. See https://scastie.scala-lang.org/ggnoSWYGTFiGGqD6wA0VuQ