### PR TITLE
Fix source compatibility with Scala 3.6.3

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -18,3 +18,6 @@ b4d207e9fa9f1463f0827fe20101e7901fecf820
 
 # Scala Steward: Reformat with scalafmt 3.8.4
 42490f49d2a62289c8ca0a57357f323982eeb93b
+
+# Fix errors under Scala 3.6.3
+fab4479a6b2975e5243565671a3a33a24469662d

--- a/algebra-core/src/main/scala/algebra/ring/EuclideanRing.scala
+++ b/algebra-core/src/main/scala/algebra/ring/EuclideanRing.scala
@@ -46,7 +46,7 @@ trait EuclideanRing[@sp(Int, Long, Float, Double) A] extends Any with GCDRing[A]
   def emod(a: A, b: A): A
   def equotmod(a: A, b: A): (A, A) = (equot(a, b), emod(a, b))
   def gcd(a: A, b: A)(implicit ev: Eq[A]): A =
-    EuclideanRing.euclid(a, b)(ev, self)
+    EuclideanRing.euclid(a, b)(using ev, self)
   def lcm(a: A, b: A)(implicit ev: Eq[A]): A =
     if (isZero(a) || isZero(b)) zero else times(equot(a, gcd(a, b)), b)
 }

--- a/algebra-laws/shared/src/test/scala/algebra/laws/LawTests.scala
+++ b/algebra-laws/shared/src/test/scala/algebra/laws/LawTests.scala
@@ -134,7 +134,7 @@ class LawTests extends munit.DisciplineSuite {
         Arbitrary(arbitrary[Double].map(x => BigDecimal(x, mc)))
       implicit val epsBigDecimal = FPApprox.Epsilon.bigDecimalEpsilon(mc)
       implicit val algebra: FPApproxAlgebra[BigDecimal] =
-        FPApprox.fpApproxAlgebra(new BigDecimalAlgebra(mc), Order[BigDecimal], epsBigDecimal)
+        FPApprox.fpApproxAlgebra(using new BigDecimalAlgebra(mc), Order[BigDecimal], epsBigDecimal)
       checkAll("FPApprox[BigDecimal]", RingLaws[FPApprox[BigDecimal]].field(algebra))
     }
   } else ()

--- a/algebra-laws/shared/src/test/scala/algebra/laws/Rat.scala
+++ b/algebra-laws/shared/src/test/scala/algebra/laws/Rat.scala
@@ -118,7 +118,7 @@ object Rat {
     new RatAlgebra
 
   val RatMinMaxLattice: DistributiveLattice[Rat] =
-    DistributiveLattice.minMax[Rat](ratAlgebra)
+    DistributiveLattice.minMax[Rat](using ratAlgebra)
 
   // Is this horrible? Yes. Am I ashamed? Yes.
   private[this] def genNonZero: Gen[BigInt] =

--- a/bench/src/main/scala/cats/bench/ParTraverseBench.scala
+++ b/bench/src/main/scala/cats/bench/ParTraverseBench.scala
@@ -46,12 +46,12 @@ class ParTraverseBench {
   val f: Int => Either[Int, Int] = Right(_)
 
   def parTraversePointfree[T[_]: Traverse, M[_], A, B](ta: T[A])(f: A => M[B])(implicit P: Parallel[M]): M[T[B]] = {
-    val gtb: P.F[T[B]] = Traverse[T].traverse(ta)(f.andThen(P.parallel.apply(_)))(P.applicative)
+    val gtb: P.F[T[B]] = Traverse[T].traverse(ta)(f.andThen(P.parallel.apply(_)))(using P.applicative)
     P.sequential(gtb)
   }
 
   def parTraversePointfull[T[_]: Traverse, M[_], A, B](ta: T[A])(f: A => M[B])(implicit P: Parallel[M]): M[T[B]] = {
-    val gtb: P.F[T[B]] = Traverse[T].traverse(ta)(a => P.parallel(f(a)))(P.applicative)
+    val gtb: P.F[T[B]] = Traverse[T].traverse(ta)(a => P.parallel(f(a)))(using P.applicative)
     P.sequential(gtb)
   }
 
@@ -59,7 +59,7 @@ class ParTraverseBench {
     tab: T[A, B]
   )(f: A => M[C], g: B => M[D])(implicit P: Parallel[M]): M[T[C, D]] = {
     val ftcd: P.F[T[C, D]] =
-      Bitraverse[T].bitraverse(tab)(f.andThen(P.parallel.apply(_)), g.andThen(P.parallel.apply(_)))(P.applicative)
+      Bitraverse[T].bitraverse(tab)(f.andThen(P.parallel.apply(_)), g.andThen(P.parallel.apply(_)))(using P.applicative)
     P.sequential(ftcd)
   }
 
@@ -67,7 +67,7 @@ class ParTraverseBench {
     tab: T[A, B]
   )(f: A => M[C], g: B => M[D])(implicit P: Parallel[M]): M[T[C, D]] = {
     val ftcd: P.F[T[C, D]] =
-      Bitraverse[T].bitraverse(tab)(a => P.parallel.apply(f(a)), b => P.parallel.apply(g(b)))(P.applicative)
+      Bitraverse[T].bitraverse(tab)(a => P.parallel.apply(f(a)), b => P.parallel.apply(g(b)))(using P.applicative)
     P.sequential(ftcd)
   }
 

--- a/core/src/main/scala/cats/Parallel.scala
+++ b/core/src/main/scala/cats/Parallel.scala
@@ -224,7 +224,7 @@ object Parallel extends ParallelArityFunctions2 {
    * corresponding to the Parallel instance instead.
    */
   def parSequence[T[_]: Traverse, M[_], A](tma: T[M[A]])(implicit P: Parallel[M]): M[T[A]] = {
-    val fta: P.F[T[A]] = Traverse[T].traverse(tma)(P.parallel.apply(_))(P.applicative)
+    val fta: P.F[T[A]] = Traverse[T].traverse(tma)(P.parallel.apply(_))(using P.applicative)
     P.sequential(fta)
   }
 
@@ -233,7 +233,7 @@ object Parallel extends ParallelArityFunctions2 {
    * corresponding to the Parallel instance instead.
    */
   def parTraverse[T[_]: Traverse, M[_], A, B](ta: T[A])(f: A => M[B])(implicit P: Parallel[M]): M[T[B]] = {
-    val gtb: P.F[T[B]] = Traverse[T].traverse(ta)(a => P.parallel(f(a)))(P.applicative)
+    val gtb: P.F[T[B]] = Traverse[T].traverse(ta)(a => P.parallel(f(a)))(using P.applicative)
     P.sequential(gtb)
   }
 
@@ -320,7 +320,7 @@ object Parallel extends ParallelArityFunctions2 {
   def parNonEmptySequence[T[_]: NonEmptyTraverse, M[_], A](
     tma: T[M[A]]
   )(implicit P: NonEmptyParallel[M]): M[T[A]] = {
-    val fta: P.F[T[A]] = NonEmptyTraverse[T].nonEmptyTraverse(tma)(P.parallel.apply(_))(P.apply)
+    val fta: P.F[T[A]] = NonEmptyTraverse[T].nonEmptyTraverse(tma)(P.parallel.apply(_))(using P.apply)
     P.sequential(fta)
   }
 
@@ -331,7 +331,7 @@ object Parallel extends ParallelArityFunctions2 {
   def parNonEmptyTraverse[T[_]: NonEmptyTraverse, M[_], A, B](
     ta: T[A]
   )(f: A => M[B])(implicit P: NonEmptyParallel[M]): M[T[B]] = {
-    val gtb: P.F[T[B]] = NonEmptyTraverse[T].nonEmptyTraverse(ta)(a => P.parallel(f(a)))(P.apply)
+    val gtb: P.F[T[B]] = NonEmptyTraverse[T].nonEmptyTraverse(ta)(a => P.parallel(f(a)))(using P.apply)
     P.sequential(gtb)
   }
 
@@ -408,7 +408,7 @@ object Parallel extends ParallelArityFunctions2 {
     tab: T[A, B]
   )(f: A => M[C], g: B => M[D])(implicit P: Parallel[M]): M[T[C, D]] = {
     val ftcd: P.F[T[C, D]] =
-      Bitraverse[T].bitraverse(tab)(a => P.parallel(f(a)), b => P.parallel(g(b)))(P.applicative)
+      Bitraverse[T].bitraverse(tab)(a => P.parallel(f(a)), b => P.parallel(g(b)))(using P.applicative)
     P.sequential(ftcd)
   }
 
@@ -419,7 +419,8 @@ object Parallel extends ParallelArityFunctions2 {
   def parBisequence[T[_, _]: Bitraverse, M[_], A, B](
     tmamb: T[M[A], M[B]]
   )(implicit P: Parallel[M]): M[T[A, B]] = {
-    val ftab: P.F[T[A, B]] = Bitraverse[T].bitraverse(tmamb)(P.parallel.apply(_), P.parallel.apply(_))(P.applicative)
+    val ftab: P.F[T[A, B]] =
+      Bitraverse[T].bitraverse(tmamb)(P.parallel.apply(_), P.parallel.apply(_))(using P.applicative)
     P.sequential(ftab)
   }
 
@@ -431,7 +432,7 @@ object Parallel extends ParallelArityFunctions2 {
     tab: T[A, B]
   )(f: A => M[C])(implicit P: Parallel[M]): M[T[C, B]] = {
     val ftcb: P.F[T[C, B]] =
-      Bitraverse[T].bitraverse(tab)(a => P.parallel.apply(f(a)), P.applicative.pure(_))(P.applicative)
+      Bitraverse[T].bitraverse(tab)(a => P.parallel.apply(f(a)), P.applicative.pure(_))(using P.applicative)
     P.sequential(ftcb)
   }
 
@@ -442,7 +443,8 @@ object Parallel extends ParallelArityFunctions2 {
   def parLeftSequence[T[_, _]: Bitraverse, M[_], A, B](
     tmab: T[M[A], B]
   )(implicit P: Parallel[M]): M[T[A, B]] = {
-    val ftab: P.F[T[A, B]] = Bitraverse[T].bitraverse(tmab)(P.parallel.apply(_), P.applicative.pure(_))(P.applicative)
+    val ftab: P.F[T[A, B]] =
+      Bitraverse[T].bitraverse(tmab)(P.parallel.apply(_), P.applicative.pure(_))(using P.applicative)
     P.sequential(ftab)
   }
 

--- a/core/src/main/scala/cats/Representable.scala
+++ b/core/src/main/scala/cats/Representable.scala
@@ -84,7 +84,7 @@ trait Representable[F[_]] extends Serializable { self =>
     G: Representable[G]
   ): Representable.Aux[λ[α => F[G[α]]], (self.Representation, G.Representation)] =
     new Representable[λ[α => F[G[α]]]] { inner =>
-      override val F = self.F.compose(G.F)
+      override val F = self.F.compose(using G.F)
 
       type Representation = (self.Representation, G.Representation)
 

--- a/core/src/main/scala/cats/UnorderedFoldable.scala
+++ b/core/src/main/scala/cats/UnorderedFoldable.scala
@@ -54,7 +54,7 @@ trait UnorderedFoldable[F[_]] extends Serializable {
   def unorderedFoldMapA[G[_], A, B](fa: F[A])(
     f: A => G[B]
   )(implicit G: CommutativeApplicative[G], B: CommutativeMonoid[B]): G[B] =
-    unorderedFoldMap(fa)(f)(CommutativeApplicative.commutativeMonoidFor)
+    unorderedFoldMap(fa)(f)(using CommutativeApplicative.commutativeMonoidFor)
 
   /**
    * Tests if `fa` contains `v` using the `Eq` instance for `A`
@@ -77,7 +77,7 @@ trait UnorderedFoldable[F[_]] extends Serializable {
    * If there are no elements, the result is `false`.
    */
   def exists[A](fa: F[A])(p: A => Boolean): Boolean =
-    unorderedFoldMap(fa)(a => Eval.later(p(a)))(UnorderedFoldable.orEvalMonoid).value
+    unorderedFoldMap(fa)(a => Eval.later(p(a)))(using UnorderedFoldable.orEvalMonoid).value
 
   /**
    * Check whether all elements satisfy the predicate.
@@ -85,7 +85,7 @@ trait UnorderedFoldable[F[_]] extends Serializable {
    * If there are no elements, the result is `true`.
    */
   def forall[A](fa: F[A])(p: A => Boolean): Boolean =
-    unorderedFoldMap(fa)(a => Eval.later(p(a)))(UnorderedFoldable.andEvalMonoid).value
+    unorderedFoldMap(fa)(a => Eval.later(p(a)))(using UnorderedFoldable.andEvalMonoid).value
 
   /**
    * The size of this UnorderedFoldable.

--- a/core/src/main/scala/cats/data/Const.scala
+++ b/core/src/main/scala/cats/data/Const.scala
@@ -86,13 +86,13 @@ object Const extends ConstInstances {
 sealed abstract private[data] class ConstInstances extends ConstInstances0 {
   implicit def catsDataUpperBoundedForConst[A, B](implicit A: UpperBounded[A]): UpperBounded[Const[A, B]] =
     new UpperBounded[Const[A, B]] {
-      override def partialOrder: PartialOrder[Const[A, B]] = catsDataPartialOrderForConst(A.partialOrder)
+      override def partialOrder: PartialOrder[Const[A, B]] = catsDataPartialOrderForConst(using A.partialOrder)
       override def maxBound: Const[A, B] = Const(A.maxBound)
     }
 
   implicit def catsDataLowerBoundedForConst[A, B](implicit A: LowerBounded[A]): LowerBounded[Const[A, B]] =
     new LowerBounded[Const[A, B]] {
-      override def partialOrder: PartialOrder[Const[A, B]] = catsDataPartialOrderForConst(A.partialOrder)
+      override def partialOrder: PartialOrder[Const[A, B]] = catsDataPartialOrderForConst(using A.partialOrder)
       override def minBound: Const[A, B] = Const(A.minBound)
     }
 

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -1019,7 +1019,8 @@ abstract private[data] class EitherTInstances extends EitherTInstances1 {
       implicit val monadM: Monad[M] = P.monad
 
       def applicative: Applicative[Nested[P.F, Validated[E, *], *]] =
-        cats.data.Nested.catsDataApplicativeForNested(P.applicative, Validated.catsDataApplicativeErrorForValidated)
+        cats.data.Nested
+          .catsDataApplicativeForNested(using P.applicative, Validated.catsDataApplicativeErrorForValidated)
 
       def monad: Monad[EitherT[M, E, *]] = cats.data.EitherT.catsDataMonadErrorForEitherT
 
@@ -1050,7 +1051,7 @@ abstract private[data] class EitherTInstances extends EitherTInstances1 {
       implicit val monadEither: Monad[Either[E, *]] = cats.instances.either.catsStdInstancesForEither
 
       def applicative: Applicative[Nested[P.F, Either[E, *], *]] =
-        cats.data.Nested.catsDataApplicativeForNested(P.applicative, implicitly)
+        cats.data.Nested.catsDataApplicativeForNested(using P.applicative, implicitly)
 
       def monad: Monad[EitherT[M, E, *]] = cats.data.EitherT.catsDataMonadErrorForEitherT
 

--- a/core/src/main/scala/cats/data/Func.scala
+++ b/core/src/main/scala/cats/data/Func.scala
@@ -131,7 +131,7 @@ sealed abstract class AppFunc[F[_], A, B] extends Func[F, A, B] { self =>
   }
 
   def compose[G[_], C](g: AppFunc[G, C, A]): AppFunc[Nested[G, F, *], C, B] = {
-    implicit val gfApplicative: Applicative[Nested[G, F, *]] = Nested.catsDataApplicativeForNested[G, F](g.F, F)
+    implicit val gfApplicative: Applicative[Nested[G, F, *]] = Nested.catsDataApplicativeForNested[G, F](using g.F, F)
     Func.appFunc[Nested[G, F, *], C, B] { (c: C) =>
       Nested(g.F.map(g.run(c))(self.run))
     }
@@ -146,7 +146,7 @@ sealed abstract class AppFunc[F[_], A, B] extends Func[F, A, B] { self =>
   }
 
   def traverse[G[_]](ga: G[A])(implicit GG: Traverse[G]): F[G[B]] =
-    GG.traverse(ga)(self.run)(F)
+    GG.traverse(ga)(self.run)(using F)
 }
 
 object AppFunc extends AppFuncInstances

--- a/core/src/main/scala/cats/data/Nested.scala
+++ b/core/src/main/scala/cats/data/Nested.scala
@@ -118,7 +118,7 @@ sealed abstract private[data] class NestedInstances0 extends NestedInstances1 {
     val FG = F0.compose(G0)
 
     val F: Functor[Nested[F, G, *]] = new NestedFunctor[F, G] {
-      val FG = F0.F.compose(G0.F)
+      val FG = F0.F.compose(using G0.F)
     }
 
     type Representation = FG.Representation
@@ -301,7 +301,7 @@ abstract private[data] class NestedApplicativeError[F[_], G[_], E]
   def G: Applicative[G]
   def AEF: ApplicativeError[F, E]
 
-  def FG: Applicative[λ[α => F[G[α]]]] = AEF.compose[G](G)
+  def FG: Applicative[λ[α => F[G[α]]]] = AEF.compose[G](using G)
 
   def raiseError[A](e: E): Nested[F, G, A] = Nested(AEF.map(AEF.raiseError[A](e))(G.pure))
 
@@ -421,7 +421,7 @@ abstract private[data] class NestedFunctorFilter[F[_], G[_]] extends FunctorFilt
 
   implicit val G: FunctorFilter[G]
 
-  def functor: Functor[Nested[F, G, *]] = Nested.catsDataFunctorForNested(F, G.functor)
+  def functor: Functor[Nested[F, G, *]] = Nested.catsDataFunctorForNested(using F, G.functor)
 
   def mapFilter[A, B](fa: Nested[F, G, A])(f: (A) => Option[B]): Nested[F, G, B] =
     Nested[F, G, B](F.map(fa.value)(G.mapFilter(_)(f)))
@@ -447,7 +447,7 @@ abstract private[data] class NestedTraverseFilter[F[_], G[_]]
 
   implicit val G: TraverseFilter[G]
 
-  def traverse: Traverse[Nested[F, G, *]] = Nested.catsDataTraverseForNested(F, G.traverse)
+  def traverse: Traverse[Nested[F, G, *]] = Nested.catsDataTraverseForNested(using F, G.traverse)
 
   override def filterA[H[_], A](
     fa: Nested[F, G, A]
@@ -465,7 +465,7 @@ abstract private[data] class NestedAlign[F[_], G[_]] extends Align[Nested[F, G, 
   implicit val G: Align[G]
 
   override def functor: Functor[Nested[F, G, *]] =
-    Nested.catsDataFunctorForNested(F.functor, G.functor)
+    Nested.catsDataFunctorForNested(using F.functor, G.functor)
 
   override def align[A, B](
     fa: Nested[F, G, A],

--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -362,7 +362,7 @@ sealed abstract private[data] class NonEmptyMapInstances extends NonEmptyMapInst
 
   @deprecated("Use catsDataHashForNonEmptyMap override without Order", "2.2.0-M3")
   def catsDataHashForNonEmptyMap[K, A](hashK: Hash[K], orderK: Order[K], hashA: Hash[A]): Hash[NonEmptyMap[K, A]] =
-    catsDataHashForNonEmptyMap(hashK, hashA)
+    catsDataHashForNonEmptyMap(using hashK, hashA)
 
   implicit def catsDataShowForNonEmptyMap[K: Show, A: Show]: Show[NonEmptyMap[K, A]] = _.show
 
@@ -378,5 +378,5 @@ sealed abstract private[data] class NonEmptyMapInstances0 {
 
   @deprecated("Use catsDataEqForNonEmptyMap override without Order", "2.2.0-M3")
   def catsDataEqForNonEmptyMap[K, A](orderK: Order[K], eqA: Eq[A]): Eq[NonEmptyMap[K, A]] =
-    catsDataEqForNonEmptyMap(eqA)
+    catsDataEqForNonEmptyMap(using eqA)
 }

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -609,7 +609,7 @@ final case class OptionT[F[_], A](value: F[Option[A]]) {
    * }}}
    */
   def traverse[G[_], B](f: A => G[B])(implicit F: Traverse[F], G: Applicative[G]): G[OptionT[F, B]] =
-    G.map(F.compose(Traverse[Option]).traverse(value)(f))(OptionT.apply)
+    G.map(F.compose(using Traverse[Option]).traverse(value)(f))(OptionT.apply)
 
   /**
    * Example:
@@ -637,7 +637,7 @@ final case class OptionT[F[_], A](value: F[Option[A]]) {
    * }}}
    */
   def foldLeft[B](b: B)(f: (B, A) => B)(implicit F: Foldable[F]): B =
-    F.compose(Foldable[Option]).foldLeft(value, b)(f)
+    F.compose(using Foldable[Option]).foldLeft(value, b)(f)
 
   /**
    * Example:
@@ -651,7 +651,7 @@ final case class OptionT[F[_], A](value: F[Option[A]]) {
    * }}}
    */
   def foldRight[B](lb: Eval[B])(f: (A, Eval[B]) => Eval[B])(implicit F: Foldable[F]): Eval[B] =
-    F.compose(Foldable[Option]).foldRight(value, lb)(f)
+    F.compose(using Foldable[Option]).foldRight(value, lb)(f)
 
   /**
    * Transform this `OptionT[F, A]` into a `[[Nested]][F, Option, A]`.
@@ -858,7 +858,8 @@ sealed abstract private[data] class OptionTInstances extends OptionTInstances0 {
       implicit val monadM: Monad[M] = P.monad
 
       def applicative: Applicative[Nested[P.F, Option, *]] =
-        cats.data.Nested.catsDataApplicativeForNested(P.applicative, cats.instances.option.catsStdInstancesForOption)
+        cats.data.Nested
+          .catsDataApplicativeForNested(using P.applicative, cats.instances.option.catsStdInstancesForOption)
 
       def monad: Monad[OptionT[M, *]] = cats.data.OptionT.catsDataMonadErrorMonadForOptionT[M]
 

--- a/core/src/main/scala/cats/instances/sortedSet.scala
+++ b/core/src/main/scala/cats/instances/sortedSet.scala
@@ -94,7 +94,7 @@ trait SortedSetInstances extends SortedSetInstances1 {
 private[instances] trait SortedSetInstances1 {
   @deprecated("Use cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet", "2.0.0-RC2")
   private[instances] def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
-    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A](Hash[A])
+    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A](using Hash[A])
 
   @deprecated("Use cats.kernel.instances.sortedSet.catsKernelStdSemilatticeForSortedSet", "2.0.0-RC2")
   def catsKernelStdSemilatticeForSortedSet[A: Order]: BoundedSemilattice[SortedSet[A]] =
@@ -114,11 +114,11 @@ private[instances] trait SortedSetInstancesBinCompat0 {
 
 private[instances] trait SortedSetInstancesBinCompat1 extends LowPrioritySortedSetInstancesBinCompat1 {
   implicit def catsKernelStdHashForSortedSet1[A: Hash]: Hash[SortedSet[A]] =
-    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A](Hash[A])
+    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A](using Hash[A])
 
   @deprecated("Use cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet", "2.0.0-RC3")
   override def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
-    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A](Hash[A])
+    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A](using Hash[A])
 }
 
 private[instances] trait LowPrioritySortedSetInstancesBinCompat1
@@ -128,11 +128,11 @@ private[instances] trait LowPrioritySortedSetInstancesBinCompat1
     cats.kernel.instances.sortedSet.catsKernelStdOrderForSortedSet[A]
 
   implicit override def catsKernelStdHashForSortedSet[A: Hash]: Hash[SortedSet[A]] =
-    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A](Hash[A])
+    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A](using Hash[A])
 
   @deprecated("Use cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet", "2.0.0-RC2")
   override def catsKernelStdHashForSortedSet[A: Order: Hash]: Hash[SortedSet[A]] =
-    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A](Hash[A])
+    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A](using Hash[A])
 }
 
 @deprecated("Use cats.kernel.instances.SortedSetHash", "2.0.0-RC2")

--- a/free/src/test/scala/cats/free/FreeSuite.scala
+++ b/free/src/test/scala/cats/free/FreeSuite.scala
@@ -233,8 +233,8 @@ class FreeSuite extends CatsSuite {
       f: Free[F, A]
     )(implicit F: Functor[F], I0: Test1Algebra :<: F, I1: Test2Algebra :<: F): Option[Free[F, A]] =
       for {
-        Test1(x, h) <- Free.match_[F, Test1Algebra, A](f)
-        Test2(y, k) <- Free.match_[F, Test2Algebra, A](h(x))
+        case Test1(x, h) <- Free.match_[F, Test1Algebra, A](f)
+        case Test2(y, k) <- Free.match_[F, Test2Algebra, A](h(x))
       } yield k(x + y)
 
     forAll { (x: Int, y: Int) =>

--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -158,11 +158,11 @@ class Tests extends TestsConfig with DisciplineSuite {
 
   checkAll("PartialOrder[Set[Int]]", PartialOrderTests[Set[Int]].partialOrder)
   checkAll("PartialOrder.reverse(PartialOrder[Set[Int]])",
-           PartialOrderTests(PartialOrder.reverse(PartialOrder[Set[Int]])).partialOrder
+           PartialOrderTests(using PartialOrder.reverse(PartialOrder[Set[Int]])).partialOrder
   )
   checkAll(
     "PartialOrder.reverse(PartialOrder.reverse(PartialOrder[Set[Int]]))",
-    PartialOrderTests(PartialOrder.reverse(PartialOrder.reverse(PartialOrder[Set[Int]]))).partialOrder
+    PartialOrderTests(using PartialOrder.reverse(PartialOrder.reverse(PartialOrder[Set[Int]]))).partialOrder
   )
   checkAll("PartialOrder[Option[HasPartialOrder[Int]]]", PartialOrderTests[Option[HasPartialOrder[Int]]].partialOrder)
   checkAll("PartialOrder[List[HasPartialOrder[Int]]]", PartialOrderTests[List[HasPartialOrder[Int]]].partialOrder)
@@ -173,10 +173,10 @@ class Tests extends TestsConfig with DisciplineSuite {
            PartialOrderTests[SortedMap[Int, HasPartialOrder[Int]]].partialOrder
   )
   checkAll("Semilattice.asMeetPartialOrder[Set[Int]]",
-           PartialOrderTests(Semilattice.asMeetPartialOrder[Set[Int]]).partialOrder
+           PartialOrderTests(using Semilattice.asMeetPartialOrder[Set[Int]]).partialOrder
   )
   checkAll("Semilattice.asJoinPartialOrder[Set[Int]]",
-           PartialOrderTests(Semilattice.asJoinPartialOrder[Set[Int]]).partialOrder
+           PartialOrderTests(using Semilattice.asJoinPartialOrder[Set[Int]]).partialOrder
   )
 
   checkAll("Order[String]", OrderTests[String].order)
@@ -196,10 +196,10 @@ class Tests extends TestsConfig with DisciplineSuite {
   checkAll("Order[Queue[Int]]", OrderTests[Queue[Int]].order)
   checkAll("Order[SortedSet[String]", OrderTests[SortedSet[String]].order)
   checkAll("Order[SortedMap[Int, String]]", OrderTests[SortedMap[Int, String]].order)
-  checkAll("fromOrdering[Int]", OrderTests(Order.fromOrdering[Int]).order)
-  checkAll("Order.reverse(Order[Int])", OrderTests(Order.reverse(Order[Int])).order)
-  checkAll("Order.reverse(Order.reverse(Order[Int]))", OrderTests(Order.reverse(Order.reverse(Order[Int]))).order)
-  checkAll("Order.fromLessThan[Int](_ < _)", OrderTests(Order.fromLessThan[Int](_ < _)).order)
+  checkAll("fromOrdering[Int]", OrderTests(using Order.fromOrdering[Int]).order)
+  checkAll("Order.reverse(Order[Int])", OrderTests(using Order.reverse(Order[Int])).order)
+  checkAll("Order.reverse(Order.reverse(Order[Int]))", OrderTests(using Order.reverse(Order.reverse(Order[Int]))).order)
+  checkAll("Order.fromLessThan[Int](_ < _)", OrderTests(using Order.fromLessThan[Int](_ < _)).order)
 
   checkAll("LowerBounded[Duration]", LowerBoundedTests[Duration].lowerBounded)
   checkAll("LowerBounded[FiniteDuration]", LowerBoundedTests[FiniteDuration].lowerBounded)
@@ -218,13 +218,14 @@ class Tests extends TestsConfig with DisciplineSuite {
   checkAll("BoundedEnumerable[Int]", BoundedEnumerableTests[Int].boundedEnumerable)
   checkAll("BoundedEnumerable[Char]", BoundedEnumerableTests[Char].boundedEnumerable)
   checkAll("BoundedEnumerable[Long]", BoundedEnumerableTests[Long].boundedEnumerable)
-  checkAll("BoundedEnumerable.reverse(BoundedEnumerable[Int])",
-           BoundedEnumerableTests(BoundedEnumerable.reverse(BoundedEnumerable[Int])).boundedEnumerable
+  checkAll(
+    "BoundedEnumerable.reverse(BoundedEnumerable[Int])",
+    BoundedEnumerableTests(using BoundedEnumerable.reverse(BoundedEnumerable[Int])).boundedEnumerable
   )
   checkAll(
     "BoundedEnumerable.reverse(BoundedEnumerable.reverse(BoundedEnumerable[Int]))",
     BoundedEnumerableTests(
-      BoundedEnumerable.reverse(BoundedEnumerable.reverse(BoundedEnumerable[Int]))
+      using BoundedEnumerable.reverse(BoundedEnumerable.reverse(BoundedEnumerable[Int]))
     ).boundedEnumerable
   )
 
@@ -359,7 +360,7 @@ class Tests extends TestsConfig with DisciplineSuite {
     else if (y.subsetOf(x)) 1.0
     else Double.NaN
 
-  checkAll("subsetPartialOrder[Int]", PartialOrderTests(subsetPartialOrder[Int]).partialOrder)
+  checkAll("subsetPartialOrder[Int]", PartialOrderTests(using subsetPartialOrder[Int]).partialOrder)
 
   {
     implicit def subsetPartialOrdering[A]: PartialOrdering[Set[A]] =
@@ -373,7 +374,9 @@ class Tests extends TestsConfig with DisciplineSuite {
 
         override def lteq(x: Set[A], y: Set[A]): Boolean = (x.subsetOf(y)) || (x == y)
       }
-    checkAll("fromPartialOrdering[Int]", PartialOrderTests(PartialOrder.fromPartialOrdering[Set[Int]]).partialOrder)
+    checkAll("fromPartialOrdering[Int]",
+             PartialOrderTests(using PartialOrder.fromPartialOrdering[Set[Int]]).partialOrder
+    )
   }
 
   implicit val arbitraryComparison: Arbitrary[Comparison] =

--- a/kernel/src/main/scala/cats/kernel/Eq.scala
+++ b/kernel/src/main/scala/cats/kernel/Eq.scala
@@ -256,7 +256,7 @@ private[kernel] trait HashInstances extends HashInstances0 {
   implicit def catsKernelHashForQueue[A: Hash]: Hash[Queue[A]] =
     cats.kernel.instances.queue.catsKernelStdHashForQueue[A]
   implicit def catsKernelHashForSortedSet[A: Hash]: Hash[SortedSet[A]] =
-    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A](Hash[A])
+    cats.kernel.instances.sortedSet.catsKernelStdHashForSortedSet[A](using Hash[A])
   implicit def catsKernelHashForFunction0[A: Hash]: Hash[() => A] =
     cats.kernel.instances.function.catsKernelHashForFunction0[A]
   implicit def catsKernelHashForMap[K: Hash, V: Hash]: Hash[Map[K, V]] =

--- a/tests/js/src/test/scala/cats/tests/FutureTests.scala
+++ b/tests/js/src/test/scala/cats/tests/FutureTests.scala
@@ -76,7 +76,7 @@ class FutureTests extends CatsSuite {
     Cogen[Unit].contramap(_ => ())
 
   checkAll("Future[Int]", MonadErrorTests[Future, Throwable].monadError[Int, Int, Int])
-  checkAll("Future[Int]", ComonadTests[Future](comonad).comonad[Int, Int, Int])
+  checkAll("Future[Int]", ComonadTests[Future](using comonad).comonad[Int, Int, Int])
   checkAll("Future", MonadTests[Future].monad[Int, Int, Int])
 
   {

--- a/tests/shared/src/test/scala/cats/tests/AlgebraInvariantSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/AlgebraInvariantSuite.scala
@@ -214,9 +214,10 @@ class AlgebraInvariantSuite extends CatsSuite with ScalaVersionSpecificAlgebraIn
       )
     }
 
-  checkAll("InvariantMonoidal[Semigroup]", SemigroupTests[Int](InvariantMonoidal[Semigroup].point(0)).semigroup)
-  checkAll("InvariantMonoidal[CommutativeSemigroup]",
-           CommutativeSemigroupTests[Int](InvariantMonoidal[CommutativeSemigroup].point(0)).commutativeSemigroup
+  checkAll("InvariantMonoidal[Semigroup]", SemigroupTests[Int](using InvariantMonoidal[Semigroup].point(0)).semigroup)
+  checkAll(
+    "InvariantMonoidal[CommutativeSemigroup]",
+    CommutativeSemigroupTests[Int](using InvariantMonoidal[CommutativeSemigroup].point(0)).commutativeSemigroup
   )
 
   checkAll("InvariantSemigroupal[Monoid]",
@@ -225,61 +226,61 @@ class AlgebraInvariantSuite extends CatsSuite with ScalaVersionSpecificAlgebraIn
 
   {
     val S: Semigroup[Int] = Semigroup[Int].imap(identity)(identity)
-    checkAll("Semigroup[Int]", SemigroupTests[Int](S).semigroup)
+    checkAll("Semigroup[Int]", SemigroupTests[Int](using S).semigroup)
   }
 
   {
     val S: Monoid[Int] = Monoid[Int].imap(identity)(identity)
-    checkAll("Monoid[Int]", MonoidTests[Int](S).monoid)
+    checkAll("Monoid[Int]", MonoidTests[Int](using S).monoid)
   }
 
   {
     val S: Group[Int] = Group[Int].imap(identity)(identity)
-    checkAll("Group[Int]", GroupTests[Int](S).group)
+    checkAll("Group[Int]", GroupTests[Int](using S).group)
   }
 
   {
     val S: CommutativeSemigroup[Int] = CommutativeSemigroup[Int].imap(identity)(identity)
-    checkAll("CommutativeSemigroup[Int]", CommutativeSemigroupTests[Int](S).commutativeSemigroup)
+    checkAll("CommutativeSemigroup[Int]", CommutativeSemigroupTests[Int](using S).commutativeSemigroup)
   }
 
   {
     val S: CommutativeSemigroup[Option[Int]] = CommutativeApply.commutativeSemigroupFor[Option, Int]
-    checkAll("CommutativeSemigroup[Option[Int]", CommutativeSemigroupTests[Option[Int]](S).commutativeSemigroup)
+    checkAll("CommutativeSemigroup[Option[Int]", CommutativeSemigroupTests[Option[Int]](using S).commutativeSemigroup)
   }
 
   {
     val S: CommutativeMonoid[Option[Int]] = CommutativeApplicative.commutativeMonoidFor[Option, Int]
-    checkAll("CommutativeMonoid[Option[Int]", CommutativeMonoidTests[Option[Int]](S).commutativeMonoid)
+    checkAll("CommutativeMonoid[Option[Int]", CommutativeMonoidTests[Option[Int]](using S).commutativeMonoid)
   }
 
   {
     val S: CommutativeMonoid[Int] = CommutativeMonoid[Int].imap(identity)(identity)
-    checkAll("CommutativeMonoid[Int]", CommutativeMonoidTests[Int](S).commutativeMonoid)
+    checkAll("CommutativeMonoid[Int]", CommutativeMonoidTests[Int](using S).commutativeMonoid)
   }
 
   {
-    checkAll("CommutativeMonoid[MiniInt]", CommutativeMonoidTests[MiniInt](miniIntAddition).commutativeMonoid)
+    checkAll("CommutativeMonoid[MiniInt]", CommutativeMonoidTests[MiniInt](using miniIntAddition).commutativeMonoid)
   }
 
   {
     val S: CommutativeGroup[Int] = CommutativeGroup[Int].imap(identity)(identity)
-    checkAll("CommutativeGroup[Int]", CommutativeGroupTests[Int](S).commutativeGroup)
+    checkAll("CommutativeGroup[Int]", CommutativeGroupTests[Int](using S).commutativeGroup)
   }
 
   {
     val S: Band[Set[Int]] = Band[Set[Int]].imap(identity)(identity)
-    checkAll("Band[Set[Int]]", BandTests[Set[Int]](S).band)
+    checkAll("Band[Set[Int]]", BandTests[Set[Int]](using S).band)
   }
 
   {
     val S: Semilattice[Set[Int]] = Semilattice[Set[Int]].imap(identity)(identity)
-    checkAll("Semilattice[Set[Int]]", SemilatticeTests[Set[Int]](S).semilattice)
+    checkAll("Semilattice[Set[Int]]", SemilatticeTests[Set[Int]](using S).semilattice)
   }
 
   {
     val S: BoundedSemilattice[Set[Int]] = BoundedSemilattice[Set[Int]].imap(identity)(identity)
-    checkAll("BoundedSemilattice[Set[Int]]", BoundedSemilatticeTests[Set[Int]](S).boundedSemilattice)
+    checkAll("BoundedSemilattice[Set[Int]]", BoundedSemilatticeTests[Set[Int]](using S).boundedSemilattice)
   }
 
   checkAll("Invariant[Semigroup]", InvariantTests[Semigroup].invariant[MiniInt, Boolean, Boolean])

--- a/tests/shared/src/test/scala/cats/tests/AlignSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/AlignSuite.scala
@@ -27,9 +27,9 @@ import cats.kernel.laws.discipline.SemigroupTests
 class AlignSuite extends CatsSuite {
   {
     val optionSemigroup = Align.semigroup[Option, Int]
-    checkAll("Align[Option].semigroup", SemigroupTests[Option[Int]](optionSemigroup).semigroup)
+    checkAll("Align[Option].semigroup", SemigroupTests[Option[Int]](using optionSemigroup).semigroup)
 
     val listSemigroup = Align.semigroup[List, String]
-    checkAll("Align[List].semigroup", SemigroupTests[List[String]](listSemigroup).semigroup)
+    checkAll("Align[List].semigroup", SemigroupTests[List[String]](using listSemigroup).semigroup)
   }
 }

--- a/tests/shared/src/test/scala/cats/tests/ApplicativeSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/ApplicativeSuite.scala
@@ -90,12 +90,12 @@ class ApplicativeSuite extends CatsSuite {
 
   {
     implicit val optionMonoid: Monoid[Option[Int]] = Applicative.monoid[Option, Int]
-    checkAll("Applicative[Option].monoid", MonoidTests[Option[Int]](optionMonoid).monoid)
+    checkAll("Applicative[Option].monoid", MonoidTests[Option[Int]](using optionMonoid).monoid)
   }
 
   {
     val optionSemigroupFromApply = Apply.semigroup[Option, Int]
-    checkAll("Apply[Option].semigroup", SemigroupTests[Option[Int]](optionSemigroupFromApply).semigroup)
+    checkAll("Apply[Option].semigroup", SemigroupTests[Option[Int]](using optionSemigroupFromApply).semigroup)
   }
 
   {

--- a/tests/shared/src/test/scala/cats/tests/BifoldableSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/BifoldableSuite.scala
@@ -31,7 +31,7 @@ class BifoldableSuite extends CatsSuite {
   val eitherComposeEither: Bifoldable[EitherEither] =
     Bifoldable[Either].compose[Either]
 
-  checkAll("Either compose Either", BifoldableTests(eitherComposeEither).bifoldable[Int, Int, Int])
+  checkAll("Either compose Either", BifoldableTests(using eitherComposeEither).bifoldable[Int, Int, Int])
   checkAll("Bifoldable[Either compose Either]", SerializableTests.serializable(eitherComposeEither))
 
   test("bifold works for 2 monoids") {

--- a/tests/shared/src/test/scala/cats/tests/BifunctorSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/BifunctorSuite.scala
@@ -30,7 +30,7 @@ class BifunctorSuite extends CatsSuite {
     Bifunctor[Tuple2].compose[Either]
 
   checkAll("Tuple2 compose Either",
-           BifunctorTests(tuple2ComposeEither).bifunctor[Int, Int, Int, String, String, String]
+           BifunctorTests(using tuple2ComposeEither).bifunctor[Int, Int, Int, String, String, String]
   )
   checkAll("Bifunctor[Tuple2 compose Either]", SerializableTests.serializable(tuple2ComposeEither))
 

--- a/tests/shared/src/test/scala/cats/tests/BitraverseSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/BitraverseSuite.scala
@@ -30,7 +30,7 @@ class BitraverseSuite extends CatsSuite {
     Bitraverse[Either].compose[Tuple2]
 
   checkAll("Either compose Tuple2",
-           BitraverseTests(eitherComposeTuple2).bitraverse[Option, Int, Int, Int, String, String, String]
+           BitraverseTests(using eitherComposeTuple2).bitraverse[Option, Int, Int, Int, String, String, String]
   )
   checkAll("Bitraverse[Either compose Tuple2]", SerializableTests.serializable(eitherComposeTuple2))
 }

--- a/tests/shared/src/test/scala/cats/tests/CategorySuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/CategorySuite.scala
@@ -31,9 +31,9 @@ import cats.laws.discipline.arbitrary.{catsLawsArbitraryForMiniInt, catsLawsCoge
 class CategorySuite extends CatsSuite {
   val functionCategory = Category[Function1]
 
-  checkAll("Category[Function1].algebraK", MonoidKTests[Endo](functionCategory.algebraK).monoidK[MiniInt])
+  checkAll("Category[Function1].algebraK", MonoidKTests[Endo](using functionCategory.algebraK).monoidK[MiniInt])
   checkAll("Category[Function1].algebraK", SerializableTests.serializable(functionCategory.algebraK))
 
   val functionAlgebra = functionCategory.algebra[MiniInt]
-  checkAll("Category[Function1].algebra[MiniInt]", MonoidTests[Endo[MiniInt]](functionAlgebra).monoid)
+  checkAll("Category[Function1].algebra[MiniInt]", MonoidTests[Endo[MiniInt]](using functionAlgebra).monoid)
 }

--- a/tests/shared/src/test/scala/cats/tests/ComposeSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/ComposeSuite.scala
@@ -32,11 +32,11 @@ import cats.syntax.compose._
 class ComposeSuite extends CatsSuite {
   val functionCompose = Compose[Function1]
 
-  checkAll("Compose[Function1].algebraK", SemigroupKTests[Endo](functionCompose.algebraK).semigroupK[MiniInt])
+  checkAll("Compose[Function1].algebraK", SemigroupKTests[Endo](using functionCompose.algebraK).semigroupK[MiniInt])
   checkAll("Compose[Function1].algebraK", SerializableTests.serializable(functionCompose.algebraK))
 
   val functionAlgebra = functionCompose.algebra[MiniInt]
-  checkAll("Compose[Function1].algebra[MiniInt]", SemigroupTests[Endo[MiniInt]](functionAlgebra).semigroup)
+  checkAll("Compose[Function1].algebra[MiniInt]", SemigroupTests[Endo[MiniInt]](using functionAlgebra).semigroup)
 
   test("syntax") {
     assertEquals((((_: Int) + 1) <<< ((_: Int) / 2))(2), 2)

--- a/tests/shared/src/test/scala/cats/tests/EitherSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/EitherSuite.scala
@@ -83,8 +83,8 @@ class EitherSuite extends CatsSuite {
     )
   }
 
-  checkAll("Either[Int, String]", PartialOrderTests[Either[Int, String]](partialOrder).partialOrder)
-  checkAll("Either[Int, String]", OrderTests[Either[Int, String]](order).order)
+  checkAll("Either[Int, String]", PartialOrderTests[Either[Int, String]](using partialOrder).partialOrder)
+  checkAll("Either[Int, String]", OrderTests[Either[Int, String]](using order).order)
 
   test("Left/Right cast syntax") {
     forAll { (e: Either[Int, String]) =>

--- a/tests/shared/src/test/scala/cats/tests/FunctionSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/FunctionSuite.scala
@@ -140,9 +140,10 @@ class FunctionSuite extends CatsSuite {
 
   // Test for Arrow applicative
   Applicative[String => *]
-  checkAll("Function1[MiniInt, *]",
-           ApplicativeTests[Function1[MiniInt, *]](Applicative.catsApplicativeForArrow[Function1, MiniInt])
-             .applicative[Int, Int, Int]
+  checkAll(
+    "Function1[MiniInt, *]",
+    ApplicativeTests[Function1[MiniInt, *]](using Applicative.catsApplicativeForArrow[Function1, MiniInt])
+      .applicative[Int, Int, Int]
   )
 
   // serialization tests for the various Function0-related instances

--- a/tests/shared/src/test/scala/cats/tests/IndexedReaderWriterStateTSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/IndexedReaderWriterStateTSuite.scala
@@ -458,7 +458,7 @@ class ReaderWriterStateTSuite extends CatsSuite {
 
     checkAll(
       "IndexedReaderWriterStateT[ListWrapper, String, String, Int, Int, *]",
-      AlternativeTests[IRWST[ListWrapper, Boolean, String, MiniInt, MiniInt, *]](SA).alternative[Int, Int, Int]
+      AlternativeTests[IRWST[ListWrapper, Boolean, String, MiniInt, MiniInt, *]](using SA).alternative[Int, Int, Int]
     )
     checkAll("Alternative[IndexedReaderWriterStateT[ListWrapper, String, String, Int, Int, *]]",
              SerializableTests.serializable(SA)

--- a/tests/shared/src/test/scala/cats/tests/IndexedStateTSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/IndexedStateTSuite.scala
@@ -521,7 +521,7 @@ class IndexedStateTSuite extends CatsSuite {
     implicit val f: Isomorphisms[IndexedStateT[ListWrapper, MiniInt, MiniInt, *]] = Isomorphisms.invariant(SA)
 
     checkAll("IndexedStateT[ListWrapper, MiniInt, Int, Int]",
-             AlternativeTests[IndexedStateT[ListWrapper, MiniInt, MiniInt, *]](SA).alternative[Int, Int, Int]
+             AlternativeTests[IndexedStateT[ListWrapper, MiniInt, MiniInt, *]](using SA).alternative[Int, Int, Int]
     )
     checkAll("Alternative[IndexedStateT[ListWrapper, Int, Int, *]]", SerializableTests.serializable(SA))
 

--- a/tests/shared/src/test/scala/cats/tests/InjectKSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/InjectKSuite.scala
@@ -88,8 +88,8 @@ class InjectKSuite extends CatsSuite {
                        f2: F[A]
     )(implicit F: Functor[F], I0: Test1Algebra :<: F, I1: Test2Algebra :<: F): Option[Int] =
       for {
-        Test1(x, _) <- I0.prj(f1)
-        Test2(y, _) <- I1.prj(f2)
+        case Test1(x, _) <- I0.prj(f1)
+        case Test2(y, _) <- I1.prj(f2)
       } yield x + y
 
     forAll { (x: Int, y: Int) =>
@@ -105,8 +105,8 @@ class InjectKSuite extends CatsSuite {
                        f2: F[A]
     )(implicit F: Functor[F], I0: Test1Algebra :<: F, I1: Test2Algebra :<: F): Option[Int] =
       for {
-        Test1(x, _) <- I0.unapply(f1)
-        Test2(y, _) <- I1.unapply(f2)
+        case Test1(x, _) <- I0.unapply(f1)
+        case Test2(y, _) <- I1.unapply(f2)
       } yield x + y
 
     forAll { (x: Int, y: Int) =>

--- a/tests/shared/src/test/scala/cats/tests/NestedSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NestedSuite.scala
@@ -77,9 +77,9 @@ class NestedSuite extends CatsSuite {
   {
     // Invariant + Covariant = Invariant
     val instance: Invariant[Nested[ListWrapper, ListWrapper, *]] =
-      Nested.catsDataInvariantForCovariantNested(ListWrapper.invariant, ListWrapper.functor)
+      Nested.catsDataInvariantForCovariantNested(using ListWrapper.invariant, ListWrapper.functor)
     checkAll("Nested[ListWrapper, ListWrapper] - Invariant + Covariant",
-             InvariantTests[Nested[ListWrapper, ListWrapper, *]](instance).invariant[Int, Int, Int]
+             InvariantTests[Nested[ListWrapper, ListWrapper, *]](using instance).invariant[Int, Int, Int]
     )
     checkAll("Invariant[Nested[ListWrapper, ListWrapper, *]] - Invariant + Covariant",
              SerializableTests.serializable(instance)
@@ -88,9 +88,9 @@ class NestedSuite extends CatsSuite {
 
   {
     // Invariant + Contravariant = Invariant
-    val instance = Nested.catsDataInvariantForNestedContravariant(ListWrapper.invariant, Contravariant[Show])
+    val instance = Nested.catsDataInvariantForNestedContravariant(using ListWrapper.invariant, Contravariant[Show])
     checkAll("Nested[ListWrapper, Show, *]",
-             InvariantTests[Nested[ListWrapper, Show, *]](instance).invariant[MiniInt, Int, Boolean]
+             InvariantTests[Nested[ListWrapper, Show, *]](using instance).invariant[MiniInt, Int, Boolean]
     )
     checkAll("Invariant[Nested[ListWrapper, Show, *]]", SerializableTests.serializable(instance))
   }

--- a/tests/shared/src/test/scala/cats/tests/RepresentableStoreTSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/RepresentableStoreTSuite.scala
@@ -48,26 +48,9 @@ class RepresentableStoreTSuite extends CatsSuite {
   val h: Eq[StoreT[Id, MiniInt, StoreT[Id, MiniInt, StoreT[Id, MiniInt, Int]]]] =
     Eq[StoreT[Id, MiniInt, StoreT[Id, MiniInt, StoreT[Id, MiniInt, Int]]]]
 
-  checkAll("StoreT[Id, MiniInt, *]",
-           ComonadTests[StoreT[Id, MiniInt, *]].comonad[Int, Int, Int](
-             a,
-             b,
-             a,
-             b,
-             a,
-             b,
-             c,
-             d,
-             d,
-             d,
-             e,
-             e,
-             f,
-             g,
-             h,
-             f,
-             f
-           )
+  checkAll(
+    "StoreT[Id, MiniInt, *]",
+    ComonadTests[StoreT[Id, MiniInt, *]].comonad[Int, Int, Int](using a, b, a, b, a, b, c, d, d, d, e, e, f, g, h, f, f)
   )
 
   checkAll("Comonad[StoreT[Id, MiniInt, *]]", SerializableTests.serializable(Comonad[StoreT[Id, MiniInt, *]]))

--- a/tests/shared/src/test/scala/cats/tests/SemigroupSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/SemigroupSuite.scala
@@ -47,11 +47,11 @@ class SemigroupSuite extends CatsSuite {
 
   {
     val S = Semigroup.first[Int]
-    checkAll("Semigroup.first", SemigroupTests[Int](S).semigroup)
+    checkAll("Semigroup.first", SemigroupTests[Int](using S).semigroup)
   }
 
   {
     val S = Semigroup.last[Int]
-    checkAll("Semigroup.last", SemigroupTests[Int](S).semigroup)
+    checkAll("Semigroup.last", SemigroupTests[Int](using S).semigroup)
   }
 }

--- a/tests/shared/src/test/scala/cats/tests/SortedSetSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/SortedSetSuite.scala
@@ -43,14 +43,14 @@ class SortedSetSuite extends CatsSuite {
 
   checkAll("SortedSet[Int]", FoldableTests[SortedSet].foldable[Int, Int])
   checkAll("Order[SortedSet[Int]]", OrderTests[SortedSet[Int]].order)
-  checkAll("Order.reverse(Order[SortedSet[Int]])", OrderTests(Order.reverse(Order[SortedSet[Int]])).order)
+  checkAll("Order.reverse(Order[SortedSet[Int]])", OrderTests(using Order.reverse(Order[SortedSet[Int]])).order)
   checkAll("PartialOrder[SortedSet[Int]]", PartialOrderTests[SortedSet[Int]].partialOrder)
   checkAll("PartialOrder.reverse(PartialOrder[SortedSet[Int]])",
-           PartialOrderTests(PartialOrder.reverse(PartialOrder[SortedSet[Int]])).partialOrder
+           PartialOrderTests(using PartialOrder.reverse(PartialOrder[SortedSet[Int]])).partialOrder
   )
   checkAll(
     "PartialOrder.reverse(PartialOrder.reverse(PartialOrder[SortedSet[Int]]))",
-    PartialOrderTests(PartialOrder.reverse(PartialOrder.reverse(PartialOrder[SortedSet[Int]]))).partialOrder
+    PartialOrderTests(using PartialOrder.reverse(PartialOrder.reverse(PartialOrder[SortedSet[Int]]))).partialOrder
   )
 
   checkAll("BoundedSemilattice[SortedSet[String]]", BoundedSemilatticeTests[SortedSet[String]].boundedSemilattice)
@@ -59,10 +59,10 @@ class SortedSetSuite extends CatsSuite {
   )
 
   checkAll("Semilattice.asMeetPartialOrder[SortedSet[Int]]",
-           PartialOrderTests(Semilattice.asMeetPartialOrder[SortedSet[Int]]).partialOrder
+           PartialOrderTests(using Semilattice.asMeetPartialOrder[SortedSet[Int]]).partialOrder
   )
   checkAll("Semilattice.asJoinPartialOrder[SortedSet[Int]]",
-           PartialOrderTests(Semilattice.asJoinPartialOrder[SortedSet[Int]]).partialOrder
+           PartialOrderTests(using Semilattice.asJoinPartialOrder[SortedSet[Int]]).partialOrder
   )
   checkAll("Hash[SortedSet[Int]]", HashTests[SortedSet[Int]].hash)
 

--- a/tests/shared/src/test/scala/cats/tests/TraverseSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/TraverseSuite.scala
@@ -104,7 +104,7 @@ abstract class TraverseSuite[F[_]: Traverse](name: String)(implicit ArbFInt: Arb
 object TraverseSuite {
   // forces testing of the underlying implementation (avoids overridden methods)
   abstract class Underlying[F[_]: Traverse](name: String)(implicit ArbFInt: Arbitrary[F[Int]])
-      extends TraverseSuite(s"$name (underlying)")(proxyTraverse[F], ArbFInt)
+      extends TraverseSuite(s"$name (underlying)")(using proxyTraverse[F], ArbFInt)
 
   // proxies a traverse instance so we can test default implementations
   // to achieve coverage using default datatype instances

--- a/tests/shared/src/test/scala/cats/tests/UnorderedFoldableSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/UnorderedFoldableSuite.scala
@@ -76,7 +76,7 @@ sealed abstract class UnorderedFoldableSuite[F[_]](name: String)(implicit
     }
   }
 
-  checkAll("F[Int]", UnorderedFoldableTests[F](instance).unorderedFoldable[Int, Int])
+  checkAll("F[Int]", UnorderedFoldableTests[F](using instance).unorderedFoldable[Int, Int])
 }
 
 final class UnorderedFoldableSetSuite extends UnorderedFoldableSuite[Set]("set") {


### PR DESCRIPTION
While trying to update Cats in the Dotty community build (a list of projects that the Dotty CI compiles on every push) (see https://github.com/scala/scala3/pull/22949), I found that Cats currently doesn't compile with Scala 3.6.3 for two reasons:

1. When calling a function with implicit parameters, it is now required to explicit pass arguments prefixed with `using`.

    Here is a minimal reproduction:

    ```scala
    package using1
    
    trait Hash[T]
    trait Order[T]
    
    def catsKernelStdHashForSortedSet[X: Hash] = ???
    def catsKernelStdHashForSortedSet[X: Order, Y: Hash] = ???
    
    @main def main =
      val intHash: Hash[Int] = ???
      catsKernelStdHashForSortedSet(intHash)
    ```

    Compiles with Scala 3.3.4:

    ```
    $ scala compile -S 3.3.4 using1.scala
    ```

    Does not compile with Scala 3.6.3:

    ```scala
    $ scala compile -S 3.6.3 using1.scala
    Compiling project (Scala 3.6.3, JVM (21))
    [error] ./using1.scala:11:3
    [error] None of the overloaded alternatives of method catsKernelStdHashForSortedSet in package using1 with types
    [error]  [X, Y](using evidence$1: using1.Order[X], evidence$2: using1.Hash[Y]): Nothing
    [error]  [X](using evidence$1: using1.Hash[X]): Nothing
    [error] match arguments ((intHash : using1.Hash[Int]))
    [error]   catsKernelStdHashForSortedSet(intHash)
    [error]   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    Error compiling project (Scala 3.6.3, JVM (21))
    Compilation failed
    ```

     Instead, a `using` is required before `intHash`:

    ```scala
      catsKernelStdHashForSortedSet(using intHash)
    ```
    
    Note: this change has already been made in at least one other typelevel project: https://github.com/typelevel/doobie/pull/2228.

2. When using a pattern in a for loop that is more specialized than the right hand-side, Scala 3.3.4 emitted a warning:

    ```scala
    package for_case

    @main def main =
      val o: List[Option[Int]] = List(Some(42))
      for Some(x) <- o do
        print(x)
    ```

    ```scala
    $ scala compile -S 3.3.4 for_case.scala
    Compiling project (Scala 3.3.4, JVM (21))
    [warn] ./for_case.scala:5:7
    [warn] pattern's type Some[Int] is more specialized than the right hand side expression's type Option[Int]
    [warn] 
    [warn] If the narrowing is intentional, this can be communicated by adding the `case` keyword before the full pattern,
    [warn] which will result in a filtering for expression (using `withFilter`).
    [warn] This patch can be rewritten automatically under -rewrite -source 3.2-migration.
    [warn]   for Some(x) <- o do
    [warn]       ^^^^^^^
    Compiled project (Scala 3.3.4, JVM (21))
    ```

    This is now an error in Scala 3.6.3.

This PR updates both cases so that Cats compiles with Scala 3.6.3.

These changes should remain compatible with Scala 2.12 and 2.13.

Note: I also tried to apply the automatic rewrites from Scala 3.4 to reduce the number of warnings (see https://github.com/dotty-staging/cats/commit/5ea50ee3c051f02890cd529c22ca300bc0d710e5), but those changes are not compatible with Scala 2.12 and 2.13, so I have not included them.