### PR TITLE
Delete .github/FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,0 @@
-# These are supported funding model platforms
-
-custom: https://opencollective.com/typelevel


### PR DESCRIPTION
Like the Code-of-Conduct and Security Policy, sponsorship information is now inherited from the special `typelevel/.github` repository.

https://github.com/typelevel/.github/blob/main/FUNDING.yml

