### PR TITLE
Add consistency with foldMap law to UnorderedTraverseLaws

### DIFF
--- a/laws/src/main/scala/cats/laws/UnorderedTraverseLaws.scala
+++ b/laws/src/main/scala/cats/laws/UnorderedTraverseLaws.scala
@@ -22,7 +22,8 @@
 package cats
 package laws
 
-import cats.data.Nested
+import cats.data.{Const, Nested}
+import cats.kernel.CommutativeMonoid
 
 trait UnorderedTraverseLaws[F[_]] extends UnorderedFoldableLaws[F] {
   implicit def F: UnorderedTraverse[F]
@@ -71,6 +72,8 @@ trait UnorderedTraverseLaws[F[_]] extends UnorderedFoldableLaws[F] {
   def unorderedSequenceConsistent[A, G[_]: CommutativeApplicative](fga: F[G[A]]): IsEq[G[F[A]]] =
     F.unorderedTraverse(fga)(identity) <-> F.unorderedSequence(fga)
 
+  def unorderedTraverseConsistentUnorderedFoldMap[A, B: CommutativeMonoid](fa: F[A], fn: A => B): IsEq[B] =
+    F.unorderedTraverse(fa)(a => Const[B, B](fn(a))).getConst <-> F.unorderedFoldMap(fa)(fn)
 }
 
 object UnorderedTraverseLaws {

--- a/laws/src/main/scala/cats/laws/discipline/UnorderedTraverseTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/UnorderedTraverseTests.scala
@@ -58,7 +58,10 @@ trait UnorderedTraverseTests[F[_]] extends UnorderedFoldableTests[F] {
       laws.unorderedTraverseSequentialComposition[A, B, C, X, Y] _
     ),
     "unordered traverse parallel composition" -> forAll(laws.unorderedTraverseParallelComposition[A, B, X, Y] _),
-    "unordered traverse consistent with sequence" -> forAll(laws.unorderedSequenceConsistent[B, X] _)
+    "unordered traverse consistent with sequence" -> forAll(laws.unorderedSequenceConsistent[B, X] _),
+    "unordered traverse consistent with unorderedFoldMap" -> forAll(
+      laws.unorderedTraverseConsistentUnorderedFoldMap[A, B](_, _)
+    )
   )
 }
 


### PR DESCRIPTION
This adds that unorderedTraverse should be consistent with unorderedFoldMap, which seems intuitively obvious, but isn't checked.

Adding this law passes for both the current implementations of UnorderedTraverse (a typeclass I think very rarely used). However, note I just created: https://github.com/typelevel/cats/issues/4802 which argues that `UnorderedTraverse[Set]` should be deprecated because it *should* be unlawful (although with the current laws it is not).