### PR TITLE
Add `using` clause. fix compile error with Scala 3.8

### DIFF
--- a/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
+++ b/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
@@ -475,7 +475,7 @@ class NonEmptyLazyListOps[A](private val value: NonEmptyLazyList[A])
    * }}}
    */
   final def toNem[T, U](implicit ev: A <:< (T, U), order: Order[T]): NonEmptyMap[T, U] =
-    NonEmptyMap.fromMapUnsafe(SortedMap(toLazyList.map(ev): _*)(order.toOrdering))
+    NonEmptyMap.fromMapUnsafe(SortedMap(toLazyList.map(ev): _*)(using order.toOrdering))
 
   /**
    * Creates new `NonEmptySet`, similarly to List#toSet from scala standard library.

--- a/core/src/main/scala/cats/data/NonEmptyChain.scala
+++ b/core/src/main/scala/cats/data/NonEmptyChain.scala
@@ -611,7 +611,7 @@ class NonEmptyChainOps[A](private val value: NonEmptyChain[A])
   final def sortBy[B](f: A => B)(implicit B: Order[B]): NonEmptyChain[A] = create(toChain.sortBy(f))
   final def sorted[AA >: A](implicit AA: Order[AA]): NonEmptyChain[AA] = create(toChain.sorted[AA])
   final def toNem[T, V](implicit ev: A <:< (T, V), order: Order[T]): NonEmptyMap[T, V] =
-    NonEmptyMap.fromMapUnsafe(SortedMap(toChain.toVector.map(ev): _*)(order.toOrdering))
+    NonEmptyMap.fromMapUnsafe(SortedMap(toChain.toVector.map(ev): _*)(using order.toOrdering))
   final def toNes[B >: A](implicit order: Order[B]): NonEmptySet[B] = NonEmptySet.of(head, tail.toVector: _*)
   final def zipWithIndex: NonEmptyChain[(A, Int)] = create(toChain.zipWithIndex)
 

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -693,7 +693,7 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
    * }}}
    */
   def toNem[T, U](implicit ev: A <:< (T, U), order: Order[T]): NonEmptyMap[T, U] =
-    NonEmptyMap.fromMapUnsafe(SortedMap(toList.map(ev): _*)(order.toOrdering))
+    NonEmptyMap.fromMapUnsafe(SortedMap(toList.map(ev): _*)(using order.toOrdering))
 
   /**
    * Creates new `NonEmptySet`, similarly to List#toSet from scala standard library.

--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -57,13 +57,13 @@ object NonEmptyMapImpl extends NonEmptyMapInstances with Newtype2 {
     fromMapUnsafe(m)
 
   def apply[K, A](head: (K, A), tail: SortedMap[K, A])(implicit K: Order[K]): NonEmptyMap[K, A] =
-    create(SortedMap(head)(K.toOrdering) ++ tail)
+    create(SortedMap(head)(using K.toOrdering) ++ tail)
 
   def of[K, A](a: (K, A), as: (K, A)*)(implicit K: Order[K]): NonEmptyMap[K, A] =
-    create(SortedMap(as: _*)(K.toOrdering) + a)
+    create(SortedMap(as: _*)(using K.toOrdering) + a)
 
   def one[K, A](k: K, a: A)(implicit K: Order[K]): NonEmptyMap[K, A] =
-    create(SortedMap((k, a))(K.toOrdering))
+    create(SortedMap((k, a))(using K.toOrdering))
 
   implicit def catsNonEmptyMapOps[K, A](value: Type[K, A]): NonEmptyMapOps[K, A] =
     new NonEmptyMapOps(value)

--- a/core/src/main/scala/cats/data/NonEmptySeq.scala
+++ b/core/src/main/scala/cats/data/NonEmptySeq.scala
@@ -381,7 +381,7 @@ final class NonEmptySeq[+A] private (val toSeq: Seq[A]) extends AnyVal with NonE
    * }}}
    */
   final def toNem[T, U](implicit ev: A <:< (T, U), order: Order[T]): NonEmptyMap[T, U] =
-    NonEmptyMap.fromMapUnsafe(SortedMap(toSeq.map(ev): _*)(order.toOrdering))
+    NonEmptyMap.fromMapUnsafe(SortedMap(toSeq.map(ev): _*)(using order.toOrdering))
 
   /**
    * Creates new `NonEmptySet`, similarly to List#toSet from scala standard library.

--- a/core/src/main/scala/cats/data/NonEmptySet.scala
+++ b/core/src/main/scala/cats/data/NonEmptySet.scala
@@ -51,11 +51,11 @@ object NonEmptySetImpl extends NonEmptySetInstances with Newtype {
     else throw new IllegalArgumentException("Cannot create NonEmptySet from empty set")
 
   def of[A](a: A, as: A*)(implicit A: Order[A]): NonEmptySet[A] =
-    create(SortedSet(a +: as: _*)(A.toOrdering))
+    create(SortedSet(a +: as: _*)(using A.toOrdering))
 
   def apply[A](head: A, tail: SortedSet[A])(implicit A: Order[A]): NonEmptySet[A] =
-    create(SortedSet(head)(A.toOrdering) ++ tail)
-  def one[A](a: A)(implicit A: Order[A]): NonEmptySet[A] = create(SortedSet(a)(A.toOrdering))
+    create(SortedSet(head)(using A.toOrdering) ++ tail)
+  def one[A](a: A)(implicit A: Order[A]): NonEmptySet[A] = create(SortedSet(a)(using A.toOrdering))
 
   implicit def catsNonEmptySetOps[A](value: NonEmptySet[A]): NonEmptySetOps[A] =
     new NonEmptySetOps(value)

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -373,7 +373,7 @@ final class NonEmptyVector[+A] private (val toVector: Vector[A])
    * }}}
    */
   final def toNem[T, U](implicit ev: A <:< (T, U), order: Order[T]): NonEmptyMap[T, U] =
-    NonEmptyMap.fromMapUnsafe(SortedMap(toVector.map(ev): _*)(order.toOrdering))
+    NonEmptyMap.fromMapUnsafe(SortedMap(toVector.map(ev): _*)(using order.toOrdering))
 
   /**
    * Creates new `NonEmptySet`, similarly to List#toSet from scala standard library.

--- a/core/src/main/scala/cats/instances/sortedMap.scala
+++ b/core/src/main/scala/cats/instances/sortedMap.scala
@@ -80,8 +80,8 @@ trait SortedMapInstances extends SortedMapInstances2 {
 
       override def unzip[A, B](fab: SortedMap[K, (A, B)]): (SortedMap[K, A], SortedMap[K, B]) = {
         implicit val ordering: Ordering[K] = fab.ordering
-        val leftBuilder = SortedMap.newBuilder[K, A](ordering)
-        val rightBuilder = SortedMap.newBuilder[K, B](ordering)
+        val leftBuilder = SortedMap.newBuilder[K, A](using ordering)
+        val rightBuilder = SortedMap.newBuilder[K, B](using ordering)
         leftBuilder.sizeHint(fab.size)
         rightBuilder.sizeHint(fab.size)
         fab.foreach { case (k, (a, b)) =>
@@ -95,7 +95,7 @@ trait SortedMapInstances extends SortedMapInstances2 {
         fa: SortedMap[K, A],
         fb: Eval[SortedMap[K, B]]
       )(f: (A, B) => Z): Eval[SortedMap[K, Z]] =
-        if (fa.isEmpty) Eval.now(SortedMap.empty(fa.ordering)) // no need to evaluate fb
+        if (fa.isEmpty) Eval.now(SortedMap.empty(using fa.ordering)) // no need to evaluate fb
         else fb.map(fb => map2(fa, fb)(f))
 
       override def ap2[A, B, Z](f: SortedMap[K, (A, B) => Z])(
@@ -116,7 +116,7 @@ trait SortedMapInstances extends SortedMapInstances2 {
 
       def tailRecM[A, B](a: A)(f: A => SortedMap[K, Either[A, B]]): SortedMap[K, B] = {
         val fa = f(a)
-        val bldr = SortedMap.newBuilder[K, B](fa.ordering)
+        val bldr = SortedMap.newBuilder[K, B](using fa.ordering)
 
         @tailrec def descend(k: K, either: Either[A, B]): Unit =
           either match {
@@ -169,7 +169,7 @@ trait SortedMapInstances extends SortedMapInstances2 {
 
       override def alignWith[A, B, C](fa: SortedMap[K, A], fb: SortedMap[K, B])(f: Ior[A, B] => C): SortedMap[K, C] = {
         val keys = fa.keySet ++ fb.keySet
-        val builder = SortedMap.newBuilder[K, C](fa.ordering)
+        val builder = SortedMap.newBuilder[K, C](using fa.ordering)
         builder.sizeHint(keys.size)
         keys
           .foldLeft(builder) { (builder, k) =>
@@ -285,7 +285,7 @@ private[instances] trait SortedMapInstancesBinCompat1 {
 
   implicit def catsStdMonoidKForSortedMap[K: Order]: MonoidK[SortedMap[K, *]] =
     new MonoidK[SortedMap[K, *]] {
-      override def empty[A]: SortedMap[K, A] = SortedMap.empty[K, A](Order[K].toOrdering)
+      override def empty[A]: SortedMap[K, A] = SortedMap.empty[K, A](using Order[K].toOrdering)
       override def combineK[A](x: SortedMap[K, A], y: SortedMap[K, A]): SortedMap[K, A] = x ++ y
     }
 }

--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -77,7 +77,7 @@ object KernelCheck {
 
   // Copied from cats-laws.
   implicit def arbitrarySortedMap[K: Arbitrary: Order, V: Arbitrary]: Arbitrary[SortedMap[K, V]] =
-    Arbitrary(arbitrary[Map[K, V]].map(s => SortedMap.empty[K, V](implicitly[Order[K]].toOrdering) ++ s))
+    Arbitrary(arbitrary[Map[K, V]].map(s => SortedMap.empty[K, V](using implicitly[Order[K]].toOrdering) ++ s))
 
   // Copied from cats-laws.
   implicit def cogenSortedMap[K: Order: Cogen, V: Cogen]: Cogen[SortedMap[K, V]] = {
@@ -88,7 +88,7 @@ object KernelCheck {
 
   // Copied from cats-laws.
   implicit def arbitrarySortedSet[A: Arbitrary: Order]: Arbitrary[SortedSet[A]] =
-    Arbitrary(arbitrary[Set[A]].map(s => SortedSet.empty[A](implicitly[Order[A]].toOrdering) ++ s))
+    Arbitrary(arbitrary[Set[A]].map(s => SortedSet.empty[A](using implicitly[Order[A]].toOrdering) ++ s))
 
   // Copied from cats-laws.
   implicit def cogenSortedSet[A: Order: Cogen]: Cogen[SortedSet[A]] = {

--- a/kernel/src/main/scala/cats/kernel/instances/SortedMapInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/SortedMapInstances.scala
@@ -178,5 +178,5 @@ class SortedMapMonoid[K, V](implicit V: Semigroup[V], O: Order[K])
     extends SortedMapSemigroup[K, V]
     with Monoid[SortedMap[K, V]] {
 
-  def empty: SortedMap[K, V] = SortedMap.empty(O.toOrdering)
+  def empty: SortedMap[K, V] = SortedMap.empty(using O.toOrdering)
 }

--- a/kernel/src/main/scala/cats/kernel/instances/SortedSetInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/SortedSetInstances.scala
@@ -102,6 +102,6 @@ class SortedSetHash[A](implicit hashA: Hash[A]) extends Hash[SortedSet[A]] {
 }
 
 class SortedSetSemilattice[A: Order] extends BoundedSemilattice[SortedSet[A]] {
-  def empty: SortedSet[A] = SortedSet.empty(implicitly[Order[A]].toOrdering)
+  def empty: SortedSet[A] = SortedSet.empty(using implicitly[Order[A]].toOrdering)
   def combine(x: SortedSet[A], y: SortedSet[A]): SortedSet[A] = x | y
 }

--- a/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
+++ b/laws/src/main/scala/cats/laws/discipline/arbitrary.scala
@@ -297,7 +297,7 @@ object arbitrary extends ArbitraryInstances0 with ScalaVersionSpecific.Arbitrary
     Arbitrary(getArbitrary[Int => Int].map(f => Order.by(x => f(x.##))))
 
   implicit def catsLawsArbitraryForSortedMap[K: Arbitrary: Order, V: Arbitrary]: Arbitrary[SortedMap[K, V]] =
-    Arbitrary(getArbitrary[Map[K, V]].map(s => SortedMap.empty[K, V](implicitly[Order[K]].toOrdering) ++ s))
+    Arbitrary(getArbitrary[Map[K, V]].map(s => SortedMap.empty[K, V](using implicitly[Order[K]].toOrdering) ++ s))
 
   @deprecated("Preserved for bincompat", "2.9.0")
   def catsLawsCogenForSortedMap[K, V](kOrder: Order[K],
@@ -319,7 +319,7 @@ object arbitrary extends ArbitraryInstances0 with ScalaVersionSpecific.Arbitrary
   }
 
   implicit def catsLawsArbitraryForSortedSet[A: Arbitrary: Order]: Arbitrary[SortedSet[A]] =
-    Arbitrary(getArbitrary[Set[A]].map(s => SortedSet.empty[A](implicitly[Order[A]].toOrdering) ++ s))
+    Arbitrary(getArbitrary[Set[A]].map(s => SortedSet.empty[A](using implicitly[Order[A]].toOrdering) ++ s))
 
   implicit def catsLawsCogenForSortedSet[A: Order: Cogen]: Cogen[SortedSet[A]] = {
     implicit val orderingA: Ordering[A] = Order[A].toOrdering


### PR DESCRIPTION
```
Welcome to Scala 3.7.4 (21.0.9, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                            
scala> scala.collection.immutable.SortedMap(1 -> 2)(implicitly[Ordering[Int]])
1 warning found
-- Warning: --------------------------------------------------------------------
1 |scala.collection.immutable.SortedMap(1 -> 2)(implicitly[Ordering[Int]])
  |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^
  |Implicit parameters should be provided with a `using` clause.
  |To disable the warning, please use the following option:
  |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
val res0: scala.collection.immutable.SortedMap[Int, Int] = TreeMap(1 -> 2)
```

```
Welcome to Scala 3.8.0-RC5 (21.0.9, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                            
scala> scala.collection.immutable.SortedMap(1 -> 2)(implicitly[Ordering[Int]])
-- [E007] Type Mismatch Error: -------------------------------------------------
1 |scala.collection.immutable.SortedMap(1 -> 2)(implicitly[Ordering[Int]])
  |                                             ^^^^^^^^^^^^^^^^^^^^^^^^^
  |                                             Found:    Ordering[Int]
  |                                             Required: Int
  |
  | longer explanation available when compiling with `-explain`
1 error found
                                                                                                                                            
scala> scala.collection.immutable.SortedMap(1 -> 2)(using implicitly[Ordering[Int]])
val res0: scala.collection.immutable.SortedMap[Int, Int] = TreeMap(1 -> 2)
```