### PR TITLE
Add Nullable type to cats data with instances

### DIFF
--- a/core/src/main/scala-3/cats/data/Nullable.scala
+++ b/core/src/main/scala-3/cats/data/Nullable.scala
@@ -28,6 +28,31 @@ import scala.quoted.*
 opaque type Nullable[+A] = A | Null
 
 object Nullable extends NullableInstances {
+  type Flattened[A] = A match {
+    case Nullable[x] => Nullable[x]
+    case _           => Nullable[A]
+  }
+
+  private[data] sealed trait Flattening[A, B] {
+    def apply(value: Nullable[A]): B
+  }
+
+  private[data] object Flattening extends Flattening0 {
+    given [A, B](using next: Flattening[A, B]): Flattening[Nullable[A], B] with {
+      def apply(value: Nullable[Nullable[A]]): B = {
+        next(value.asInstanceOf[Nullable[A]])
+      }
+    }
+  }
+
+  private[data] trait Flattening0 {
+    given [A]: Flattening[A, Nullable[A]] with {
+      def apply(value: Nullable[A]): Nullable[A] = {
+        value
+      }
+    }
+  }
+
   // If we enable explicit nulls, strict equality needs this `CanEqual` for `== null` checks.
   // We keep it `private[data]` (not `private`) because explicit nulls are not enabled right now,
   // and a `private given` would otherwise trigger an unused-private-member warning.
@@ -79,11 +104,9 @@ object Nullable extends NullableInstances {
     inline def iterator: Iterator[A] = {
       fold(Iterator.empty)(Iterator.single(_))
     }
-  }
 
-  extension [A](inline nested: Nullable[Nullable[A]]) {
-    inline def flatten: Nullable[A] = {
-      nested
+    inline def flatten[B](using flattening: Flattening[A, B]): B = {
+      flattening(nullable)
     }
   }
 

--- a/tests/shared/src/test/scala-3/cats/tests/NullableSuite.scala
+++ b/tests/shared/src/test/scala-3/cats/tests/NullableSuite.scala
@@ -135,6 +135,17 @@ class NullableSuite extends CatsSuite {
     }
   }
 
+  test("flatten removes any number of nested Nullable wrappers down to one layer") {
+    val tripleEmpty: Nullable[Nullable[Nullable[Int]]] = Nullable(Nullable(Nullable.empty[Int]))
+    val tripleNonEmpty: Nullable[Nullable[Nullable[Int]]] = Nullable(Nullable(Nullable(1)))
+
+    val flattenedEmpty: Nullable[Int] = tripleEmpty.flatten
+    val flattenedNonEmpty: Nullable[Int] = tripleNonEmpty.flatten
+
+    assert(flattenedEmpty === Nullable.empty[Int])
+    assert(flattenedNonEmpty === Nullable(1))
+  }
+
   test("minimal Functor[Nullable] fails composition when composed with itself") {
     val candidate = new Functor[Nullable] {
       def map[A, B](fa: Nullable[A])(f: A => B): Nullable[B] =


### PR DESCRIPTION
closes #4822 

The idea is to be able to use nullable types from java (or even scala for unboxed optionality) but do so fully safely, so we can't confuse the nullable type with a non-nullable type.

Note: as suspected in #4822 both Monad and Applicative are not lawful. So instances were not added (someone could add them to alleycats, but I'm not motivated to add non-lawful instances).

For those cases, the user should be able to use `.fold` which is as efficient as a hand written if/else with casting and can express all the operations you want to do.

The functor methods are implemented which could be more efficiently done than with map and we test against the default implementations.