### PR TITLE
Fix copy-paste scaladoc variable names in NonEmptyVector, NonEmptySeq, NonEmptyChain

### DIFF
--- a/core/src/main/scala/cats/data/NonEmptyChain.scala
+++ b/core/src/main/scala/cats/data/NonEmptyChain.scala
@@ -434,9 +434,9 @@ class NonEmptyChainOps[A](private val value: NonEmptyChain[A])
    * {{{
    * scala> import cats.data.NonEmptyChain
    * scala> import cats.syntax.all._
-   * scala> val nel = NonEmptyChain.of(12, -2, 3, -5)
+   * scala> val nec = NonEmptyChain.of(12, -2, 3, -5)
    * scala> val expectedResult = List(NonEmptyChain.of(12, -2), NonEmptyChain.of(3, -5))
-   * scala> val result = nel.grouped(2)
+   * scala> val result = nec.grouped(2)
    * scala> result.toList === expectedResult
    * res0: Boolean = true
    * }}}

--- a/core/src/main/scala/cats/data/NonEmptySeq.scala
+++ b/core/src/main/scala/cats/data/NonEmptySeq.scala
@@ -339,9 +339,9 @@ final class NonEmptySeq[+A] private (val toSeq: Seq[A]) extends AnyVal with NonE
    * {{{
    * scala> import cats.data.{NonEmptyMap, NonEmptySeq}
    * scala> import cats.syntax.all._
-   * scala> val nel = NonEmptySeq.of(12, -2, 3, -5)
+   * scala> val neSeq = NonEmptySeq.of(12, -2, 3, -5)
    * scala> val expectedResult = NonEmptyMap.of(false -> NonEmptySeq.of(-2, -5), true -> NonEmptySeq.of(12, 3))
-   * scala> val result = nel.groupByNem(_ >= 0)
+   * scala> val result = neSeq.groupByNem(_ >= 0)
    * scala> result === expectedResult
    * res0: Boolean = true
    * }}}
@@ -355,9 +355,9 @@ final class NonEmptySeq[+A] private (val toSeq: Seq[A]) extends AnyVal with NonE
    * {{{
    * scala> import cats.data.NonEmptySeq
    * scala> import cats.syntax.all._
-   * scala> val nel = NonEmptySeq.of(12, -2, 3, -5)
+   * scala> val neSeq = NonEmptySeq.of(12, -2, 3, -5)
    * scala> val expectedResult = List(NonEmptySeq.of(12, -2), NonEmptySeq.of(3, -5))
-   * scala> val result = nel.grouped(2)
+   * scala> val result = neSeq.grouped(2)
    * scala> result.toList === expectedResult
    * res0: Boolean = true
    * }}}

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -332,9 +332,9 @@ final class NonEmptyVector[+A] private (val toVector: Vector[A])
    * {{{
    * scala> import cats.data.{NonEmptyMap, NonEmptyVector}
    * scala> import cats.syntax.all._
-   * scala> val nel = NonEmptyVector.of(12, -2, 3, -5)
+   * scala> val nev = NonEmptyVector.of(12, -2, 3, -5)
    * scala> val expectedResult = NonEmptyMap.of(false -> NonEmptyVector.of(-2, -5), true -> NonEmptyVector.of(12, 3))
-   * scala> val result = nel.groupByNem(_ >= 0)
+   * scala> val result = nev.groupByNem(_ >= 0)
    * scala> result === expectedResult
    * res0: Boolean = true
    * }}}
@@ -348,9 +348,9 @@ final class NonEmptyVector[+A] private (val toVector: Vector[A])
    * {{{
    * scala> import cats.data.NonEmptyVector
    * scala> import cats.syntax.all._
-   * scala> val nel = NonEmptyVector.of(12, -2, 3, -5)
+   * scala> val nev = NonEmptyVector.of(12, -2, 3, -5)
    * scala> val expectedResult = List(NonEmptyVector.of(12, -2), NonEmptyVector.of(3, -5))
-   * scala> val result = nel.grouped(2)
+   * scala> val result = nev.grouped(2)
    * scala> result.toList === expectedResult
    * res0: Boolean = true
    * }}}


### PR DESCRIPTION
## Problem

Scaladoc examples in `groupByNem` and `grouped` inside `NonEmptyVector`, `NonEmptySeq`, and `NonEmptyChain` were copied from `NonEmptyList` and never had their variable names updated. All three used `nel` (short for NonEmptyList) instead of a name matching the actual type.

## Changes

Renamed the scaladoc example variable in each affected file:

| File | Before | After |
|---|---|---|
| `NonEmptyVector.scala` | `val nel = NonEmptyVector.of(...)` | `val nev = NonEmptyVector.of(...)` |
| `NonEmptySeq.scala` | `val nel = NonEmptySeq.of(...)` | `val neSeq = NonEmptySeq.of(...)` |
| `NonEmptyChain.scala` | `val nel = NonEmptyChain.of(...)` | `val nec = NonEmptyChain.of(...)` |

