### PR TITLE
Deprecate shadowed sequenceVoid/sequence_/foldK in Foldable.Ops

### DIFF
--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -1073,13 +1073,22 @@ object Foldable {
       typeClassInstance.traverseVoid[G, A, B](self)(f)(G)
     def traverse_[G[_], B](f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
       traverseVoid[G, B](f)
-    // TODO: looks like these two methods below duplicate the same named methods from `NestedFoldableOps`.
-    //       Moreover, the other two methods take precedence, thereby these two are not in use whatsoever.
-    //       Perhaps it makes sense to deprecate one pair of them either here or there.
+    @deprecated(
+      "Use catsSyntaxNestedFoldable (via cats.syntax.all._) to call sequenceVoid on F[G[A]]",
+      "2.13.0"
+    )
     def sequenceVoid[G[_], B](implicit ev$1: A <:< G[B], ev$2: Applicative[G]): G[Unit] =
       typeClassInstance.sequenceVoid[G, B](self.asInstanceOf[F[G[B]]])
+    @deprecated(
+      "Use catsSyntaxNestedFoldable (via cats.syntax.all._) to call sequence_ on F[G[A]]",
+      "2.13.0"
+    )
     def sequence_[G[_], B](implicit ev$1: A <:< G[B], ev$2: Applicative[G]): G[Unit] =
       sequenceVoid[G, B]
+    @deprecated(
+      "Use catsSyntaxNestedFoldable (via cats.syntax.all._) to call foldK on F[G[A]]",
+      "2.13.0"
+    )
     def foldK[G[_], B](implicit ev$1: A <:< G[B], G: MonoidK[G]): G[B] =
       typeClassInstance.foldK[G, B](self.asInstanceOf[F[G[B]]])(G)
     def find(f: A => Boolean): Option[A] = typeClassInstance.find[A](self)(f)

--- a/core/src/main/scala/cats/syntax/foldable.scala
+++ b/core/src/main/scala/cats/syntax/foldable.scala
@@ -47,8 +47,6 @@ private[syntax] trait FoldableSyntaxBinCompat1 {
 }
 
 final class NestedFoldableOps[F[_], G[_], A](private val fga: F[G[A]]) extends AnyVal {
-  // TODO: looks like these two methods below duplicate the same named methods from `Foldable.Ops`.
-  //       Perhaps it makes sense to deprecate one pair of them either here or there.
   def sequenceVoid(implicit F: Foldable[F], G: Applicative[G]): G[Unit] = F.sequenceVoid(fga)
   def sequence_(implicit F: Foldable[F], G: Applicative[G]): G[Unit] = sequenceVoid
 
@@ -64,8 +62,6 @@ final class NestedFoldableOps[F[_], G[_], A](private val fga: F[G[A]]) extends A
    * res0: Set[Int] = Set(1, 2, 3, 4)
    * }}}
    */
-  // TODO: looks like this method below duplicate the same named one from `Foldable.Ops`.
-  //       Perhaps it makes sense to deprecate one of them.
   def foldK(implicit F: Foldable[F], G: MonoidK[G]): G[A] = F.foldK(fga)
 }
 


### PR DESCRIPTION
## Background

Both `Foldable.scala` and `syntax/foldable.scala` contained TODO comments noting that three methods are duplicated across `Foldable.Ops` and `NestedFoldableOps`:

## Root cause

The three methods — `sequenceVoid`, `sequence_`, and `foldK` — exist in both:

- `Foldable.Ops` (in `Foldable.scala`): defined on `F[A]` with an `A <:< G[B]` constraint
- `NestedFoldableOps` (in `syntax/foldable.scala`): defined on `F[G[A]]` directly

Scala's implicit resolution picks `NestedFoldableOps` because it has a more specific type, meaning the `Foldable.Ops` versions are **permanently unreachable** and have never been called in practice.

## Changes

- Adds `@deprecated("...", "2.13.0")` to the three shadowed methods in `Foldable.Ops`
- Removes the now-resolved TODO comments from both `Foldable.scala` and `syntax/foldable.scala`
