### PR TITLE
Add withFilter to FunctorFilter.Ops for  efficient compilation of for-comprehensions with if guard

### DIFF
--- a/core/src/main/scala/cats/FunctorFilter.scala
+++ b/core/src/main/scala/cats/FunctorFilter.scala
@@ -97,6 +97,20 @@ trait FunctorFilter[F[_]] extends Serializable {
 }
 
 object FunctorFilter extends ScalaVersionSpecificTraverseFilterInstances with FunctorFilterInstances0 {
+
+  /**
+   * A lazy wrapper supporting Scala `for`-comprehensions.
+   */
+  class WithFilter[F[_], A](fa: F[A], p: A => Boolean)(implicit F: FunctorFilter[F]) {
+    def map[B](f: A => B): F[B] =
+      F.mapFilter(fa)(a => if (p(a)) Some(f(a)) else None)
+
+    def flatMap[B](f: A => F[B])(implicit flatMapF: FlatMap[F]): F[B] =
+      flatMapF.flatMap(F.filter(fa)(p))(f)
+
+    def withFilter(q: A => Boolean): WithFilter[F, A] =
+      new WithFilter[F, A](fa, a => p(a) && q(a))
+  }
   implicit def catsTraverseFilterForOption: TraverseFilter[Option] =
     cats.instances.option.catsStdTraverseFilterForOption
   implicit def catsTraverseFilterForList: TraverseFilter[List] = cats.instances.list.catsStdTraverseFilterForList
@@ -135,6 +149,8 @@ object FunctorFilter extends ScalaVersionSpecificTraverseFilterInstances with Fu
       typeClassInstance.flattenOption[B](self.asInstanceOf[F[Option[B]]])
     def filter(f: A => Boolean): F[A] = typeClassInstance.filter[A](self)(f)
     def filterNot(f: A => Boolean): F[A] = typeClassInstance.filterNot[A](self)(f)
+    def withFilter(f: A => Boolean): FunctorFilter.WithFilter[F, A] =
+      new FunctorFilter.WithFilter[F, A](self, f)(typeClassInstance)
   }
   trait AllOps[F[_], A] extends Ops[F, A]
   trait ToFunctorFilterOps extends Serializable {

--- a/tests/shared/src/test/scala/cats/tests/FunctorFilterSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/FunctorFilterSuite.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright (c) 2015 Typelevel
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package cats.tests
+
+import cats.syntax.all.*
+import cats.Functor
+import cats.FunctorFilter
+
+class FunctorFilterSuite extends CatsSuite {
+
+  test("withFilter alias allows for-comprehensions with guards") {
+    // Explicitly use FunctorFilter to provide the withFilter method
+    // to prove that for-comprehension guards work on any FunctorFilter
+    def filterEvens[F[_]: FunctorFilter, A](fa: F[A])(implicit
+      ev: A =:= Int
+    ): F[A] = {
+      implicit val F: Functor[F] = FunctorFilter[F].functor
+      for {
+        a <- fa
+        if ev(a) % 2 == 0
+      } yield a
+    }
+
+    val list = List(1, 2, 3, 4, 5)
+    val evens = filterEvens(list)
+
+    assertEquals(evens, List(2, 4))
+  }
+
+  test("withFilter is lazy and does not evaluate until map is called") {
+    var evaluationCount = 0
+
+    val list = List(1, 2, 3)
+
+    def getWrapper[F[_]: FunctorFilter, A](fa: F[A])(f: A => Boolean) =
+      fa.withFilter(f)
+
+    // Create the lazy WithFilter wrapper.
+    // If it were strict, it would iterate immediately.
+    val lazyWrapper = getWrapper(list) { x =>
+      evaluationCount += 1
+      x > 1
+    }
+
+    // It has not been mapped yet, so the evaluation count should be 0.
+    assertEquals(evaluationCount, 0)
+
+    // Now we map over it. This forces the evaluation.
+    val result = lazyWrapper.map(_ * 2)
+
+    // The list has 3 elements, so the predicate should be called 3 times.
+    assertEquals(evaluationCount, 3)
+    assertEquals(result, List(4, 6))
+  }
+
+}


### PR DESCRIPTION
## What does this does PR do?
In this PR I tried to solve compilation issue by Scala compiler when it try compiles _for-comprehensions with if guards_ by adding **withFilter()** method.

I took the help AI to understand what withFilter() method is and what does it do , what is for-comprehensions and for-comprehensions with if guard and since withFilter() method missing I took the help of AI to add it.

## What is the problem?
The **cats.FunctorFilter** typeclass (which is designed exactly for filtering data structures!) only had a method named filter(). It was missing a method named withFilter(). Because of this naming mismatch, if a user tried to write a for-comprehension with an if guard on a Cats FunctorFilter type, the Scala compiler would throw an error saying value withFilter is not a member, and the code would fail to compile!

## How I resolve this?
We simply needed to provide a withFilter method that the Scala compiler could find when it translates those for-comprehensions.
**How??**:
1.In **FunctorFilter.scala**, we added a new method to the FunctorFilter trait:
```scala
def withFilter[A](<fa: F[A]>)(f: A => Boolean): F[A] =
  filter(fa)(f)
```

2. We also added that same withFilter method to the implicit syntax operations (FunctorFilter.Ops). This allows users to call **.withFilter** on any type that has a FunctorFilter instance (like a List, Vector, Option, etc.) as if it were a built-in method

By simply providing this method name, the Scala compiler is now happy. When a user writes an if guard inside a for-comprehension using Cats types, the compiler successfully finds our new .withFilter method, and the code compiles and runs perfectly.

I took the help AI to understand what withFilter() method is and what does it do , what is for-comprehensions and for-comprehensions with if guard and since withFilter() method missing I took the help of AI to add it.



## Code overview
1. 

**(cats/core/src/main/scala/cats/FunctorFilter.scala)**
**Adding the withFilter method alias onto the core typeclass:**
```scala
  /**
   * Apply a filter to a structure such that the output structure contains all
   * `A` elements in the input structure that satisfy the predicate `f` but none
   * that don't.
   */
  def filter[A](<fa: F[A]>)(f: A => Boolean): F[A] =
    mapFilter(fa)(a => if (f(a)) Some(a) else None)

  /**
   * Alias for [[filter]].
   * Enables Scala `for`-comprehension `if` guards on FunctorFilter instances.
   */
  def withFilter[A](<fa: F[A]>)(f: A => Boolean): F[A] =
    filter(fa)(f)
```
**Adding withFilter to the extension methods (Syntax Ops):**
```scala

  trait Ops[F[_], A] extends Serializable {
    type TypeClassType <: FunctorFilter[F]
    def self: F[A]
    val typeClassInstance: TypeClassType
    def mapFilter[B](<f: A => Option[B]>): F[B] = typeClassInstance.mapFilter[A, B](self)(f)
    def collect[B](<f: PartialFunction[A, B]>): F[B] = typeClassInstance.collect[A, B](self)(f)
    def flattenOption[B](<implicit ev$1: A <:< Option[B]>): F[B] =
      typeClassInstance.flattenOption[B](self.asInstanceOf[F[Option[B]]])
    def filter(f: A => Boolean): F[A] = typeClassInstance.filter[A](self)(f)
    def filterNot(f: A => Boolean): F[A] = typeClassInstance.filterNot[A](self)(f)
    def withFilter(f: A => Boolean): F[A] = typeClassInstance.withFilter[A](self)(f)
  }
```

2. 

**(cats/tests/shared/src/test/scala/cats/tests/FunctorFilterSuite.scala)**
**Creating the suite to prevent regression and verify for-comprehensions compile:**
```scala
// NEW FILE
package cats.tests

import cats.syntax.all._
import cats.Functor
import cats.FunctorFilter

class FunctorFilterSuite extends CatsSuite {

  test("withFilter alias allows for-comprehensions with guards") {
    // Explicitly use FunctorFilter to provide the withFilter method
    // to prove that for-comprehension guards work on any FunctorFilter
    def filterEvens[F[_]: FunctorFilter, A](fa: F[A])(implicit
        ev: A =:= Int
    ): F[A] = {
      implicit val F: Functor[F] = FunctorFilter[F].functor
      for {
        a <- fa
        if ev(a) % 2 == 0
      } yield a
    }

    val list = List(1, 2, 3, 4, 5)
    val evens = filterEvens(list)

    assertEquals(evens, List(2, 4))
  }

}
```

Below you can see some commands with output to check if withFilter() method working properly:
```text
sbt "coreJVM/compile"

[info] welcome to sbt 1.12.4 (Eclipse Adoptium Java 25.0.2)
[info] loading settings for project cats-build from plugins.sbt...
[info] loading project definition from /Users/alokkumardalei/Desktop/gsoc/gsoc-cats/cats/project
[info] loading settings for project cats from build.sbt, mima.sbt...
[info] resolving key references (41740 settings) ...
[info] set scmInfo to https://github.com/typelevel/cats
[info] set current project to cats (in build file:/Users/alokkumardalei/Desktop/gsoc/gsoc-cats/cats/)
[warn] there are 2 keys that are not used by any other settings/tasks:
[warn]  
[warn] * algebraLawsNative / tlVersionIntroduced
[warn]   +- /Users/alokkumardalei/Desktop/gsoc/gsoc-cats/cats/build.sbt:138
[warn] * algebraNative / tlVersionIntroduced
[warn]   +- /Users/alokkumardalei/Desktop/gsoc/gsoc-cats/cats/build.sbt:138
[warn]  
[warn] note: a setting might still be used by a command; to exclude a key from this `lintUnused` check
[warn] either append it to `Global / excludeLintKeys` or call .withRank(KeyRanks.Invisible) on the key
[success] Total time: 1 s, completed 2 Mar 2026, 10:03:21 pm
alokkumardalei@Aloks-MacBook-Air cats % sbt "testsJVM/testOnly *FunctorFilter*"

[info] welcome to sbt 1.12.4 (Eclipse Adoptium Java 25.0.2)
[info] loading settings for project cats-build from plugins.sbt...
[info] loading project definition from /Users/alokkumardalei/Desktop/gsoc/gsoc-cats/cats/project
[info] loading settings for project cats from build.sbt, mima.sbt...
[info] resolving key references (41740 settings) ...
[info] set scmInfo to https://github.com/typelevel/cats
[info] set current project to cats (in build file:/Users/alokkumardalei/Desktop/gsoc/gsoc-cats/cats/)
[warn] there are 2 keys that are not used by any other settings/tasks:
[warn]  
[warn] * algebraLawsNative / tlVersionIntroduced
[warn]   +- /Users/alokkumardalei/Desktop/gsoc/gsoc-cats/cats/build.sbt:138
[warn] * algebraNative / tlVersionIntroduced
[warn]   +- /Users/alokkumardalei/Desktop/gsoc/gsoc-cats/cats/build.sbt:138
[warn]  
[warn] note: a setting might still be used by a command; to exclude a key from this `lintUnused` check
[warn] either append it to `Global / excludeLintKeys` or call .withRank(KeyRanks.Invisible) on the key
cats.tests.FunctorFilterSuite:
  + withFilter alias allows for-comprehensions with guards 0.033s
[info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[success] Total time: 1 s, completed 2 Mar 2026, 10:03:46 pm
alokkumardalei@Aloks-MacBook-Air cats % sbt "testsJVM/testOnly cats.tests.FunctorFilterSuite"

[info] welcome to sbt 1.12.4 (Eclipse Adoptium Java 25.0.2)
[info] loading settings for project cats-build from plugins.sbt...
[info] loading project definition from /Users/alokkumardalei/Desktop/gsoc/gsoc-cats/cats/project
[info] loading settings for project cats from build.sbt, mima.sbt...
[info] resolving key references (41740 settings) ...
[info] set scmInfo to https://github.com/typelevel/cats
[info] set current project to cats (in build file:/Users/alokkumardalei/Desktop/gsoc/gsoc-cats/cats/)
[warn] there are 2 keys that are not used by any other settings/tasks:
[warn]  
[warn] * algebraLawsNative / tlVersionIntroduced
[warn]   +- /Users/alokkumardalei/Desktop/gsoc/gsoc-cats/cats/build.sbt:138
[warn] * algebraNative / tlVersionIntroduced
[warn]   +- /Users/alokkumardalei/Desktop/gsoc/gsoc-cats/cats/build.sbt:138
[warn]  
[warn] note: a setting might still be used by a command; to exclude a key from this `lintUnused` check
[warn] either append it to `Global / excludeLintKeys` or call .withRank(KeyRanks.Invisible) on the key
cats.tests.FunctorFilterSuite:
  + withFilter alias allows for-comprehensions with guards 0.035s
[info] Passed: Total 1, Failed 0, Errors 0, Passed 1
[success] Total time: 1 s, completed 2 Mar 2026, 10:04:00 pm
```

 After running all three commands each , if you can see _success_ at last then withFilter() method is working perfectly.