### PR TITLE
Update .scalafmt.conf. Avoid old vararg splices syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -29,4 +29,3 @@ project.excludeFilters = [
 rewrite.scala3.convertToNewSyntax = true
 runner.dialectOverride.allowSignificantIndentation = false
 runner.dialectOverride.allowAsForImportRename = false
-runner.dialectOverride.allowPostfixStarVarargSplices = false

--- a/algebra-laws/shared/src/main/scala/algebra/laws/OrderLaws.scala
+++ b/algebra-laws/shared/src/main/scala/algebra/laws/OrderLaws.scala
@@ -243,6 +243,6 @@ trait OrderLaws[A] extends Laws {
     name: String,
     parent: Option[RuleSet],
     props: (String, Prop)*
-  ) extends DefaultRuleSet(name, parent, props: _*)
+  ) extends DefaultRuleSet(name, parent, props*)
 
 }

--- a/algebra-laws/shared/src/main/scala/algebra/laws/RingLaws.scala
+++ b/algebra-laws/shared/src/main/scala/algebra/laws/RingLaws.scala
@@ -66,7 +66,7 @@ trait RingLaws[A] extends GroupLaws[A] { self =>
     new nonZeroLaws.GroupProperties(
       name = props.name,
       parents = parents,
-      props = props.props: _*
+      props = props.props*
     )
 
   implicit def Arb: Arbitrary[A]
@@ -398,7 +398,7 @@ trait RingLaws[A] extends GroupLaws[A] { self =>
 
   object RingProperties {
     def fromParent(name: String, parent: RingProperties, props: (String, Prop)*) =
-      new RingProperties(name, parent.al, parent.ml, Seq(parent), props: _*)
+      new RingProperties(name, parent.al, parent.ml, Seq(parent), props*)
   }
 
   class RingProperties(

--- a/algebra-laws/shared/src/test/scala/algebra/laws/LawTests.scala
+++ b/algebra-laws/shared/src/test/scala/algebra/laws/LawTests.scala
@@ -141,7 +141,7 @@ class LawTests extends munit.DisciplineSuite {
 
   {
     implicit val arbBitSet: Arbitrary[BitSet] =
-      Arbitrary(arbitrary[List[Byte]].map(s => BitSet(s.map(_ & 0xff): _*)))
+      Arbitrary(arbitrary[List[Byte]].map(s => BitSet(s.map(_ & 0xff)*)))
     checkAll("BitSet", LogicLaws[BitSet].generalizedBool)
   }
 

--- a/alleycats-laws/shared/src/test/scala/alleycats/tests/MapSuite.scala
+++ b/alleycats-laws/shared/src/test/scala/alleycats/tests/MapSuite.scala
@@ -34,7 +34,7 @@ class MapSuite extends AlleycatsSuite {
   checkAll("Map[Int, *]", ShortCircuitingTests[Map[Int, *]].traverseFilter[Int])
 
   test("traverse is stack-safe") {
-    val items = Map((0 until 100000).map { i => (i.toString, i) }: _*)
+    val items = Map((0 until 100000).map { i => (i.toString, i) }*)
     val sumAll = Traverse[Map[String, *]]
       .traverse(items) { i => () => i }
       .apply()

--- a/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
+++ b/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
@@ -475,7 +475,7 @@ class NonEmptyLazyListOps[A](private val value: NonEmptyLazyList[A])
    * }}}
    */
   final def toNem[T, U](implicit ev: A <:< (T, U), order: Order[T]): NonEmptyMap[T, U] =
-    NonEmptyMap.fromMapUnsafe(SortedMap(toLazyList.map(ev): _*)(using order.toOrdering))
+    NonEmptyMap.fromMapUnsafe(SortedMap(toLazyList.map(ev)*)(using order.toOrdering))
 
   /**
    * Creates new `NonEmptySet`, similarly to List#toSet from scala standard library.
@@ -488,7 +488,7 @@ class NonEmptyLazyListOps[A](private val value: NonEmptyLazyList[A])
    * }}}
    */
   final def toNes[B >: A](implicit order: Order[B]): NonEmptySet[B] =
-    NonEmptySet.of(head, tail: _*)
+    NonEmptySet.of(head, tail*)
 
   /**
    * Creates new `NonEmptyVector`, similarly to List#toVector from scala standard library.

--- a/core/src/main/scala/cats/Show.scala
+++ b/core/src/main/scala/cats/Show.scala
@@ -76,7 +76,7 @@ object Show extends ScalaVersionSpecificShowInstances with ShowInstances {
   }
 
   final case class ShowInterpolator(_sc: StringContext) extends AnyVal {
-    def show(args: Shown*): String = _sc.s(args: _*)
+    def show(args: Shown*): String = _sc.s(args*)
   }
 
   implicit val catsContravariantForShow: Contravariant[Show] = new Contravariant[Show] {

--- a/core/src/main/scala/cats/data/NonEmptyChain.scala
+++ b/core/src/main/scala/cats/data/NonEmptyChain.scala
@@ -611,8 +611,8 @@ class NonEmptyChainOps[A](private val value: NonEmptyChain[A])
   final def sortBy[B](f: A => B)(implicit B: Order[B]): NonEmptyChain[A] = create(toChain.sortBy(f))
   final def sorted[AA >: A](implicit AA: Order[AA]): NonEmptyChain[AA] = create(toChain.sorted[AA])
   final def toNem[T, V](implicit ev: A <:< (T, V), order: Order[T]): NonEmptyMap[T, V] =
-    NonEmptyMap.fromMapUnsafe(SortedMap(toChain.toVector.map(ev): _*)(using order.toOrdering))
-  final def toNes[B >: A](implicit order: Order[B]): NonEmptySet[B] = NonEmptySet.of(head, tail.toVector: _*)
+    NonEmptyMap.fromMapUnsafe(SortedMap(toChain.toVector.map(ev)*)(using order.toOrdering))
+  final def toNes[B >: A](implicit order: Order[B]): NonEmptySet[B] = NonEmptySet.of(head, tail.toVector*)
   final def zipWithIndex: NonEmptyChain[(A, Int)] = create(toChain.zipWithIndex)
 
   final def show[AA >: A](implicit AA: Show[AA]): String = s"NonEmpty${Show[Chain[AA]].show(toChain)}"

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -693,7 +693,7 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
    * }}}
    */
   def toNem[T, U](implicit ev: A <:< (T, U), order: Order[T]): NonEmptyMap[T, U] =
-    NonEmptyMap.fromMapUnsafe(SortedMap(toList.map(ev): _*)(using order.toOrdering))
+    NonEmptyMap.fromMapUnsafe(SortedMap(toList.map(ev)*)(using order.toOrdering))
 
   /**
    * Creates new `NonEmptySet`, similarly to List#toSet from scala standard library.
@@ -706,7 +706,7 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
    * }}}
    */
   def toNes[B >: A](implicit order: Order[B]): NonEmptySet[B] =
-    NonEmptySet.of(head, tail: _*)
+    NonEmptySet.of(head, tail*)
 
   /**
    * Creates new `NonEmptyVector`, similarly to List#toVector from scala standard library.

--- a/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
+++ b/core/src/main/scala/cats/data/NonEmptyMapImpl.scala
@@ -60,7 +60,7 @@ object NonEmptyMapImpl extends NonEmptyMapInstances with Newtype2 {
     create(SortedMap(head)(using K.toOrdering) ++ tail)
 
   def of[K, A](a: (K, A), as: (K, A)*)(implicit K: Order[K]): NonEmptyMap[K, A] =
-    create(SortedMap(as: _*)(using K.toOrdering) + a)
+    create(SortedMap(as*)(using K.toOrdering) + a)
 
   def one[K, A](k: K, a: A)(implicit K: Order[K]): NonEmptyMap[K, A] =
     create(SortedMap((k, a))(using K.toOrdering))

--- a/core/src/main/scala/cats/data/NonEmptySeq.scala
+++ b/core/src/main/scala/cats/data/NonEmptySeq.scala
@@ -381,7 +381,7 @@ final class NonEmptySeq[+A] private (val toSeq: Seq[A]) extends AnyVal with NonE
    * }}}
    */
   final def toNem[T, U](implicit ev: A <:< (T, U), order: Order[T]): NonEmptyMap[T, U] =
-    NonEmptyMap.fromMapUnsafe(SortedMap(toSeq.map(ev): _*)(using order.toOrdering))
+    NonEmptyMap.fromMapUnsafe(SortedMap(toSeq.map(ev)*)(using order.toOrdering))
 
   /**
    * Creates new `NonEmptySet`, similarly to List#toSet from scala standard library.
@@ -395,7 +395,7 @@ final class NonEmptySeq[+A] private (val toSeq: Seq[A]) extends AnyVal with NonE
    * }}}
    */
   final def toNes[B >: A](implicit order: Order[B]): NonEmptySet[B] =
-    NonEmptySet.of(head, tail: _*)
+    NonEmptySet.of(head, tail*)
 }
 
 @suppressUnusedImportWarningForScalaVersionSpecific

--- a/core/src/main/scala/cats/data/NonEmptySet.scala
+++ b/core/src/main/scala/cats/data/NonEmptySet.scala
@@ -51,7 +51,7 @@ object NonEmptySetImpl extends NonEmptySetInstances with Newtype {
     else throw new IllegalArgumentException("Cannot create NonEmptySet from empty set")
 
   def of[A](a: A, as: A*)(implicit A: Order[A]): NonEmptySet[A] =
-    create(SortedSet(a +: as: _*)(using A.toOrdering))
+    create(SortedSet((a +: as)*)(using A.toOrdering))
 
   def apply[A](head: A, tail: SortedSet[A])(implicit A: Order[A]): NonEmptySet[A] =
     create(SortedSet(head)(using A.toOrdering) ++ tail)

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -373,7 +373,7 @@ final class NonEmptyVector[+A] private (val toVector: Vector[A])
    * }}}
    */
   final def toNem[T, U](implicit ev: A <:< (T, U), order: Order[T]): NonEmptyMap[T, U] =
-    NonEmptyMap.fromMapUnsafe(SortedMap(toVector.map(ev): _*)(using order.toOrdering))
+    NonEmptyMap.fromMapUnsafe(SortedMap(toVector.map(ev)*)(using order.toOrdering))
 
   /**
    * Creates new `NonEmptySet`, similarly to List#toSet from scala standard library.
@@ -386,7 +386,7 @@ final class NonEmptyVector[+A] private (val toVector: Vector[A])
    * }}}
    */
   final def toNes[B >: A](implicit order: Order[B]): NonEmptySet[B] =
-    NonEmptySet.of(head, tail: _*)
+    NonEmptySet.of(head, tail*)
 }
 
 @suppressUnusedImportWarningForScalaVersionSpecific

--- a/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
+++ b/kernel-laws/shared/src/test/scala/cats/kernel/laws/LawTests.scala
@@ -43,7 +43,7 @@ import org.scalacheck.Test.Parameters
 object KernelCheck {
 
   implicit val arbitraryBitSet: Arbitrary[BitSet] =
-    Arbitrary(arbitrary[List[Short]].map(ns => BitSet(ns.map(_ & 0xffff): _*)))
+    Arbitrary(arbitrary[List[Short]].map(ns => BitSet(ns.map(_ & 0xffff)*)))
 
   implicit val arbitrarySymbol: Arbitrary[Symbol] =
     Arbitrary(arbitrary[String].map(s => Symbol(s)))

--- a/tests/shared/src/test/scala-2.12/cats/tests/NonEmptyStreamSuite.scala
+++ b/tests/shared/src/test/scala-2.12/cats/tests/NonEmptyStreamSuite.scala
@@ -90,7 +90,7 @@ class NonEmptyStreamSuite extends CatsSuite {
   test("Creating OneAnd + unwrap is identity") {
     forAll { (i: Int, tail: Stream[Int]) =>
       val stream = i #:: tail
-      val oneAnd = NonEmptyStream(i, tail: _*)
+      val oneAnd = NonEmptyStream(i, tail*)
       assert(stream === (oneAnd.unwrap))
     }
   }
@@ -201,5 +201,5 @@ class ReducibleNonEmptyStreamSuite extends ReducibleSuite[NonEmptyStream]("NonEm
     NonEmptyStream(start, tailStart.to(endInclusive).toStream)
   }
 
-  def fromValues[A](el: A, els: A*): NonEmptyStream[A] = NonEmptyStream(el, els: _*)
+  def fromValues[A](el: A, els: A*): NonEmptyStream[A] = NonEmptyStream(el, els*)
 }

--- a/tests/shared/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
+++ b/tests/shared/src/test/scala-2.13+/cats/tests/NonEmptyLazyListSuite.scala
@@ -211,7 +211,7 @@ class ReducibleNonEmptyLazyListSuite extends ReducibleSuite[NonEmptyLazyList]("N
   def iterator[T](nel: NonEmptyLazyList[T]): Iterator[T] = nel.toLazyList.iterator
 
   def range(start: Long, endInclusive: Long): NonEmptyLazyList[Long] =
-    NonEmptyLazyList(start, (start + 1L).to(endInclusive): _*)
+    NonEmptyLazyList(start, (start + 1L).to(endInclusive)*)
 
-  def fromValues[A](el: A, els: A*): NonEmptyLazyList[A] = NonEmptyLazyList(el, els: _*)
+  def fromValues[A](el: A, els: A*): NonEmptyLazyList[A] = NonEmptyLazyList(el, els*)
 }

--- a/tests/shared/src/test/scala-2.13+/cats/tests/ScalaVersionSpecific.scala
+++ b/tests/shared/src/test/scala-2.13+/cats/tests/ScalaVersionSpecific.scala
@@ -37,11 +37,11 @@ trait ScalaVersionSpecificFoldableSuite { self: FoldableSuiteAdditional =>
   test("Foldable[LazyList].slidingN stack safety")(checkSlidingNStackSafety(_.to(LazyList)))
 
   test("Foldable[NonEmptyLazyList] monadic folds stack safety")(
-    checkMonadicFoldsStackSafety(xs => NonEmptyLazyList(xs.head, xs.tail: _*))
+    checkMonadicFoldsStackSafety(xs => NonEmptyLazyList(xs.head, xs.tail*))
   )
 
   test("Foldable[NonEmptyLazyList].slidingN stack safety")(
-    checkSlidingNStackSafety(xs => NonEmptyLazyList(xs.head, xs.tail: _*))
+    checkSlidingNStackSafety(xs => NonEmptyLazyList(xs.head, xs.tail*))
   )
 
   private def bombLazyList[A]: A = sys.error("boom")
@@ -69,7 +69,7 @@ trait ScalaVersionSpecificFoldableSuite { self: FoldableSuiteAdditional =>
   }
 
   test("Foldable[LazyList]  trampolining") {
-    val large = LazyList((1 to 10000): _*)
+    val large = LazyList((1 to 10000)*)
     assert(contains(large, 10000).value)
   }
 

--- a/tests/shared/src/test/scala/cats/tests/BitSetSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/BitSetSuite.scala
@@ -30,7 +30,7 @@ import org.scalacheck.Prop.*
 
 class BitSetSuite extends CatsSuite {
   implicit val arbitraryBitSet: Arbitrary[BitSet] =
-    Arbitrary(arbitrary[List[Short]].map(ns => BitSet(ns.map(_ & 0xffff): _*)))
+    Arbitrary(arbitrary[List[Short]].map(ns => BitSet(ns.map(_ & 0xffff)*)))
 
   test("show BitSet") {
     assert(BitSet(1, 1, 2, 3).show === "BitSet(1, 2, 3)")

--- a/tests/shared/src/test/scala/cats/tests/FoldableSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/FoldableSuite.scala
@@ -547,12 +547,12 @@ class FoldableSuiteAdditional
   test("Foldable[Vector] monadic folds stack safety")(checkMonadicFoldsStackSafety(_.toVector))
   test("Foldable[Vector].slidingN stack safety")(checkSlidingNStackSafety(_.toVector))
 
-  test("Foldable[SortedSet] monadic folds stack safety")(checkMonadicFoldsStackSafety(xs => SortedSet(xs: _*)))
-  test("Foldable[SortedSet].slidingN stack safety")(checkSlidingNStackSafety(xs => SortedSet(xs: _*)))
+  test("Foldable[SortedSet] monadic folds stack safety")(checkMonadicFoldsStackSafety(xs => SortedSet(xs*)))
+  test("Foldable[SortedSet].slidingN stack safety")(checkSlidingNStackSafety(xs => SortedSet(xs*)))
 
   // Can't checkSlidingNStackSafety because of iteration order.
   test("Foldable[SortedMap[String, *]] monadic stack safety") {
-    checkMonadicFoldsStackSafety(xs => SortedMap(xs.map(x => x.toString -> x): _*))
+    checkMonadicFoldsStackSafety(xs => SortedMap(xs.map(x => x.toString -> x)*))
   }
 
   test("Foldable[NonEmptyList] monadic folds stack safety")(
@@ -586,11 +586,11 @@ sealed trait FoldableSuiteAdditionalStreamSpecific { self: FoldableSuiteAddition
   test("Foldable[Stream].slidingN stack safety")(checkSlidingNStackSafety(_.toStream))
 
   test("Foldable[NonEmptyStream] monadic folds stack safety")(
-    checkMonadicFoldsStackSafety(xs => NonEmptyStream(xs.head, xs.tail: _*))
+    checkMonadicFoldsStackSafety(xs => NonEmptyStream(xs.head, xs.tail*))
   )
 
   test("Foldable[NonEmptyStream].slidingN stack safety")(
-    checkSlidingNStackSafety(xs => NonEmptyStream(xs.head, xs.tail: _*))
+    checkSlidingNStackSafety(xs => NonEmptyStream(xs.head, xs.tail*))
   )
 
   val F = Foldable[Stream]
@@ -619,7 +619,7 @@ sealed trait FoldableSuiteAdditionalStreamSpecific { self: FoldableSuiteAddition
   }
 
   test("Foldable[Stream]  trampolining") {
-    val large = Stream((1 to 10000): _*)
+    val large = Stream((1 to 10000)*)
     assert(contains(large, 10000).value)
   }
 

--- a/tests/shared/src/test/scala/cats/tests/MonadSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/MonadSuite.scala
@@ -135,14 +135,14 @@ class MonadSuite extends CatsSuite {
     forAll(Gen.listOf(tupleGen)) { (xs: List[(Boolean, Int)]) =>
       val expected = xs.collectFirst { case (true, x) => x }.getOrElse(-1)
       val branches = xs.map { case (b, x) => (Eval.now(b), Eval.now(x)) }
-      assert(Monad[Eval].ifElseM(branches: _*)(Eval.now(-1)).value === expected)
+      assert(Monad[Eval].ifElseM(branches*)(Eval.now(-1)).value === expected)
     }
   }
 
   test("ifElseM resorts to default") {
     forAll(Gen.listOf(smallPosInt)) { (xs: List[Int]) =>
       val branches = xs.map(x => (Eval.now(false), Eval.now(x)))
-      assert(Monad[Eval].ifElseM(branches: _*)(Eval.now(-1)).value === -1)
+      assert(Monad[Eval].ifElseM(branches*)(Eval.now(-1)).value === -1)
     }
   }
 

--- a/tests/shared/src/test/scala/cats/tests/NonEmptyChainSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NonEmptyChainSuite.scala
@@ -229,7 +229,7 @@ class NonEmptyChainSuite extends NonEmptyCollectionSuite[Chain, NonEmptyChain, N
 
   test("of") {
     forAll { (head: Int, tail: Seq[Int]) =>
-      assert(NonEmptyChain.of(head, tail: _*).toList === (head :: tail.toList))
+      assert(NonEmptyChain.of(head, tail*).toList === (head :: tail.toList))
     }
   }
 }
@@ -238,7 +238,7 @@ class ReducibleNonEmptyChainSuite extends ReducibleSuite[NonEmptyChain]("NonEmpt
   def iterator[T](nel: NonEmptyChain[T]): Iterator[T] = nel.toChain.iterator
 
   def range(start: Long, endInclusive: Long): NonEmptyChain[Long] =
-    NonEmptyChain(start, (start + 1L).to(endInclusive): _*)
+    NonEmptyChain(start, (start + 1L).to(endInclusive)*)
 
-  def fromValues[A](el: A, els: A*): NonEmptyChain[A] = NonEmptyChain(el, els: _*)
+  def fromValues[A](el: A, els: A*): NonEmptyChain[A] = NonEmptyChain(el, els*)
 }

--- a/tests/shared/src/test/scala/cats/tests/NonEmptyListSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NonEmptyListSuite.scala
@@ -121,7 +121,7 @@ class NonEmptyListSuite extends NonEmptyCollectionSuite[List, NonEmptyList, NonE
   test("Creating NonEmptyList + toList is identity") {
     forAll { (i: Int, tail: List[Int]) =>
       val list = i :: tail
-      val nonEmptyList = NonEmptyList.of(i, tail: _*)
+      val nonEmptyList = NonEmptyList.of(i, tail*)
       assert(list === (nonEmptyList.toList))
     }
   }
@@ -329,7 +329,7 @@ class NonEmptyListSuite extends NonEmptyCollectionSuite[List, NonEmptyList, NonE
   test("NonEmptyList#take is consistent with List#take") {
     forAll { (n: Int, head: Int, tail: List[Int]) =>
       val list = head :: tail
-      val nonEmptyList = NonEmptyList.of(head, tail: _*)
+      val nonEmptyList = NonEmptyList.of(head, tail*)
       assert(nonEmptyList.take(n) === list.take(n))
     }
   }
@@ -467,5 +467,5 @@ class ReducibleNonEmptyListSuite extends ReducibleSuite[NonEmptyList]("NonEmptyL
     NonEmptyList(start, tailStart.to(endInclusive).toList)
   }
 
-  def fromValues[A](el: A, els: A*): NonEmptyList[A] = NonEmptyList(el, List(els: _*))
+  def fromValues[A](el: A, els: A*): NonEmptyList[A] = NonEmptyList(el, List(els*))
 }

--- a/tests/shared/src/test/scala/cats/tests/NonEmptySetSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NonEmptySetSuite.scala
@@ -261,7 +261,7 @@ class NonEmptySetSuite extends CatsSuite {
 
   test("NonEmptySet.of is consistent with removal") {
     forAll { (is: SortedSet[Int], i: Int) =>
-      assert(NonEmptySet.of(i, is.toList: _*) - i === (is - i))
+      assert(NonEmptySet.of(i, is.toList*) - i === (is - i))
     }
   }
 

--- a/tests/shared/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/NonEmptyVectorSuite.scala
@@ -279,7 +279,7 @@ class NonEmptyVectorSuite extends NonEmptyCollectionSuite[Vector, NonEmptyVector
 
   test("NonEmptyVector#of on varargs is consistent with NonEmptyVector#apply on Vector") {
     forAll { (head: Int, tail: Vector[Int]) =>
-      assert(NonEmptyVector.of(head, tail: _*) === (NonEmptyVector(head, tail)))
+      assert(NonEmptyVector.of(head, tail*) === (NonEmptyVector(head, tail)))
     }
   }
 
@@ -463,5 +463,5 @@ class ReducibleNonEmptyVectorSuite extends ReducibleSuite[NonEmptyVector]("NonEm
     NonEmptyVector(start, tailStart.to(endInclusive).toVector)
   }
 
-  def fromValues[A](el: A, els: A*): NonEmptyVector[A] = NonEmptyVector(el, Vector(els: _*))
+  def fromValues[A](el: A, els: A*): NonEmptyVector[A] = NonEmptyVector(el, Vector(els*))
 }

--- a/tests/shared/src/test/scala/cats/tests/SortedMapSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/SortedMapSuite.scala
@@ -102,7 +102,7 @@ class SortedMapSuite extends CatsSuite {
   checkAll("MonoidK[SortedMap[String, *]]", SerializableTests.serializable(MonoidK[SortedMap[String, *]]))
 
   test("traverse is stack-safe") {
-    val items = SortedMap((0 until 100000).map { i => (i.toString, i) }: _*)
+    val items = SortedMap((0 until 100000).map { i => (i.toString, i) }*)
     val sumAll = Traverse[SortedMap[String, *]]
       .traverse(items) { i => () => i }
       .apply()


### PR DESCRIPTION
https://docs.scala-lang.org/scala3/reference/changed-features/vararg-splices.html