### PR TITLE
Fix small grammatical typos in CONTRIBUTING and nomenclature docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,7 +33,7 @@ skip these steps and jump straight to submitting a pull request.
 
 ### Find something that belongs in Cats
 
-Looking for a way that you can help out? Check out our [open issues](https://github.com/typelevel/cats/issues) and look for ones tagged as _**help wanted**_ or _**low-hanging fruit**_. These issues are the easiest way to start contributing, but if you find other items that catch your eye, you're most than welcome to tackle them!
+Looking for a way that you can help out? Check out our [open issues](https://github.com/typelevel/cats/issues) and look for ones tagged as _**help wanted**_ or _**low-hanging fruit**_. These issues are the easiest way to start contributing, but if you find other items that catch your eye, you're more than welcome to tackle them!
 
 Make sure that it's not already assigned to someone and that nobody has left a comment saying that they are working on it!
 

--- a/docs/nomenclature.md
+++ b/docs/nomenclature.md
@@ -1,6 +1,6 @@
 # Glossary
 
-This is a catalogue of the major functions, type classes, and data types in `Cats`. It serves as a bird's-eye view of each class capabilities. It is also intended as a go-to reference for `Cats` users, who may not recall the answer to questions like these:
+This is a catalogue of the major functions, type classes, and data types in `Cats`. It serves as a bird's-eye view of each class's capabilities. It is also intended as a go-to reference for `Cats` users, who may not recall the answer to questions like these:
 
 - What is the difference between `unit` and `void`?
 - To discard the first value and keep only the first effect, is it `<*` or `*>`?


### PR DESCRIPTION

**Repo:** typelevel/cats (⭐ 5300)
**Type:** docs
**Files changed:** 2
**Lines:** +2/-2

## What
Fixes two small grammatical typos in the project documentation:
- `CONTRIBUTING.md`: "most than welcome" → "more than welcome"
- `docs/nomenclature.md`: "each class capabilities" → "each class's capabilities"

## Why
Both are user-facing docs read by new contributors and users browsing the nomenclature glossary. The CONTRIBUTING phrasing is a clear word-swap error, and the nomenclature line was missing a possessive. These are pure wording corrections with no semantic change.

## Testing
Docs-only change; no code paths affected. Verified the replacements with `git diff` — each edit is a single token substitution. No build or test run required for doc prose fixes of this form.

## Risk
Low — two single-line doc edits; no code or links touched.
