### PR TITLE
Add doctests for Eval (closes #2479 in part)

### DIFF
--- a/core/src/main/scala/cats/Eval.scala
+++ b/core/src/main/scala/cats/Eval.scala
@@ -75,6 +75,14 @@ sealed abstract class Eval[+A] extends Serializable { self =>
    *
    * Computation performed in f is always lazy, even when called on an
    * eager (Now) instance.
+   *
+   * Example:
+   * {{{
+   * scala> import cats.Eval
+   *
+   * scala> Eval.now(1).map(_ + 2).value
+   * res0: Int = 3
+   * }}}
    */
   def map[B](f: A => B): Eval[B] =
     flatMap(a => Now(f(a)))
@@ -90,6 +98,14 @@ sealed abstract class Eval[+A] extends Serializable { self =>
    *
    * Computation performed in f is always lazy, even when called on an
    * eager (Now) instance.
+   *
+   * Example:
+   * {{{
+   * scala> import cats.Eval
+   *
+   * scala> Eval.now(1).flatMap(x => Eval.now(x + 2)).value
+   * res0: Int = 3
+   * }}}
    */
   def flatMap[B](f: A => Eval[B]): Eval[B] =
     this match {
@@ -127,6 +143,20 @@ sealed abstract class Eval[+A] extends Serializable { self =>
    *
    * Practically, this means that when called on an Always[A] a
    * Later[A] with an equivalent computation will be returned.
+   *
+   * Example:
+   * {{{
+   * scala> import cats.Eval
+   *
+   * scala> var counter = 0
+   * scala> val memo = Eval.always { counter += 1; counter }.memoize
+   *
+   * scala> memo.value
+   * res0: Int = 1
+   *
+   * scala> memo.value
+   * res1: Int = 1
+   * }}}
    */
   def memoize: Eval[A]
 }
@@ -210,16 +240,66 @@ object Eval extends EvalInstances {
 
   /**
    * Construct an eager Eval[A] value (i.e. Now[A]).
+   *
+   * Example:
+   * {{{
+   * scala> import cats.Eval
+   *
+   * scala> Eval.now(42).value
+   * res0: Int = 42
+   * }}}
    */
   def now[A](a: A): Eval[A] = Now(a)
 
   /**
    * Construct a lazy Eval[A] value with caching (i.e. Later[A]).
+   *
+   * The computation is performed once, the first time `.value` is
+   * called, and the result is memoized for subsequent calls.
+   *
+   * Example:
+   * {{{
+   * scala> import cats.Eval
+   *
+   * scala> var counter = 0
+   * scala> val lazyEval = Eval.later { counter += 1; counter }
+   *
+   * scala> counter
+   * res0: Int = 0
+   *
+   * scala> lazyEval.value
+   * res1: Int = 1
+   *
+   * scala> lazyEval.value
+   * res2: Int = 1
+   *
+   * scala> counter
+   * res3: Int = 1
+   * }}}
    */
   def later[A](a: => A): Eval[A] = new Later(() => a)
 
   /**
    * Construct a lazy Eval[A] value without caching (i.e. Always[A]).
+   *
+   * The computation is performed every time `.value` is called.
+   *
+   * Example:
+   * {{{
+   * scala> import cats.Eval
+   *
+   * scala> var counter = 0
+   * scala> val alwaysEval = Eval.always { counter += 1; counter }
+   *
+   * scala> alwaysEval.value
+   * res0: Int = 1
+   *
+   * scala> alwaysEval.value
+   * res1: Int = 2
+   *
+   * scala> counter
+   * res2: Int = 2
+   * }}}
    */
   def always[A](a: => A): Eval[A] = new Always(() => a)
 
@@ -228,6 +308,26 @@ object Eval extends EvalInstances {
    *
    * This is useful when you want to delay execution of an expression
    * which produces an Eval[A] value. Like .flatMap, it is stack-safe.
+   *
+   * Example:
+   * {{{
+   * scala> import cats.Eval
+   *
+   * scala> var built = false
+   * scala> val deferred = Eval.defer {
+   *      |   built = true
+   *      |   Eval.now(7)
+   *      | }
+   *
+   * scala> built
+   * res0: Boolean = false
+   *
+   * scala> deferred.value
+   * res1: Int = 7
+   *
+   * scala> built
+   * res2: Boolean = true
+   * }}}
    */
   def defer[A](a: => Eval[A]): Eval[A] =
     new Eval.Defer[A](() => a) {}


### PR DESCRIPTION
  Partially closes #2479.

  `Eval.scala` had zero existing doctests despite `Eval` being the lazy /
  memoized FP-flagship data type in cats.  This PR adds scaladoc examples to
  seven `Eval` methods:

  - `Eval#map`, `Eval#flatMap` — basic mapping and chaining.
  - `Eval#memoize` — confirms `Always.memoize` does not re-evaluate on repeated
  `.value`.
  - `Eval.now` — eager evaluation.
  - `Eval.later` — lazy with memoization; counter increments once across
  multiple `.value` calls.
  - `Eval.always` — lazy without memoization; counter increments per `.value`
  call.
  - `Eval.defer` — computation deferred until `.value` is forced.

  The `Later`, `Always`, `memoize`, and `defer` examples use the `var counter =
  0` plus side-effecting block pattern already established in `Defer.scala:39`
  and `FlatMap.scala:88`, to demonstrate the eager vs lazy-memoized vs
  lazy-not-memoized distinction at the doctest assertion level.

  ## Local validation

  - `++ 2.13; coreJVM/test` 916 / 916 pass (16 newly generated `EvalDoctest`
  assertions included).
  - `++ 3; coreJVM/compile coreJVM/test` clean (doctest generation is 2.13-only
  per `build.sbt:59`).
  - `scalafmtCheckAll` clean.
  - `scalafmtSbtCheck` clean.
  - `coreJVM/mimaReportBinaryIssues` no binary issues.

  ## A note for future Eval doctest authors

  `sbt-doctest` silently skips `scala>` lines that contain a brace-lambda with a
   `;`-separated body (e.g. `Eval.now(1).map { x => mutate; x + 2 }`).  I caught
   this on the first pass when `map.example` was missing from the test report
  despite being a valid scaladoc block.  The workaround is to either avoid `;`
  (use parens-lambda + a helper `def`) or to keep the example brace-lambda-free.