### PR TITLE
Add unorderedReduceOption to UnorderedFoldable

### DIFF
--- a/core/src/main/scala/cats/UnorderedFoldable.scala
+++ b/core/src/main/scala/cats/UnorderedFoldable.scala
@@ -21,7 +21,7 @@
 
 package cats
 
-import cats.kernel.CommutativeMonoid
+import cats.kernel.{CommutativeMonoid, CommutativeSemigroup}
 import scala.collection.immutable.{Queue, Seq, SortedMap, SortedSet}
 import scala.util.Try
 
@@ -34,6 +34,11 @@ trait UnorderedFoldable[F[_]] extends Serializable {
 
   def unorderedFold[A: CommutativeMonoid](fa: F[A]): A =
     unorderedFoldMap(fa)(identity)
+
+  def unorderedReduceOption[A](fa: F[A])(implicit A: CommutativeSemigroup[A]): Option[A] =
+    unorderedFoldMap(fa)(a => Some(a): Option[A])(
+      cats.kernel.instances.option.catsKernelStdCommutativeMonoidForOption
+    )
 
   /**
    * Fold in a [[CommutativeApplicative]] context by mapping the `A` values to `G[B]`. combining

--- a/core/src/main/scala/cats/UnorderedFoldable.scala
+++ b/core/src/main/scala/cats/UnorderedFoldable.scala
@@ -35,10 +35,15 @@ trait UnorderedFoldable[F[_]] extends Serializable {
   def unorderedFold[A: CommutativeMonoid](fa: F[A]): A =
     unorderedFoldMap(fa)(identity)
 
-  def unorderedReduceOption[A](fa: F[A])(implicit A: CommutativeSemigroup[A]): Option[A] =
-    unorderedFoldMap(fa)(a => Some(a): Option[A])(
-      cats.kernel.instances.option.catsKernelStdCommutativeMonoidForOption
-    )
+  /**
+   * Reduce this unordered structure by combining its elements with a [[CommutativeSemigroup]] instance.
+   *
+   * If there are no elements, the result is `None`.
+   */
+  def unorderedReduceOption[A: CommutativeSemigroup](fa: F[A]): Option[A] = {
+    val reducer = CommutativeMonoid[Option[A]]
+    unorderedFoldMap(fa)(a => Some(a): Option[A])(using reducer)
+  }
 
   /**
    * Fold in a [[CommutativeApplicative]] context by mapping the `A` values to `G[B]`. combining

--- a/core/src/main/scala/cats/syntax/unorderedFoldable.scala
+++ b/core/src/main/scala/cats/syntax/unorderedFoldable.scala
@@ -22,6 +22,8 @@
 package cats
 package syntax
 
+import cats.kernel.CommutativeSemigroup
+
 trait UnorderedFoldableSyntax extends UnorderedFoldable.ToUnorderedFoldableOps {
   implicit final def catsSyntaxUnorderedFoldableOps[F[_]: UnorderedFoldable, A](fa: F[A]): UnorderedFoldableOps[F, A] =
     new UnorderedFoldableOps[F, A](fa)
@@ -66,4 +68,7 @@ final class UnorderedFoldableOps[F[_], A](private val fa: F[A]) extends AnyVal {
    */
   def count(p: A => Boolean)(implicit F: UnorderedFoldable[F]): Long =
     F.count(fa)(p)
+
+  def unorderedReduceOption(implicit A: CommutativeSemigroup[A], F: UnorderedFoldable[F]): Option[A] =
+    F.unorderedReduceOption(fa)
 }

--- a/laws/src/main/scala/cats/laws/UnorderedFoldableLaws.scala
+++ b/laws/src/main/scala/cats/laws/UnorderedFoldableLaws.scala
@@ -33,6 +33,9 @@ trait UnorderedFoldableLaws[F[_]] {
   def unorderedFoldMapAIdentity[A, B: CommutativeMonoid](fa: F[A], f: A => B): IsEq[B] =
     F.unorderedFoldMapA[Id, A, B](fa)(f) <-> F.unorderedFoldMap(fa)(f)
 
+  def unorderedReduceOptionConsistentWithUnorderedFold[A: CommutativeMonoid](fa: F[A]): IsEq[Option[A]] =
+    F.unorderedReduceOption(fa) <-> (if (F.isEmpty(fa)) None else Some(F.unorderedFold(fa)))
+
   def forallConsistentWithExists[A](fa: F[A], p: A => Boolean): Boolean =
     if (F.forall(fa)(p)) {
       val negationExists = F.exists(fa)(a => !p(a))

--- a/laws/src/main/scala/cats/laws/discipline/UnorderedFoldableTests.scala
+++ b/laws/src/main/scala/cats/laws/discipline/UnorderedFoldableTests.scala
@@ -28,6 +28,7 @@ import Prop.*
 import org.typelevel.discipline.Laws
 import cats.kernel.CommutativeMonoid
 import cats.instances.boolean.*
+import cats.instances.option.*
 
 trait UnorderedFoldableTests[F[_]] extends Laws {
   def laws: UnorderedFoldableLaws[F]
@@ -53,7 +54,10 @@ trait UnorderedFoldableTests[F[_]] extends Laws {
       "forall is lazy" -> forAll(laws.forallLazy[A] _),
       "contains consistent with exists" -> forAll(laws.containsConsistentWithExists[A] _),
       "contains consistent with forall" -> forAll(laws.containsConsistentWithForall[A] _),
-      "contains all elements from itself" -> forAll(laws.containsAllElementsFromItself[A] _)
+      "contains all elements from itself" -> forAll(laws.containsAllElementsFromItself[A] _),
+      "unorderedReduceOption consistent with unorderedFold" -> forAll(
+        laws.unorderedReduceOptionConsistentWithUnorderedFold[A] _
+      )
     )
 }
 

--- a/tests/shared/src/test/scala/cats/tests/UnorderedFoldableSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/UnorderedFoldableSuite.scala
@@ -76,6 +76,16 @@ sealed abstract class UnorderedFoldableSuite[F[_]](name: String)(implicit
     }
   }
 
+  test(s"UnorderedFoldable[$name].unorderedReduceOption") {
+    forAll { (fa: F[Int]) =>
+      implicit val F: UnorderedFoldable[F] = instance
+      val expected =
+        if (instance.isEmpty(fa)) None
+        else Some(instance.unorderedFold(fa))
+      assert(fa.unorderedReduceOption === expected)
+    }
+  }
+
   checkAll("F[Int]", UnorderedFoldableTests[F](using instance).unorderedFoldable[Int, Int])
 }
 

--- a/tests/shared/src/test/scala/cats/tests/UnorderedFoldableSuite.scala
+++ b/tests/shared/src/test/scala/cats/tests/UnorderedFoldableSuite.scala
@@ -76,16 +76,6 @@ sealed abstract class UnorderedFoldableSuite[F[_]](name: String)(implicit
     }
   }
 
-  test(s"UnorderedFoldable[$name].unorderedReduceOption") {
-    forAll { (fa: F[Int]) =>
-      implicit val F: UnorderedFoldable[F] = instance
-      val expected =
-        if (instance.isEmpty(fa)) None
-        else Some(instance.unorderedFold(fa))
-      assert(fa.unorderedReduceOption === expected)
-    }
-  }
-
   checkAll("F[Int]", UnorderedFoldableTests[F](using instance).unorderedFoldable[Int, Int])
 }
 


### PR DESCRIPTION
# Add `unorderedReduceOption` to `UnorderedFoldable`

## Motivation

`Foldable` has ordered reduction methods such as `reduceLeftOption` and `reduceRightOption`,
but `UnorderedFoldable` does not currently have an unordered equivalent for reducing a
possibly-empty structure.

This PR adds `unorderedReduceOption`, which reduces an unordered structure to `Option[A]`,
returning `None` for empty structures and `Some(combined)` for non-empty ones.

The constraint is `CommutativeSemigroup[A]`, rather than `Semigroup[A]`, because
`UnorderedFoldable` provides no guarantee on element order.

This is related to the discussion in #2715 and extracts the focused `unorderedReduceOption`
part of #3309. Unlike #3309, this PR intentionally leaves `minimumOption`, `maximumOption`,
`minimumByOption`, and `maximumByOption` out of scope, since those raise separate API and
binary-compatibility considerations, as also discussed around #3132.

## API

```scala
def unorderedReduceOption[A](fa: F[A])(implicit A: CommutativeSemigroup[A]): Option[A]
```

Also available as syntax via `cats.syntax.all._`:

```scala
import cats.syntax.all._

Set(1, 2, 3).unorderedReduceOption   // Some(6)
Set.empty[Int].unorderedReduceOption // None
```

## Implementation

The implementation is defined in terms of `unorderedFoldMap`, by lifting each `A` into
`Option[A]` and folding with the existing `CommutativeMonoid[Option[A]]` instance derived
from `CommutativeSemigroup[A]`.

## Law

The PR adds a law checking consistency with `unorderedFold`:

```scala
def unorderedReduceOptionConsistentWithUnorderedFold[A: CommutativeMonoid](fa: F[A]): IsEq[Option[A]] =
  F.unorderedReduceOption(fa) <-> (if (F.isEmpty(fa)) None else Some(F.unorderedFold(fa)))
```

The law is wired into the existing `UnorderedFoldableTests.unorderedFoldable` rule set.
`Eq[Option[A]]` is resolved internally from the existing `Eq[A]` instance via
`cats.instances.option`, so the public signature of `unorderedFoldable` is unchanged.

## Included changes

- `UnorderedFoldable#unorderedReduceOption`
- syntax support via `cats.syntax.all._`
- a law checking consistency with `unorderedFold`
- discipline test integration
- ~~a focused test in `UnorderedFoldableSuite`~~
