### PR TITLE
Fix warnings with Scala 3.9

### DIFF
--- a/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
+++ b/core/src/main/scala-2.13+/cats/data/NonEmptyLazyList.scala
@@ -375,7 +375,7 @@ class NonEmptyLazyListOps[A](private val value: NonEmptyLazyList[A])
    */
   final def sortBy[B](f: A => B)(implicit B: Order[B]): NonEmptyLazyList[A] =
     // safe: sorting a NonEmptyList cannot produce an empty List
-    create(toLazyList.sortBy(f)(B.toOrdering))
+    create(toLazyList.sortBy(f)(using B.toOrdering))
 
   /**
    * Sorts this `NonEmptyList` according to an `Order`
@@ -389,7 +389,7 @@ class NonEmptyLazyListOps[A](private val value: NonEmptyLazyList[A])
    * }}}
    */
   final def sorted[AA >: A](implicit AA: Order[AA]): NonEmptyLazyList[AA] =
-    create(toLazyList.sorted(AA.toOrdering))
+    create(toLazyList.sorted(using AA.toOrdering))
 
   /**
    * Groups elements inside this `NonEmptyLazyList` according to the `Order`
@@ -564,7 +564,7 @@ sealed abstract private[data] class NonEmptyLazyListInstances extends NonEmptyLa
       type F[x] = OneAnd[ZipLazyList, x]
 
       def applicative: Applicative[OneAnd[ZipLazyList, *]] =
-        OneAnd.catsDataApplicativeForOneAnd(ZipLazyList.catsDataAlternativeForZipLazyList)
+        OneAnd.catsDataApplicativeForOneAnd(using ZipLazyList.catsDataAlternativeForZipLazyList)
       def monad: Monad[NonEmptyLazyList] = NonEmptyLazyList.catsDataInstancesForNonEmptyLazyList
 
       def sequential: OneAnd[ZipLazyList, *] ~> NonEmptyLazyList =

--- a/core/src/main/scala-2.13+/cats/data/OneAndLowPriority4.scala
+++ b/core/src/main/scala-2.13+/cats/data/OneAndLowPriority4.scala
@@ -43,7 +43,7 @@ abstract private[data] class OneAndLowPriority4 {
         fa.head
 
       def map[A, B](fa: OneAnd[Stream, A])(f: A => B): OneAnd[Stream, B] =
-        fa.map(f)(cats.instances.stream.catsStdInstancesForStream)
+        fa.map(f)(using cats.instances.stream.catsStdInstancesForStream)
     }
 
   implicit val catsDataComonadForNonEmptyLazyList: Comonad[OneAnd[LazyList, *]] =
@@ -62,6 +62,6 @@ abstract private[data] class OneAndLowPriority4 {
         fa.head
 
       def map[A, B](fa: OneAnd[LazyList, A])(f: A => B): OneAnd[LazyList, B] =
-        fa.map(f)(cats.instances.lazyList.catsStdInstancesForLazyList)
+        fa.map(f)(using cats.instances.lazyList.catsStdInstancesForLazyList)
     }
 }

--- a/core/src/main/scala-2.13+/cats/data/ZipLazyList.scala
+++ b/core/src/main/scala-2.13+/cats/data/ZipLazyList.scala
@@ -48,5 +48,5 @@ object ZipLazyList {
     }
 
   implicit def catsDataEqForZipLazyList[A: Eq]: Eq[ZipLazyList[A]] =
-    Eq.by((_: ZipLazyList[A]).value)(cats.kernel.instances.lazyList.catsKernelStdEqForLazyList[A])
+    Eq.by((_: ZipLazyList[A]).value)(using cats.kernel.instances.lazyList.catsKernelStdEqForLazyList[A])
 }

--- a/core/src/main/scala-2.13+/cats/data/ZipStream.scala
+++ b/core/src/main/scala-2.13+/cats/data/ZipStream.scala
@@ -50,5 +50,5 @@ object ZipStream {
     }
 
   implicit def catsDataEqForZipStream[A: Eq]: Eq[ZipStream[A]] =
-    Eq.by((_: ZipStream[A]).value)(cats.kernel.instances.stream.catsKernelStdEqForStream[A])
+    Eq.by((_: ZipStream[A]).value)(using cats.kernel.instances.stream.catsKernelStdEqForStream[A])
 }

--- a/core/src/main/scala-2.13+/cats/instances/arraySeq.scala
+++ b/core/src/main/scala-2.13+/cats/instances/arraySeq.scala
@@ -106,7 +106,7 @@ private[cats] object ArraySeqInstances {
       def traverse[G[_], A, B](fa: ArraySeq[A])(f: A => G[B])(implicit G: Applicative[G]): G[ArraySeq[B]] =
         G match {
           case x: StackSafeMonad[G] =>
-            x.map(Traverse.traverseDirectly(fa.iterator)(f)(x))(_.iterator.to(ArraySeq.untagged))
+            x.map(Traverse.traverseDirectly(fa.iterator)(f)(using x))(_.iterator.to(ArraySeq.untagged))
           case _ =>
             G.map(Chain.traverseViaChain(fa)(f))(_.iterator.to(ArraySeq.untagged))
 
@@ -114,7 +114,7 @@ private[cats] object ArraySeqInstances {
 
       override def traverseVoid[G[_], A, B](fa: ArraySeq[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
         G match {
-          case x: StackSafeMonad[G] => Traverse.traverseVoidDirectly(fa)(f)(x)
+          case x: StackSafeMonad[G] => Traverse.traverseVoidDirectly(fa)(f)(using x)
           case _                    =>
             foldRight(fa, Eval.now(G.unit)) { (a, acc) =>
               G.map2Eval(f(a), acc) { (_, _) =>
@@ -124,7 +124,7 @@ private[cats] object ArraySeqInstances {
         }
 
       override def mapAccumulate[S, A, B](init: S, fa: ArraySeq[A])(f: (S, A) => (S, B)): (S, ArraySeq[B]) =
-        StaticMethods.mapAccumulateFromStrictFunctor(init, fa, f)(this)
+        StaticMethods.mapAccumulateFromStrictFunctor(init, fa, f)(using this)
 
       override def mapWithIndex[A, B](fa: ArraySeq[A])(f: (A, Int) => B): ArraySeq[B] =
         ArraySeq.untagged.tabulate(n = fa.length) { i =>
@@ -235,7 +235,7 @@ private[cats] object ArraySeqInstances {
       )(f: (A) => G[Option[B]])(implicit G: Applicative[G]): G[ArraySeq[B]] =
         G match {
           case x: StackSafeMonad[G] =>
-            x.map(TraverseFilter.traverseFilterDirectly(fa.iterator)(f)(x))(
+            x.map(TraverseFilter.traverseFilterDirectly(fa.iterator)(f)(using x))(
               _.iterator.to(ArraySeq.untagged)
             )
           case _ =>

--- a/core/src/main/scala/cats/Alternative.scala
+++ b/core/src/main/scala/cats/Alternative.scala
@@ -49,7 +49,7 @@ trait Alternative[F[_]] extends NonEmptyAlternative[F] with MonoidK[F] { self =>
    * }}}
    */
   def unite[G[_], A](fga: F[G[A]])(implicit FM: FlatMap[F], G: Foldable[G]): F[A] =
-    FM.flatMap(fga) { G.foldMapK(_)(pure)(self) }
+    FM.flatMap(fga) { G.foldMapK(_)(pure)(using self) }
 
   // Note: `protected` is only necessary to enforce binary compatibility
   // since neither `private` nor `private[cats]` work properly here.
@@ -71,8 +71,8 @@ trait Alternative[F[_]] extends NonEmptyAlternative[F] with MonoidK[F] { self =>
    * }}}
    */
   def separate[G[_, _], A, B](fgab: F[G[A, B]])(implicit FM: FlatMap[F], G: Bifoldable[G]): (F[A], F[B]) = {
-    val as = FM.flatMap(fgab)(gab => G.bifoldMap(gab)(pure, _ => empty[A])(algebra[A]))
-    val bs = FM.flatMap(fgab)(gab => G.bifoldMap(gab)(_ => empty[B], pure)(algebra[B]))
+    val as = FM.flatMap(fgab)(gab => G.bifoldMap(gab)(pure, _ => empty[A])(using algebra[A]))
+    val bs = FM.flatMap(fgab)(gab => G.bifoldMap(gab)(_ => empty[B], pure)(using algebra[B]))
     (as, bs)
   }
 
@@ -157,7 +157,7 @@ object Alternative {
       // Note: edited manually since seems Simulacrum is not able to handle the bin-compat redirection properly.
       typeClassInstance.separate[G, B, C](self.asInstanceOf[F[G[B, C]]])
     def separateFoldable[G[_, _], B, C](implicit ev$1: A <:< G[B, C], G: Bifoldable[G], FF: Foldable[F]): (F[B], F[C]) =
-      typeClassInstance.separateFoldable[G, B, C](self.asInstanceOf[F[G[B, C]]])(G, FF)
+      typeClassInstance.separateFoldable[G, B, C](self.asInstanceOf[F[G[B, C]]])(using G, FF)
   }
   trait AllOps[F[_], A] extends Ops[F, A] with NonEmptyAlternative.AllOps[F, A] with MonoidK.AllOps[F, A] {
     type TypeClassType <: Alternative[F]

--- a/core/src/main/scala/cats/Bifoldable.scala
+++ b/core/src/main/scala/cats/Bifoldable.scala
@@ -132,8 +132,8 @@ object Bifoldable extends cats.instances.NTupleBitraverseInstances {
     def bifoldRight[C](c: Eval[C])(f: (A, Eval[C]) => Eval[C], g: (B, Eval[C]) => Eval[C]): Eval[C] =
       typeClassInstance.bifoldRight[A, B, C](self, c)(f, g)
     def bifoldMap[C](f: A => C, g: B => C)(implicit C: Monoid[C]): C =
-      typeClassInstance.bifoldMap[A, B, C](self)(f, g)(C)
-    def bifold(implicit A: Monoid[A], B: Monoid[B]): (A, B) = typeClassInstance.bifold[A, B](self)(A, B)
+      typeClassInstance.bifoldMap[A, B, C](self)(f, g)(using C)
+    def bifold(implicit A: Monoid[A], B: Monoid[B]): (A, B) = typeClassInstance.bifold[A, B](self)(using A, B)
   }
   trait AllOps[F[_, _], A, B] extends Ops[F, A, B]
   trait ToBifoldableOps extends Serializable {

--- a/core/src/main/scala/cats/ContravariantSemigroupal.scala
+++ b/core/src/main/scala/cats/ContravariantSemigroupal.scala
@@ -83,5 +83,5 @@ object ContravariantSemigroupal extends SemigroupalArityFunctions {
 
 private[cats] class ContravariantSemigroupalSemigroup[F[_], A](f: ContravariantSemigroupal[F]) extends Semigroup[F[A]] {
   def combine(a: F[A], b: F[A]): F[A] =
-    ContravariantSemigroupal.contramap2(a, b)((a: A) => (a, a))(f, f)
+    ContravariantSemigroupal.contramap2(a, b)((a: A) => (a, a))(using f, f)
 }

--- a/core/src/main/scala/cats/Foldable.scala
+++ b/core/src/main/scala/cats/Foldable.scala
@@ -122,7 +122,7 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
         case None            => gb
       }
     }
-    Defer[G].defer(loop(Source.fromFoldable(fa)(self)))
+    Defer[G].defer(loop(Source.fromFoldable(fa)(using self)))
   }
 
   def reduceLeftToOption[A, B](fa: F[A])(f: A => B)(g: (B, A) => B): Option[B] =
@@ -132,7 +132,7 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
     }
 
   def reduceRightToOption[A, B](fa: F[A])(f: A => B)(g: (A, Eval[B]) => Eval[B]): Eval[Option[B]] = {
-    Source.fromFoldable(fa)(self).uncons match {
+    Source.fromFoldable(fa)(using self).uncons match {
       case Some((first, s)) =>
         def loop(now: A, source: Source[A]): Eval[B] =
           source.uncons match {
@@ -241,7 +241,7 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
    * @see [[maximumByOption]] for maximum instead of minimum.
    */
   def minimumByOption[A, B: Order](fa: F[A])(f: A => B): Option[A] =
-    minimumOption(fa)(Order.by(f))
+    minimumOption(fa)(using Order.by(f))
 
   /**
    * Find the maximum `A` item in this structure according to an `Order.by(f)`.
@@ -255,7 +255,7 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
    * @see [[minimumByOption]] for minimum instead of maximum.
    */
   def maximumByOption[A, B: Order](fa: F[A])(f: A => B): Option[A] =
-    maximumOption(fa)(Order.by(f))
+    maximumOption(fa)(using Order.by(f))
 
   /**
    * Find all the minimum `A` items in this structure.
@@ -299,7 +299,7 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
    * @see [[maximumByList]] for maximum instead of minimum.
    */
   def minimumByList[A, B: Order](fa: F[A])(f: A => B): List[A] =
-    minimumList(fa)(Order.by(f))
+    minimumList(fa)(using Order.by(f))
 
   /**
    * Find all the maximum `A` items in this structure according to an `Order.by(f)`.
@@ -311,7 +311,7 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
    * @see [[minimumByList]] for minimum instead of maximum.
    */
   def maximumByList[A, B: Order](fa: F[A])(f: A => B): List[A] =
-    maximumList(fa)(Order.by(f))
+    maximumList(fa)(using Order.by(f))
 
   def sumAll[A](fa: F[A])(implicit A: Numeric[A]): A =
     foldLeft(fa, A.zero)(A.plus)
@@ -390,7 +390,7 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
    */
 
   def collectFirstSomeM[G[_], A, B](fa: F[A])(f: A => G[Option[B]])(implicit G: Monad[G]): G[Option[B]] =
-    G.tailRecM(Foldable.Source.fromFoldable(fa)(self))(_.uncons match {
+    G.tailRecM(Foldable.Source.fromFoldable(fa)(using self))(_.uncons match {
       case Some((a, src)) =>
         G.map(f(a)) {
           case None => Left(src.value)
@@ -474,7 +474,7 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
    * in terms of `foldRight`.
    */
   def foldM[G[_], A, B](fa: F[A], z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] = {
-    val src = Foldable.Source.fromFoldable(fa)(self)
+    val src = Foldable.Source.fromFoldable(fa)(using self)
     G.tailRecM((z, src)) { case (b, src) =>
       src.uncons match {
         case Some((a, src)) => G.map(f(b, a))(b => Left((b, src.value)))
@@ -647,7 +647,7 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
    * }}}
    */
   def foldK[G[_], A](fga: F[G[A]])(implicit G: MonoidK[G]): G[A] =
-    fold(fga)(G.algebra)
+    fold(fga)(using G.algebra)
 
   /**
    * Find the first element matching the predicate, if one exists.
@@ -680,7 +680,7 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
    */
 
   def findM[G[_], A](fa: F[A])(p: A => G[Boolean])(implicit G: Monad[G]): G[Option[A]] =
-    G.tailRecM(Foldable.Source.fromFoldable(fa)(self))(_.uncons match {
+    G.tailRecM(Foldable.Source.fromFoldable(fa)(using self))(_.uncons match {
       case Some((a, src)) => G.map(p(a))(if (_) Right(Some(a)) else Left(src.value))
       case None           => G.pure(Right(None))
     })
@@ -729,7 +729,7 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
    * }}}
    */
   def existsM[G[_], A](fa: F[A])(p: A => G[Boolean])(implicit G: Monad[G]): G[Boolean] =
-    G.tailRecM(Foldable.Source.fromFoldable(fa)(self)) { src =>
+    G.tailRecM(Foldable.Source.fromFoldable(fa)(using self)) { src =>
       src.uncons match {
         case Some((a, src)) => G.map(p(a))(bb => if (bb) Right(true) else Left(src.value))
         case None           => G.pure(Right(false))
@@ -764,7 +764,7 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
    * }}}
    */
   def forallM[G[_], A](fa: F[A])(p: A => G[Boolean])(implicit G: Monad[G]): G[Boolean] =
-    G.tailRecM(Foldable.Source.fromFoldable(fa)(self)) { src =>
+    G.tailRecM(Foldable.Source.fromFoldable(fa)(using self)) { src =>
       src.uncons match {
         case Some((a, src)) => G.map(p(a))(bb => if (!bb) Right(false) else Left(src.value))
         case None           => G.pure(Right(true))
@@ -853,7 +853,7 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
    * }}}
    */
   def intercalate[A](fa: F[A], a: A)(implicit A: Monoid[A]): A =
-    combineAllOption(fa)(A.intercalate(a)) match {
+    combineAllOption(fa)(using A.intercalate(a)) match {
       case None    => A.empty
       case Some(a) => a
     }
@@ -958,7 +958,7 @@ trait Foldable[F[_]] extends UnorderedFoldable[F] with FoldableNFunctions[F] { s
     fa: F[A]
   )(f: A => G[Either[B, C]])(implicit A: Alternative[F], M: Monad[G]): G[(F[B], F[C])] = {
     import cats.instances.either.*
-    partitionBifoldM[G, Either, A, B, C](fa)(f)(A, M, Bifoldable[Either])
+    partitionBifoldM[G, Either, A, B, C](fa)(f)(using A, M, Bifoldable[Either])
   }
 }
 
@@ -1041,38 +1041,38 @@ object Foldable {
       typeClassInstance.reduceRightToOption[A, B](self)(f)(g)
     def reduceLeftOption(f: (A, A) => A): Option[A] = typeClassInstance.reduceLeftOption[A](self)(f)
     def reduceRightOption(f: (A, Eval[A]) => Eval[A]): Eval[Option[A]] = typeClassInstance.reduceRightOption[A](self)(f)
-    def minimumOption(implicit A: Order[A]): Option[A] = typeClassInstance.minimumOption[A](self)(A)
-    def maximumOption(implicit A: Order[A]): Option[A] = typeClassInstance.maximumOption[A](self)(A)
+    def minimumOption(implicit A: Order[A]): Option[A] = typeClassInstance.minimumOption[A](self)(using A)
+    def maximumOption(implicit A: Order[A]): Option[A] = typeClassInstance.maximumOption[A](self)(using A)
     def minimumByOption[B](f: A => B)(implicit ev$1: Order[B]): Option[A] =
       typeClassInstance.minimumByOption[A, B](self)(f)
     def maximumByOption[B](f: A => B)(implicit ev$1: Order[B]): Option[A] =
       typeClassInstance.maximumByOption[A, B](self)(f)
-    def minimumList(implicit A: Order[A]): List[A] = typeClassInstance.minimumList[A](self)(A)
-    def maximumList(implicit A: Order[A]): List[A] = typeClassInstance.maximumList[A](self)(A)
+    def minimumList(implicit A: Order[A]): List[A] = typeClassInstance.minimumList[A](self)(using A)
+    def maximumList(implicit A: Order[A]): List[A] = typeClassInstance.maximumList[A](self)(using A)
     def minimumByList[B](f: A => B)(implicit ev$1: Order[B]): List[A] = typeClassInstance.minimumByList[A, B](self)(f)
     def maximumByList[B](f: A => B)(implicit ev$1: Order[B]): List[A] = typeClassInstance.maximumByList[A, B](self)(f)
     def get(idx: Long): Option[A] = typeClassInstance.get[A](self)(idx)
     def collectFirst[B](pf: PartialFunction[A, B]): Option[B] = typeClassInstance.collectFirst[A, B](self)(pf)
     def collectFirstSome[B](f: A => Option[B]): Option[B] = typeClassInstance.collectFirstSome[A, B](self)(f)
     def collectFoldSome[B](f: A => Option[B])(implicit B: Monoid[B]): B =
-      typeClassInstance.collectFoldSome[A, B](self)(f)(B)
-    def fold(implicit A: Monoid[A]): A = typeClassInstance.fold[A](self)(A)
+      typeClassInstance.collectFoldSome[A, B](self)(f)(using B)
+    def fold(implicit A: Monoid[A]): A = typeClassInstance.fold[A](self)(using A)
     def sumAll(implicit A: Numeric[A]): A = typeClassInstance.sumAll[A](self)
     def productAll(implicit A: Numeric[A]): A = typeClassInstance.productAll[A](self)
     def combineAll(implicit ev$1: Monoid[A]): A = typeClassInstance.combineAll[A](self)
-    def combineAllOption(implicit ev: Semigroup[A]): Option[A] = typeClassInstance.combineAllOption[A](self)(ev)
+    def combineAllOption(implicit ev: Semigroup[A]): Option[A] = typeClassInstance.combineAllOption[A](self)(using ev)
     def toIterable: Iterable[A] = typeClassInstance.toIterable[A](self)
-    def foldMap[B](f: A => B)(implicit B: Monoid[B]): B = typeClassInstance.foldMap[A, B](self)(f)(B)
+    def foldMap[B](f: A => B)(implicit B: Monoid[B]): B = typeClassInstance.foldMap[A, B](self)(f)(using B)
     def foldM[G[_], B](z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
-      typeClassInstance.foldM[G, A, B](self, z)(f)(G)
+      typeClassInstance.foldM[G, A, B](self, z)(f)(using G)
     final def foldLeftM[G[_], B](z: B)(f: (B, A) => G[B])(implicit G: Monad[G]): G[B] =
-      typeClassInstance.foldLeftM[G, A, B](self, z)(f)(G)
+      typeClassInstance.foldLeftM[G, A, B](self, z)(f)(using G)
     def foldMapM[G[_], B](f: A => G[B])(implicit G: Monad[G], B: Monoid[B]): G[B] =
-      typeClassInstance.foldMapM[G, A, B](self)(f)(G, B)
+      typeClassInstance.foldMapM[G, A, B](self)(f)(using G, B)
     def foldMapA[G[_], B](f: A => G[B])(implicit G: Applicative[G], B: Monoid[B]): G[B] =
-      typeClassInstance.foldMapA[G, A, B](self)(f)(G, B)
+      typeClassInstance.foldMapA[G, A, B](self)(f)(using G, B)
     def traverseVoid[G[_], B](f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
-      typeClassInstance.traverseVoid[G, A, B](self)(f)(G)
+      typeClassInstance.traverseVoid[G, A, B](self)(f)(using G)
     def traverse_[G[_], B](f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
       traverseVoid[G, B](f)
     // TODO: looks like these two methods below duplicate the same named methods from `NestedFoldableOps`.
@@ -1083,19 +1083,19 @@ object Foldable {
     def sequence_[G[_], B](implicit ev$1: A <:< G[B], ev$2: Applicative[G]): G[Unit] =
       sequenceVoid[G, B]
     def foldK[G[_], B](implicit ev$1: A <:< G[B], G: MonoidK[G]): G[B] =
-      typeClassInstance.foldK[G, B](self.asInstanceOf[F[G[B]]])(G)
+      typeClassInstance.foldK[G, B](self.asInstanceOf[F[G[B]]])(using G)
     def find(f: A => Boolean): Option[A] = typeClassInstance.find[A](self)(f)
     def existsM[G[_]](p: A => G[Boolean])(implicit G: Monad[G]): G[Boolean] =
-      typeClassInstance.existsM[G, A](self)(p)(G)
+      typeClassInstance.existsM[G, A](self)(p)(using G)
     def forallM[G[_]](p: A => G[Boolean])(implicit G: Monad[G]): G[Boolean] =
-      typeClassInstance.forallM[G, A](self)(p)(G)
+      typeClassInstance.forallM[G, A](self)(p)(using G)
     def toList: List[A] = typeClassInstance.toList[A](self)
     def partitionEither[B, C](f: A => Either[B, C])(implicit A: Alternative[F]): (F[B], F[C]) =
-      typeClassInstance.partitionEither[A, B, C](self)(f)(A)
+      typeClassInstance.partitionEither[A, B, C](self)(f)(using A)
     def filter_(p: A => Boolean): List[A] = typeClassInstance.filter_[A](self)(p)
     def takeWhile_(p: A => Boolean): List[A] = typeClassInstance.takeWhile_[A](self)(p)
     def dropWhile_(p: A => Boolean): List[A] = typeClassInstance.dropWhile_[A](self)(p)
-    def intercalate(a: A)(implicit A: Monoid[A]): A = typeClassInstance.intercalate[A](self, a)(A)
+    def intercalate(a: A)(implicit A: Monoid[A]): A = typeClassInstance.intercalate[A](self, a)(using A)
   }
   trait AllOps[F[_], A] extends Ops[F, A] with UnorderedFoldable.AllOps[F, A] {
     type TypeClassType <: Foldable[F]

--- a/core/src/main/scala/cats/Invariant.scala
+++ b/core/src/main/scala/cats/Invariant.scala
@@ -166,7 +166,7 @@ object Invariant extends ScalaVersionSpecificInvariantInstances with InvariantIn
   implicit def catsInstancesForFuture(implicit
     ec: ExecutionContext
   ): MonadThrow[Future] & CoflatMap[Future] =
-    cats.instances.future.catsStdInstancesForFuture(ec)
+    cats.instances.future.catsStdInstancesForFuture(using ec)
 
   implicit def catsContravariantMonoidalForOrder: ContravariantMonoidal[Order] =
     cats.instances.order.catsContravariantMonoidalForOrder

--- a/core/src/main/scala/cats/InvariantSemigroupal.scala
+++ b/core/src/main/scala/cats/InvariantSemigroupal.scala
@@ -87,5 +87,5 @@ object InvariantSemigroupal extends SemigroupalArityFunctions {
 private[cats] class InvariantSemigroupalSemigroup[F[_], A](f: InvariantSemigroupal[F], sg: Semigroup[A])
     extends Semigroup[F[A]] {
   def combine(a: F[A], b: F[A]): F[A] =
-    InvariantSemigroupal.imap2(a, b)(sg.combine)(a => (a, a))(f, f)
+    InvariantSemigroupal.imap2(a, b)(sg.combine)(a => (a, a))(using f, f)
 }

--- a/core/src/main/scala/cats/Monad.scala
+++ b/core/src/main/scala/cats/Monad.scala
@@ -200,7 +200,7 @@ object Monad {
     def self: F[A]
     val typeClassInstance: TypeClassType
     def untilM[G[_]](cond: => F[Boolean])(implicit G: Alternative[G]): F[G[A]] =
-      typeClassInstance.untilM[G, A](self)(cond)(G)
+      typeClassInstance.untilM[G, A](self)(cond)(using G)
     def untilM_(cond: => F[Boolean]): F[Unit] = typeClassInstance.untilM_[A](self)(cond)
     def iterateWhile(p: A => Boolean): F[A] = typeClassInstance.iterateWhile[A](self)(p)
     def iterateUntil(p: A => Boolean): F[A] = typeClassInstance.iterateUntil[A](self)(p)

--- a/core/src/main/scala/cats/NonEmptyTraverse.scala
+++ b/core/src/main/scala/cats/NonEmptyTraverse.scala
@@ -140,9 +140,9 @@ object NonEmptyTraverse {
     def nonEmptySequence[G[_], B](implicit ev$1: A <:< G[B], ev$2: Apply[G]): G[F[B]] =
       typeClassInstance.nonEmptySequence[G, B](self.asInstanceOf[F[G[B]]])
     def nonEmptyFlatTraverse[G[_], B](f: A => G[F[B]])(implicit G: Apply[G], F: FlatMap[F]): G[F[B]] =
-      typeClassInstance.nonEmptyFlatTraverse[G, A, B](self)(f)(G, F)
+      typeClassInstance.nonEmptyFlatTraverse[G, A, B](self)(f)(using G, F)
     def nonEmptyFlatSequence[G[_], B](implicit ev$1: A <:< G[F[B]], G: Apply[G], F: FlatMap[F]): G[F[B]] =
-      typeClassInstance.nonEmptyFlatSequence[G, B](self.asInstanceOf[F[G[F[B]]]])(G, F)
+      typeClassInstance.nonEmptyFlatSequence[G, B](self.asInstanceOf[F[G[F[B]]]])(using G, F)
   }
   trait AllOps[F[_], A] extends Ops[F, A] with Traverse.AllOps[F, A] with Reducible.AllOps[F, A] {
     type TypeClassType <: NonEmptyTraverse[F]

--- a/core/src/main/scala/cats/Parallel.scala
+++ b/core/src/main/scala/cats/Parallel.scala
@@ -56,7 +56,7 @@ trait NonEmptyParallel[M[_]] extends Serializable {
    * corresponding to the Parallel instance instead.
    */
   def parProductR[A, B](ma: M[A])(mb: M[B]): M[B] =
-    Parallel.parMap2(ma, mb)((_, b) => b)(this)
+    Parallel.parMap2(ma, mb)((_, b) => b)(using this)
 
   @deprecated("Use parProductR instead.", "1.0.0-RC2")
   @inline private[cats] def parFollowedBy[A, B](ma: M[A])(mb: M[B]): M[B] = parProductR(ma)(mb)
@@ -66,7 +66,7 @@ trait NonEmptyParallel[M[_]] extends Serializable {
    * corresponding to the Parallel instance instead.
    */
   def parProductL[A, B](ma: M[A])(mb: M[B]): M[A] =
-    Parallel.parMap2(ma, mb)((a, _) => a)(this)
+    Parallel.parMap2(ma, mb)((a, _) => a)(using this)
 
   @deprecated("Use parProductL instead.", "1.0.0-RC2")
   @inline private[cats] def parForEffect[A, B](ma: M[A])(mb: M[B]): M[A] = parProductL(ma)(mb)
@@ -171,7 +171,7 @@ object Parallel extends ParallelArityFunctions2 {
   def parTraverseFilter[T[_], M[_], A, B](
     ta: T[A]
   )(f: A => M[Option[B]])(implicit T: TraverseFilter[T], P: Parallel[M]): M[T[B]] = {
-    val ftb: P.F[T[B]] = T.traverseFilter[P.F, A, B](ta)(a => P.parallel(f(a)))(P.applicative)
+    val ftb: P.F[T[B]] = T.traverseFilter[P.F, A, B](ta)(a => P.parallel(f(a)))(using P.applicative)
 
     P.sequential(ftb)
   }
@@ -190,7 +190,7 @@ object Parallel extends ParallelArityFunctions2 {
    * }}}
    */
   def parSequenceFilter[T[_], M[_], A](ta: T[M[Option[A]]])(implicit T: TraverseFilter[T], P: Parallel[M]): M[T[A]] = {
-    val fta: P.F[T[A]] = T.traverseFilter[P.F, M[Option[A]], A](ta)(P.parallel.apply(_))(P.applicative)
+    val fta: P.F[T[A]] = T.traverseFilter[P.F, M[Option[A]], A](ta)(P.parallel.apply(_))(using P.applicative)
 
     P.sequential(fta)
   }
@@ -214,7 +214,7 @@ object Parallel extends ParallelArityFunctions2 {
   def parFilterA[T[_], M[_], A](
     ta: T[A]
   )(f: A => M[Boolean])(implicit T: TraverseFilter[T], P: Parallel[M]): M[T[A]] = {
-    val fta: P.F[T[A]] = T.filterA(ta)(a => P.parallel(f(a)))(P.applicative)
+    val fta: P.F[T[A]] = T.filterA(ta)(a => P.parallel(f(a)))(using P.applicative)
 
     P.sequential(fta)
   }
@@ -244,7 +244,7 @@ object Parallel extends ParallelArityFunctions2 {
   def parFlatTraverse[T[_]: Traverse: FlatMap, M[_], A, B](
     ta: T[A]
   )(f: A => M[T[B]])(implicit P: Parallel[M]): M[T[B]] = {
-    val gtb: P.F[T[B]] = Traverse[T].flatTraverse(ta)(a => P.parallel(f(a)))(P.applicative, FlatMap[T])
+    val gtb: P.F[T[B]] = Traverse[T].flatTraverse(ta)(a => P.parallel(f(a)))(using P.applicative, FlatMap[T])
     P.sequential(gtb)
   }
 
@@ -255,7 +255,7 @@ object Parallel extends ParallelArityFunctions2 {
   def parFlatSequence[T[_]: Traverse: FlatMap, M[_], A](
     tma: T[M[T[A]]]
   )(implicit P: Parallel[M]): M[T[A]] = {
-    val fta: P.F[T[A]] = Traverse[T].flatTraverse(tma)(P.parallel.apply(_))(P.applicative, FlatMap[T])
+    val fta: P.F[T[A]] = Traverse[T].flatTraverse(tma)(P.parallel.apply(_))(using P.applicative, FlatMap[T])
     P.sequential(fta)
   }
 
@@ -264,7 +264,7 @@ object Parallel extends ParallelArityFunctions2 {
    * corresponding to the Parallel instance instead.
    */
   def parSequenceVoid[T[_]: Foldable, M[_], A](tma: T[M[A]])(implicit P: Parallel[M]): M[Unit] = {
-    val fu: P.F[Unit] = Foldable[T].traverseVoid(tma)(P.parallel.apply(_))(P.applicative)
+    val fu: P.F[Unit] = Foldable[T].traverseVoid(tma)(P.parallel.apply(_))(using P.applicative)
     P.sequential(fu)
   }
 
@@ -281,7 +281,7 @@ object Parallel extends ParallelArityFunctions2 {
    * corresponding to the Parallel instance instead.
    */
   def parTraverseVoid[T[_]: Foldable, M[_], A, B](ta: T[A])(f: A => M[B])(implicit P: Parallel[M]): M[Unit] = {
-    val gtb: P.F[Unit] = Foldable[T].traverseVoid(ta)(a => P.parallel(f(a)))(P.applicative)
+    val gtb: P.F[Unit] = Foldable[T].traverseVoid(ta)(a => P.parallel(f(a)))(using P.applicative)
     P.sequential(gtb)
   }
 
@@ -343,7 +343,7 @@ object Parallel extends ParallelArityFunctions2 {
     ta: T[A]
   )(f: A => M[T[B]])(implicit P: NonEmptyParallel[M]): M[T[B]] = {
     val gtb: P.F[T[B]] =
-      NonEmptyTraverse[T].nonEmptyFlatTraverse(ta)(a => P.parallel(f(a)))(P.apply, FlatMap[T])
+      NonEmptyTraverse[T].nonEmptyFlatTraverse(ta)(a => P.parallel(f(a)))(using P.apply, FlatMap[T])
     P.sequential(gtb)
   }
 
@@ -354,7 +354,7 @@ object Parallel extends ParallelArityFunctions2 {
   def parNonEmptyFlatSequence[T[_]: NonEmptyTraverse: FlatMap, M[_], A](
     tma: T[M[T[A]]]
   )(implicit P: NonEmptyParallel[M]): M[T[A]] = {
-    val fta: P.F[T[A]] = NonEmptyTraverse[T].nonEmptyFlatTraverse(tma)(P.parallel.apply(_))(P.apply, FlatMap[T])
+    val fta: P.F[T[A]] = NonEmptyTraverse[T].nonEmptyFlatTraverse(tma)(P.parallel.apply(_))(using P.apply, FlatMap[T])
     P.sequential(fta)
   }
 
@@ -365,7 +365,7 @@ object Parallel extends ParallelArityFunctions2 {
   def parNonEmptySequenceVoid[T[_]: Reducible, M[_], A](
     tma: T[M[A]]
   )(implicit P: NonEmptyParallel[M]): M[Unit] = {
-    val fu: P.F[Unit] = Reducible[T].nonEmptyTraverseVoid(tma)(P.parallel.apply(_))(P.apply)
+    val fu: P.F[Unit] = Reducible[T].nonEmptyTraverseVoid(tma)(P.parallel.apply(_))(using P.apply)
     P.sequential(fu)
   }
 
@@ -386,7 +386,7 @@ object Parallel extends ParallelArityFunctions2 {
   def parNonEmptyTraverseVoid[T[_]: Reducible, M[_], A, B](
     ta: T[A]
   )(f: A => M[B])(implicit P: NonEmptyParallel[M]): M[Unit] = {
-    val gtb: P.F[Unit] = Reducible[T].nonEmptyTraverseVoid(ta)(a => P.parallel(f(a)))(P.apply)
+    val gtb: P.F[Unit] = Reducible[T].nonEmptyTraverseVoid(ta)(a => P.parallel(f(a)))(using P.apply)
     P.sequential(gtb)
   }
 
@@ -456,7 +456,7 @@ object Parallel extends ParallelArityFunctions2 {
     ta: T[A]
   )(f: A => M[B])(implicit T: Foldable[T], P: Parallel[M], B: Monoid[B]): M[B] = {
     val fb: P.F[B] =
-      Foldable[T].foldMapA(ta)(a => P.parallel(f(a)))(P.applicative, B)
+      Foldable[T].foldMapA(ta)(a => P.parallel(f(a)))(using P.applicative, B)
     P.sequential(fb)
   }
 
@@ -468,7 +468,7 @@ object Parallel extends ParallelArityFunctions2 {
     ta: T[A]
   )(f: A => M[B])(implicit T: Reducible[T], P: NonEmptyParallel[M], B: Semigroup[B]): M[B] = {
     val fb: P.F[B] =
-      T.reduceMapA(ta)(a => P.parallel(f(a)))(P.apply, B)
+      T.reduceMapA(ta)(a => P.parallel(f(a)))(using P.apply, B)
     P.sequential(fb)
   }
 

--- a/core/src/main/scala/cats/Reducible.scala
+++ b/core/src/main/scala/cats/Reducible.scala
@@ -72,7 +72,7 @@ trait Reducible[F[_]] extends Foldable[F] { self =>
    * }}}
    */
   def reduceK[G[_], A](fga: F[G[A]])(implicit G: SemigroupK[G]): G[A] =
-    reduce(fga)(G.algebra)
+    reduce(fga)(using G.algebra)
 
   /**
    * Apply `f` to each element of `fa` and combine them using the
@@ -266,7 +266,7 @@ trait Reducible[F[_]] extends Foldable[F] { self =>
    * @see [[maximumBy]] for maximum instead of minimum.
    */
   def minimumBy[A, B: Order](fa: F[A])(f: A => B): A =
-    minimum(fa)(Order.by(f))
+    minimum(fa)(using Order.by(f))
 
   /**
    * Find the maximum `A` item in this structure according to an `Order.by(f)`.
@@ -274,7 +274,7 @@ trait Reducible[F[_]] extends Foldable[F] { self =>
    * @see [[minimumBy]] for minimum instead of maximum.
    */
   def maximumBy[A, B: Order](fa: F[A])(f: A => B): A =
-    maximum(fa)(Order.by(f))
+    maximum(fa)(using Order.by(f))
 
   /**
    * Find all the minimum `A` items in this structure.
@@ -309,7 +309,7 @@ trait Reducible[F[_]] extends Foldable[F] { self =>
    * @see [[maximumByNel]] for maximum instead of minimum.
    */
   def minimumByNel[A, B: Order](fa: F[A])(f: A => B): NonEmptyList[A] =
-    minimumNel(fa)(Order.by(f))
+    minimumNel(fa)(using Order.by(f))
 
   /**
    * Find all the maximum `A` items in this structure according to an `Order.by(f)`.
@@ -318,7 +318,7 @@ trait Reducible[F[_]] extends Foldable[F] { self =>
    * @see [[minimumByNel]] for minimum instead of maximum.
    */
   def maximumByNel[A, B: Order](fa: F[A])(f: A => B): NonEmptyList[A] =
-    maximumNel(fa)(Order.by(f))
+    maximumNel(fa)(using Order.by(f))
 
   /**
    * Intercalate/insert an element between the existing elements while reducing.
@@ -333,7 +333,7 @@ trait Reducible[F[_]] extends Foldable[F] { self =>
    * }}}
    */
   def nonEmptyIntercalate[A](fa: F[A], a: A)(implicit A: Semigroup[A]): A =
-    reduce(fa)(A.intercalate(a))
+    reduce(fa)(using A.intercalate(a))
 
   /**
    * Partition this Reducible by a separating function `A => Either[B, C]`
@@ -401,17 +401,17 @@ object Reducible {
     val typeClassInstance: TypeClassType
     def reduceLeft(f: (A, A) => A): A = typeClassInstance.reduceLeft[A](self)(f)
     def reduceRight(f: (A, Eval[A]) => Eval[A]): Eval[A] = typeClassInstance.reduceRight[A](self)(f)
-    def reduce(implicit A: Semigroup[A]): A = typeClassInstance.reduce[A](self)(A)
+    def reduce(implicit A: Semigroup[A]): A = typeClassInstance.reduce[A](self)(using A)
     def reduceK[G[_], B](implicit ev$1: A <:< G[B], G: SemigroupK[G]): G[B] =
-      typeClassInstance.reduceK[G, B](self.asInstanceOf[F[G[B]]])(G)
-    def reduceMap[B](f: A => B)(implicit B: Semigroup[B]): B = typeClassInstance.reduceMap[A, B](self)(f)(B)
+      typeClassInstance.reduceK[G, B](self.asInstanceOf[F[G[B]]])(using G)
+    def reduceMap[B](f: A => B)(implicit B: Semigroup[B]): B = typeClassInstance.reduceMap[A, B](self)(f)(using B)
     def reduceLeftTo[B](f: A => B)(g: (B, A) => B): B = typeClassInstance.reduceLeftTo[A, B](self)(f)(g)
     def reduceLeftM[G[_], B](f: A => G[B])(g: (B, A) => G[B])(implicit G: FlatMap[G]): G[B] =
-      typeClassInstance.reduceLeftM[G, A, B](self)(f)(g)(G)
+      typeClassInstance.reduceLeftM[G, A, B](self)(f)(g)(using G)
     def reduceMapA[G[_], B](f: A => G[B])(implicit G: Apply[G], B: Semigroup[B]): G[B] =
-      typeClassInstance.reduceMapA[G, A, B](self)(f)(G, B)
+      typeClassInstance.reduceMapA[G, A, B](self)(f)(using G, B)
     def reduceMapM[G[_], B](f: A => G[B])(implicit G: FlatMap[G], B: Semigroup[B]): G[B] =
-      typeClassInstance.reduceMapM[G, A, B](self)(f)(G, B)
+      typeClassInstance.reduceMapM[G, A, B](self)(f)(using G, B)
     def reduceRightTo[B](f: A => B)(g: (A, Eval[B]) => Eval[B]): Eval[B] =
       typeClassInstance.reduceRightTo[A, B](self)(f)(g)
     def nonEmptyTraverseVoid[G[_], B](f: A => G[B])(implicit G: Apply[G]): G[Unit] =
@@ -423,17 +423,18 @@ object Reducible {
     def nonEmptySequence_[G[_], B](implicit ev$1: A <:< G[B], G: Apply[G]): G[Unit] =
       nonEmptySequenceVoid[G, B]
     def toNonEmptyList: NonEmptyList[A] = typeClassInstance.toNonEmptyList[A](self)
-    def minimum(implicit A: Order[A]): A = typeClassInstance.minimum[A](self)(A)
-    def maximum(implicit A: Order[A]): A = typeClassInstance.maximum[A](self)(A)
+    def minimum(implicit A: Order[A]): A = typeClassInstance.minimum[A](self)(using A)
+    def maximum(implicit A: Order[A]): A = typeClassInstance.maximum[A](self)(using A)
     def minimumBy[B](f: A => B)(implicit ev$1: Order[B]): A = typeClassInstance.minimumBy[A, B](self)(f)
     def maximumBy[B](f: A => B)(implicit ev$1: Order[B]): A = typeClassInstance.maximumBy[A, B](self)(f)
-    def minimumNel(implicit A: Order[A]): NonEmptyList[A] = typeClassInstance.minimumNel[A](self)(A)
-    def maximumNel(implicit A: Order[A]): NonEmptyList[A] = typeClassInstance.maximumNel[A](self)(A)
+    def minimumNel(implicit A: Order[A]): NonEmptyList[A] = typeClassInstance.minimumNel[A](self)(using A)
+    def maximumNel(implicit A: Order[A]): NonEmptyList[A] = typeClassInstance.maximumNel[A](self)(using A)
     def minimumByNel[B](f: A => B)(implicit ev$1: Order[B]): NonEmptyList[A] =
       typeClassInstance.minimumByNel[A, B](self)(f)
     def maximumByNel[B](f: A => B)(implicit ev$1: Order[B]): NonEmptyList[A] =
       typeClassInstance.maximumByNel[A, B](self)(f)
-    def nonEmptyIntercalate(a: A)(implicit A: Semigroup[A]): A = typeClassInstance.nonEmptyIntercalate[A](self, a)(A)
+    def nonEmptyIntercalate(a: A)(implicit A: Semigroup[A]): A =
+      typeClassInstance.nonEmptyIntercalate[A](self, a)(using A)
     def nonEmptyPartition[B, C](f: A => Either[B, C]): Ior[NonEmptyList[B], NonEmptyList[C]] =
       typeClassInstance.nonEmptyPartition[A, B, C](self)(f)
   }

--- a/core/src/main/scala/cats/SemigroupK.scala
+++ b/core/src/main/scala/cats/SemigroupK.scala
@@ -233,7 +233,7 @@ object SemigroupK extends ScalaVersionSpecificMonoidKInstances with SemigroupKIn
     def combineK(y: F[A]): F[A] = typeClassInstance.combineK[A](self, y)
     def <+>(y: F[A]): F[A] = typeClassInstance.combineK[A](self, y)
     def combineKEval(y: Eval[F[A]]): Eval[F[A]] = typeClassInstance.combineKEval[A](self, y)
-    def sum[B](fb: F[B])(implicit F: Functor[F]): F[Either[A, B]] = typeClassInstance.sum[A, B](self, fb)(F)
+    def sum[B](fb: F[B])(implicit F: Functor[F]): F[Either[A, B]] = typeClassInstance.sum[A, B](self, fb)(using F)
   }
   trait AllOps[F[_], A] extends Ops[F, A]
   trait ToSemigroupKOps extends Serializable {

--- a/core/src/main/scala/cats/Semigroupal.scala
+++ b/core/src/main/scala/cats/Semigroupal.scala
@@ -81,7 +81,7 @@ object Semigroupal extends SemigroupalArityFunctions with ScalaVersionSpecificSe
    * @see [[https://github.com/typelevel/cats/issues/4176 Changes in Future traverse behavior between 2.6 and 2.7]]
    */
   implicit def catsSemigroupalForFuture(implicit ec: ExecutionContext): Semigroupal[Future] =
-    cats.instances.future.catsStdInstancesForFuture(ec)
+    cats.instances.future.catsStdInstancesForFuture(using ec)
 
   implicit def catsSemigroupalForList: Semigroupal[List] = cats.instances.list.catsStdInstancesForList
   implicit def catsSemigroupalForSeq: Semigroupal[Seq] = cats.instances.seq.catsStdInstancesForSeq

--- a/core/src/main/scala/cats/Traverse.scala
+++ b/core/src/main/scala/cats/Traverse.scala
@@ -244,17 +244,17 @@ object Traverse {
     def traverseTap[G[_], B](f: A => G[B])(implicit ev$1: Applicative[G]): G[F[A]] =
       typeClassInstance.traverseTap[G, A, B](self)(f)
     def flatTraverse[G[_], B](f: A => G[F[B]])(implicit G: Applicative[G], F: FlatMap[F]): G[F[B]] =
-      typeClassInstance.flatTraverse[G, A, B](self)(f)(G, F)
+      typeClassInstance.flatTraverse[G, A, B](self)(f)(using G, F)
     def sequence[G[_], B](implicit ev$1: A <:< G[B], ev$2: Applicative[G]): G[F[B]] =
       typeClassInstance.sequence[G, B](self.asInstanceOf[F[G[B]]])
     def flatSequence[G[_], B](implicit ev$1: A <:< G[F[B]], G: Applicative[G], F: FlatMap[F]): G[F[B]] =
-      typeClassInstance.flatSequence[G, B](self.asInstanceOf[F[G[F[B]]]])(G, F)
+      typeClassInstance.flatSequence[G, B](self.asInstanceOf[F[G[F[B]]]])(using G, F)
     def mapAccumulate[S, B](init: S)(f: (S, A) => (S, B)): (S, F[B]) =
       typeClassInstance.mapAccumulate[S, A, B](init, self)(f)
     def mapWithIndex[B](f: (A, Int) => B): F[B] =
       typeClassInstance.mapWithIndex[A, B](self)(f)
     def traverseWithIndexM[G[_], B](f: (A, Int) => G[B])(implicit G: Monad[G]): G[F[B]] =
-      typeClassInstance.traverseWithIndexM[G, A, B](self)(f)(G)
+      typeClassInstance.traverseWithIndexM[G, A, B](self)(f)(using G)
     def zipWithIndex: F[(A, Int)] =
       typeClassInstance.zipWithIndex[A](self)
     def zipWithLongIndex: F[(A, Long)] =

--- a/core/src/main/scala/cats/TraverseFilter.scala
+++ b/core/src/main/scala/cats/TraverseFilter.scala
@@ -180,11 +180,11 @@ object TraverseFilter {
     def self: F[A]
     val typeClassInstance: TypeClassType
     def traverseFilter[G[_], B](f: A => G[Option[B]])(implicit G: Applicative[G]): G[F[B]] =
-      typeClassInstance.traverseFilter[G, A, B](self)(f)(G)
+      typeClassInstance.traverseFilter[G, A, B](self)(f)(using G)
     def filterA[G[_]](f: A => G[Boolean])(implicit G: Applicative[G]): G[F[A]] =
-      typeClassInstance.filterA[G, A](self)(f)(G)
+      typeClassInstance.filterA[G, A](self)(f)(using G)
     def traverseEither[G[_], B, C](f: A => G[Either[C, B]])(g: (A, C) => G[Unit])(implicit G: Monad[G]): G[F[B]] =
-      typeClassInstance.traverseEither[G, A, B, C](self)(f)(g)(G)
+      typeClassInstance.traverseEither[G, A, B, C](self)(f)(g)(using G)
     def ordDistinct(implicit O: Order[A]): F[A] = typeClassInstance.ordDistinct(self)
     def hashDistinct(implicit H: Hash[A]): F[A] = typeClassInstance.hashDistinct(self)
   }

--- a/core/src/main/scala/cats/data/Chain.scala
+++ b/core/src/main/scala/cats/data/Chain.scala
@@ -1051,16 +1051,16 @@ sealed abstract class Chain[+A] extends ChainCompat[A] {
     KernelStaticMethods.orderedHash((this: Chain[AA]).iterator)
 
   override def toString: String =
-    show(Show.fromToString)
+    show(using Show.fromToString)
 
   override def equals(o: Any): Boolean =
     o match {
       case thatChain: Chain[?] =>
-        (this: Chain[Any]).===(thatChain: Chain[Any])(Eq.fromUniversalEquals[Any])
+        (this: Chain[Any]).===(thatChain: Chain[Any])(using Eq.fromUniversalEquals[Any])
       case _ => false
     }
 
-  override def hashCode: Int = hash(Hash.fromUniversalHashCode[A])
+  override def hashCode: Int = hash(using Hash.fromUniversalHashCode[A])
 
   final def get(idx: Long): Option[A] =
     if (idx < 0) None
@@ -1081,8 +1081,8 @@ sealed abstract class Chain[+A] extends ChainCompat[A] {
 
   final def sortBy[B](f: A => B)(implicit B: Order[B]): Chain[A] =
     this match {
-      case Append(_, _) => Wrap(toVector.sortBy(f)(B.toOrdering))
-      case Wrap(seq)    => Wrap(seq.sortBy(f)(B.toOrdering))
+      case Append(_, _) => Wrap(toVector.sortBy(f)(using B.toOrdering))
+      case Wrap(seq)    => Wrap(seq.sortBy(f)(using B.toOrdering))
       case _            =>
         // Empty | Singleton(_)
         this
@@ -1090,8 +1090,8 @@ sealed abstract class Chain[+A] extends ChainCompat[A] {
 
   final def sorted[AA >: A](implicit AA: Order[AA]): Chain[AA] =
     this match {
-      case Append(_, _) => Wrap(toVector.sorted(AA.toOrdering))
-      case Wrap(seq)    => Wrap(seq.sorted(AA.toOrdering))
+      case Append(_, _) => Wrap(toVector.sorted(using AA.toOrdering))
+      case Wrap(seq)    => Wrap(seq.sorted(using AA.toOrdering))
       case _            =>
         // Empty | Singleton(_)
         this
@@ -1444,7 +1444,7 @@ sealed abstract private[data] class ChainInstances extends ChainInstances1 {
         else
           G match {
             case x: StackSafeMonad[G] =>
-              Traverse.traverseDirectly(fa.iterator)(f)(x)
+              Traverse.traverseDirectly(fa.iterator)(f)(using x)
             case _ =>
               traverseViaChain {
                 val as = collection.mutable.ArrayBuffer[A]()
@@ -1455,7 +1455,7 @@ sealed abstract private[data] class ChainInstances extends ChainInstances1 {
 
       override def traverseVoid[G[_], A, B](fa: Chain[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
         G match {
-          case x: StackSafeMonad[G] => Traverse.traverseVoidDirectly(fa.iterator)(f)(x)
+          case x: StackSafeMonad[G] => Traverse.traverseVoidDirectly(fa.iterator)(f)(using x)
           case _                    =>
             @tailrec
             def go(fa: NonEmpty[A], rhs: Chain[A], acc: G[Unit]): G[Unit] =
@@ -1492,13 +1492,13 @@ sealed abstract private[data] class ChainInstances extends ChainInstances1 {
       }
 
       override def mapAccumulate[S, A, B](init: S, fa: Chain[A])(f: (S, A) => (S, B)): (S, Chain[B]) =
-        StaticMethods.mapAccumulateFromStrictFunctor(init, fa, f)(this)
+        StaticMethods.mapAccumulateFromStrictFunctor(init, fa, f)(using this)
 
       override def mapWithIndex[A, B](fa: Chain[A])(f: (A, Int) => B): Chain[B] =
-        StaticMethods.mapWithIndexFromStrictFunctor(fa, f)(this)
+        StaticMethods.mapWithIndexFromStrictFunctor(fa, f)(using this)
 
       override def mapWithLongIndex[A, B](fa: Chain[A])(f: (A, Long) => B): Chain[B] =
-        StaticMethods.mapWithLongIndexFromStrictFunctor(fa, f)(this)
+        StaticMethods.mapWithLongIndexFromStrictFunctor(fa, f)(using this)
 
       override def zipWithIndex[A](fa: Chain[A]): Chain[(A, Int)] =
         fa.zipWithIndex
@@ -1600,7 +1600,7 @@ sealed abstract private[data] class ChainInstances extends ChainInstances1 {
       else
         G match {
           case x: StackSafeMonad[G] =>
-            TraverseFilter.traverseFilterDirectly(fa.iterator)(f)(x)
+            TraverseFilter.traverseFilterDirectly(fa.iterator)(f)(using x)
           case _ =>
             traverseFilterViaChain {
               val as = collection.mutable.ArrayBuffer[A]()

--- a/core/src/main/scala/cats/data/EitherT.scala
+++ b/core/src/main/scala/cats/data/EitherT.scala
@@ -1102,10 +1102,10 @@ abstract private[data] class EitherTInstances1 extends EitherTInstances2 {
     new EitherTMonadError[F, L] {
       implicit val F = F0
       override def ensure[A](fa: EitherT[F, L, A])(error: => L)(predicate: (A) => Boolean): EitherT[F, L, A] =
-        fa.ensure(error)(predicate)(F)
+        fa.ensure(error)(predicate)(using F)
 
       override def ensureOr[A](fa: EitherT[F, L, A])(error: (A) => L)(predicate: (A) => Boolean): EitherT[F, L, A] =
-        fa.ensureOr(error)(predicate)(F)
+        fa.ensureOr(error)(predicate)(using F)
     }
 
   implicit def catsDataParallelForEitherTWithSequentialEffect[M[_]: Monad, E: Semigroup]

--- a/core/src/main/scala/cats/data/Func.scala
+++ b/core/src/main/scala/cats/data/Func.scala
@@ -93,7 +93,7 @@ abstract private[data] class FuncInstances1 {
 sealed private[data] trait FuncFunctor[F[_], C] extends Functor[λ[α => Func[F, C, α]]] {
   def F: Functor[F]
   override def map[A, B](fa: Func[F, C, A])(f: A => B): Func[F, C, B] =
-    fa.map(f)(F)
+    fa.map(f)(using F)
 }
 
 sealed private[data] trait FuncContravariant[F[_], C] extends Contravariant[λ[α => Func[F, α, C]]] {
@@ -168,9 +168,9 @@ sealed abstract private[data] class AppFuncApplicative[F[_], C]
   override def map[A, B](fa: AppFunc[F, C, A])(f: A => B): AppFunc[F, C, B] =
     fa.map(f)
   def ap[A, B](f: AppFunc[F, C, A => B])(fa: AppFunc[F, C, A]): AppFunc[F, C, B] =
-    Func.appFunc[F, C, B](c => F.ap(f.run(c))(fa.run(c)))(F)
+    Func.appFunc[F, C, B](c => F.ap(f.run(c))(fa.run(c)))(using F)
   override def product[A, B](fa: AppFunc[F, C, A], fb: AppFunc[F, C, B]): AppFunc[F, C, (A, B)] =
-    Func.appFunc[F, C, (A, B)](c => F.product(fa.run(c), fb.run(c)))(F)
+    Func.appFunc[F, C, (A, B)](c => F.product(fa.run(c), fb.run(c)))(using F)
   def pure[A](a: A): AppFunc[F, C, A] =
-    Func.appFunc[F, C, A](Function.const(F.pure(a)))(F)
+    Func.appFunc[F, C, A](Function.const(F.pure(a)))(using F)
 }

--- a/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedReaderWriterStateT.scala
@@ -500,7 +500,7 @@ object IndexedReaderWriterStateT extends IRWSTInstances with CommonIRWSTConstruc
   )(implicit F: FlatMap[F]): IndexedReaderWriterStateT[F, E, L, SA, SB, A] =
     F match {
       case ap: Applicative[F] @unchecked =>
-        IndexedReaderWriterStateT.apply[F, E, L, SA, SB, A]((e: E, sa: SA) => F.flatMap(runF)(f => f(e, sa)))(ap)
+        IndexedReaderWriterStateT.apply[F, E, L, SA, SB, A]((e: E, sa: SA) => F.flatMap(runF)(f => f(e, sa)))(using ap)
       case _ =>
         IndexedReaderWriterStateT.applyF(runF)
     }
@@ -840,6 +840,6 @@ private trait RWSTAlternative1[F[_], E, L, S]
   def ap[A, B](
     ff: ReaderWriterStateT[F, E, L, S, A => B]
   )(fa: ReaderWriterStateT[F, E, L, S, A]): ReaderWriterStateT[F, E, L, S, B] =
-    ff.flatMap(f => fa.map(f)(F))(F, L)
+    ff.flatMap(f => fa.map(f)(using F))(using F, L)
 
 }

--- a/core/src/main/scala/cats/data/IndexedStateT.scala
+++ b/core/src/main/scala/cats/data/IndexedStateT.scala
@@ -503,7 +503,7 @@ sealed abstract private[data] class IndexedStateTContravariantMonoidal[F[_], S]
           f(tup._2) match {
             case (b, c) => (G.pure((tup._1, b)), G.pure((tup._1, c)))
           }
-        )(G, F)
+        )(using G, F)
       )
     )
 }
@@ -514,10 +514,10 @@ sealed abstract private[data] class IndexedStateTAlternative[F[_], S]
   def G: Alternative[F]
 
   def combineK[A](x: IndexedStateT[F, S, S, A], y: IndexedStateT[F, S, S, A]): IndexedStateT[F, S, S, A] =
-    IndexedStateT[F, S, S, A](s => G.combineK(x.run(s), y.run(s)))(G)
+    IndexedStateT[F, S, S, A](s => G.combineK(x.run(s), y.run(s)))(using G)
 
   def empty[A]: IndexedStateT[F, S, S, A] =
-    IndexedStateT.liftF[F, S, A](G.empty[A])(G)
+    IndexedStateT.liftF[F, S, A](G.empty[A])(using G)
 }
 
 sealed abstract private[data] class IndexedStateTMonadError[F[_], S, E]
@@ -537,7 +537,7 @@ private[this] trait IndexedStateTFunctorFilter[F[_], SA, SB] extends FunctorFilt
   def FF: FunctorFilter[F]
 
   def functor: Functor[IndexedStateT[F, SA, SB, *]] =
-    IndexedStateT.catsDataFunctorForIndexedStateT(FF.functor)
+    IndexedStateT.catsDataFunctorForIndexedStateT(using FF.functor)
 
   def mapFilter[A, B](fa: IndexedStateT[F, SA, SB, A])(f: A => Option[B]): IndexedStateT[F, SA, SB, B] =
     fa.flatMapF(a => FF.mapFilter(F0.pure(a))(f))

--- a/core/src/main/scala/cats/data/IorT.scala
+++ b/core/src/main/scala/cats/data/IorT.scala
@@ -102,7 +102,8 @@ final case class IorT[F[_], A, B](value: F[Ior[A, B]]) {
 
   def collectRight(implicit FA: Alternative[F], FM: FlatMap[F]): F[B] = FM.flatMap(value)(_.to[F, B])
 
-  def merge[AA >: A](implicit ev: B <:< AA, F: Functor[F], AA: Semigroup[AA]): F[AA] = F.map(value)(_.merge(ev, AA))
+  def merge[AA >: A](implicit ev: B <:< AA, F: Functor[F], AA: Semigroup[AA]): F[AA] =
+    F.map(value)(_.merge(using ev, AA))
 
   def show(implicit show: Show[F[Ior[A, B]]]): String = show.show(value)
 
@@ -529,7 +530,7 @@ abstract private[data] class IorTInstances extends IorTInstances1 {
 
       val applicative: Applicative[IorT[P.F, E, *]] = new Apply.AbstractApply[IorT[P.F, E, *]]
         with Applicative[IorT[P.F, E, *]] {
-        def pure[A](a: A): IorT[P.F, E, A] = IorT.pure(a)(FA)
+        def pure[A](a: A): IorT[P.F, E, A] = IorT.pure(a)(using FA)
         def ap[A, B](ff: IorT[P.F, E, A => B])(fa: IorT[P.F, E, A]): IorT[P.F, E, B] =
           IorT(FA.map2(ff.value, fa.value)((f, a) => IorA.ap(f)(a)))
       }
@@ -563,7 +564,7 @@ abstract private[data] class IorTInstances extends IorTInstances1 {
 
       val applicative: Applicative[IorT[P.F, E, *]] = new Apply.AbstractApply[IorT[P.F, E, *]]
         with Applicative[IorT[P.F, E, *]] {
-        def pure[A](a: A): IorT[P.F, E, A] = IorT.pure(a)(FA)
+        def pure[A](a: A): IorT[P.F, E, A] = IorT.pure(a)(using FA)
         def ap[A, B](ff: IorT[P.F, E, A => B])(fa: IorT[P.F, E, A]): IorT[P.F, E, B] =
           IorT(FA.map2(ff.value, fa.value)((f, a) => IorA.ap(f)(a)))
       }

--- a/core/src/main/scala/cats/data/Kleisli.scala
+++ b/core/src/main/scala/cats/data/Kleisli.scala
@@ -461,7 +461,7 @@ sealed abstract private[data] class KleisliInstances1 extends KleisliInstances2 
     new Parallel[Kleisli[M, A, *]] {
       type F[x] = Kleisli[P.F, A, x]
       implicit val monadM: Monad[M] = P.monad
-      def applicative: Applicative[Kleisli[P.F, A, *]] = catsDataApplicativeForKleisli(P.applicative)
+      def applicative: Applicative[Kleisli[P.F, A, *]] = catsDataApplicativeForKleisli(using P.applicative)
       def monad: Monad[Kleisli[M, A, *]] = catsDataMonadForKleisli
 
       def sequential: Kleisli[P.F, A, *] ~> Kleisli[M, A, *] =
@@ -765,7 +765,7 @@ private[this] trait KleisliFunctorFilter[F[_], R] extends FunctorFilter[Kleisli[
 
   def FF: FunctorFilter[F]
 
-  def functor: Functor[Kleisli[F, R, *]] = Kleisli.catsDataFunctorForKleisli(FF.functor)
+  def functor: Functor[Kleisli[F, R, *]] = Kleisli.catsDataFunctorForKleisli(using FF.functor)
 
-  def mapFilter[A, B](fa: Kleisli[F, R, A])(f: A => Option[B]): Kleisli[F, R, B] = fa.mapFilter(f)(FF)
+  def mapFilter[A, B](fa: Kleisli[F, R, A])(f: A => Option[B]): Kleisli[F, R, B] = fa.mapFilter(f)(using FF)
 }

--- a/core/src/main/scala/cats/data/Nested.scala
+++ b/core/src/main/scala/cats/data/Nested.scala
@@ -115,7 +115,7 @@ sealed abstract private[data] class NestedInstances0 extends NestedInstances1 {
     F0: Representable[F],
     G0: Representable[G]
   ): Representable.Aux[Nested[F, G, *], (F0.Representation, G0.Representation)] = new Representable[Nested[F, G, *]] {
-    val FG = F0.compose(G0)
+    val FG = F0.compose(using G0)
 
     val F: Functor[Nested[F, G, *]] = new NestedFunctor[F, G] {
       val FG = F0.F.compose(using G0.F)

--- a/core/src/main/scala/cats/data/NonEmptyChain.scala
+++ b/core/src/main/scala/cats/data/NonEmptyChain.scala
@@ -647,13 +647,13 @@ sealed abstract private[data] class NonEmptyChainInstances extends NonEmptyChain
       }
 
       override def mapAccumulate[S, A, B](init: S, fa: NonEmptyChain[A])(f: (S, A) => (S, B)): (S, NonEmptyChain[B]) =
-        StaticMethods.mapAccumulateFromStrictFunctor(init, fa, f)(this)
+        StaticMethods.mapAccumulateFromStrictFunctor(init, fa, f)(using this)
 
       override def mapWithIndex[A, B](fa: NonEmptyChain[A])(f: (A, Int) => B): NonEmptyChain[B] =
-        StaticMethods.mapWithIndexFromStrictFunctor(fa, f)(this)
+        StaticMethods.mapWithIndexFromStrictFunctor(fa, f)(using this)
 
       override def mapWithLongIndex[A, B](fa: NonEmptyChain[A])(f: (A, Long) => B): NonEmptyChain[B] =
-        StaticMethods.mapWithLongIndexFromStrictFunctor(fa, f)(this)
+        StaticMethods.mapWithLongIndexFromStrictFunctor(fa, f)(using this)
 
       override def zipWithIndex[A](fa: NonEmptyChain[A]): NonEmptyChain[(A, Int)] =
         fa.zipWithIndex

--- a/core/src/main/scala/cats/data/NonEmptyList.scala
+++ b/core/src/main/scala/cats/data/NonEmptyList.scala
@@ -499,7 +499,7 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
    */
   def sortBy[B](f: A => B)(implicit B: Order[B]): NonEmptyList[A] =
     // safe: sorting a NonEmptyList cannot produce an empty List
-    NonEmptyList.fromListUnsafe(toList.sortBy(f)(B.toOrdering))
+    NonEmptyList.fromListUnsafe(toList.sortBy(f)(using B.toOrdering))
 
   /**
    * Sorts this `NonEmptyList` according to an `Order`
@@ -514,7 +514,7 @@ final case class NonEmptyList[+A](head: A, tail: List[A]) extends NonEmptyCollec
    */
   def sorted[AA >: A](implicit AA: Order[AA]): NonEmptyList[AA] =
     // safe: sorting a NonEmptyList cannot produce an empty List
-    NonEmptyList.fromListUnsafe(toList.sorted(AA.toOrdering))
+    NonEmptyList.fromListUnsafe(toList.sorted(using AA.toOrdering))
 
   /**
    * Groups elements inside this `NonEmptyList` according to the `Order`
@@ -916,13 +916,13 @@ sealed abstract private[data] class NonEmptyListInstances extends NonEmptyListIn
         fa.traverse(f)
 
       override def mapAccumulate[S, A, B](init: S, fa: NonEmptyList[A])(f: (S, A) => (S, B)): (S, NonEmptyList[B]) =
-        StaticMethods.mapAccumulateFromStrictFunctor(init, fa, f)(this)
+        StaticMethods.mapAccumulateFromStrictFunctor(init, fa, f)(using this)
 
       override def mapWithIndex[A, B](fa: NonEmptyList[A])(f: (A, Int) => B): NonEmptyList[B] =
-        StaticMethods.mapWithIndexFromStrictFunctor(fa, f)(this)
+        StaticMethods.mapWithIndexFromStrictFunctor(fa, f)(using this)
 
       override def mapWithLongIndex[A, B](fa: NonEmptyList[A])(f: (A, Long) => B): NonEmptyList[B] =
-        StaticMethods.mapWithLongIndexFromStrictFunctor(fa, f)(this)
+        StaticMethods.mapWithLongIndexFromStrictFunctor(fa, f)(using this)
 
       override def zipWithIndex[A](fa: NonEmptyList[A]): NonEmptyList[(A, Int)] =
         fa.zipWithIndex

--- a/core/src/main/scala/cats/data/NonEmptySeq.scala
+++ b/core/src/main/scala/cats/data/NonEmptySeq.scala
@@ -294,10 +294,10 @@ final class NonEmptySeq[+A] private (val toSeq: Seq[A]) extends AnyVal with NonE
     new NonEmptySeq(toSeq.zipWithIndex)
 
   def sortBy[B](f: A => B)(implicit B: Order[B]): NonEmptySeq[A] =
-    new NonEmptySeq(toSeq.sortBy(f)(B.toOrdering))
+    new NonEmptySeq(toSeq.sortBy(f)(using B.toOrdering))
 
   def sorted[AA >: A](implicit AA: Order[AA]): NonEmptySeq[AA] =
-    new NonEmptySeq(toSeq.sorted(AA.toOrdering))
+    new NonEmptySeq(toSeq.sorted(using AA.toOrdering))
 
   /**
    * Groups elements inside this `NonEmptySeq` according to the `Order`

--- a/core/src/main/scala/cats/data/NonEmptyVector.scala
+++ b/core/src/main/scala/cats/data/NonEmptyVector.scala
@@ -287,10 +287,10 @@ final class NonEmptyVector[+A] private (val toVector: Vector[A])
     new NonEmptyVector(toVector.zipWithIndex)
 
   def sortBy[B](f: A => B)(implicit B: Order[B]): NonEmptyVector[A] =
-    new NonEmptyVector(toVector.sortBy(f)(B.toOrdering))
+    new NonEmptyVector(toVector.sortBy(f)(using B.toOrdering))
 
   def sorted[AA >: A](implicit AA: Order[AA]): NonEmptyVector[AA] =
-    new NonEmptyVector(toVector.sorted(AA.toOrdering))
+    new NonEmptyVector(toVector.sorted(using AA.toOrdering))
 
   /**
    * Groups elements inside this `NonEmptyVector` according to the `Order`
@@ -478,13 +478,13 @@ sealed abstract private[data] class NonEmptyVectorInstances extends NonEmptyVect
       override def mapAccumulate[S, A, B](init: S, fa: NonEmptyVector[A])(
         f: (S, A) => (S, B)
       ): (S, NonEmptyVector[B]) =
-        StaticMethods.mapAccumulateFromStrictFunctor(init, fa, f)(this)
+        StaticMethods.mapAccumulateFromStrictFunctor(init, fa, f)(using this)
 
       override def mapWithLongIndex[A, B](fa: NonEmptyVector[A])(f: (A, Long) => B): NonEmptyVector[B] =
-        StaticMethods.mapWithLongIndexFromStrictFunctor(fa, f)(this)
+        StaticMethods.mapWithLongIndexFromStrictFunctor(fa, f)(using this)
 
       override def mapWithIndex[A, B](fa: NonEmptyVector[A])(f: (A, Int) => B): NonEmptyVector[B] =
-        StaticMethods.mapWithIndexFromStrictFunctor(fa, f)(this)
+        StaticMethods.mapWithIndexFromStrictFunctor(fa, f)(using this)
 
       override def zipWithIndex[A](fa: NonEmptyVector[A]): NonEmptyVector[(A, Int)] =
         fa.zipWithIndex

--- a/core/src/main/scala/cats/data/OneAnd.scala
+++ b/core/src/main/scala/cats/data/OneAnd.scala
@@ -126,11 +126,11 @@ final case class OneAnd[F[_], A](head: A, tail: F[A]) extends OneAndBinCompat0[F
 sealed private[data] trait OneAndBinCompat0[F[_], A] { self: OneAnd[F, A] =>
   // Kept for binary compatibility
   private[data] def unwrap(F: Alternative[F]): F[A] =
-    self.unwrap(F)
+    self.unwrap(using F)
 
   // Kept for binary compatibility
   private[data] def combine(other: OneAnd[F, A])(F: Alternative[F]): OneAnd[F, A] =
-    self.combine(other)(F)
+    self.combine(other)(using F)
 }
 
 @suppressUnusedImportWarningForScalaVersionSpecific
@@ -141,9 +141,9 @@ sealed abstract private[data] class OneAndInstances extends OneAndLowPriority0 w
   ): Parallel.Aux[OneAnd[M, *], OneAnd[F0, *]] =
     new Parallel[OneAnd[M, *]] {
       type F[x] = OneAnd[F0, x]
-      def monad: Monad[OneAnd[M, *]] = catsDataMonadForOneAnd(P.monad, Alternative[M])
+      def monad: Monad[OneAnd[M, *]] = catsDataMonadForOneAnd(using P.monad, Alternative[M])
 
-      def applicative: Applicative[OneAnd[F0, *]] = catsDataApplicativeForOneAnd(Alternative[F0])
+      def applicative: Applicative[OneAnd[F0, *]] = catsDataApplicativeForOneAnd(using Alternative[F0])
 
       def sequential: OneAnd[F0, *] ~> OneAnd[M, *] =
         new (OneAnd[F0, *] ~> OneAnd[M, *]) {
@@ -183,7 +183,7 @@ sealed abstract private[data] class OneAndInstances extends OneAndLowPriority0 w
   ): Monad[OneAnd[F, *]] =
     new FlatMap.AbstractFlatMap[OneAnd[F, *]] with Monad[OneAnd[F, *]] {
       override def map[A, B](fa: OneAnd[F, A])(f: A => B): OneAnd[F, B] =
-        fa.map(f)(monad)
+        fa.map(f)(using monad)
 
       def pure[A](x: A): OneAnd[F, A] =
         OneAnd(x, alternative.empty)

--- a/core/src/main/scala/cats/data/OptionT.scala
+++ b/core/src/main/scala/cats/data/OptionT.scala
@@ -395,7 +395,7 @@ final case class OptionT[F[_], A](value: F[Option[A]]) {
    * }}}
    */
   def withFilter(p: A => Boolean)(implicit F: Functor[F]): OptionT[F, A] =
-    filter(p)(F)
+    filter(p)(using F)
 
   /**
    * Example:

--- a/core/src/main/scala/cats/data/Validated.scala
+++ b/core/src/main/scala/cats/data/Validated.scala
@@ -1107,10 +1107,10 @@ private[data] class ValidatedApplicative[E: Semigroup]
   def pure[A](a: A): Validated[E, A] = Validated.valid(a)
 
   def ap[A, B](ff: Validated[E, (A) => B])(fa: Validated[E, A]): Validated[E, B] =
-    fa.ap(ff)(Semigroup[E])
+    fa.ap(ff)(using Semigroup[E])
 
   override def product[A, B](fa: Validated[E, A], fb: Validated[E, B]): Validated[E, (A, B)] =
-    fa.product(fb)(Semigroup[E])
+    fa.product(fb)(using Semigroup[E])
 
   override def unit: Validated[E, Unit] = Validated.validUnit
 }

--- a/core/src/main/scala/cats/data/WriterT.scala
+++ b/core/src/main/scala/cats/data/WriterT.scala
@@ -372,7 +372,7 @@ object WriterT extends WriterTInstances with WriterTFunctions with WriterTFuncti
 
 sealed abstract private[data] class WriterTInstances extends WriterTInstances0 {
   implicit def catsDataTraverseForWriterTId[L](implicit F: Traverse[Id]): Traverse[WriterT[Id, L, *]] =
-    catsDataTraverseForWriterT[Id, L](F)
+    catsDataTraverseForWriterT[Id, L](using F)
 
   implicit def catsDataDeferForWriterT[F[_], L](implicit F: Defer[F]): Defer[WriterT[F, L, *]] =
     new Defer[WriterT[F, L, *]] {
@@ -400,7 +400,7 @@ sealed abstract private[data] class WriterTInstances1 extends WriterTInstances2 
     }
 
   implicit def catsDataFoldableForWriterTId[L](implicit F: Foldable[Id]): Foldable[WriterT[Id, L, *]] =
-    catsDataFoldableForWriterT[Id, L](F)
+    catsDataFoldableForWriterT[Id, L](using F)
 
   implicit def catsDataOrderForWriterT[F[_], L, V](implicit Ord: Order[F[(L, V)]]): Order[WriterT[F, L, V]] =
     _ compare _
@@ -423,7 +423,7 @@ sealed abstract private[data] class WriterTInstances2 extends WriterTInstances3 
       type F[x] = WriterT[P.F, L, x]
       implicit val monadM: Monad[M] = P.monad
 
-      def applicative: Applicative[WriterT[P.F, L, *]] = catsDataApplicativeForWriterT(P.applicative, Monoid[L])
+      def applicative: Applicative[WriterT[P.F, L, *]] = catsDataApplicativeForWriterT(using P.applicative, Monoid[L])
       def monad: Monad[WriterT[M, L, *]] = catsDataMonadForWriterT
 
       def sequential: WriterT[P.F, L, *] ~> WriterT[M, L, *] =
@@ -468,7 +468,7 @@ sealed abstract private[data] class WriterTInstances3 extends WriterTInstances4 
     catsDataSemigroupForWriterT[Id, L, V]
 
   implicit def catsDataComonadForWriterTId[L](implicit F: Comonad[Id]): Comonad[WriterT[Id, L, *]] =
-    catsDataComonadForWriterT[Id, L](F)
+    catsDataComonadForWriterT[Id, L](using F)
 }
 
 sealed abstract private[data] class WriterTInstances4 extends WriterTInstances5 {

--- a/core/src/main/scala/cats/evidence/As.scala
+++ b/core/src/main/scala/cats/evidence/As.scala
@@ -122,7 +122,7 @@ object As extends AsInstances with AsSupport {
    * of an abundance of caution
    */
   def fromPredef[A, B](eq: A <:< B): A As B =
-    asFromPredef(eq)
+    asFromPredef(using eq)
 
   /**
    * We can lift subtyping into any covariant type constructor

--- a/core/src/main/scala/cats/evidence/Is.scala
+++ b/core/src/main/scala/cats/evidence/Is.scala
@@ -136,5 +136,5 @@ object Is extends IsInstances with IsSupport {
    */
   @deprecated("use Is.isFromPredef", "2.2.0")
   @inline def unsafeFromPredef[A, B](eq: A =:= B): A Is B =
-    Is.isFromPredef(eq)
+    Is.isFromPredef(using eq)
 }

--- a/core/src/main/scala/cats/instances/eq.scala
+++ b/core/src/main/scala/cats/instances/eq.scala
@@ -40,7 +40,7 @@ trait EqInstances extends kernel.instances.EqInstances {
        * Note: resulting instances are law-abiding only when the functions used are injective (represent a one-to-one mapping)
        */
       def contramap[A, B](fa: Eq[A])(f: B => A): Eq[B] =
-        Eq.by(f)(fa)
+        Eq.by(f)(using fa)
 
       def product[A, B](fa: Eq[A], fb: Eq[B]): Eq[(A, B)] =
         (left, right) => fa.eqv(left._1, right._1) && fb.eqv(left._2, right._2)

--- a/core/src/main/scala/cats/instances/hash.scala
+++ b/core/src/main/scala/cats/instances/hash.scala
@@ -32,7 +32,7 @@ trait HashInstances extends kernel.instances.HashInstances {
       /**
        * Derive a `Hash` for `B` given an `Hash[A]` and a function `B => A`.
        */
-      def contramap[A, B](ha: Hash[A])(f: B => A): Hash[B] = Hash.by(f)(ha)
+      def contramap[A, B](ha: Hash[A])(f: B => A): Hash[B] = Hash.by(f)(using ha)
 
     }
 

--- a/core/src/main/scala/cats/instances/list.scala
+++ b/core/src/main/scala/cats/instances/list.scala
@@ -128,7 +128,7 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
         if (fa.isEmpty) G.pure(Nil)
         else
           G match {
-            case x: StackSafeMonad[G] => x.map(Traverse.traverseDirectly[G, A, B](fa)(f)(x))(_.toList)
+            case x: StackSafeMonad[G] => x.map(Traverse.traverseDirectly[G, A, B](fa)(f)(using x))(_.toList)
             case _                    =>
               G.map(Chain.traverseViaChain {
                 val as = collection.mutable.ArrayBuffer[A]()
@@ -142,7 +142,7 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
        */
       override def traverseVoid[G[_], A, B](fa: List[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] = {
         G match {
-          case x: StackSafeMonad[G] => Traverse.traverseVoidDirectly(fa)(f)(x)
+          case x: StackSafeMonad[G] => Traverse.traverseVoidDirectly(fa)(f)(using x)
           case _                    =>
             // the cost of this is O(size log size)
             // c(n) = n + 2 * c(n/2) = n + 2(n/2 log (n/2)) = n + n (logn - 1) = n log n
@@ -198,13 +198,13 @@ trait ListInstances extends cats.kernel.instances.ListInstances {
       }
 
       override def mapAccumulate[S, A, B](init: S, fa: List[A])(f: (S, A) => (S, B)): (S, List[B]) =
-        StaticMethods.mapAccumulateFromStrictFunctor(init, fa, f)(this)
+        StaticMethods.mapAccumulateFromStrictFunctor(init, fa, f)(using this)
 
       override def mapWithLongIndex[A, B](fa: List[A])(f: (A, Long) => B): List[B] =
-        StaticMethods.mapWithLongIndexFromStrictFunctor(fa, f)(this)
+        StaticMethods.mapWithLongIndexFromStrictFunctor(fa, f)(using this)
 
       override def mapWithIndex[A, B](fa: List[A])(f: (A, Int) => B): List[B] =
-        StaticMethods.mapWithIndexFromStrictFunctor(fa, f)(this)
+        StaticMethods.mapWithIndexFromStrictFunctor(fa, f)(using this)
 
       override def zipWithIndex[A](fa: List[A]): List[(A, Int)] =
         fa.zipWithIndex
@@ -329,7 +329,7 @@ private[instances] trait ListInstancesBinCompat0 {
       if (fa.isEmpty) G.pure(Nil)
       else
         G match {
-          case x: StackSafeMonad[G] => x.map(TraverseFilter.traverseFilterDirectly(fa)(f)(x))(_.toList)
+          case x: StackSafeMonad[G] => x.map(TraverseFilter.traverseFilterDirectly(fa)(f)(using x))(_.toList)
           case _                    =>
             G.map(Chain.traverseFilterViaChain {
               val as = collection.mutable.ArrayBuffer[A]()

--- a/core/src/main/scala/cats/instances/order.scala
+++ b/core/src/main/scala/cats/instances/order.scala
@@ -42,7 +42,7 @@ trait OrderInstances extends kernel.instances.OrderInstances {
        * Note: resulting instances are law-abiding only when the functions used are injective (represent a one-to-one mapping)
        */
       def contramap[A, B](fa: Order[A])(f: B => A): Order[B] =
-        Order.by(f)(fa)
+        Order.by(f)(using fa)
 
       def product[A, B](fa: Order[A], fb: Order[B]): Order[(A, B)] = { (x, y) =>
         val z = fa.compare(x._1, y._1)

--- a/core/src/main/scala/cats/instances/partialOrder.scala
+++ b/core/src/main/scala/cats/instances/partialOrder.scala
@@ -34,7 +34,7 @@ trait PartialOrderInstances extends kernel.instances.PartialOrderInstances {
        *
        * Note: resulting instances are law-abiding only when the functions used are injective (represent a one-to-one mapping)
        */
-      def contramap[A, B](fa: PartialOrder[A])(f: B => A): PartialOrder[B] = PartialOrder.by[B, A](f)(fa)
+      def contramap[A, B](fa: PartialOrder[A])(f: B => A): PartialOrder[B] = PartialOrder.by[B, A](f)(using fa)
 
       def product[A, B](fa: PartialOrder[A], fb: PartialOrder[B]): PartialOrder[(A, B)] = { (x, y) =>
         val z = fa.partialCompare(x._1, y._1)

--- a/core/src/main/scala/cats/instances/queue.scala
+++ b/core/src/main/scala/cats/instances/queue.scala
@@ -127,7 +127,7 @@ trait QueueInstances extends cats.kernel.instances.QueueInstances {
         else
           G match {
             case x: StackSafeMonad[G] =>
-              G.map(Traverse.traverseDirectly(fa)(f)(x))(c => fromIterableOnce(c.iterator))
+              G.map(Traverse.traverseDirectly(fa)(f)(using x))(c => fromIterableOnce(c.iterator))
             case _ =>
               G.map(Chain.traverseViaChain {
                 val as = collection.mutable.ArrayBuffer[A]()
@@ -140,7 +140,7 @@ trait QueueInstances extends cats.kernel.instances.QueueInstances {
 
       override def traverseVoid[G[_], A, B](fa: Queue[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
         G match {
-          case x: StackSafeMonad[G] => Traverse.traverseVoidDirectly(fa)(f)(x)
+          case x: StackSafeMonad[G] => Traverse.traverseVoidDirectly(fa)(f)(using x)
           case _                    =>
             foldRight(fa, Eval.now(G.unit)) { (a, acc) =>
               G.map2Eval(f(a), acc) { (_, _) =>
@@ -150,13 +150,13 @@ trait QueueInstances extends cats.kernel.instances.QueueInstances {
         }
 
       override def mapAccumulate[S, A, B](init: S, fa: Queue[A])(f: (S, A) => (S, B)): (S, Queue[B]) =
-        StaticMethods.mapAccumulateFromStrictFunctor(init, fa, f)(this)
+        StaticMethods.mapAccumulateFromStrictFunctor(init, fa, f)(using this)
 
       override def mapWithLongIndex[A, B](fa: Queue[A])(f: (A, Long) => B): Queue[B] =
-        StaticMethods.mapWithLongIndexFromStrictFunctor(fa, f)(this)
+        StaticMethods.mapWithLongIndexFromStrictFunctor(fa, f)(using this)
 
       override def mapWithIndex[A, B](fa: Queue[A])(f: (A, Int) => B): Queue[B] =
-        StaticMethods.mapWithIndexFromStrictFunctor(fa, f)(this)
+        StaticMethods.mapWithIndexFromStrictFunctor(fa, f)(using this)
 
       override def zipWithIndex[A](fa: Queue[A]): Queue[(A, Int)] =
         fa.zipWithIndex
@@ -248,7 +248,7 @@ private object QueueInstances {
       else
         G match {
           case x: StackSafeMonad[G] =>
-            x.map(TraverseFilter.traverseFilterDirectly(fa)(f)(x))(c => traverse.fromIterableOnce(c.iterator))
+            x.map(TraverseFilter.traverseFilterDirectly(fa)(f)(using x))(c => traverse.fromIterableOnce(c.iterator))
           case _ =>
             G.map(Chain.traverseFilterViaChain {
               val as = collection.mutable.ArrayBuffer[A]()

--- a/core/src/main/scala/cats/instances/seq.scala
+++ b/core/src/main/scala/cats/instances/seq.scala
@@ -133,14 +133,14 @@ trait SeqInstances extends cats.kernel.instances.SeqInstances {
       final override def traverse[G[_], A, B](fa: Seq[A])(f: A => G[B])(implicit G: Applicative[G]): G[Seq[B]] =
         G match {
           case x: StackSafeMonad[G] =>
-            x.map(Traverse.traverseDirectly(fa)(f)(x))(_.toList)
+            x.map(Traverse.traverseDirectly(fa)(f)(using x))(_.toList)
           case _ =>
             G.map(Chain.traverseViaChain(fa.toIndexedSeq)(f))(_.toList)
         }
 
       override def traverseVoid[G[_], A, B](fa: Seq[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] =
         G match {
-          case x: StackSafeMonad[G] => Traverse.traverseVoidDirectly(fa)(f)(x)
+          case x: StackSafeMonad[G] => Traverse.traverseVoidDirectly(fa)(f)(using x)
           case _                    =>
             foldRight(fa, Eval.now(G.unit)) { (a, acc) =>
               G.map2Eval(f(a), acc) { (_, _) =>
@@ -217,7 +217,7 @@ trait SeqInstances extends cats.kernel.instances.SeqInstances {
 
     def traverseFilter[G[_], A, B](fa: Seq[A])(f: (A) => G[Option[B]])(implicit G: Applicative[G]): G[Seq[B]] =
       G match {
-        case x: StackSafeMonad[G] => x.map(TraverseFilter.traverseFilterDirectly(fa)(f)(x))(_.toVector)
+        case x: StackSafeMonad[G] => x.map(TraverseFilter.traverseFilterDirectly(fa)(f)(using x))(_.toVector)
         case _                    =>
           G.map(Chain.traverseFilterViaChain(fa.toIndexedSeq)(f))(_.toVector)
       }

--- a/core/src/main/scala/cats/instances/sortedMap.scala
+++ b/core/src/main/scala/cats/instances/sortedMap.scala
@@ -46,7 +46,7 @@ trait SortedMapInstances extends SortedMapInstances2 {
 
   @deprecated("Use catsStdShowForSortedMap override without Order", "2.2.0-M3")
   implicit def catsStdShowForSortedMap[A, B](orderA: Order[A], showA: Show[A], showB: Show[B]): Show[SortedMap[A, B]] =
-    catsStdShowForSortedMap(showA, showB)
+    catsStdShowForSortedMap(using showA, showB)
 
   implicit def catsStdInstancesForSortedMap[K]
     : Traverse[SortedMap[K, *]] & FlatMap[SortedMap[K, *]] & Align[SortedMap[K, *]] =
@@ -66,7 +66,7 @@ trait SortedMapInstances extends SortedMapInstances2 {
       }
 
       override def mapAccumulate[S, A, B](init: S, fa: SortedMap[K, A])(f: (S, A) => (S, B)): (S, SortedMap[K, B]) =
-        StaticMethods.mapAccumulateFromStrictFunctor(init, fa, f)(this)
+        StaticMethods.mapAccumulateFromStrictFunctor(init, fa, f)(using this)
 
       def flatMap[A, B](fa: SortedMap[K, A])(f: A => SortedMap[K, B]): SortedMap[K, B] = {
         implicit val ordering: Ordering[K] = fa.ordering

--- a/core/src/main/scala/cats/instances/vector.scala
+++ b/core/src/main/scala/cats/instances/vector.scala
@@ -131,7 +131,7 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
 
       final override def traverse[G[_], A, B](fa: Vector[A])(f: A => G[B])(implicit G: Applicative[G]): G[Vector[B]] =
         G match {
-          case x: StackSafeMonad[G] => x.map(Traverse.traverseDirectly(fa)(f)(x))(_.toVector)
+          case x: StackSafeMonad[G] => x.map(Traverse.traverseDirectly(fa)(f)(using x))(_.toVector)
           case _                    => G.map(Chain.traverseViaChain(fa)(f))(_.toVector)
         }
 
@@ -147,7 +147,7 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
        */
       override def traverseVoid[G[_], A, B](fa: Vector[A])(f: A => G[B])(implicit G: Applicative[G]): G[Unit] = {
         G match {
-          case x: StackSafeMonad[G] => Traverse.traverseVoidDirectly(fa)(f)(x)
+          case x: StackSafeMonad[G] => Traverse.traverseVoidDirectly(fa)(f)(using x)
           case _                    =>
             // the cost of this is O(size)
             // c(n) = 1 + 2 * c(n/2)
@@ -185,13 +185,13 @@ trait VectorInstances extends cats.kernel.instances.VectorInstances {
       }
 
       override def mapAccumulate[S, A, B](init: S, fa: Vector[A])(f: (S, A) => (S, B)): (S, Vector[B]) =
-        StaticMethods.mapAccumulateFromStrictFunctor(init, fa, f)(this)
+        StaticMethods.mapAccumulateFromStrictFunctor(init, fa, f)(using this)
 
       override def mapWithIndex[A, B](fa: Vector[A])(f: (A, Int) => B): Vector[B] =
-        StaticMethods.mapWithIndexFromStrictFunctor(fa, f)(this)
+        StaticMethods.mapWithIndexFromStrictFunctor(fa, f)(using this)
 
       override def mapWithLongIndex[A, B](fa: Vector[A])(f: (A, Long) => B): Vector[B] =
-        StaticMethods.mapWithLongIndexFromStrictFunctor(fa, f)(this)
+        StaticMethods.mapWithLongIndexFromStrictFunctor(fa, f)(using this)
 
       override def zipWithIndex[A](fa: Vector[A]): Vector[(A, Int)] =
         fa.zipWithIndex
@@ -279,7 +279,7 @@ private[instances] trait VectorInstancesBinCompat0 {
 
     def traverseFilter[G[_], A, B](fa: Vector[A])(f: (A) => G[Option[B]])(implicit G: Applicative[G]): G[Vector[B]] =
       G match {
-        case x: StackSafeMonad[G] => x.map(TraverseFilter.traverseFilterDirectly(fa)(f)(x))(_.toVector)
+        case x: StackSafeMonad[G] => x.map(TraverseFilter.traverseFilterDirectly(fa)(f)(using x))(_.toVector)
         case _                    =>
           G.map(Chain.traverseFilterViaChain(fa)(f))(_.toVector)
       }

--- a/core/src/main/scala/cats/syntax/alternative.scala
+++ b/core/src/main/scala/cats/syntax/alternative.scala
@@ -38,7 +38,7 @@ final class UniteOps[F[_], G[_], A](protected val fga: F[G[A]]) extends AnyVal w
 
   @deprecated("use a FlatMap-constrained version instead", "2.6.2")
   protected def unite(F: Monad[F], A: Alternative[F], G: Foldable[G]): F[A] =
-    A.unite(fga)(F, G)
+    A.unite(fga)(using F, G)
 }
 
 sealed private[syntax] trait UniteOpsBinCompat0[F[_], G[_], A] extends Any { self: UniteOps[F, G, A] =>
@@ -64,7 +64,7 @@ final class SeparateOps[F[_], G[_, _], A, B](protected val fgab: F[G[A, B]])
 
   @deprecated("use a FlatMap-constrained version instead", "2.6.2")
   protected def separate(F: Monad[F], A: Alternative[F], G: Bifoldable[G]): (F[A], F[B]) =
-    A.separate[G, A, B](fgab)(F, G)
+    A.separate[G, A, B](fgab)(using F, G)
 
   /**
    * See [[Alternative.separateFoldable]]

--- a/core/src/main/scala/cats/syntax/foldable.scala
+++ b/core/src/main/scala/cats/syntax/foldable.scala
@@ -80,7 +80,7 @@ final class FoldableOps[F[_], A](private val fa: F[A]) extends AnyVal {
     F.foldA[G, B](fa.asInstanceOf[F[G[B]]])
 
   private[syntax] def contains_(v: A, eq: Eq[A], F: Foldable[F]): Boolean =
-    F.contains_(fa, v)(eq)
+    F.contains_(fa, v)(using eq)
 
   /**
    * Intercalate with a prefix and a suffix
@@ -264,7 +264,7 @@ final class FoldableOps0[F[_], A](private val fa: F[A]) extends AnyVal {
   def partitionBifold[H[_, _], B, C](
     f: A => H[B, C]
   )(implicit A: Alternative[F], F: Foldable[F], H: Bifoldable[H]): (F[B], F[C]) =
-    F.partitionBifold[H, A, B, C](fa)(f)(A, H)
+    F.partitionBifold[H, A, B, C](fa)(f)(using A, H)
 
   /**
    * Separate this Foldable into a Tuple by an effectful separating function `A => G[H[B, C]]` for some `Bifoldable[H]`
@@ -281,7 +281,7 @@ final class FoldableOps0[F[_], A](private val fa: F[A]) extends AnyVal {
   def partitionBifoldM[G[_], H[_, _], B, C](
     f: A => G[H[B, C]]
   )(implicit A: Alternative[F], F: Foldable[F], M: Monad[G], H: Bifoldable[H]): G[(F[B], F[C])] =
-    F.partitionBifoldM[G, H, A, B, C](fa)(f)(A, M, H)
+    F.partitionBifoldM[G, H, A, B, C](fa)(f)(using A, M, H)
 
   /**
    * Separate this Foldable into a Tuple by an effectful separating function `A => G[Either[B, C]]`
@@ -302,7 +302,7 @@ final class FoldableOps0[F[_], A](private val fa: F[A]) extends AnyVal {
   def partitionEitherM[G[_], B, C](
     f: A => G[Either[B, C]]
   )(implicit A: Alternative[F], F: Foldable[F], M: Monad[G]): G[(F[B], F[C])] =
-    F.partitionEitherM[G, A, B, C](fa)(f)(A, M)
+    F.partitionEitherM[G, A, B, C](fa)(f)(using A, M)
 
   def sliding2(implicit F: Foldable[F]): List[(A, A)] =
     F.sliding2(fa)

--- a/core/src/main/scala/cats/syntax/monoid.scala
+++ b/core/src/main/scala/cats/syntax/monoid.scala
@@ -29,5 +29,5 @@ trait MonoidSyntax extends SemigroupSyntax {
 }
 
 final class MonoidOps[A](private val lhs: A) extends AnyVal {
-  def isEmpty(implicit A: Monoid[A], eq: Eq[A]): Boolean = A.isEmpty(lhs)(eq)
+  def isEmpty(implicit A: Monoid[A], eq: Eq[A]): Boolean = A.isEmpty(lhs)(using eq)
 }

--- a/core/src/main/scala/cats/syntax/parallel.scala
+++ b/core/src/main/scala/cats/syntax/parallel.scala
@@ -332,7 +332,7 @@ final class NonEmptyParallelApOps[M[_], A](private val ma: M[A]) extends AnyVal 
 @deprecated("Kept for binary compatibility", "2.8.0")
 final class ParallelApplyOps[M[_], A, B](private val mab: M[A => B]) extends AnyVal {
   def <&>(ma: M[A])(implicit P: Parallel[M]): M[B] =
-    Parallel.parAp(mab)(ma)(P)
+    Parallel.parAp(mab)(ma)(using P)
 
   def parAp(ma: M[A])(implicit P: Parallel[M]): M[B] =
     Parallel.parAp(mab)(ma)
@@ -340,7 +340,7 @@ final class ParallelApplyOps[M[_], A, B](private val mab: M[A => B]) extends Any
 
 final class NonEmptyParallelApplyOps[M[_], A, B](private val mab: M[A => B]) extends AnyVal {
   def <&>(ma: M[A])(implicit P: NonEmptyParallel[M]): M[B] =
-    Parallel.parAp[M, A, B](mab)(ma)(P)
+    Parallel.parAp[M, A, B](mab)(ma)(using P)
 
   def parAp(ma: M[A])(implicit P: NonEmptyParallel[M]): M[B] =
     Parallel.parAp[M, A, B](mab)(ma)

--- a/kernel/src/main/scala-2.13+/cats/kernel/instances/ArraySeqInstances.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/instances/ArraySeqInstances.scala
@@ -81,7 +81,7 @@ object ArraySeqInstances {
     }
   }
 
-  private class ArraySeqHash[A](implicit ev: Hash[A]) extends ArraySeqEq[A]()(ev) with Hash[ArraySeq[A]] {
+  private class ArraySeqHash[A](implicit ev: Hash[A]) extends ArraySeqEq[A]()(using ev) with Hash[ArraySeq[A]] {
     final def hash(xs: ArraySeq[A]): Int = StaticMethods.orderedHash(xs)
   }
 

--- a/kernel/src/main/scala-2.13+/cats/kernel/instances/LazyListInstances.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/instances/LazyListInstances.scala
@@ -57,7 +57,7 @@ class LazyListPartialOrder[A](implicit ev: PartialOrder[A]) extends PartialOrder
     else StaticMethods.iteratorPartialCompare(xs.iterator, ys.iterator)
 }
 
-class LazyListHash[A](implicit ev: Hash[A]) extends LazyListEq[A]()(ev) with Hash[LazyList[A]] {
+class LazyListHash[A](implicit ev: Hash[A]) extends LazyListEq[A]()(using ev) with Hash[LazyList[A]] {
   def hash(xs: LazyList[A]): Int = StaticMethods.orderedHash(xs)
 }
 

--- a/kernel/src/main/scala-2.13+/cats/kernel/instances/StreamInstances.scala
+++ b/kernel/src/main/scala-2.13+/cats/kernel/instances/StreamInstances.scala
@@ -62,7 +62,7 @@ class StreamPartialOrder[A](implicit ev: PartialOrder[A]) extends PartialOrder[S
 }
 
 @deprecated("Use cats.kernel.instances.lazyList", "2.0.0-RC2")
-class StreamHash[A](implicit ev: Hash[A]) extends StreamEq[A]()(ev) with Hash[Stream[A]] {
+class StreamHash[A](implicit ev: Hash[A]) extends StreamEq[A]()(using ev) with Hash[Stream[A]] {
   def hash(xs: Stream[A]): Int = StaticMethods.orderedHash(xs)
 }
 

--- a/kernel/src/main/scala/cats/kernel/Semigroup.scala
+++ b/kernel/src/main/scala/cats/kernel/Semigroup.scala
@@ -354,5 +354,5 @@ private class FutureMonoid[A](A: Monoid[A], ec: ExecutionContext)
 }
 
 private class FutureSemigroup[A](A: Semigroup[A], ec: ExecutionContext) extends Semigroup[Future[A]] {
-  def combine(x: Future[A], y: Future[A]): Future[A] = x.flatMap(xv => y.map(A.combine(xv, _))(ec))(ec)
+  def combine(x: Future[A], y: Future[A]): Future[A] = x.flatMap(xv => y.map(A.combine(xv, _))(using ec))(using ec)
 }

--- a/kernel/src/main/scala/cats/kernel/Semilattice.scala
+++ b/kernel/src/main/scala/cats/kernel/Semilattice.scala
@@ -70,9 +70,9 @@ trait Semilattice[@sp(Int, Long, Float, Double) A] extends Any with Band[A] with
 
 abstract class SemilatticeFunctions[S[T] <: Semilattice[T]] extends SemigroupFunctions[S] {
   def asMeetPartialOrder[A](implicit s: S[A], ev: Eq[A]): PartialOrder[A] =
-    s.asMeetPartialOrder(ev)
+    s.asMeetPartialOrder(using ev)
   def asJoinPartialOrder[A](implicit s: S[A], ev: Eq[A]): PartialOrder[A] =
-    s.asJoinPartialOrder(ev)
+    s.asJoinPartialOrder(using ev)
 }
 
 object Semilattice extends SemilatticeFunctions[Semilattice] {

--- a/kernel/src/main/scala/cats/kernel/instances/ListInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/ListInstances.scala
@@ -83,8 +83,8 @@ class ListPartialOrder[A](implicit ev: PartialOrder[A]) extends PartialOrder[Lis
   }
 }
 
-class ListHash[A](implicit ev: Hash[A]) extends ListEq[A]()(ev) with Hash[List[A]] {
-  def hash(x: List[A]): Int = StaticMethods.listHash(x)(ev)
+class ListHash[A](implicit ev: Hash[A]) extends ListEq[A]()(using ev) with Hash[List[A]] {
+  def hash(x: List[A]): Int = StaticMethods.listHash(x)(using ev)
 }
 
 class ListEq[A](implicit ev: Eq[A]) extends Eq[List[A]] {

--- a/kernel/src/main/scala/cats/kernel/instances/MapInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/MapInstances.scala
@@ -64,7 +64,7 @@ private[instances] trait MapInstances1 {
     new MapMonoid[K, V]
 }
 
-class MapHash[K, V](implicit V: Hash[V]) extends MapEq[K, V]()(V) with Hash[Map[K, V]] {
+class MapHash[K, V](implicit V: Hash[V]) extends MapEq[K, V]()(using V) with Hash[Map[K, V]] {
   // adapted from [[scala.util.hashing.MurmurHash3]],
   // but modified standard `Any#hashCode` to `ev.hash`.
   import scala.util.hashing.MurmurHash3.*

--- a/kernel/src/main/scala/cats/kernel/instances/OptionInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/OptionInstances.scala
@@ -72,7 +72,7 @@ class OptionPartialOrder[A](implicit A: PartialOrder[A]) extends PartialOrder[Op
     }
 }
 
-class OptionHash[A](implicit A: Hash[A]) extends OptionEq[A]()(A) with Hash[Option[A]] {
+class OptionHash[A](implicit A: Hash[A]) extends OptionEq[A]()(using A) with Hash[Option[A]] {
   def hash(x: Option[A]): Int =
     x match {
       case None     => None.hashCode()
@@ -106,5 +106,5 @@ class OptionMonoid[A](implicit A: Semigroup[A]) extends Monoid[Option[A]] {
 }
 
 private class OptionCommutativeMonoid[A](implicit A: CommutativeSemigroup[A])
-    extends OptionMonoid[A]()(A)
+    extends OptionMonoid[A]()(using A)
     with CommutativeMonoid[Option[A]]

--- a/kernel/src/main/scala/cats/kernel/instances/SortedMapInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/SortedMapInstances.scala
@@ -50,7 +50,7 @@ trait SortedMapInstances extends SortedMapInstances3 {
 
   @deprecated("Use catsKernelStdHashForSortedMap override without Order", "2.2.0-M3")
   def catsKernelStdHashForSortedMap[K, V](hashK: Hash[K], orderK: Order[K], hashV: Hash[V]): Hash[SortedMap[K, V]] =
-    new SortedMapHash[K, V]()(hashV, hashK)
+    new SortedMapHash[K, V]()(using hashV, hashK)
 
   implicit def catsKernelStdCommutativeSemigroupForSortedMap[K, V: CommutativeSemigroup]
     : CommutativeSemigroup[SortedMap[K, V]] =
@@ -67,7 +67,7 @@ private[instances] trait SortedMapInstances1 {
 
   @deprecated("Use catsKernelStdEqForSortedMap override without Order", "2.2.0-M3")
   def catsKernelStdEqForSortedMap[K, V](orderK: Order[K], eqV: Eq[V]): Eq[SortedMap[K, V]] =
-    new SortedMapEq[K, V]()(eqV)
+    new SortedMapEq[K, V]()(using eqV)
 }
 
 private[instances] trait SortedMapInstances2 extends SortedMapInstances1 {
@@ -88,7 +88,7 @@ private[instances] trait SortedMapInstances3 extends SortedMapInstances2 {
 
 private[instances] class SortedMapOrder[K, V](implicit V: Order[V]) extends Order[SortedMap[K, V]] {
   override def compare(x: SortedMap[K, V], y: SortedMap[K, V]): Int = {
-    implicit val order: Order[K] = Order.fromOrdering(x.ordering)
+    implicit val order: Order[K] = Order.fromOrdering(using x.ordering)
     if (x eq y) {
       0
     } else {
@@ -100,7 +100,7 @@ private[instances] class SortedMapOrder[K, V](implicit V: Order[V]) extends Orde
 private[instances] class SortedMapPartialOrder[K, V](implicit V: PartialOrder[V])
     extends PartialOrder[SortedMap[K, V]] {
   override def partialCompare(x: SortedMap[K, V], y: SortedMap[K, V]): Double = {
-    implicit val order: Order[K] = Order.fromOrdering(x.ordering)
+    implicit val order: Order[K] = Order.fromOrdering(using x.ordering)
 
     if (x eq y) {
       0.0
@@ -110,10 +110,12 @@ private[instances] class SortedMapPartialOrder[K, V](implicit V: PartialOrder[V]
   }
 }
 
-class SortedMapHash[K, V](implicit V: Hash[V], K: Hash[K]) extends SortedMapEq[K, V]()(V) with Hash[SortedMap[K, V]] {
+class SortedMapHash[K, V](implicit V: Hash[V], K: Hash[K])
+    extends SortedMapEq[K, V]()(using V)
+    with Hash[SortedMap[K, V]] {
 
   @deprecated("Use the constructor _without_ Order instead, since Order is not required", "2.2.0-M3")
-  private[instances] def this(V: Hash[V], O: Order[K], K: Hash[K]) = this()(V, K)
+  private[instances] def this(V: Hash[V], O: Order[K], K: Hash[K]) = this()(using V, K)
 
   // adapted from [[scala.util.hashing.MurmurHash3]],
   // but modified standard `Any#hashCode` to `ev.hash`.
@@ -139,7 +141,7 @@ class SortedMapHash[K, V](implicit V: Hash[V], K: Hash[K]) extends SortedMapEq[K
 class SortedMapEq[K, V](implicit V: Eq[V]) extends Eq[SortedMap[K, V]] {
 
   @deprecated("Use the constructor _without_ Order instead, since Order is not required", "2.2.0")
-  private[instances] def this(V: Eq[V], O: Order[K]) = this()(V)
+  private[instances] def this(V: Eq[V], O: Order[K]) = this()(using V)
 
   def eqv(x: SortedMap[K, V], y: SortedMap[K, V]): Boolean =
     if (x eq y) true

--- a/kernel/src/main/scala/cats/kernel/instances/SortedSetInstances.scala
+++ b/kernel/src/main/scala/cats/kernel/instances/SortedSetInstances.scala
@@ -77,7 +77,7 @@ class SortedSetHash[A](implicit hashA: Hash[A]) extends Hash[SortedSet[A]] {
   import scala.util.hashing.MurmurHash3.*
 
   @deprecated("Use the constructor _without_ Order instead, since Order is not required", "2.1.0")
-  private[instances] def this(o: Order[A], h: Hash[A]) = this()(h)
+  private[instances] def this(o: Order[A], h: Hash[A]) = this()(using h)
 
   // adapted from [[scala.util.hashing.MurmurHash3]],
   // but modified standard `Any#hashCode` to `ev.hash`.
@@ -98,7 +98,7 @@ class SortedSetHash[A](implicit hashA: Hash[A]) extends Hash[SortedSet[A]] {
     finalizeHash(h, n)
   }
   override def eqv(s1: SortedSet[A], s2: SortedSet[A]): Boolean =
-    StaticMethods.iteratorEq(s1.iterator, s2.iterator)(Eq[A])
+    StaticMethods.iteratorEq(s1.iterator, s2.iterator)(using Eq[A])
 }
 
 class SortedSetSemilattice[A: Order] extends BoundedSemilattice[SortedSet[A]] {

--- a/project/Boilerplate.scala
+++ b/project/Boilerplate.scala
@@ -265,13 +265,13 @@ object Boilerplate {
       | * @groupprio TupleArity 999
       | */
       |trait ApplyArityFunctions[F[_]] { self: Apply[F] =>
-      |  def tuple2[A, B](f1: F[A], f2: F[B]): F[(A, B)] = Semigroupal.tuple2(f1, f2)(self, self)
+      |  def tuple2[A, B](f1: F[A], f2: F[B]): F[(A, B)] = Semigroupal.tuple2(f1, f2)(using self, self)
         -  /** @group ApArity */
         -  def ap$arity[${`A..N`}, Z](f: F[(${`A..N`}) => Z])($fparams):F[Z] = $apply
         -  /** @group MapArity */
-        -  def map$arity[${`A..N`}, Z]($fparams)(f: (${`A..N`}) => Z): F[Z] = Semigroupal.map$arity($fparams)(f)(self, self)
+        -  def map$arity[${`A..N`}, Z]($fparams)(f: (${`A..N`}) => Z): F[Z] = Semigroupal.map$arity($fparams)(f)(using self, self)
         -  /** @group TupleArity */
-        -  def tuple$arity[${`A..N`}]($fparams): F[(${`A..N`})] = Semigroupal.tuple$arity($fparams)(self, self)
+        -  def tuple$arity[${`A..N`}]($fparams): F[(${`A..N`})] = Semigroupal.tuple$arity($fparams)(using self, self)
       |}
       """
     }


### PR DESCRIPTION
```
Welcome to Scala 3.9.0 (21.0.12, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                            
scala> def foo(implicit x: Int): Int = x
def foo(implicit x: Int): Int
                                                                                                                                            
scala> foo(2)
1 warning found
-- Warning: --------------------------------------------------------------------
1 |foo(2)
  |    ^
  |Implicit parameters should be provided with a `using` clause.
  |To disable the warning, please use the following option:
  |  "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s"
val res0: Int = 2
                                                                                                                                            
scala> foo(using 2)
val res1: Int = 2
```