### PR TITLE
Fix Deferred warnings

### DIFF
--- a/core/src/main/scala/cats/instances/eq.scala
+++ b/core/src/main/scala/cats/instances/eq.scala
@@ -49,22 +49,22 @@ trait EqInstances extends kernel.instances.EqInstances {
   implicit def catsDeferForEq: Defer[Eq] = EqInstances.catsDeferForEqCache
 }
 object EqInstances {
+  final private case class Deferred[A](fa: () => Eq[A]) extends Eq[A] {
+    private lazy val resolved: Eq[A] = {
+      @tailrec
+      def loop(f: () => Eq[A]): Eq[A] =
+        f() match {
+          case Deferred(f) => loop(f)
+          case next        => next
+        }
+
+      loop(fa)
+    }
+    override def eqv(x: A, y: A): Boolean = resolved.eqv(x, y)
+  }
+
   private val catsDeferForEqCache: Defer[Eq] =
     new Defer[Eq] {
-      case class Deferred[A](fa: () => Eq[A]) extends Eq[A] {
-        private lazy val resolved: Eq[A] = {
-          @tailrec
-          def loop(f: () => Eq[A]): Eq[A] =
-            f() match {
-              case Deferred(f) => loop(f)
-              case next        => next
-            }
-
-          loop(fa)
-        }
-        override def eqv(x: A, y: A): Boolean = resolved.eqv(x, y)
-      }
-
       override def defer[A](fa: => Eq[A]): Eq[A] = {
         lazy val cachedFa = fa
         Deferred(() => cachedFa)

--- a/core/src/main/scala/cats/instances/equiv.scala
+++ b/core/src/main/scala/cats/instances/equiv.scala
@@ -58,22 +58,22 @@ trait EquivInstances {
   implicit def catsDeferForEquiv: Defer[Equiv] = EquivInstances.catsDeferForEquivCache
 }
 object EquivInstances {
+  final private case class Deferred[A](fa: () => Equiv[A]) extends Equiv[A] {
+    private lazy val resolved: Equiv[A] = {
+      @tailrec
+      def loop(f: () => Equiv[A]): Equiv[A] =
+        f() match {
+          case Deferred(f) => loop(f)
+          case next        => next
+        }
+
+      loop(fa)
+    }
+    override def equiv(x: A, y: A): Boolean = resolved.equiv(x, y)
+  }
+
   private val catsDeferForEquivCache: Defer[Equiv] =
     new Defer[Equiv] {
-      case class Deferred[A](fa: () => Equiv[A]) extends Equiv[A] {
-        private lazy val resolved: Equiv[A] = {
-          @tailrec
-          def loop(f: () => Equiv[A]): Equiv[A] =
-            f() match {
-              case Deferred(f) => loop(f)
-              case next        => next
-            }
-
-          loop(fa)
-        }
-        override def equiv(x: A, y: A): Boolean = resolved.equiv(x, y)
-      }
-
       override def defer[A](fa: => Equiv[A]): Equiv[A] = {
         lazy val cachedFa = fa
         Deferred(() => cachedFa)

--- a/core/src/main/scala/cats/instances/hash.scala
+++ b/core/src/main/scala/cats/instances/hash.scala
@@ -39,28 +39,28 @@ trait HashInstances extends kernel.instances.HashInstances {
   implicit def catsDeferForHash: Defer[Hash] = HashInstances.catsDeferForHashCache
 }
 object HashInstances {
-  private val catsDeferForHashCache: Defer[Hash] =
-    new Defer[Hash] {
-      case class Deferred[A](fa: () => Hash[A]) extends Hash[A] {
-        private lazy val resolve: Hash[A] = {
-          @tailrec
-          def loop(f: () => Hash[A]): Hash[A] =
-            f() match {
-              case Deferred(f) => loop(f)
-              case next        => next
-            }
-
-          loop(fa)
+  final private case class Deferred[A](fa: () => Hash[A]) extends Hash[A] {
+    private lazy val resolve: Hash[A] = {
+      @tailrec
+      def loop(f: () => Hash[A]): Hash[A] =
+        f() match {
+          case Deferred(f) => loop(f)
+          case next        => next
         }
 
-        override def hash(x: A): Int = resolve.hash(x)
+      loop(fa)
+    }
 
-        /**
-         * Returns `true` if `x` and `y` are equivalent, `false` otherwise.
-         */
-        override def eqv(x: A, y: A): Boolean = resolve.eqv(x, y)
-      }
+    override def hash(x: A): Int = resolve.hash(x)
 
+    /**
+     * Returns `true` if `x` and `y` are equivalent, `false` otherwise.
+     */
+    override def eqv(x: A, y: A): Boolean = resolve.eqv(x, y)
+  }
+
+  private val catsDeferForHashCache: Defer[Hash] =
+    new Defer[Hash] {
       override def defer[A](fa: => Hash[A]): Hash[A] = {
         lazy val cachedFa = fa
         Deferred(() => cachedFa)

--- a/core/src/main/scala/cats/instances/order.scala
+++ b/core/src/main/scala/cats/instances/order.scala
@@ -53,22 +53,22 @@ trait OrderInstances extends kernel.instances.OrderInstances {
   implicit def catsDeferForOrder: Defer[Order] = OrderInstances.catsDeferForOrderCache
 }
 object OrderInstances {
+  final private case class Deferred[A](fa: () => Order[A]) extends Order[A] {
+    private lazy val resolved: Order[A] = {
+      @tailrec
+      def loop(f: () => Order[A]): Order[A] =
+        f() match {
+          case Deferred(f) => loop(f)
+          case next        => next
+        }
+
+      loop(fa)
+    }
+    override def compare(x: A, y: A): Int = resolved.compare(x, y)
+  }
+
   private val catsDeferForOrderCache: Defer[Order] =
     new Defer[Order] {
-      case class Deferred[A](fa: () => Order[A]) extends Order[A] {
-        private lazy val resolved: Order[A] = {
-          @tailrec
-          def loop(f: () => Order[A]): Order[A] =
-            f() match {
-              case Deferred(f) => loop(f)
-              case next        => next
-            }
-
-          loop(fa)
-        }
-        override def compare(x: A, y: A): Int = resolved.compare(x, y)
-      }
-
       override def defer[A](fa: => Order[A]): Order[A] = {
         lazy val cachedFa = fa
         Deferred(() => cachedFa)

--- a/core/src/main/scala/cats/instances/ordering.scala
+++ b/core/src/main/scala/cats/instances/ordering.scala
@@ -49,22 +49,22 @@ trait OrderingInstances {
   implicit def catsStdDeferForOrdering: Defer[Ordering] = OrderingInstances.catsStdDeferForOrderingCache
 }
 object OrderingInstances {
+  final private case class Deferred[A](fa: () => Ordering[A]) extends Ordering[A] {
+    private lazy val resolved: Ordering[A] = {
+      @tailrec
+      def loop(f: () => Ordering[A]): Ordering[A] =
+        f() match {
+          case Deferred(f) => loop(f)
+          case next        => next
+        }
+
+      loop(fa)
+    }
+    override def compare(x: A, y: A): Int = resolved.compare(x, y)
+  }
+
   private val catsStdDeferForOrderingCache: Defer[Ordering] =
     new Defer[Ordering] {
-      case class Deferred[A](fa: () => Ordering[A]) extends Ordering[A] {
-        private lazy val resolved: Ordering[A] = {
-          @tailrec
-          def loop(f: () => Ordering[A]): Ordering[A] =
-            f() match {
-              case Deferred(f) => loop(f)
-              case next        => next
-            }
-
-          loop(fa)
-        }
-        override def compare(x: A, y: A): Int = resolved.compare(x, y)
-      }
-
       override def defer[A](fa: => Ordering[A]): Ordering[A] = {
         lazy val cachedFa = fa
         Deferred(() => cachedFa)

--- a/core/src/main/scala/cats/instances/partialOrder.scala
+++ b/core/src/main/scala/cats/instances/partialOrder.scala
@@ -47,22 +47,22 @@ trait PartialOrderInstances extends kernel.instances.PartialOrderInstances {
   implicit def catsDeferForPartialOrder: Defer[PartialOrder] = PartialOrderInstances.catsDeferForPartialOrderCache
 }
 object PartialOrderInstances {
+  final private case class Deferred[A](fa: () => PartialOrder[A]) extends PartialOrder[A] {
+    private lazy val resolved: PartialOrder[A] = {
+      @tailrec
+      def loop(f: () => PartialOrder[A]): PartialOrder[A] =
+        f() match {
+          case Deferred(f) => loop(f)
+          case next        => next
+        }
+
+      loop(fa)
+    }
+    override def partialCompare(x: A, y: A): Double = resolved.partialCompare(x, y)
+  }
+
   private val catsDeferForPartialOrderCache: Defer[PartialOrder] =
     new Defer[PartialOrder] {
-      case class Deferred[A](fa: () => PartialOrder[A]) extends PartialOrder[A] {
-        private lazy val resolved: PartialOrder[A] = {
-          @tailrec
-          def loop(f: () => PartialOrder[A]): PartialOrder[A] =
-            f() match {
-              case Deferred(f) => loop(f)
-              case next        => next
-            }
-
-          loop(fa)
-        }
-        override def partialCompare(x: A, y: A): Double = resolved.partialCompare(x, y)
-      }
-
       override def defer[A](fa: => PartialOrder[A]): PartialOrder[A] = {
         lazy val cachedFa = fa
         Deferred(() => cachedFa)

--- a/core/src/main/scala/cats/instances/partialOrdering.scala
+++ b/core/src/main/scala/cats/instances/partialOrdering.scala
@@ -57,25 +57,25 @@ trait PartialOrderingInstances {
     PartialOrderingInstances.catsStdDeferForPartialOrderingCache
 }
 object PartialOrderingInstances {
-  private val catsStdDeferForPartialOrderingCache: Defer[PartialOrdering] =
-    new Defer[PartialOrdering] {
-      case class Deferred[A](fa: () => PartialOrdering[A]) extends PartialOrdering[A] {
-        private lazy val resolve: PartialOrdering[A] = {
-          @tailrec
-          def loop(f: () => PartialOrdering[A]): PartialOrdering[A] =
-            f() match {
-              case Deferred(f) => loop(f)
-              case next        => next
-            }
-
-          loop(fa)
+  final private case class Deferred[A](fa: () => PartialOrdering[A]) extends PartialOrdering[A] {
+    private lazy val resolve: PartialOrdering[A] = {
+      @tailrec
+      def loop(f: () => PartialOrdering[A]): PartialOrdering[A] =
+        f() match {
+          case Deferred(f) => loop(f)
+          case next        => next
         }
 
-        override def tryCompare(x: A, y: A): Option[Int] = resolve.tryCompare(x, y)
+      loop(fa)
+    }
 
-        override def lteq(x: A, y: A): Boolean = resolve.lteq(x, y)
-      }
+    override def tryCompare(x: A, y: A): Option[Int] = resolve.tryCompare(x, y)
 
+    override def lteq(x: A, y: A): Boolean = resolve.lteq(x, y)
+  }
+
+  private val catsStdDeferForPartialOrderingCache: Defer[PartialOrdering] =
+    new Defer[PartialOrdering] {
       override def defer[A](fa: => PartialOrdering[A]): PartialOrdering[A] = {
         lazy val cachedFa = fa
         Deferred(() => cachedFa)

--- a/core/src/main/scala/cats/instances/show.scala
+++ b/core/src/main/scala/cats/instances/show.scala
@@ -28,22 +28,22 @@ trait ShowInstances {
   implicit def catsDeferForShow: Defer[Show] = ShowInstances.catsDeferForShowCache
 }
 object ShowInstances {
+  final private case class Deferred[A](fa: () => Show[A]) extends Show[A] {
+    private lazy val resolved: Show[A] = {
+      @tailrec
+      def loop(f: () => Show[A]): Show[A] =
+        f() match {
+          case Deferred(f) => loop(f)
+          case next        => next
+        }
+
+      loop(fa)
+    }
+    override def show(t: A): String = resolved.show(t)
+  }
+
   private val catsDeferForShowCache: Defer[Show] =
     new Defer[Show] {
-      case class Deferred[A](fa: () => Show[A]) extends Show[A] {
-        private lazy val resolved: Show[A] = {
-          @tailrec
-          def loop(f: () => Show[A]): Show[A] =
-            f() match {
-              case Deferred(f) => loop(f)
-              case next        => next
-            }
-
-          loop(fa)
-        }
-        override def show(t: A): String = resolved.show(t)
-      }
-
       override def defer[A](fa: => Show[A]): Show[A] = {
         lazy val cachedFa = fa
         Deferred(() => cachedFa)


### PR DESCRIPTION
```
[warn] -- [E092] Pattern Match Unchecked Warning: /home/runner/work/cats/cats/core/src/main/scala/cats/instances/order.scala:63:19 
[warn] 63 |              case Deferred(f) => loop(f)
[warn]    |                   ^
[warn]    |the type test for Deferred[A] cannot be checked at runtime because it's a local class
[warn]    |
[warn]    | longer explanation available when compiling with `-explain`
[warn] -- [E092] Pattern Match Unchecked Warning: /home/runner/work/cats/cats/core/src/main/scala/cats/instances/ordering.scala:59:19 
[warn] 59 |              case Deferred(f) => loop(f)
[warn]    |                   ^
[warn]    |the type test for Deferred[A] cannot be checked at runtime because it's a local class
[warn]    |
[warn]    | longer explanation available when compiling with `-explain`
[warn] -- [E092] Pattern Match Unchecked Warning: /home/runner/work/cats/cats/core/src/main/scala/cats/instances/partialOrder.scala:57:19 
[warn] 57 |              case Deferred(f) => loop(f)
[warn]    |                   ^
[warn]    |the type test for Deferred[A] cannot be checked at runtime because it's a local class
[warn]    |
[warn]    | longer explanation available when compiling with `-explain`
[warn] -- [E092] Pattern Match Unchecked Warning: /home/runner/work/cats/cats/core/src/main/scala/cats/instances/partialOrdering.scala:67:19 
[warn] 67 |              case Deferred(f) => loop(f)
[warn]    |                   ^
[warn]    |the type test for Deferred[A] cannot be checked at runtime because it's a local class
[warn]    |
[warn]    | longer explanation available when compiling with `-explain`
[warn] -- [E092] Pattern Match Unchecked Warning: /home/runner/work/cats/cats/core/src/main/scala/cats/instances/show.scala:38:19 
[warn] 38 |              case Deferred(f) => loop(f)
[warn]    |                   ^
[warn]    |the type test for Deferred[A] cannot be checked at runtime because it's a local class
[warn]    |
[warn]    | longer explanation available when compiling with `-explain`
```